### PR TITLE
♻️ refactor(policy): refactor policy classes to use a unified base Policy class instead of…

### DIFF
--- a/library/src/getiaction/policies/act/lightning_module.py
+++ b/library/src/getiaction/policies/act/lightning_module.py
@@ -4,10 +4,10 @@
 """ACT policy implementation via Lightning module."""
 
 from getiaction.policies.act.torch_model import ACTModel
-from getiaction.policies.base.base_lightning_module import TrainerModule
+from getiaction.policies.base.policy import Policy
 
 
-class ACTPolicy(TrainerModule):
+class ACTPolicy(Policy):
     """ACT policy wrapper."""
 
     def __init__(self) -> None:

--- a/library/src/getiaction/policies/base/__init__.py
+++ b/library/src/getiaction/policies/base/__init__.py
@@ -3,6 +3,6 @@
 
 """Base classes for policies."""
 
-from .base_lightning_module import TrainerModule
+from .policy import Policy
 
-__all__ = ["TrainerModule"]
+__all__ = ["Policy"]

--- a/library/src/getiaction/policies/base/policy.py
+++ b/library/src/getiaction/policies/base/policy.py
@@ -10,7 +10,7 @@ import torch
 from torch import nn
 
 
-class TrainerModule(L.LightningModule, ABC):
+class Policy(L.LightningModule, ABC):
     """Base Lightning Module for Policies."""
 
     def __init__(self) -> None:

--- a/library/src/getiaction/policies/dummy/policy.py
+++ b/library/src/getiaction/policies/dummy/policy.py
@@ -7,12 +7,12 @@ from collections.abc import Iterable
 
 import torch
 
-from getiaction.policies.base import TrainerModule
+from getiaction.policies.base import Policy
 from getiaction.policies.dummy.config import DummyConfig
 from getiaction.policies.dummy.model import Dummy as DummyModel
 
 
-class Dummy(TrainerModule):
+class Dummy(Policy):
     """Dummy policy wrapper."""
 
     def __init__(self, config: DummyConfig) -> None:

--- a/library/src/getiaction/train/trainer.py
+++ b/library/src/getiaction/train/trainer.py
@@ -8,7 +8,7 @@ from abc import abstractmethod
 import lightning as L  # noqa: N812
 
 from getiaction.data import DataModule
-from getiaction.policies.base import TrainerModule
+from getiaction.policies.base import Policy
 from getiaction.train.callbacks import PolicyDatasetInteraction
 
 
@@ -41,7 +41,7 @@ class Trainer:
             **trainer_kwargs,
         )
 
-    def fit(self, model: TrainerModule, datamodule: DataModule, **kwargs) -> None:  # noqa: ANN003
+    def fit(self, model: Policy, datamodule: DataModule, **kwargs) -> None:  # noqa: ANN003
         """Fit the model."""
         # if we don't have any validation datasets, limit batch size to zero
         if datamodule.eval_dataset is None:

--- a/library/src/getiaction/train/utils.py
+++ b/library/src/getiaction/train/utils.py
@@ -13,10 +13,10 @@ from getiaction.data import LeRobotDatasetWrapper
 
 if TYPE_CHECKING:
     from getiaction.data import DataModule
-    from getiaction.policies.base.base_lightning_module import TrainerModule
+    from getiaction.policies.base.policy import Policy
 
 
-def reformat_dataset_to_match_policy(policy: TrainerModule, datamodule: DataModule) -> None:
+def reformat_dataset_to_match_policy(policy: Policy, datamodule: DataModule) -> None:
     """Reformat dataset to have correct deltas and parametrs depending on policy."""
     # if lerobot dataset, set delta timesteps correctly
     # https://github.com/huggingface/lerobot/blob/33cad37054c2b594ceba57463e8f11ee374fa93c/src/lerobot/datasets/factory.py#L37


### PR DESCRIPTION
## Description
Refactor the base policy class by renaming `TrainerModule` to `Policy` throughout the codebase. This change improves code clarity by using a more descriptive and intuitive name that better reflects the purpose of the class as a policy implementation rather than just a training module.

## Type of Change
- [x] ♻️ refactor: A code change that neither fixes a bug nor adds a feature

## Related Issues
<!-- No specific issue mentioned -->

## Changes Made
- Renamed `TrainerModule` class to `Policy` in `library/src/getiaction/policies/base/policy.py`
- Deleted the old `base_lightning_module.py` file containing `TrainerModule`
- Updated all imports and class inheritance references across the codebase:
  - `library/src/getiaction/policies/act/lightning_module.py` - Updated `ACTPolicy` to inherit from `Policy`
  - `library/src/getiaction/policies/dummy/policy.py` - Updated `Dummy` to inherit from `Policy`
  - `library/src/getiaction/train/trainer.py` - Updated type hints to use `Policy`
  - `library/src/getiaction/train/utils.py` - Updated type hints and function parameters
  - `library/src/getiaction/policies/base/__init__.py` - Updated exports
- Maintained all existing functionality and abstract method contracts
- Preserved the ABC (Abstract Base Class) pattern with the `select_action` abstract method

## Screenshots/Videos
<!-- Not applicable for this refactor -->

## Additional Notes
This is a pure refactoring change that improves code readability without affecting functionality. The class still:
- Inherits from both `L.LightningModule` and `ABC`
- Maintains the abstract `select_action` method
- Provides the same `forward` method implementation
- Preserves all Lightning-specific functionality

The new name `Policy` is more semantically appropriate as these classes represent immitation learning policies rather than generic training modules.

## Breaking Changes
This is a breaking change for any code that imports or references `TrainerModule`. Users will need to:
- Update imports from `from getiaction.policies.base import TrainerModule` to `from getiaction.policies.base import Policy`
- Update class inheritance from `class MyPolicy(TrainerModule)` to `class MyPolicy(Policy)`

## Deployment Notes
No special deployment considerations. This is a code-level refactoring that doesn't affect runtime behavior or external APIs beyond the class naming.