### PR TITLE
✨ feature(data): add `data_format` arg to `LeRobotDataModule` 

### DIFF
--- a/library/src/getiaction/data/lerobot.py
+++ b/library/src/getiaction/data/lerobot.py
@@ -395,15 +395,8 @@ class LeRobotDataModule(DataModule):
             msg = "Cannot provide both 'repo_id' and 'dataset'. Please provide only one."
             raise ValueError(msg)
 
-        # Convert string to enum if needed
-        if isinstance(data_format, str):
-            try:
-                data_format = DataFormat(data_format)
-            except ValueError as e:
-                msg = f"Invalid data_format '{data_format}'. Must be 'getiaction' or 'lerobot'."
-                raise ValueError(msg) from e
-
-        self.data_format = data_format
+        # Convert `data_format` to enum if it's a string
+        self.data_format = DataFormat(data_format)
 
         # Create the appropriate dataset based on format
         if dataset is not None:


### PR DESCRIPTION
## Description

This PR adds support for choosing between **getiaction** and **lerobot** data formats in the `LeRobotDataModule`. Previously, the module only supported the getiaction `Observation` format. Now users can specify which format they want based on their use case:

- **`getiaction` format** (default): Returns `Observation` dataclass instances with custom collation
- **`lerobot` format**: Returns the original LeRobot dict format, useful when working with native LeRobot policies

This change makes the `LeRobotDataModule` more flexible and compatible with both getiaction and native LeRobot training pipelines.

## Type of Change

- [x] ✨ feat: A new feature
- [ ] 🐛 fix: A bug fix
- [ ] 📚 docs: Documentation only changes
- [ ] 🎨 style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ♻️ refactor: A code change that neither fixes a bug nor adds a feature
- [ ] ⚡ perf: A code change that improves performance
- [ ] 🧪 test: Adding missing tests or correcting existing tests
- [ ] 📦 build: Changes that affect the build system or external dependencies
- [ ] 👷 ci: Changes to our CI configuration files and scripts
- [ ] 🔧 chore: Other changes that don't modify src or test files
- [ ] ⏪ revert: Reverts a previous commit

## Related Issues

N/A

## Changes Made

### 1. Added `DataFormat` Enum
- Created a new `DataFormat` enum with two options:
  - `GETIACTION = "getiaction"`: Native getiaction format
  - `LEROBOT = "lerobot"`: Original LeRobot format
- Provides type-safe format selection

### 2. Enhanced `LeRobotDataModule`
- Added `data_format` parameter to `__init__()` method
  - Type: `Literal["getiaction", "lerobot"] | DataFormat`
  - Default: `"getiaction"` (backward compatible)
- Supports both string literals and enum values
- Automatic validation of format values

### 3. Format-Aware Dataset Creation
- When `data_format="getiaction"`: wraps LeRobotDataset with `_LeRobotDatasetAdapter`
- When `data_format="lerobot"`: uses LeRobotDataset directly
- Works with both `repo_id` and existing `dataset` instances

### 4. Custom DataLoader Implementation
- Added `train_dataloader()` method that returns format-appropriate DataLoaders
- **getiaction format**: Uses parent's custom collate function for `Observation` batching
- **lerobot format**: Uses PyTorch's default collate to preserve dict structure

## Usage Examples

### Example 1: Default getiaction format
```python
from getiaction.data import LeRobotDataModule

# Uses getiaction Observation format by default
datamodule = LeRobotDataModule(
    repo_id="lerobot/aloha_sim_transfer_cube_human",
    train_batch_size=32
)

# Returns batches of Observation dataclasses
for batch in datamodule.train_dataloader():
    print(type(batch))  # <class 'getiaction.data.Observation'>
    print(batch.images.keys())  # Image modalities
    print(batch.action.shape)   # Action tensor
```

### Example 2: LeRobot original format (string)
```python
from getiaction.data import LeRobotDataModule

# Use LeRobot's native dict format
datamodule = LeRobotDataModule(
    repo_id="lerobot/aloha_sim_transfer_cube_human",
    train_batch_size=32,
    data_format="lerobot"  # String literal
)

# Returns batches of dicts (LeRobot's native format)
for batch in datamodule.train_dataloader():
    print(type(batch))  # <class 'dict'>
    print(batch.keys())  # ['observation.image', 'action', 'timestamp', ...]
    print(batch["action"].shape)
```

### Example 3: Type-safe enum usage
```python
from getiaction.data import LeRobotDataModule
from getiaction.data.lerobot import DataFormat

# Type-safe format selection with enum
datamodule = LeRobotDataModule(
    repo_id="lerobot/aloha_sim_transfer_cube_human",
    train_batch_size=32,
    data_format=DataFormat.LEROBOT  # Enum value
)
```

### Example 4: With existing LeRobotDataset instance
```python
from lerobot.datasets import LeRobotDataset
from getiaction.data import LeRobotDataModule

# Create LeRobotDataset separately
raw_dataset = LeRobotDataset(
    "lerobot/aloha_sim_transfer_cube_human",
    delta_timestamps={"observation.image": [-0.1, 0.0]}
)

# Use with LeRobotDataModule in original format
datamodule = LeRobotDataModule(
    dataset=raw_dataset,
    train_batch_size=32,
    data_format="lerobot"
)
```

### Example 5: Training with LeRobot policies
```python
from getiaction.data import LeRobotDataModule
from lerobot.common.policies.act.modeling_act import ACTPolicy

# Use lerobot format for native LeRobot policies
datamodule = LeRobotDataModule(
    repo_id="lerobot/aloha_sim_transfer_cube_human",
    train_batch_size=32,
    data_format="lerobot"  # Required for LeRobot policies
)

policy = ACTPolicy(...)

# Train with LeRobot-compatible data
for batch in datamodule.train_dataloader():
    # batch is a dict with LeRobot's expected structure
    output = policy.forward(batch)
```

## Additional Notes

### Backward Compatibility
- **Default behavior unchanged**: The module defaults to `data_format="getiaction"`, maintaining backward compatibility
- Existing code continues to work without modifications
- No breaking changes to the public API

### When to use which format?
- **Use `getiaction` format** when:
  - Training with getiaction policies
  - Want type-safe `Observation` dataclass
  - Need custom collation logic
  
- **Use `lerobot` format** when:
  - Training with native LeRobot policies (ACT, Diffusion, etc.)
  - Need compatibility with LeRobot's training pipeline
  - Want the original dict structure with hierarchical keys

### Validation
- The `data_format` parameter is validated on initialization
- Invalid values raise a clear `ValueError` with helpful message
- Supports both string literals (`"getiaction"`, `"lerobot"`) and enum values

## Breaking Changes

None. This is a backward-compatible feature addition.

## Deployment Notes

No special deployment considerations. The change is fully backward compatible and self-contained within the `LeRobotDataModule` class.
