### PR TITLE
♻️ refactor(gym): rename `BaseGym` to `Gym`

### DIFF
--- a/library/docs/design/data/datamodules.md
+++ b/library/docs/design/data/datamodules.md
@@ -14,10 +14,10 @@ classDiagram
     class DataModule {
         - Dataset train_dataset
         - int train_batch_size
-        - BaseGym|list~BaseGym~|None eval_gyms
+        - Gym|list~Gym~|None eval_gyms
         - Dataset eval_dataset
         - int num_rollouts_eval
-        - BaseGym|list~BaseGym~|None test_gyms
+        - Gym|list~Gym~|None test_gyms
         - Dataset test_dataset
         - int num_rollouts_test
         - int|None max_episode_steps
@@ -30,7 +30,7 @@ classDiagram
 
     class Dataset
     class DataLoader
-    class BaseGym
+    class Gym
     class GymDataset
     class ConcatDataset
     class TimeLimit
@@ -38,7 +38,7 @@ classDiagram
     LightningDataModule <|-- DataModule
     DataModule --> Dataset
     DataModule --> DataLoader
-    DataModule --> BaseGym
+    DataModule --> Gym
     DataModule --> GymDataset
     DataModule --> ConcatDataset
     DataModule --> TimeLimit

--- a/library/docs/design/data/gym.md
+++ b/library/docs/design/data/gym.md
@@ -7,15 +7,15 @@ We calculate the length of an evaluation dataset based on the number of rollouts
 ```mermaid
 classDiagram
     class Dataset
-    class BaseGym
+    class Gym
 
     class GymDataset{
-        +BaseGym env
+        +Gym env
         +int num_rollouts
-        +__init__(env: BaseGym, num_rollouts: int)
+        +__init__(env: Gym, num_rollouts: int)
         +__len__() int
-        +__getitem__(index: int) BaseGym
+        +__getitem__(index: int) Gym
     }
     GymDataset --|> Dataset
-    GymDataset --> BaseGym : uses
+    GymDataset --> Gym : uses
 ```

--- a/library/docs/design/gyms/base.md
+++ b/library/docs/design/gyms/base.md
@@ -1,12 +1,12 @@
-# BaseGym
+# Gym
 
-The `BaseGym` serves as an interface to the gymnasium framework.
+The `Gym` serves as an interface to the gymnasium framework.
 
 At a later date we plan to convert output `ObsType` to our internal representation.
 
 ```mermaid
 classDiagram
-    class BaseGym {
+    class Gym {
         + str _gym_id
         + gym_env env
         + Space observation_space
@@ -32,5 +32,5 @@ classDiagram
         + close()
     }
 
-    BaseGym --> gymnasium.Env : wraps
+    Gym --> gymnasium.Env : wraps
 ```

--- a/library/docs/design/gyms/pusht.md
+++ b/library/docs/design/gyms/pusht.md
@@ -1,6 +1,6 @@
 # PushTGym
 
-A child class of the `BaseGym`. We init with default parameters for `PushT`.
+A child class of the `Gym`. We init with default parameters for `PushT`.
 
 ```mermaid
 classDiagram
@@ -8,7 +8,7 @@ classDiagram
         + __init__(gym_id: str, obs_type: str)
     }
 
-    PushTGym --|> BaseGym : inherits
+    PushTGym --|> Gym : inherits
 ```
 
 Example:

--- a/library/src/getiaction/data/datamodules.py
+++ b/library/src/getiaction/data/datamodules.py
@@ -17,7 +17,7 @@ from torch.utils.data import ConcatDataset, DataLoader, Dataset
 
 from getiaction.data import Observation
 from getiaction.data.gym import GymDataset
-from getiaction.gyms import BaseGym
+from getiaction.gyms import Gym
 
 if TYPE_CHECKING:
     from getiaction.data import Dataset
@@ -110,9 +110,9 @@ class DataModule(LightningDataModule):
         self,
         train_dataset: Dataset,
         train_batch_size: int = 16,
-        eval_gyms: BaseGym | list[BaseGym] | None = None,
+        eval_gyms: Gym | list[Gym] | None = None,
         num_rollouts_eval: int = 10,
-        test_gyms: BaseGym | list[BaseGym] | None = None,
+        test_gyms: Gym | list[Gym] | None = None,
         num_rollouts_test: int = 10,
         max_episode_steps: int | None = 300,
     ) -> None:
@@ -121,9 +121,9 @@ class DataModule(LightningDataModule):
         Args:
             train_dataset (ActionDataset): Dataset for training.
             train_batch_size (int): Batch size for training DataLoader.
-            eval_gyms (BaseGym, list[BaseGym], None]): Evaluation environments.
+            eval_gyms (Gym, list[Gym], None]): Evaluation environments.
             num_rollouts_eval (int): Number of rollouts to run for evaluation environments.
-            test_gyms (BaseGym, list[BaseGym], None]): Test environments.
+            test_gyms (Gym, list[Gym], None]): Test environments.
             num_rollouts_test (int): Number of rollouts to run for test environments.
             max_episode_steps (int, None): Maximum steps allowed per episode. If None, no time limit.
         """
@@ -134,17 +134,17 @@ class DataModule(LightningDataModule):
         self.train_batch_size: int = train_batch_size
 
         # gym environments
-        self.eval_gyms: BaseGym | list[BaseGym] | None = eval_gyms
+        self.eval_gyms: Gym | list[Gym] | None = eval_gyms
         self.eval_dataset: Dataset[Any] | None = None
         self.num_rollouts_eval: int = num_rollouts_eval
-        self.test_gyms: BaseGym | list[BaseGym] | None = test_gyms
+        self.test_gyms: Gym | list[Gym] | None = test_gyms
         self.test_dataset: Dataset[Any] | None = None
         self.num_rollouts_test: int = num_rollouts_test
         self.max_episode_steps = max_episode_steps
 
         # setup time limit if max_episode steps
         if (self.max_episode_steps is not None) and self.eval_gyms is not None:
-            if isinstance(self.eval_gyms, BaseGym):
+            if isinstance(self.eval_gyms, Gym):
                 self.eval_gyms.env = TimeLimit(
                     env=self.eval_gyms.env,
                     max_episode_steps=self.max_episode_steps,
@@ -156,7 +156,7 @@ class DataModule(LightningDataModule):
                         max_episode_steps=self.max_episode_steps,
                     )
         if (self.max_episode_steps is not None) and self.test_gyms is not None:
-            if isinstance(self.test_gyms, BaseGym):
+            if isinstance(self.test_gyms, Gym):
                 self.test_gyms.env = TimeLimit(
                     env=self.test_gyms.env,
                     max_episode_steps=self.max_episode_steps,

--- a/library/src/getiaction/data/gym.py
+++ b/library/src/getiaction/data/gym.py
@@ -7,24 +7,24 @@ from __future__ import annotations
 
 from torch.utils.data import Dataset
 
-from getiaction.gyms import BaseGym
+from getiaction.gyms import Gym
 
 
-class GymDataset(Dataset[BaseGym]):
+class GymDataset(Dataset[Gym]):
     """A dataset wrapper for Gym environments.
 
     This class allows a Gym environment to be treated as a dataset,
     where each item corresponds to a single rollout of the environment.
     """
 
-    def __init__(self, env: BaseGym, num_rollouts: int) -> None:
+    def __init__(self, env: Gym, num_rollouts: int) -> None:
         """Initialize the GymDataset.
 
         Args:
-            env (BaseGym): The Gym environment to wrap as a dataset.
+            env (Gym): The Gym environment to wrap as a dataset.
             num_rollouts (int): The number of rollouts to include in the dataset.
         """
-        self.env: BaseGym = env
+        self.env: Gym = env
         self.num_rollouts: int = num_rollouts
 
     def __len__(self) -> int:
@@ -35,7 +35,7 @@ class GymDataset(Dataset[BaseGym]):
         """
         return self.num_rollouts
 
-    def __getitem__(self, index: int) -> BaseGym:
+    def __getitem__(self, index: int) -> Gym:
         """Retrieve a specific rollout of the environment.
 
         This resets the environment with a seed corresponding to the index.
@@ -44,7 +44,7 @@ class GymDataset(Dataset[BaseGym]):
             index (int): Index of the rollout.
 
         Returns:
-            BaseGym: The environment after being reset for this rollout.
+            Gym: The environment after being reset for this rollout.
         """
         self.env.reset(seed=index)
         return self.env

--- a/library/src/getiaction/gyms/__init__.py
+++ b/library/src/getiaction/gyms/__init__.py
@@ -3,7 +3,7 @@
 
 """Action trainer gym simulation environments."""
 
-from .base import BaseGym
+from .base import Gym
 from .pusht import PushTGym
 
-__all__ = ["BaseGym", "PushTGym"]
+__all__ = ["Gym", "PushTGym"]

--- a/library/src/getiaction/gyms/base.py
+++ b/library/src/getiaction/gyms/base.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from gymnasium.core import ActType, ObsType
 
 
-class BaseGym:
+class Gym:
     """Base class for Gym environments.
 
     This class wraps a Gym environment and provides standard methods

--- a/library/src/getiaction/gyms/pusht.py
+++ b/library/src/getiaction/gyms/pusht.py
@@ -5,10 +5,10 @@
 
 import gym_pusht  # noqa: F401
 
-from getiaction.gyms import BaseGym
+from getiaction.gyms import Gym
 
 
-class PushTGym(BaseGym):
+class PushTGym(Gym):
     """A PushT Gymnasium environment wrapper for the PushT task."""
 
     def __init__(


### PR DESCRIPTION
## Description

This PR renames the `BaseGym` class to `Gym` throughout the codebase to better reflect its purpose and improve code clarity. The name "BaseGym" implied it was only a base class to be inherited from, but "Gym" better represents its role as the primary wrapper for gymnasium environments.

## Type of Change

- [x] ♻️ refactor: A code change that neither fixes a bug nor adds a feature

## Related Issues

N/A

## Changes Made

- Renamed `BaseGym` class to `Gym` in `library/src/getiaction/gyms/base.py`
- Updated all imports from `BaseGym` to `Gym` in:
- Updated all type hints and references to `BaseGym` → `Gym`
- Updated documentation files:
- Updated mermaid diagrams to use the new class name

## Screenshots/Videos

N/A

## Additional Notes

This is a pure refactoring change with no functional modifications. All existing functionality remains the same. The change improves code readability and better communicates the purpose of the class.

## Breaking Changes

**Yes** - This is a breaking change for external users who directly import or reference `BaseGym`. Users will need to update their imports from:

```python
from getiaction.gyms import BaseGym
```

to:

```python
from getiaction.gyms import Gym
```

## Deployment Notes

No special deployment considerations needed.
