### PR TITLE
🐛 fix: training of ACT and Dummy policies

### DIFF
--- a/library/src/getiaction/policies/act/policy.py
+++ b/library/src/getiaction/policies/act/policy.py
@@ -100,7 +100,7 @@ class ACT(Policy):
             Dict[str, torch.Tensor]: Dictionary containing the loss.
         """
         del batch_idx
-        loss, loss_dict = self.forward(batch)  # noqa: RUF059
+        loss, loss_dict = self.model.forward(batch.to_dict())  # noqa: RUF059
         self.log("train/loss_step", loss, on_step=True, on_epoch=False, prog_bar=True, logger=True)
         self.log(
             "train/loss",

--- a/library/src/getiaction/policies/dummy/policy.py
+++ b/library/src/getiaction/policies/dummy/policy.py
@@ -88,7 +88,7 @@ class Dummy(Policy):
             Dict[str, torch.Tensor]: Dictionary containing the loss.
         """
         del batch_idx  # Unused variable
-        loss, loss_dict = self.forward(batch)  # noqa: RUF059
+        loss, _ = self.model.forward(batch.to_dict())
         self.log("train/loss_step", loss, on_step=True, on_epoch=False, prog_bar=True, logger=True)
         self.log(
             "train/loss",

--- a/library/tests/unit/policies/test_act.py
+++ b/library/tests/unit/policies/test_act.py
@@ -61,3 +61,10 @@ class TestACTolicy:
         actions = policy.model(batch.to_dict())
         assert isinstance(actions, torch.Tensor)
         assert actions.shape == batch.action.shape
+
+    def test_training_step(self, policy, batch):
+        policy.model.train()
+        loss = policy.training_step(batch, 0)
+
+        assert "loss" in loss
+        assert loss["loss"] >= 0

--- a/library/tests/unit/policies/test_dummy.py
+++ b/library/tests/unit/policies/test_dummy.py
@@ -50,6 +50,14 @@ class TestDummyPolicy:
         assert isinstance(actions, torch.Tensor)
         assert actions.shape[0] == batch_dict["obs"].shape[0]
 
+    def test_training_step(self, policy):
+        policy.model.train()
+        batch = Observation(state=torch.randn(5, 4))
+        loss = policy.training_step(batch, 0)
+
+        assert "loss" in loss
+        assert loss["loss"] >= 0
+
     def test_action_queue_and_reset(self):
         """Action queue fills and resets correctly."""
         model = DummyModel(action_shape=torch.Size([2]), n_action_steps=3)


### PR DESCRIPTION
# Pull Request

## Description
`Observation.to_dict()` call was missing in `policy.training_step()`

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [x] 🐛 fix: A bug fix

## Related Issues
<!-- Link to any related issues -->
Fixes #(issue number)
Relates to #(issue number)

## Changes Made
<!-- List the main changes made in this PR -->
- `policy.training_step()` method was updated to unpack observation to a dict