### PR TITLE
 👷ci: Exclude .lock files from Semgrep scan

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -90,3 +90,4 @@ jobs:
           fail-on-findings: true # reports only
           config: "p/ci p/default p/cwe-top-25 p/trailofbits p/owasp-top-ten"
           output-format: "text" # Use plain text output format to omit uploading code scanning results to Security tab
+          exclude: "*.lock,uv.lock"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -113,3 +113,4 @@ jobs:
           fail-on-findings: false # reports only
           config: "p/ci p/default p/cwe-top-25 p/trailofbits p/owasp-top-ten"
           output-format: "text" # Use plain text output format to omit uploading code scanning results to Security tab
+          exclude: "*.lock,uv.lock"


### PR DESCRIPTION
# Pull Request

## Description
cc @AlexanderBarabanov 

The scanner reacts to jsonargparse now:
```
┌─────────────────┐
│ 2 Code Findings │
└─────────────────┘
           
    uv.lock
   ❯❯❱ generic.secrets.security.detected-sonarqube-docs-api-key.detected-sonarqube-docs-api-key
          SonarQube Docs API Key detected
          Details: https://sg.run/x10P   
                                         
          1295┆ sdist = { url = "https://files.pythonhosted.org/packages/44/86/60032fb5623df8d938d31f733e4
               b3385c40791d85d0fae3dfb4e3be10c42/jsonargparse-4.41.0.tar.gz", hash =                      
               "sha256:ba1806bf0ed0ad1975e403dffb18b3a755fee3bfe4e7b36d8cce2f297b552b5f", size = 206634,  
               upload-time = "2025-09-04T03:46:34.715Z" }                                                 
            ⋮┆----------------------------------------
          1297┆ { url = "https://files.pythonhosted.org/packages/62/fc/6ac1943f22f3d2e14703335d64a7d68496f
               0480c82a3077cde44b2c55ef5/jsonargparse-4.41.0-py3-none-any.whl", hash =                    
               "sha256:cd49b6a2fea723ee4d80f9df034f51af226128a7f166be8755d6acdeb3e077a7", size = 228528,  
               upload-time = "2025-09-04T03:46:32.668Z" },     
```


## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [x] 👷 ci: Changes to our CI configuration files and scripts

