### PR TITLE
fix: export action queue metadata

### DIFF
--- a/library/tests/unit/export/test_mixin_export.py
+++ b/library/tests/unit/export/test_mixin_export.py
@@ -4,6 +4,7 @@
 """Unit tests for mixin_export module."""
 
 from dataclasses import dataclass
+from typing import Any
 
 import onnx
 import pytest
@@ -129,6 +130,10 @@ class ExportWrapper(Export):
 
     def __init__(self, model: torch.nn.Module):
         self.model = model
+
+    @property
+    def metadata_extra(self) -> dict[str, Any]:
+        return {"chunk_size": 10, "use_action_queue": True}
 
 
 class TestToOnnx:


### PR DESCRIPTION
# Pull Request

## Description

- Ensures exported models include policy-provided inference metadata (e.g. `use_action_queue`, `chunk_size`) via `metadata_extra`.
- Validates `metadata_extra` is a mapping and fails fast on key collisions with existing export metadata.
- Adds regression coverage verifying `InferenceModel` uses exported metadata to enable action queueing for chunked-action policies.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [x] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

None.

---

<!-- Optional sections below - delete if not needed -->