### PR TITLE
fix(backend): Set port and host based on settings

### DIFF
--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -40,5 +40,5 @@ app.include_router(job_router)
 register_application_exception_handlers(app)
 
 if __name__ == "__main__":
-    uvicorn_port = int(os.environ.get("HTTP_SERVER_PORT", "7860"))
-    uvicorn.run("main:app", host="0.0.0.0", port=uvicorn_port)  # noqa: S104  # nosec B104
+    uvicorn_port = int(os.environ.get("HTTP_SERVER_PORT", settings.port))
+    uvicorn.run("main:app", host=settings.host, port=uvicorn_port)


### PR DESCRIPTION
# Pull Request

## Description

Set the port and host of the application based on our settings object. This fixes the ignore that I added [here](https://github.com/open-edge-platform/geti-action/pull/182/changes/ca37fb6b6a6621acc66c398608daf45820d9c46d)

## Type of Change

- [x] 🐞 `fix` - Bug fix