### PR TITLE
feat(backend): Add robot environments api

### DIFF
--- a/application/backend/src/alembic/versions/4a70ddb2d384_add_project_environments_table.py
+++ b/application/backend/src/alembic/versions/4a70ddb2d384_add_project_environments_table.py
@@ -1,0 +1,50 @@
+"""add project_environments table
+
+Revision ID: 4a70ddb2d384
+Revises: 6d608cb912d9
+Create Date: 2025-12-02 14:50:59.680472
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4a70ddb2d384"
+down_revision: str | Sequence[str] | None = "74d59c3fe0c8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "project_environments",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("project_id", sa.Text(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("robots", sa.JSON(), nullable=True),
+        sa.Column("camera_ids", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("project_environments")

--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -8,6 +8,7 @@ from fastapi.requests import HTTPConnection
 
 from core.scheduler import Scheduler
 from services import DatasetService, JobService, ModelService, ProjectCameraService, ProjectService, RobotService
+from services.environment_service import EnvironmentService
 from services.event_processor import EventProcessor
 from services.robot_calibration_service import RobotCalibrationService
 from settings import get_settings
@@ -76,6 +77,12 @@ def get_camera_service() -> ProjectCameraService:
 
 
 @lru_cache
+def get_environment_service() -> EnvironmentService:
+    """Provide a EnvironmentService instance for managing environments in a project."""
+    return EnvironmentService()
+
+
+@lru_cache
 def get_dataset_service() -> DatasetService:
     """Provides a DatasetService instance for managing datasets."""
     return DatasetService()
@@ -119,6 +126,13 @@ def get_camera_id(camera_id: str) -> UUID:
     if not is_valid_uuid(camera_id):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid camera ID")
     return UUID(camera_id)
+
+
+def get_environment_id(environment_id: str) -> UUID:
+    """Initialize and validates an environment ID."""
+    if not is_valid_uuid(environment_id):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid environment ID")
+    return UUID(environment_id)
 
 
 def validate_uuid(uuid: str) -> UUID:

--- a/application/backend/src/api/environments.py
+++ b/application/backend/src/api/environments.py
@@ -1,0 +1,67 @@
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+
+from api.dependencies import get_environment_id, get_environment_service, get_project_id
+from schemas.environment import Environment, EnvironmentWithRelations
+from services.environment_service import EnvironmentService
+
+router = APIRouter(prefix="/api/projects/{project_id}/environments", tags=["Project Environments"])
+
+ProjectID = Annotated[UUID, Depends(get_project_id)]
+
+
+@router.get("")
+async def list_project_environments(
+    project_id: ProjectID,
+    environment_service: Annotated[EnvironmentService, Depends(get_environment_service)],
+) -> list[Environment]:
+    """Fetch all environments."""
+    return await environment_service.get_environment_list(project_id)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_project_environment(
+    project_id: ProjectID,
+    environment: Environment,
+    environment_service: Annotated[EnvironmentService, Depends(get_environment_service)],
+) -> Environment:
+    """Create a new environment."""
+    return await environment_service.create_environment(project_id, environment)
+
+
+@router.get("/{environment_id}")
+async def get_project_environment(
+    project_id: Annotated[UUID, Depends(get_project_id)],
+    environment_id: Annotated[UUID, Depends(get_environment_id)],
+    environment_service: Annotated[EnvironmentService, Depends(get_environment_service)],
+) -> EnvironmentWithRelations | None:
+    """Get environment by id with eager loaded robots and cameras."""
+    return await environment_service.get_environment_by_id(project_id, environment_id)
+
+
+@router.put("/{environment_id}")
+async def update_project_environment(
+    project_id: Annotated[UUID, Depends(get_project_id)],
+    environment_id: Annotated[UUID, Depends(get_environment_id)],
+    environment_service: Annotated[EnvironmentService, Depends(get_environment_service)],
+    environment: Environment,
+) -> EnvironmentWithRelations:
+    """Update environment."""
+    environment_with_id = environment.model_copy(update={"id": environment_id})
+
+    return await environment_service.update_environment(
+        project_id,
+        environment_with_id,
+    )
+
+
+@router.delete("/{environment_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_project_environment(
+    project_id: Annotated[UUID, Depends(get_project_id)],
+    environment_id: Annotated[UUID, Depends(get_environment_id)],
+    environment_service: Annotated[EnvironmentService, Depends(get_environment_service)],
+) -> None:
+    """Delete an environment."""
+    await environment_service.delete_environment(project_id, environment_id)

--- a/application/backend/src/db/schema.py
+++ b/application/backend/src/db/schema.py
@@ -49,6 +49,12 @@ class ProjectDB(Base):
         cascade="all, delete-orphan",
     )
 
+    environments: Mapped[list["ProjectEnvironmentDB"]] = relationship(
+        "ProjectEnvironmentDB",
+        back_populates="project",
+        cascade="all, delete-orphan",
+    )
+
 
 class ProjectRobotDB(Base):
     __tablename__ = "project_robots"
@@ -123,6 +129,20 @@ class ProjectCameraDB(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 
     project: Mapped["ProjectDB"] = relationship(back_populates="cameras")
+
+
+class ProjectEnvironmentDB(Base):
+    __tablename__ = "project_environments"
+
+    id: Mapped[UUID] = mapped_column(Text, primary_key=True, default=uuid4)
+    project_id: Mapped[str] = mapped_column(ForeignKey("projects.id", ondelete="CASCADE"))
+    name: Mapped[str] = mapped_column(String(255))
+    robots: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    camera_ids: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
+
+    project: Mapped["ProjectDB"] = relationship(back_populates="environments")
 
 
 class ProjectConfigDB(Base):

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -10,6 +10,7 @@ class ResourceType(StrEnum):
     ROBOT = "Robot"
     ROBOT_CALIBRATION = "Robot calibration"
     CAMERA = "Camera"
+    ENVIRONMENT = "Environment"
     DATASET = "Dataset"
     MODEL = "Model"
     JOB = "JOB"

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from api.camera import router as camera_router
 from api.dataset import router as dataset_router
 from api.dependencies import CameraRegistryDep, RobotRegistryDep
+from api.environments import router as project_environments_router
 from api.hardware import router as hardware_router
 from api.job import router as job_router
 from api.models import router as models_router
@@ -34,6 +35,7 @@ app.include_router(project_robots_router)
 app.include_router(project_cameras_router)
 app.include_router(robot_calibration_router)
 app.include_router(robot_control_router)
+app.include_router(project_environments_router)
 app.include_router(hardware_router)
 app.include_router(camera_router)
 app.include_router(dataset_router)

--- a/application/backend/src/repositories/mappers/__init__.py
+++ b/application/backend/src/repositories/mappers/__init__.py
@@ -3,6 +3,7 @@ from .job_mapper import JobMapper
 from .model_mapper import ModelMapper
 from .project_camera_mapper import ProjectCameraMapper
 from .project_config_mapper import ProjectConfigMapper
+from .project_environment_mapper import ProjectEnvironmentMapper
 from .project_mapper import ProjectMapper
 from .project_robot_mapper import ProjectRobotMapper
 from .snapshot_mapper import SnapshotMapper
@@ -13,6 +14,7 @@ __all__ = [
     "ModelMapper",
     "ProjectCameraMapper",
     "ProjectConfigMapper",
+    "ProjectEnvironmentMapper",
     "ProjectMapper",
     "ProjectRobotMapper",
     "SnapshotMapper",

--- a/application/backend/src/repositories/mappers/project_environment_mapper.py
+++ b/application/backend/src/repositories/mappers/project_environment_mapper.py
@@ -1,0 +1,82 @@
+import json
+from typing import Any
+from uuid import UUID
+
+from db.schema import ProjectEnvironmentDB
+from repositories.mappers.base_mapper_interface import IBaseMapper
+from schemas.environment import Environment, RobotEnvironmentConfiguration, TeleoperatorNone, TeleoperatorRobot
+
+
+class ProjectEnvironmentMapper(IBaseMapper):
+    """Mapper for Environment schema entity <-> DB entity conversions."""
+
+    @staticmethod
+    def to_schema(environment: Environment) -> ProjectEnvironmentDB:
+        """Convert Environment schema to db model."""
+        robots_json = json.dumps(
+            [
+                {
+                    "robot_id": str(robot.robot_id),
+                    "tele_operator": (
+                        {"type": "robot", "robot_id": str(robot.tele_operator.robot_id)}
+                        if isinstance(robot.tele_operator, TeleoperatorRobot)
+                        else {"type": "none"}
+                    ),
+                }
+                for robot in environment.robots
+            ]
+        )
+
+        camera_ids_json = json.dumps([str(camera_id) for camera_id in environment.camera_ids])
+
+        return ProjectEnvironmentDB(
+            id=str(environment.id),
+            project_id="",  # Will be set by repository
+            name=environment.name,
+            robots=robots_json,
+            camera_ids=camera_ids_json,
+            created_at=environment.created_at,
+            updated_at=environment.updated_at,
+        )
+
+    @staticmethod
+    def from_schema(db_env: ProjectEnvironmentDB) -> Environment:
+        """Convert Environment db entity to schema."""
+        # Parse robots JSON
+        robots_data = ProjectEnvironmentMapper._parse_json(db_env.robots, [])
+        robots = [
+            RobotEnvironmentConfiguration(
+                robot_id=UUID(rc["robot_id"]),
+                tele_operator=(
+                    TeleoperatorRobot(robot_id=UUID(rc["tele_operator"]["robot_id"]))
+                    if rc.get("tele_operator", {}).get("type") == "robot"
+                    else TeleoperatorNone()
+                ),
+            )
+            for rc in robots_data
+        ]
+
+        # Parse camera_ids JSON
+        camera_ids_data = ProjectEnvironmentMapper._parse_json(db_env.camera_ids, [])
+        camera_ids = [UUID(cid) for cid in camera_ids_data]
+
+        return Environment(
+            id=db_env.id,
+            name=db_env.name,
+            robots=robots,
+            camera_ids=camera_ids,
+            created_at=db_env.created_at,
+            updated_at=db_env.updated_at,
+        )
+
+    @staticmethod
+    def _parse_json(value: Any, default: Any) -> Any:
+        """Safely parse JSON that might be a string or already parsed."""
+        if value is None:
+            return default
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return default
+        return value

--- a/application/backend/src/repositories/project_environment_repo.py
+++ b/application/backend/src/repositories/project_environment_repo.py
@@ -1,0 +1,104 @@
+from collections.abc import Callable
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio.session import AsyncSession
+
+from db.schema import ProjectCameraDB, ProjectEnvironmentDB, ProjectRobotDB
+from repositories.base import ProjectBaseRepository
+from repositories.mappers import ProjectCameraMapper, ProjectEnvironmentMapper, ProjectRobotMapper
+from schemas.environment import (
+    Environment,
+    EnvironmentWithRelations,
+    RobotEnvironmentConfiguration,
+    RobotWithTeleoperator,
+    TeleoperatorNoneWithRobot,
+    TeleoperatorRobot,
+    TeleoperatorRobotWithRobot,
+)
+from schemas.project_camera import Camera
+from schemas.robot import Robot
+
+
+class ProjectEnvironmentRepository(ProjectBaseRepository):
+    def __init__(self, db: AsyncSession, project_id: UUID):
+        super().__init__(db, project_id, ProjectEnvironmentDB)
+
+    @property
+    def to_schema(self) -> Callable[[Environment], ProjectEnvironmentDB]:
+        return ProjectEnvironmentMapper.to_schema
+
+    @property
+    def from_schema(self) -> Callable[[ProjectEnvironmentDB], Environment]:
+        return ProjectEnvironmentMapper.from_schema
+
+    async def get_by_id_with_relations(self, environment_id: UUID) -> EnvironmentWithRelations | None:
+        """Get an environment by ID with eager loaded robots and cameras."""
+        env = await self.get_by_id(environment_id)
+        if env is None:
+            return None
+
+        robots_map = await self._fetch_robots_map(env.robots)
+        cameras = await self._fetch_cameras(env.camera_ids)
+        robots_with_teleoperators = self._build_robots_with_teleoperators(env.robots, robots_map)
+
+        return EnvironmentWithRelations(
+            id=env.id,
+            name=env.name,
+            robots=robots_with_teleoperators,
+            cameras=cameras,
+            created_at=env.created_at,
+            updated_at=env.updated_at,
+        )
+
+    async def _fetch_robots_map(self, robot_configs: list[RobotEnvironmentConfiguration]) -> dict[str, Robot]:
+        """Fetch all robots involved in the environment and return a map by ID."""
+        robot_ids: set[str] = set()
+        for config in robot_configs:
+            robot_ids.add(str(config.robot_id))
+            if isinstance(config.tele_operator, TeleoperatorRobot):
+                robot_ids.add(str(config.tele_operator.robot_id))
+
+        if not robot_ids:
+            return {}
+
+        stmt = select(ProjectRobotDB).where(
+            ProjectRobotDB.project_id == self.project_id,
+            ProjectRobotDB.id.in_(list(robot_ids)),
+        )
+        result = await self.db.execute(stmt)
+        return {str(db_robot.id): ProjectRobotMapper.from_schema(db_robot) for db_robot in result.scalars().all()}
+
+    async def _fetch_cameras(self, camera_ids: list[UUID]) -> list[Camera]:
+        """Fetch all cameras in the environment."""
+        if not camera_ids:
+            return []
+
+        stmt = select(ProjectCameraDB).where(
+            ProjectCameraDB.project_id == self.project_id,
+            ProjectCameraDB.id.in_([str(cid) for cid in camera_ids]),
+        )
+        result = await self.db.execute(stmt)
+        return [ProjectCameraMapper.from_schema(db_camera) for db_camera in result.scalars().all()]
+
+    def _build_robots_with_teleoperators(
+        self,
+        robot_configs: list[RobotEnvironmentConfiguration],
+        robots_map: dict[str, Robot],
+    ) -> list[RobotWithTeleoperator]:
+        """Construct the list of robots with their eager-loaded teleoperators."""
+        robots_with_teleoperators = []
+        for config in robot_configs:
+            robot = robots_map.get(str(config.robot_id))
+            if robot is None:
+                continue
+
+            if isinstance(config.tele_operator, TeleoperatorRobot):
+                tele_robot = robots_map.get(str(config.tele_operator.robot_id))
+                tele_operator = TeleoperatorRobotWithRobot(robot_id=config.tele_operator.robot_id, robot=tele_robot)
+            else:
+                tele_operator = TeleoperatorNoneWithRobot()
+
+            robots_with_teleoperators.append(RobotWithTeleoperator(robot=robot, tele_operator=tele_operator))
+
+        return robots_with_teleoperators

--- a/application/backend/src/schemas/environment.py
+++ b/application/backend/src/schemas/environment.py
@@ -1,0 +1,198 @@
+from datetime import datetime
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from schemas.project_camera import Camera
+from schemas.robot import Robot
+
+
+class TeleoperatorRobot(BaseModel):
+    type: Literal["robot"] = "robot"
+    robot_id: UUID = Field(..., description="ID of the robot acting as teleoperator")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "type": "robot",
+                "robot_id": "a5e2cde6-936b-4a9e-a213-08dda0afa453",
+            }
+        }
+    )
+
+
+class TeleoperatorNone(BaseModel):
+    type: Literal["none"] = "none"
+
+    model_config = ConfigDict(json_schema_extra={"example": {"type": "none"}})
+
+
+Teleoperator = Annotated[TeleoperatorRobot | TeleoperatorNone, Field(discriminator="type")]
+
+
+class RobotEnvironmentConfiguration(BaseModel):
+    robot_id: UUID = Field(..., description="ID of the robot in this environment")
+    tele_operator: Teleoperator = Field(..., description="Teleoperator configuration for this robot")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "robot_id": "a5e2cde6-936b-4a9e-a213-08dda0afa453",
+                "tele_operator": {
+                    "type": "robot",
+                    "robot_id": "b6f3def7-047c-5b0f-b324-19eeb1bgb564",
+                },
+            }
+        }
+    )
+
+
+class Environment(BaseModel):
+    id: Annotated[UUID, Field(description="Unique identifier")]
+
+    created_at: datetime | None = Field(None)
+    updated_at: datetime | None = Field(None)
+
+    name: str = Field(..., description="Human-readable environment name")
+    robots: list[RobotEnvironmentConfiguration] = Field(
+        default_factory=list,
+        description="List of robot configurations in this environment",
+    )
+    camera_ids: list[UUID] = Field(default_factory=list, description="List of camera IDs in this environment")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "e7d4bef8-158d-6c1g-c435-20ffb2chc675",
+                "name": "Assembly Line Environment",
+                "robots": [
+                    {
+                        "robot_id": "a5e2cde6-936b-4a9e-a213-08dda0afa453",
+                        "tele_operator": {
+                            "type": "robot",
+                            "robot_id": "b6f3def7-047c-5b0f-b324-19eeb1bgb564",
+                        },
+                    },
+                    {
+                        "robot_id": "b6f3def7-047c-5b0f-b324-19eeb1bgb564",
+                        "tele_operator": {"type": "none"},
+                    },
+                ],
+                "camera_ids": [
+                    "c8g5dfh9-269e-7d2h-d546-31ggc3dic786",
+                    "d9h6egi0-370f-8e3i-e657-42hhd4ejd897",
+                ],
+                "created_at": "2024-01-15T10:30:00Z",
+                "updated_at": "2024-01-15T10:30:00Z",
+            }
+        }
+    )
+
+
+class TeleoperatorRobotWithRobot(BaseModel):
+    """Teleoperator configuration with eager-loaded robot."""
+
+    type: Literal["robot"] = "robot"
+    robot_id: UUID = Field(..., description="ID of the robot acting as teleoperator")
+    robot: Robot | None = Field(None, description="Eager-loaded robot object")
+
+
+class TeleoperatorNoneWithRobot(BaseModel):
+    """Teleoperator configuration for no teleoperator."""
+
+    type: Literal["none"] = "none"
+
+
+TeleoperatorWithRobot = Annotated[TeleoperatorRobotWithRobot | TeleoperatorNoneWithRobot, Field(discriminator="type")]
+
+
+class RobotWithTeleoperator(BaseModel):
+    """Robot configuration with eager-loaded robot and teleoperator."""
+
+    robot: Robot = Field(..., description="The robot in this environment")
+    tele_operator: TeleoperatorWithRobot = Field(..., description="Teleoperator configuration with eager-loaded data")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "robot": {
+                    "id": "a5e2cde6-936b-4a9e-a213-08dda0afa453",
+                    "name": "Assembly Line Robot 1",
+                    "serial_id": "SO101-2024-001",
+                    "type": "SO101_Leader",
+                    "cameras": [],
+                },
+                "tele_operator": {
+                    "type": "robot",
+                    "robot_id": "b6f3def7-047c-5b0f-b324-19eeb1bgb564",
+                    "robot": {
+                        "id": "b6f3def7-047c-5b0f-b324-19eeb1bgb564",
+                        "name": "Teleoperator Robot",
+                        "serial_id": "SO101-2024-002",
+                        "type": "SO101_Follower",
+                        "cameras": [],
+                    },
+                },
+            }
+        }
+    )
+
+
+class EnvironmentWithRelations(BaseModel):
+    """Environment with eager-loaded robots and cameras."""
+
+    id: Annotated[UUID, Field(description="Unique identifier")]
+
+    created_at: datetime | None = Field(None)
+    updated_at: datetime | None = Field(None)
+
+    name: str = Field(..., description="Human-readable environment name")
+    robots: list[RobotWithTeleoperator] = Field(
+        default_factory=list,
+        description="List of robots with eager-loaded teleoperators",
+    )
+    cameras: list[Camera] = Field(default_factory=list, description="List of eager-loaded cameras")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "e7d4bef8-158d-6c1g-c435-20ffb2chc675",
+                "name": "Assembly Line Environment",
+                "robots": [
+                    {
+                        "robot": {
+                            "id": "a5e2cde6-936b-4a9e-a213-08dda0afa453",
+                            "name": "Assembly Line Robot 1",
+                            "serial_id": "SO101-2024-001",
+                            "type": "SO101_Leader",
+                        },
+                        "tele_operator": {
+                            "type": "robot",
+                            "robot_id": "b6f3def7-047c-5b0f-b324-19eeb1bgb564",
+                            "robot": {
+                                "id": "b6f3def7-047c-5b0f-b324-19eeb1bgb564",
+                                "name": "Teleoperator Robot",
+                                "serial_id": "SO101-2024-002",
+                                "type": "SO101_Follower",
+                            },
+                        },
+                    }
+                ],
+                "cameras": [
+                    {
+                        "id": "c8g5dfh9-269e-7d2h-d546-31ggc3dic786",
+                        "name": "front_camera",
+                        "fingerprint": "/dev/video0",
+                        "driver": "webcam",
+                        "hardware_name": "Camera 1",
+                        "resolution_width": 480,
+                        "resolution_height": 360,
+                        "resolution_fps": 30,
+                    }
+                ],
+                "created_at": "2024-01-15T10:30:00Z",
+                "updated_at": "2024-01-15T10:30:00Z",
+            }
+        }
+    )

--- a/application/backend/src/services/environment_service.py
+++ b/application/backend/src/services/environment_service.py
@@ -1,0 +1,61 @@
+from uuid import UUID
+
+from db import get_async_db_session_ctx
+from exceptions import ResourceNotFoundError, ResourceType
+from repositories.project_environment_repo import ProjectEnvironmentRepository
+from schemas.environment import Environment, EnvironmentWithRelations
+
+
+class EnvironmentService:
+    @staticmethod
+    async def get_environment_list(project_id: UUID) -> list[Environment]:
+        async with get_async_db_session_ctx() as session:
+            repo = ProjectEnvironmentRepository(session, project_id)
+            return await repo.get_all()
+
+    @staticmethod
+    async def get_environment_by_id(project_id: UUID, environment_id: UUID) -> EnvironmentWithRelations:
+        async with get_async_db_session_ctx() as session:
+            repo = ProjectEnvironmentRepository(session, project_id)
+            environment = await repo.get_by_id_with_relations(environment_id)
+
+            if environment is None:
+                raise ResourceNotFoundError(ResourceType.ENVIRONMENT, str(environment_id))
+
+            return environment
+
+    @staticmethod
+    async def create_environment(project_id: UUID, environment: Environment) -> Environment:
+        async with get_async_db_session_ctx() as session:
+            repo = ProjectEnvironmentRepository(session, project_id)
+            return await repo.save(environment)
+
+    @staticmethod
+    async def update_environment(project_id: UUID, environment: Environment) -> EnvironmentWithRelations:
+        async with get_async_db_session_ctx() as session:
+            repo = ProjectEnvironmentRepository(session, project_id)
+
+            # Use base repository's update with partial_update dict
+            # Then fetch the updated environment with relations
+            existing = await repo.get_by_id(environment.id)
+            if existing is None:
+                raise ResourceNotFoundError(ResourceType.ENVIRONMENT, str(environment.id))
+
+            await repo.update(existing, environment.model_dump(exclude={"id", "created_at", "updated_at"}))
+
+            updated = await repo.get_by_id_with_relations(environment.id)
+            if updated is None:
+                raise ResourceNotFoundError(ResourceType.ENVIRONMENT, str(environment.id))
+
+            return updated
+
+    @staticmethod
+    async def delete_environment(project_id: UUID, environment_id: UUID) -> None:
+        async with get_async_db_session_ctx() as session:
+            repo = ProjectEnvironmentRepository(session, project_id)
+
+            environment = await repo.get_by_id(environment_id)
+            if environment is None:
+                raise ResourceNotFoundError(ResourceType.ENVIRONMENT, str(environment_id))
+
+            await repo.delete_by_id(environment_id)


### PR DESCRIPTION
# Pull Request

## Description

This PR adds new api endpoints that can be used to manage robot environments.
An environment essentially consists of:
- A name
- A list of robots + teleoperators
- A list of cameras

This is represented internally by a new `project_environments` table. This contains a json field for both `robots` and `cameras`. While this works I think that in the long term we should consider refactoring this to be using pivot tables so that the table's contents is more structured.

The new endpoints are:
- `GET /api/projects/{project_id}/environments`
- `POST /api/projects/{project_id}/environments`
- `GET /api/projects/{project_id}/environments/{environment_id}`
- `PUT /api/projects/{project_id}/environments/{environment_id}`
- `DELETE /api/projects/{project_id}/environments/{environment_id}`

Note that the `GET /api/projects/{project_id}/environments/{environment_id}` endpoint returns both the environment and eagerly loads its connected robots and cameras.

## Type of Change

- [x] ✨ `feat` - New feature