### PR TITLE
feat(backend): Robot control endpoints

### DIFF
--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -14,6 +14,7 @@ from settings import get_settings
 from utils.robot import RobotConnectionManager
 from webrtc.manager import WebRTCManager
 from workers.camera_worker_registry import CameraWorkerRegistry
+from workers.robot_worker_registry import RobotWorkerRegistry
 
 
 def is_valid_uuid(identifier: str) -> bool:
@@ -150,4 +151,13 @@ def get_camera_registry(request: HTTPConnection) -> CameraWorkerRegistry:
     return registry
 
 
+def get_robot_registry(request: HTTPConnection) -> RobotWorkerRegistry:
+    """Dependency to get robot worker registry."""
+    registry = getattr(request.app.state, "robot_registry", None)
+    if registry is None:
+        raise RuntimeError("Robot worker registry not initialized")
+    return registry
+
+
 CameraRegistryDep = Annotated[CameraWorkerRegistry, Depends(get_camera_registry)]
+RobotRegistryDep = Annotated[RobotWorkerRegistry, Depends(get_robot_registry)]

--- a/application/backend/src/api/robot_control.py
+++ b/application/backend/src/api/robot_control.py
@@ -1,0 +1,93 @@
+from typing import Annotated
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, WebSocket, status
+from loguru import logger
+
+from api.dependencies import (
+    RobotCalibrationServiceDep,
+    RobotConnectionManagerDep,
+    RobotRegistryDep,
+    get_project_id,
+    get_robot_id,
+    get_robot_service,
+)
+from services import RobotService
+from workers.robots.robot_worker import RobotWorker
+from workers.transport.websocket_transport import WebSocketTransport
+
+router = APIRouter(prefix="/api/projects/{project_id}/robots", tags=["Project Robots"])
+
+ProjectID = Annotated[UUID, Depends(get_project_id)]
+
+
+@router.websocket("/{robot_id}/ws")
+async def robot_websocket(  # noqa: PLR0913
+    project_id: Annotated[UUID, Depends(get_project_id)],
+    robot_id: Annotated[UUID, Depends(get_robot_id)],
+    robot_service: Annotated[RobotService, Depends(get_robot_service)],
+    robot_manager: RobotConnectionManagerDep,
+    calibration_service: RobotCalibrationServiceDep,
+    websocket: WebSocket,
+    registry: RobotRegistryDep,
+    normalize: bool = True,
+    fps: int = 30,
+) -> None:
+    """
+    Establish a WebSocket connection for real-time robot state monitoring and control.
+
+    Args:
+        project_id: ID of the project.
+        robot_id: ID of the robot.
+        robot_service: Service for robot metadata.
+        robot_manager: Connection manager for robot discovery.
+        calibration_service: Service for loading calibration.
+        websocket: The FastAPI WebSocket instance.
+        registry: Registry for managing active robot workers.
+        normalize: Whether to use normalized joint values.
+        fps: Target frequency for state updates.
+    """
+    await websocket.accept()
+
+    robot = await robot_service.get_robot_by_id(project_id, robot_id)
+    logger.info("Found robot with websocket {}", robot)
+
+    worker_id = uuid4()
+
+    try:
+        # Create worker
+        worker = RobotWorker(
+            robot,
+            WebSocketTransport(websocket),
+            # Manager and calibration service are used to create robot config
+            robot_manager,
+            calibration_service,
+            # Read configuration
+            fps,
+            normalize,
+        )
+
+        # Register worker
+        await registry.create_and_register(worker_id, worker)
+
+        # Run worker (blocks until complete)
+        await worker.run()
+
+    except ValueError as e:
+        logger.error(f"Failed to register worker: {e}")
+        try:
+            await websocket.send_json({"event": "error", "message": str(e)})
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        except Exception as close_err:
+            logger.error(f"Could not close websocket after ValueError: {close_err}")
+
+    except Exception as e:
+        logger.exception(f"Unexpected error in robot websocket: {e}")
+        try:
+            await websocket.close(code=status.WS_1011_INTERNAL_ERROR)
+        except Exception as close_err:
+            logger.error(f"Could not close websocket after Exception: {close_err}")
+
+    finally:
+        # Unregister worker
+        await registry.unregister(worker_id)

--- a/application/backend/src/core/lifecycle.py
+++ b/application/backend/src/core/lifecycle.py
@@ -9,6 +9,7 @@ from settings import get_settings
 from utils.robot import RobotConnectionManager
 from webrtc.manager import WebRTCManager
 from workers.camera_worker_registry import CameraWorkerRegistry
+from workers.robot_worker_registry import RobotWorkerRegistry
 
 from .scheduler import Scheduler
 
@@ -24,6 +25,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         max_workers=10,
         shutdown_timeout_s=10.0,
     )
+    app.state.robot_registry = RobotWorkerRegistry(
+        max_workers=10,
+        shutdown_timeout_s=10.0,
+    )
 
     logger.info("Starting %s application...", settings.app_name)
     webrtc_manager = WebRTCManager()
@@ -36,7 +41,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     logger.info("Application startup completed")
 
     # Initialize RobotHardwareManager
-    app.state.robot_hardware_manager = RobotConnectionManager()
+    app.state.robot_manager = RobotConnectionManager()
     await app.state.robot_manager.find_robots()
 
     yield
@@ -48,6 +53,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     camera_registry: CameraWorkerRegistry = app.state.camera_registry
     await camera_registry.shutdown_all()
+
+    robot_registry: RobotWorkerRegistry = app.state.robot_registry
+    await robot_registry.shutdown_all()
 
     # We might want to shutdown the hardware manager too, though releasing workers should handle it.
     # But a global cleanup is safe.

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 
 from api.camera import router as camera_router
 from api.dataset import router as dataset_router
-from api.dependencies import CameraRegistryDep
+from api.dependencies import CameraRegistryDep, RobotRegistryDep
 from api.hardware import router as hardware_router
 from api.job import router as job_router
 from api.models import router as models_router
@@ -13,6 +13,7 @@ from api.project import router as project_router
 from api.project_camera import router as project_cameras_router
 from api.record import router as record_router
 from api.robot_calibration import router as robot_calibration_router
+from api.robot_control import router as robot_control_router
 from api.robots import router as project_robots_router
 from api.settings import router as settings_router
 from core import lifespan
@@ -32,6 +33,7 @@ app.include_router(project_router)
 app.include_router(project_robots_router)
 app.include_router(project_cameras_router)
 app.include_router(robot_calibration_router)
+app.include_router(robot_control_router)
 app.include_router(hardware_router)
 app.include_router(camera_router)
 app.include_router(dataset_router)
@@ -44,11 +46,12 @@ register_application_exception_handlers(app)
 
 
 @app.get("/api/health")
-async def health_check(camera_registry: CameraRegistryDep) -> dict:
+async def health_check(camera_registry: CameraRegistryDep, robot_registry: RobotRegistryDep) -> dict:
     """Health check endpoint."""
     return {
         "status": "healthy",
         "camera_workers": camera_registry.get_status_summary(),
+        "robot_workers": robot_registry.get_status_summary(),
     }
 
 

--- a/application/backend/src/workers/robot_worker_registry.py
+++ b/application/backend/src/workers/robot_worker_registry.py
@@ -1,0 +1,155 @@
+"""Registry for managing robot workers."""
+
+import asyncio
+from types import TracebackType
+from typing import Self
+from uuid import UUID
+
+from loguru import logger
+
+from workers.robots.robot_worker import RobotWorker
+
+
+class RobotWorkerRegistry:
+    """
+    Manages the lifecycle and registration of active robot workers.
+
+    This registry ensures that the number of active robot workers is limited
+    and provides methods for starting, stopping, and monitoring them.
+    """
+
+    def __init__(self, max_workers: int = 10, shutdown_timeout_s: float = 10.0) -> None:
+        """
+        Initialize the registry.
+
+        Args:
+            max_workers: Maximum number of concurrent workers allowed.
+            shutdown_timeout_s: Seconds to wait for workers to shutdown gracefully.
+        """
+        self._workers: dict[UUID, RobotWorker] = {}
+        self._lock = asyncio.Lock()
+        self._max_workers = max_workers
+        self._shutdown_timeout_s = shutdown_timeout_s
+
+    async def create_and_register(
+        self,
+        worker_id: UUID,
+        worker: RobotWorker,
+    ) -> None:
+        """
+        Register a new robot worker in the registry.
+
+        Args:
+            worker_id: Unique identifier for the worker.
+            worker: The RobotWorker instance to register.
+
+        Raises:
+            ValueError: If worker_id already exists or max_workers exceeded.
+        """
+        async with self._lock:
+            if worker_id in self._workers:
+                raise ValueError(f"Worker {worker_id} already exists")
+
+            if len(self._workers) >= self._max_workers:
+                raise ValueError(f"Maximum number of workers ({self._max_workers}) reached")
+
+            self._workers[worker_id] = worker
+            logger.info(
+                f"Robot worker registered: {worker_id} ({worker.robot.id}). "
+                f"Total: {len(self._workers)}/{self._max_workers}"
+            )
+
+    async def unregister(self, worker_id: UUID) -> None:
+        """
+        Unregister and initiate shutdown for a specific worker.
+
+        Args:
+            worker_id: The ID of the worker to unregister.
+        """
+        async with self._lock:
+            worker = self._workers.pop(worker_id, None)
+
+        if worker:
+            try:
+                await worker.shutdown()
+            except Exception as e:
+                logger.error(f"Error shutting down worker {worker_id}: {e}")
+            logger.info(f"Robot worker unregistered: {worker_id}")
+
+    async def get(self, worker_id: UUID) -> RobotWorker | None:
+        """
+        Retrieve a worker by its ID.
+
+        Args:
+            worker_id: The ID of the worker.
+
+        Returns:
+            The RobotWorker instance or None if not found.
+        """
+        return self._workers.get(worker_id)
+
+    def list_all(self) -> list[RobotWorker]:
+        """
+        Get a list of all currently registered workers.
+
+        Returns:
+            List of RobotWorker instances.
+        """
+        return list(self._workers.values())
+
+    def get_status_summary(self) -> dict:
+        """
+        Generate a summary of the status of all registered workers.
+
+        Returns:
+            Dictionary containing total count and individual worker statuses.
+        """
+        return {
+            "total_workers": len(self._workers),
+            "max_workers": self._max_workers,
+            "workers": {
+                str(worker_id): {
+                    "name": worker.robot.id,
+                    "state": worker.state.value,
+                    "error": getattr(worker, "error_message", None),
+                }
+                for worker_id, worker in self._workers.items()
+            },
+        }
+
+    async def shutdown_all(self) -> None:
+        """
+        Concurrently shutdown all registered workers and clear the registry.
+        """
+        logger.info(f"Shutting down {len(self._workers)} robot workers...")
+
+        async with self._lock:
+            workers = list(self._workers.values())
+            self._workers.clear()
+
+        # Shutdown all concurrently
+        tasks = [worker.shutdown() for worker in workers]
+
+        if tasks:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*tasks, return_exceptions=True),
+                    timeout=self._shutdown_timeout_s,
+                )
+            except TimeoutError:
+                logger.error(f"Some workers did not shutdown within {self._shutdown_timeout_s}s")
+
+        logger.info("All robot workers shut down")
+
+    async def __aenter__(self) -> Self:
+        """Async context manager support."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Cleanup on context exit."""
+        await self.shutdown_all()

--- a/application/backend/src/workers/robots/calibratable_client.py
+++ b/application/backend/src/workers/robots/calibratable_client.py
@@ -1,0 +1,57 @@
+"""Calibratable protocol for robot connections.
+
+This module defines the Calibratable protocol that robot connections can
+implement to support calibration commands.
+"""
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Calibratable(Protocol):
+    """Protocol for robot connections that support calibration.
+
+    This protocol defines the interface for getting, setting, and reading
+    calibration data. Robot connections that support calibration should
+    implement these methods.
+
+    The protocol is runtime-checkable, allowing isinstance() checks in the
+    command handler to conditionally enable calibration commands.
+    """
+
+    async def get_calibration(self) -> dict[str, Any]:
+        """Get current calibration from the robot.
+
+        Returns:
+            Event dict with calibration data in LeRobot format.
+        """
+        ...
+
+    async def set_calibration(
+        self,
+        calibration: dict[str, Any],
+        *,
+        write_to_motor: bool = False,
+    ) -> dict[str, Any]:
+        """Set calibration on the robot.
+
+        Args:
+            calibration: Calibration data in LeRobot format (dict of motor dicts).
+            write_to_motor: If True, also write to motor EEPROM (requires torque off).
+
+        Returns:
+            Event dict confirming calibration was set.
+        """
+        ...
+
+    async def read_motor_calibration(self) -> dict[str, Any]:
+        """Read calibration values from motor EEPROM registers.
+
+        This reads the actual values stored in the motor hardware, which may
+        differ from the Python-side calibration if they've drifted or weren't
+        written to motors.
+
+        Returns:
+            Event dict with motor calibration data.
+        """
+        ...

--- a/application/backend/src/workers/robots/commands.py
+++ b/application/backend/src/workers/robots/commands.py
@@ -1,0 +1,256 @@
+"""Shared command handling for WebSocket and ZMQ protocols."""
+
+from http import HTTPStatus
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError, field_validator
+
+from exceptions import GetiBaseException
+from workers.robots.calibratable_client import Calibratable
+from workers.robots.robot_client import RobotClient
+
+
+class UnknownCommandError(GetiBaseException):
+    """Raised when an unknown command is received.
+
+    Use the static factory method to create instances:
+        UnknownCommandError.for_command("invalid_cmd")
+    """
+
+    @staticmethod
+    def for_command(command: str) -> "UnknownCommandError":
+        """Create error for when an unknown command is received."""
+        return UnknownCommandError(
+            message=f"Unknown command: {command}",
+            error_code="unknown_command",
+            http_status=HTTPStatus.BAD_REQUEST,
+        )
+
+
+class UnsupportedCommandError(GetiBaseException):
+    """Raised when a command is not supported by the robot connection.
+
+    Use the static factory method to create instances:
+        UnsupportedCommandError.for_command("get_calibration")
+    """
+
+    @staticmethod
+    def for_command(command: str) -> "UnsupportedCommandError":
+        """Create error for when a command is not supported."""
+        return UnsupportedCommandError(
+            message=f"Command not supported by this robot: {command}",
+            error_code="unsupported_command",
+            http_status=HTTPStatus.BAD_REQUEST,
+        )
+
+
+class InvalidPayloadError(GetiBaseException):
+    """Raised when a command payload is invalid.
+
+    Use the static factory method to create instances:
+        InvalidPayloadError.for_command("set_joints_state", "missing required field")
+    """
+
+    @staticmethod
+    def for_command(command: str, reason: str) -> "InvalidPayloadError":
+        """Create error for invalid payload for a specific command."""
+        return InvalidPayloadError(
+            message=f"Invalid {command} payload: {reason}",
+            error_code="invalid_payload",
+            http_status=HTTPStatus.BAD_REQUEST,
+        )
+
+
+# =============================================================================
+# Command Models
+# =============================================================================
+
+
+class PingCommand(BaseModel):
+    """Ping command - returns pong."""
+
+    command: Literal["ping"] = "ping"
+
+
+class EnableTorqueCommand(BaseModel):
+    """Enable motor torque."""
+
+    command: Literal["enable_torque"] = "enable_torque"
+
+
+class DisableTorqueCommand(BaseModel):
+    """Disable motor torque."""
+
+    command: Literal["disable_torque"] = "disable_torque"
+
+
+class SetJointsStateCommand(BaseModel):
+    """Set joint positions.
+
+    The joints field maps joint names to normalized position values.
+    Values should be in [-1.0, 1.0] range for normalized positions.
+    """
+
+    command: Literal["set_joints_state"] = "set_joints_state"
+    joints: dict[str, float]
+
+    @field_validator("joints")
+    @classmethod
+    def validate_joints(cls, v: dict[str, float]) -> dict[str, float]:
+        if not v:
+            raise ValueError("joints dict cannot be empty")
+        for name, value in v.items():
+            if not isinstance(name, str):
+                raise ValueError(f"joint name must be string, got {type(name).__name__}")
+            if not isinstance(value, int | float):
+                raise ValueError(f"joint '{name}' value must be numeric, got {type(value).__name__}")
+        return v
+
+
+class ReadStateCommand(BaseModel):
+    """Read current robot state."""
+
+    command: Literal["read_state"] = "read_state"
+    normalize: bool = True
+
+
+class GetCalibrationCommand(BaseModel):
+    """Get current calibration data."""
+
+    command: Literal["get_calibration"] = "get_calibration"
+
+
+class SetCalibrationCommand(BaseModel):
+    """Set calibration data.
+
+    Expects calibration data for all motors.
+    """
+
+    command: Literal["set_calibration"] = "set_calibration"
+    calibration: dict[str, dict[str, int]]
+    write_to_motor: bool = False
+
+    @field_validator("calibration")
+    @classmethod
+    def validate_calibration(cls, v: dict[str, dict[str, int]]) -> dict[str, dict[str, int]]:
+        if not v:
+            raise ValueError("calibration dict cannot be empty")
+
+        required_fields = {
+            "id",
+            "drive_mode",
+            "homing_offset",
+            "range_min",
+            "range_max",
+        }
+        for motor_name, motor_cal in v.items():
+            if not isinstance(motor_name, str):
+                raise ValueError(f"motor name must be string, got {type(motor_name).__name__}")
+            missing = required_fields - set(motor_cal.keys())
+            if missing:
+                raise ValueError(f"motor '{motor_name}' missing required fields: {missing}")
+        return v
+
+
+class ReadMotorCalibrationCommand(BaseModel):
+    """Read calibration directly from motor registers."""
+
+    command: Literal["read_motor_calibration"] = "read_motor_calibration"
+
+
+# Discriminated union of all command types
+RobotCommand = Annotated[
+    PingCommand
+    | EnableTorqueCommand
+    | DisableTorqueCommand
+    | SetJointsStateCommand
+    | ReadStateCommand
+    | GetCalibrationCommand
+    | SetCalibrationCommand
+    | ReadMotorCalibrationCommand,
+    Field(discriminator="command"),
+]
+
+
+def parse_command(data: dict[str, Any]) -> RobotCommand:
+    """Parse and validate a command from raw dict data.
+
+    Args:
+        data: Raw dict from client (e.g., from JSON)
+
+    Returns:
+        Validated RobotCommand instance
+
+    Raises:
+        InvalidPayloadError: If the command is malformed or has invalid payload
+        UnknownCommandError: If the command type is not recognized
+    """
+    # Check if command field exists
+    if "command" not in data:
+        raise InvalidPayloadError.for_command("unknown", "missing 'command' field")
+
+    command_name = data.get("command", "")
+
+    adapter: TypeAdapter[RobotCommand] = TypeAdapter(RobotCommand)
+
+    try:
+        return adapter.validate_python(data)
+    except ValidationError as e:
+        # Check if this is an unknown command type
+        error_str = str(e)
+        if "Unable to extract tag" in error_str or "Input tag" in error_str:
+            raise UnknownCommandError.for_command(command_name) from e
+        # Otherwise it's a payload validation error
+        raise InvalidPayloadError.for_command(command_name, str(e)) from e
+
+
+async def handle_command(  # noqa: PLR0911
+    robot_connection: RobotClient,
+    cmd: RobotCommand,
+) -> dict[str, Any]:
+    """Process a command and return the response.
+
+    Args:
+        robot_connection: The robot connection to execute commands on.
+        cmd: The validated command object.
+
+    Returns:
+        Response dict with event type and data.
+
+    Raises:
+        UnsupportedCommandError: If the command is not supported by this connection.
+    """
+    match cmd:
+        case PingCommand():
+            return await robot_connection.ping()
+
+        # State commands
+        case EnableTorqueCommand():
+            return await robot_connection.enable_torque()
+
+        case DisableTorqueCommand():
+            return await robot_connection.disable_torque()
+
+        case SetJointsStateCommand(joints=joints):
+            return await robot_connection.set_joints_state(joints)
+
+        case ReadStateCommand(normalize=normalize):
+            return await robot_connection.read_state(normalize=normalize)
+
+        # Calibration commands
+        case GetCalibrationCommand():
+            if not isinstance(robot_connection, Calibratable):
+                raise UnsupportedCommandError.for_command(cmd.command)
+            return await robot_connection.get_calibration()
+
+        case SetCalibrationCommand(calibration=calibration, write_to_motor=write_to_motor):
+            if not isinstance(robot_connection, Calibratable):
+                raise UnsupportedCommandError.for_command(cmd.command)
+
+            return await robot_connection.set_calibration(calibration, write_to_motor=write_to_motor)
+
+        case ReadMotorCalibrationCommand():
+            if not isinstance(robot_connection, Calibratable):
+                raise UnsupportedCommandError.for_command(cmd.command)
+
+            return await robot_connection.read_motor_calibration()

--- a/application/backend/src/workers/robots/feetech_robot_client.py
+++ b/application/backend/src/workers/robots/feetech_robot_client.py
@@ -1,0 +1,126 @@
+from lerobot.robots.so101_follower import SO101Follower, SO101FollowerConfig
+from loguru import logger
+
+from .robot_client import RobotClient
+
+
+class FeetechRobotClient(RobotClient):
+    """
+    Implementation of RobotClient for Feetech bus-connected robots.
+
+    Supports SO101, LeKiWi, and Reachy2 robots using the Feetech motor bus.
+    """
+
+    def __init__(
+        self,
+        config: SO101FollowerConfig,
+        normalize: bool = True,
+    ) -> None:
+        """
+        Initialize the Feetech robot client.
+
+        Args:
+            config: Configuration for the SO101 follower.
+            normalize: Default normalization setting for joint values.
+        """
+        self.config = config
+        self.normalize = normalize
+        self.robot = SO101Follower(config)
+        self.is_controlled = False
+
+    async def connect(self) -> None:
+        """
+        Establish connection to the robot motor bus.
+
+        Raises:
+            Exception: If the connection to the motor bus fails.
+        """
+        logger.info(f"Connecting to Feetech robot on port {self.config.port}")
+        try:
+            self.robot.bus.connect()
+        except Exception as e:
+            logger.error(f"Failed to connect to robot: {e}")
+            raise
+
+    async def disconnect(self) -> None:
+        """
+        Close the connection to the robot motor bus.
+        """
+        logger.info(f"Disconnecting from robot on port {self.config.port}")
+        if self.robot.bus.is_connected:
+            self.robot.bus.disconnect()
+
+    async def ping(self) -> dict:
+        """
+        Send a ping to verify communication.
+
+        Returns:
+            A 'pong' event dictionary.
+        """
+        return self._create_event("pong")
+
+    async def set_joints_state(self, joints: dict) -> dict:
+        """
+        Set target positions for multiple joints.
+
+        Automatically enables torque if it's currently disabled.
+
+        Args:
+            joints: Dictionary mapping joint names to target positions.
+
+        Returns:
+            Confirmation event dictionary.
+        """
+        if not self.is_controlled:
+            await self.enable_torque()
+
+        self.robot.send_action({f"{name}.pos": joints[name] for name in joints})
+        return self._create_event(
+            "joints_state_was_set",
+            joints=joints,
+        )
+
+    async def enable_torque(self) -> dict:
+        """
+        Enable torque on all motors.
+
+        Returns:
+            Confirmation event dictionary.
+        """
+        logger.info("Enabling torque")
+        self.is_controlled = True
+        self.robot.bus.enable_torque()
+        return self._create_event("torque_was_enabled")
+
+    async def disable_torque(self) -> dict:
+        """
+        Disable torque on all motors.
+
+        Returns:
+            Confirmation event dictionary.
+        """
+        logger.info("Disabling torque")
+        self.is_controlled = False
+        self.robot.bus.disable_torque()
+        return self._create_event("torque_was_disabled")
+
+    async def read_state(self, *, normalize: bool = True) -> dict:
+        """
+        Read the current position of all joints.
+
+        Args:
+            normalize: Whether to return normalized values.
+
+        Returns:
+            Event dictionary containing the current joint states.
+        """
+        try:
+            state = self.robot.bus.sync_read("Present_Position", normalize=normalize)
+            return self._create_event(
+                "state_was_updated",
+                state=state,
+                is_controlled=self.is_controlled,
+            )
+        except Exception as e:
+            logger.error(f"Robot read error: {e}")
+            raise

--- a/application/backend/src/workers/robots/robot_client.py
+++ b/application/backend/src/workers/robots/robot_client.py
@@ -1,0 +1,48 @@
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+
+class RobotClient(ABC):
+    """Abstract interface for robot communication (commands only)."""
+
+    @abstractmethod
+    async def connect(self) -> None:
+        """Connect to the robot."""
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Disconnect from the robot."""
+
+    @abstractmethod
+    async def ping(self) -> dict:
+        """Send ping command. Returns event dict with timestamp."""
+
+    @abstractmethod
+    async def set_joints_state(self, joints: dict) -> dict:
+        """Set joint positions. Returns event dict with timestamp."""
+
+    @abstractmethod
+    async def enable_torque(self) -> dict:
+        """Enable torque. Returns event dict with timestamp."""
+
+    @abstractmethod
+    async def disable_torque(self) -> dict:
+        """Disable torque. Returns event dict with timestamp."""
+
+    @abstractmethod
+    async def read_state(self, *, normalize: bool = True) -> dict:
+        """Read current robot state. Returns state dict with timestamp."""
+
+    @staticmethod
+    def _timestamp() -> float:
+        """Get current timestamp in seconds since epoch."""
+        return datetime.now().timestamp()
+
+    @staticmethod
+    def _create_event(event: str, **kwargs) -> dict:
+        """Create an event dict with timestamp."""
+        return {
+            "event": event,
+            "timestamp": RobotClient._timestamp(),
+            **kwargs,
+        }

--- a/application/backend/src/workers/robots/robot_worker.py
+++ b/application/backend/src/workers/robots/robot_worker.py
@@ -1,0 +1,159 @@
+import asyncio
+import time
+from pathlib import Path
+
+from lerobot.robots.so101_follower import SO101FollowerConfig
+from loguru import logger
+
+from exceptions import ResourceNotFoundError, ResourceType
+from schemas.robot import Robot
+from services.robot_calibration_service import RobotCalibrationService, find_robot_port
+from utils.robot import RobotConnectionManager
+from workers.robots.commands import handle_command, parse_command
+from workers.robots.feetech_robot_client import FeetechRobotClient
+from workers.robots.robot_client import RobotClient
+from workers.transport.worker_transport import WorkerTransport
+from workers.transport_worker import TransportWorker, WorkerState, WorkerStatus
+
+
+class RobotWorker(TransportWorker):
+    """Orchestrates robot communication over configurable transport."""
+
+    def __init__(
+        self,
+        robot: Robot,
+        transport: WorkerTransport,
+        robot_manager: RobotConnectionManager,
+        calibration_service: RobotCalibrationService,
+        fps: int = 30,
+        normalize: bool = False,
+    ) -> None:
+        super().__init__(transport)
+        self.robot_manager = robot_manager
+        self.calibration_service = calibration_service
+
+        self.robot = robot
+        self.client: RobotClient | None = None
+
+        self.fps = fps
+        self.normalize = normalize
+
+    async def run(self) -> None:
+        """Main worker loop."""
+        try:
+            await self.transport.connect()
+
+            config = await get_robot_config(self.robot, self.robot_manager, self.calibration_service)
+            self.client = FeetechRobotClient(config, self.normalize)
+
+            try:
+                await self.client.connect()
+                self.state = WorkerState.RUNNING
+
+                logger.info(f"Created new robot client connection: {self.robot.id}")
+                await self.transport.send_json(WorkerStatus(state=self.state, message="Robot connected").to_json())
+            except Exception as e:
+                logger.error(f"Failed to connect robot client: {e}")
+                raise
+
+            await self.run_concurrent(
+                asyncio.create_task(self._broadcast_loop()),
+                asyncio.create_task(self._command_loop()),
+            )
+
+        except Exception as e:
+            self.state = WorkerState.ERROR
+            self.error_message = str(e)
+            logger.error(f"Worker error: {e}")
+            await self.transport.send_json(WorkerStatus(state=self.state, message=str(e)).to_json())
+        finally:
+            await self.shutdown()
+
+    async def _broadcast_loop(self) -> None:
+        """Listen to robot state updates and forward to client."""
+        read_interval = 1 / self.fps
+        try:
+            previous_values = None
+
+            while not self._stop_requested:
+                if self.client is None:
+                    await asyncio.sleep(0.1)
+                    continue
+
+                start_time = time.perf_counter()
+                try:
+                    state = await self.client.read_state(normalize=self.normalize)
+
+                    # Only send if joint values changed (ignore timestamp)
+                    current_values = state.get("state")
+                    if current_values != previous_values:
+                        previous_values = current_values
+                        self.last_state = state
+                        await self.transport.send_json(state)
+
+                except Exception as e:
+                    logger.error(f"Error reading robot state: {e}")
+                    await asyncio.sleep(1)
+
+                elapsed = time.perf_counter() - start_time
+                sleep_time = max(0.001, read_interval - elapsed)
+                await asyncio.sleep(sleep_time)
+
+        except asyncio.CancelledError:
+            pass
+
+    async def _command_loop(self) -> None:
+        """Handle incoming commands from client."""
+        try:
+            while not self._stop_requested:
+                command = await self.transport.receive_command()
+
+                if not self.client or command is None:
+                    continue
+
+                try:
+                    robot_command = parse_command(command)
+                    response = await handle_command(self.client, robot_command)
+
+                    if response:
+                        await self.transport.send_json(response)
+
+                except Exception as e:
+                    logger.warning("Received unknown command: {} from command {}", e, command)
+                    await self.transport.send_json(RobotClient._create_event("error", message=str(e)))
+        except asyncio.CancelledError:
+            pass
+
+    async def shutdown(self) -> None:
+        """Graceful shutdown."""
+        logger.info(f"Shutting down robot worker: {self.robot.id}")
+        await super().shutdown()
+
+
+async def get_robot_config(
+    robot: Robot, robot_manager: RobotConnectionManager, calibration_service: RobotCalibrationService
+) -> SO101FollowerConfig:
+    """
+    Load robot configuration with calibration data.
+
+    Args:
+        robot: The robot to configure
+        robot_manager: Service for discovering robot ports
+        calibration_service: Service for loading calibration data
+
+    Returns:
+        SO101FollowerConfig configured with port and calibration
+
+    Raises:
+        ResourceNotFoundError: If robot port cannot be found
+    """
+    port = await find_robot_port(robot_manager, robot)
+    if port is None:
+        raise ResourceNotFoundError(ResourceType.ROBOT, robot.serial_id)
+
+    if robot.active_calibration_id is None:
+        return SO101FollowerConfig(port=port, id="follower")
+
+    calibration = await calibration_service.get_calibration(robot.active_calibration_id)
+
+    return SO101FollowerConfig(port=port, id=str(calibration.id), calibration_dir=Path(calibration.file_path).parent)


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a new websocket endpoint, `/api/projects/{project_id}/robots/{robot_id}/ws` which can be used to read and set state of a configured project robot.
The endpoint takes a project `Robot` that can optionally be calibrated. If it was calibrated via Geti Action then we load its relevant calibration files.
The endpoint can also be used without calibration file in which case we can only output denormalized values, which the UI will use to calibrate the robot.

At the moment this still is specific to the SO101 robot (due to the `FeetechRobotClient` directly depending on `SO101Follower`). In a follow up PR I'd like to improve this so that the endpoint will be able to support any feetech robot. This requires a bit more logic though as we'd need to define a new service that takes a `Robot` and outputs a feetech robot client based on its type and its calibration.
Later we should also be able to switch a `FeetechRobotClient` with say a `ROSRobotClient`, `TrossenRobotClient` etc assuming it implements the `RobotClient` interface.

## Type of Change

- [x] ✨ `feat` - New feature