### PR TITLE
refactor(cameras): Remove `device_index` from realsense payload

### DIFF
--- a/application/backend/src/schemas/project_camera.py
+++ b/application/backend/src/schemas/project_camera.py
@@ -68,7 +68,6 @@ class BaslerCameraPayload(BaseModel):
 class RealsenseCameraPayload(BaseModel):
     """Configuration for RealsenseCapture."""
 
-    device_index: int = Field(0, ge=0, le=10, description="Camera device index")
     width: int = Field(640, ge=424, le=1920, description="Frame width in pixels")
     height: int = Field(480, ge=240, le=1080, description="Frame height in pixels")
     fps: int = Field(30, ge=6, le=90, description="Frames per second")
@@ -179,7 +178,6 @@ class RealsenseCamera(BaseCamera):
                 "fingerprint": "123456789",
                 "hardware_name": "Intel RealSense D435",
                 "payload": {
-                    "device_index": 0,
                     "width": 640,
                     "height": 480,
                     "fps": 30,

--- a/application/ui/src/features/robots/camera-form/drivers/realsense.tsx
+++ b/application/ui/src/features/robots/camera-form/drivers/realsense.tsx
@@ -11,7 +11,6 @@ import { DriverFormSchema } from '../provider';
 export const initialRealsenseState: DriverFormSchema<'realsense'> = {
     driver: 'realsense',
     payload: {
-        device_index: 0,
         depth_range_min: 0.3,
         depth_range_max: 3,
         output_type: 'color',
@@ -24,8 +23,7 @@ export const validateRealsense = (formData: DriverFormSchema<'realsense'>): form
         !!formData.fingerprint &&
         !!formData.payload?.width &&
         !!formData.payload?.height &&
-        !!formData.payload?.fps &&
-        formData.payload?.device_index !== undefined
+        !!formData.payload?.fps
     );
 };
 


### PR DESCRIPTION
# Pull Request

The `device_index` is not necessary as the camera's `fingerprint` is the source of truth.

## Type of Change

- [x] ♻️ `refactor` - Code refactoring
