### PR TITLE
fix: Exclude root level pyproject.toml from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,6 +33,11 @@
 
   enabledManagers: ["github-actions", "pep621", "dockerfile", "npm"],
 
+  // ignore FrameSource dependencies
+  ignoreDeps: [
+    "FrameSource"
+  ],
+
   // Set limit to 10
   ignorePresets: [":prHourlyLimit2"],
   prHourlyLimit: 10,
@@ -50,6 +55,12 @@
       matchDatasources: ["python-version"],
       matchDepTypes: ["requires-python"],
       matchDepNames: ["python"],
+    },
+
+    // Exclude root level pyproject.toml and uv.lock from renovate
+    {
+      enabled: false,
+      matchFileNames: ["pyproject.toml", "uv.lock"],
     },
 
     // Group GitHub Actions updates


### PR DESCRIPTION
# Pull Request

## Description

This PR excludes root level pyproject.toml and uvl.lock files from renovate bot updates.
Also dependencies from https://github.com/ArendJanKramer/FrameSource.git are ignored.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance
