### PR TITLE
fix(pi0): ensure dtype consistency and fix checkpoint load via ClassVar

### DIFF
--- a/library/src/getiaction/policies/pi0/components/gemma.py
+++ b/library/src/getiaction/policies/pi0/components/gemma.py
@@ -205,6 +205,7 @@ class PaliGemmaWithExpert(nn.Module):
     def embed_image(self, pixel_values: torch.Tensor) -> torch.Tensor:
         """Embed images using PaliGemma's vision encoder."""  # noqa: DOC201
         self._ensure_loaded()
+        pixel_values = pixel_values.to(dtype=self.dtype)
         vision_outputs = self.paligemma.vision_tower(pixel_values)
         image_features = vision_outputs.last_hidden_state
         return self.paligemma.multi_modal_projector(image_features)
@@ -228,6 +229,10 @@ class PaliGemmaWithExpert(nn.Module):
         self._ensure_loaded()
 
         prefix_embeds, suffix_embeds = inputs_embeds
+        if prefix_embeds is not None:
+            prefix_embeds = prefix_embeds.to(self.dtype)
+        if suffix_embeds is not None:
+            suffix_embeds = suffix_embeds.to(self.dtype)
 
         prefix_len = prefix_embeds.shape[1] if prefix_embeds is not None else 0
         suffix_len = suffix_embeds.shape[1] if suffix_embeds is not None else 0

--- a/library/src/getiaction/policies/pi0/config.py
+++ b/library/src/getiaction/policies/pi0/config.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, cast
+from typing import ClassVar, Literal, cast
 
 from getiaction.config import Config
 
@@ -15,9 +15,9 @@ from getiaction.config import Config
 class Pi0Config(Config):
     """Configuration for Pi0/Pi0.5 flow matching model."""
 
-    DEFAULT_MAX_TOKEN_LEN_PI0: int = 48
-    DEFAULT_MAX_TOKEN_LEN_PI05: int = 200
-    _AUTO_MAX_TOKEN_LEN: object = object()
+    DEFAULT_MAX_TOKEN_LEN_PI0: ClassVar[int] = 48
+    DEFAULT_MAX_TOKEN_LEN_PI05: ClassVar[int] = 200
+    _AUTO_MAX_TOKEN_LEN: ClassVar[object] = object()
 
     variant: Literal["pi0", "pi05"] = "pi0"
 

--- a/library/src/getiaction/policies/pi0/model.py
+++ b/library/src/getiaction/policies/pi0/model.py
@@ -274,7 +274,7 @@ class Pi0Model(nn.Module):
         batch_size = noisy_actions.shape[0]
 
         if not self.is_pi05:
-            state_emb = self.state_proj(state.float())
+            state_emb = self.state_proj(state.to(dtype=self.state_proj.weight.dtype))
             embeddings.append(state_emb[:, None, :])
             pad_masks.append(torch.ones(batch_size, 1, dtype=torch.bool, device=device))
             att_masks.append(1)
@@ -287,7 +287,7 @@ class Pi0Model(nn.Module):
         )
         time_emb = time_emb.to(dtype=noisy_actions.dtype)
 
-        action_emb = self.action_in_proj(noisy_actions)
+        action_emb = self.action_in_proj(noisy_actions.to(dtype=self.action_in_proj.weight.dtype))
 
         if self.is_pi05:
             time_emb = self.time_mlp_in(time_emb)


### PR DESCRIPTION
# Pull Request

## Description

- Cast inputs and embeddings to bfloat16 for PaliGemma; cast state and actions to projection dtype. 
- Mark Pi0Config sentinel as ClassVar to prevent torch.load weights_only unpickling error.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
