### PR TITLE
fix(pi0): deep-copy KV cache in denoising loop to prevent inference shape mismatch

### DIFF
--- a/library/src/getiaction/policies/pi0/model.py
+++ b/library/src/getiaction/policies/pi0/model.py
@@ -42,9 +42,6 @@ def _clone_kv_cache(cache: DynamicCache) -> DynamicCache:
     same prefix cache is reused across denoising steps this causes a shape
     mismatch on step 2+.
 
-    Unlike :func:`copy.deepcopy`, this helper uses :meth:`Tensor.clone` so
-    the result is safe for ``torch.export`` / ``torch.compile`` paths.
-
     Returns:
         A new ``DynamicCache`` instance with cloned keys and values.
     """


### PR DESCRIPTION
## Summary

- **Fix Pi0 inference crash** where `sample_actions()` fails on the 2nd denoising step with `RuntimeError: The size of tensor a (406) must match the size of tensor b (355) at non-singleton dimension 3`
- Deep-copy `past_key_values` before each denoising step so the HuggingFace `DynamicCache` isn't mutated in-place

## Root Cause

During inference, the prefix KV cache is computed once and reused across all denoising steps. However, the HuggingFace `DynamicCache` is mutated in-place by the attention layers—`DynamicCache.update()` appends new key/value pairs even when `use_cache=False`. This causes the cache to grow by `suffix_len` (51) tokens on every step:

## Fix

`copy.deepcopy(past_key_values)` before each step ensures the original cache stays at `prefix_len` throughout the loop.

## Test

The integration test results are the following:

```bash
========================================================================================================================= short test summary info ==========================================================================================================================
SKIPPED [1] library/tests/integration/gyms/test_libero_e2e.py:14: could not import 'libero': No module named 'libero'
SKIPPED [1] library/tests/integration/test_lerobot_e2e.py:94: Groot requires lerobot[groot]: uv pip install 'lerobot[groot]'
SKIPPED [1] library/tests/integration/test_lerobot_e2e.py:98: Groot requires lerobot[groot]: uv pip install 'lerobot[groot]'
SKIPPED [1] library/tests/integration/test_lerobot_e2e.py:103: Groot requires lerobot[groot]: uv pip install 'lerobot[groot]'
ERROR library/tests/integration/test_first_party_e2e.py::TestE2ECore::test_train_policy[groot] - ImportError: This modeling file requires the following packages that were not found in your environment: peft. Run `pip install peft`
ERROR library/tests/integration/test_first_party_e2e.py::TestE2ECore::test_validate_policy[groot] - ImportError: This modeling file requires the following packages that were not found in your environment: peft. Run `pip install peft`
ERROR library/tests/integration/test_first_party_e2e.py::TestE2ECore::test_test_policy[groot] - ImportError: This modeling file requires the following packages that were not found in your environment: peft. Run `pip install peft`
ERROR library/tests/integration/test_first_party_e2e.py::TestE2ECore::test_export_to_torch[groot] - ImportError: This modeling file requires the following packages that were not found in your environment: peft. Run `pip install peft`
ERROR library/tests/integration/test_first_party_e2e.py::TestE2ECore::test_inference_with_exported_model[groot] - ImportError: This modeling file requires the following packages that were not found in your environment: peft. Run `pip install peft`
==================================================================================================== 28 passed, 4 skipped, 312 warnings, 5 errors in 136.03s (0:02:16) =====================================================================================================
```

Now only groot tests are failing, which I'll be handling them in a separate PR