### PR TITLE
fix: Revert camera id usage instead of name

### DIFF
--- a/application/backend/src/utils/dataset.py
+++ b/application/backend/src/utils/dataset.py
@@ -22,7 +22,7 @@ async def build_observation_features(
         raise ValueError("Environments with multiple robots not implemented yet")
     output_features = await build_action_features(environment, robot_manager, calibration_service)
     for camera in environment.cameras:
-        output_features[str(camera.id)] = await get_camera_features(camera)
+        output_features[camera.name.lower()] = await get_camera_features(camera)
 
     return output_features
 

--- a/application/backend/src/workers/teleoperate_worker.py
+++ b/application/backend/src/workers/teleoperate_worker.py
@@ -106,13 +106,13 @@ class TeleoperateWorker(BaseThreadWorker):
     async def setup_environment(self) -> None:
         """Setup environment."""
         robot = self.config.environment.robots[0]  # Assume 1 arm for now.
-        if robot.tele_operator.type == "none" or robot.tele_operator.robot is None:
+        if robot.tele_operator.robot is None:
             raise ValueError("No teleoperator given.")
         self.follower = await get_robot_client(robot.robot, self.robot_manager, self.calibration_service)
         self.leader = await get_robot_client(robot.tele_operator.robot, self.robot_manager, self.calibration_service)
 
         self.cameras = {
-            str(camera.id): create_frames_source_from_camera(camera) for camera in self.config.environment.cameras
+            camera.name: create_frames_source_from_camera(camera) for camera in self.config.environment.cameras
         }
         for camera in self.cameras.values():
             # camera.attach_processor(CameraFrameProcessor()) # TODO Not working. Fix in framesource
@@ -138,7 +138,7 @@ class TeleoperateWorker(BaseThreadWorker):
                 raise RuntimeError("Environment setup failed.")
 
             self.action_keys = self.follower.features()
-            self.camera_keys = [str(camera.id) for camera in self.config.environment.cameras]
+            self.camera_keys = [camera.name.lower() for camera in self.config.environment.cameras]
             features = self.loop.run_until_complete(
                 build_lerobot_dataset_features(self.config.environment, self.robot_manager, self.calibration_service)
             )
@@ -233,12 +233,12 @@ class TeleoperateWorker(BaseThreadWorker):
                 if forces is not None:
                     await self.leader.set_forces(forces)
 
-                for camera_id, camera in self.cameras.items():
+                for camera_name, camera in self.cameras.items():
                     _success, camera_frame = camera.get_latest_frame()  # HWC
                     if camera_frame is None:
                         raise Exception("Camera frame is None")
                     processed_frame = CameraFrameProcessor.process(camera_frame)
-                    observations[camera_id] = processed_frame
+                    observations[camera_name] = processed_frame
 
                 timestamp = time.perf_counter() - self.start_episode_t
                 self._report_observation(observations, timestamp)

--- a/application/ui/src/routes/datasets/camera-view.tsx
+++ b/application/ui/src/routes/datasets/camera-view.tsx
@@ -24,9 +24,8 @@ export const CameraView = ({ camera, observation }: CameraViewProps) => {
     const [img, setImg] = useState<string>();
 
     useInterval(() => {
-        const id = camera.id;
-        if (id !== undefined && observation.current?.cameras[id]) {
-            setImg(observation.current.cameras[id]);
+        if (observation.current?.cameras[camera.name]) {
+            setImg(observation.current.cameras[camera.name]);
         }
     }, 1000 / 30); //TODO: Change hardcoding
 


### PR DESCRIPTION
Name should be the name of the parameter, not the camera.
Cameras should be interchangable and the model should be usuable on
other environments (e.g. multiple kiwis).
uuid is not human readable which is bad/annoying for export and debugging.

Although I *do agree* we need to fix this properly. We have a leaky abstraction and some assumptions that we need to crystalize.  However, the merged change is not a proper fix in my opinion. 