### PR TITLE
fix: Store camera feature by name instead of id

### DIFF
--- a/application/backend/src/utils/dataset.py
+++ b/application/backend/src/utils/dataset.py
@@ -22,7 +22,7 @@ async def build_observation_features(
         raise ValueError("Environments with multiple robots not implemented yet")
     output_features = await build_action_features(environment, robot_manager, calibration_service)
     for camera in environment.cameras:
-        output_features[str(camera.id)] = await get_camera_features(camera)
+        output_features[camera.name.lower()] = await get_camera_features(camera)
 
     return output_features
 

--- a/application/backend/src/workers/teleoperate_worker.py
+++ b/application/backend/src/workers/teleoperate_worker.py
@@ -243,7 +243,9 @@ class TeleoperateWorker(BaseThreadWorker):
                 timestamp = time.perf_counter() - self.start_episode_t
                 self._report_observation(observations, timestamp)
                 if self.state.is_recording and self.recording_mutation is not None:
-                    self.recording_mutation.add_frame(observations, actions, self.config.task)
+                    self.recording_mutation.add_frame(
+                        self._to_lerobot_observations(observations), actions, self.config.task
+                    )
 
                 dt_s = time.perf_counter() - start_loop_t
                 wait_time = 1 / 30 - dt_s
@@ -252,6 +254,13 @@ class TeleoperateWorker(BaseThreadWorker):
             self.error = True
             traceback.print_exception(e)
             self._report_error(e)
+
+    def _to_lerobot_observations(self, observations: dict) -> dict:
+        """Remap camera observations from camera ID keys to lowercase camera name keys."""
+        lerobot_observations = dict(observations)
+        for camera in self.config.environment.cameras:
+            lerobot_observations[camera.name.lower()] = lerobot_observations.pop(str(camera.id))
+        return lerobot_observations
 
     def _on_start(self) -> None:
         logger.info("start")


### PR DESCRIPTION
# Pull Request

## Description

Instead of referencing cameras by id in our models' inputs we want to use their name as a reference.
This allows us to keep using uppercase letters in camera names without getting unclear bugs during teleoperation.

I do expect this to still have issues when users use special characters or unintentionally have duplicated names for their cameras.

## Type of Change

- [x] 🐞 `fix` - Bug fix