### PR TITLE
refactor: make pi0 preprocessor export-friendly

### DIFF
--- a/library/src/getiaction/policies/pi0/model.py
+++ b/library/src/getiaction/policies/pi0/model.py
@@ -232,8 +232,8 @@ class Pi0Model(nn.Module):
 
     def embed_prefix(
         self,
-        images: list[torch.Tensor],
-        image_masks: list[torch.Tensor],
+        images: torch.Tensor,
+        image_masks: torch.Tensor,
         language_tokens: torch.Tensor,
         language_masks: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -582,16 +582,14 @@ class Pi0Model(nn.Module):
     @staticmethod
     def _preprocess_observation(
         observation: Mapping[str, Any],
-    ) -> tuple[list[torch.Tensor], list[torch.Tensor], torch.Tensor, torch.Tensor, torch.Tensor]:
-        images = list(observation.get("images", {}).values())
-        image_masks = list(observation.get("image_masks", {}).values())
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        images = observation[IMAGES]
+        image_masks = observation["image_masks"]
 
-        image_masks = [m if isinstance(m, torch.Tensor) else torch.tensor(m, dtype=torch.bool) for m in image_masks]
+        lang_tokens = observation["tokenized_prompt"]
+        lang_masks = observation["tokenized_prompt_mask"]
 
-        lang_tokens = observation.get("tokenized_prompt")
-        lang_masks = observation.get("tokenized_prompt_mask")
-
-        state = observation.get("state")
+        state = observation[STATE]
 
         if lang_tokens is None or lang_masks is None or state is None:
             msg = "Observation is missing required fields for Pi0Model"

--- a/library/src/getiaction/policies/pi0/preprocessor.py
+++ b/library/src/getiaction/policies/pi0/preprocessor.py
@@ -147,9 +147,9 @@ class Pi0Preprocessor(torch.nn.Module):
     def _process_images(
         self,
         batch: Mapping[str, Any],
-    ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
-        images: dict[str, torch.Tensor] = {}
-        image_masks: dict[str, torch.Tensor] = {}
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        images: list[torch.Tensor] = []
+        image_masks: list[torch.Tensor] = []
 
         image_keys = [k for k in batch if "image" in k.lower() and "mask" not in k.lower() and not k.startswith("_")]
 
@@ -180,11 +180,10 @@ class Pi0Preprocessor(torch.nn.Module):
             if is_channels_first:
                 img = img.permute(0, 3, 1, 2)
 
-            clean_name = key.replace("observation.images.", "").replace("observation.", "")
-            images[clean_name] = img
-            image_masks[clean_name] = torch.ones(img.shape[0], dtype=torch.bool, device=img.device)
+            images.append(img)
+            image_masks.append(torch.ones(img.shape[0], dtype=torch.bool, device=img.device))
 
-        return images, image_masks
+        return torch.stack(images, dim=0), torch.stack(image_masks, dim=0)
 
     @staticmethod
     def _resize_with_pad(images: torch.Tensor, height: int, width: int) -> torch.Tensor:  # noqa: PLR0914


### PR DESCRIPTION
# Pull Request

## Description

- Images and masks are now collated to monolithic tensors, eliminating nested dicts structure, which is not convenient on export

## Type of Change

- [x] ♻️ `refactor` - Code refactoring


