### PR TITLE
fix: environment_id not serialized in datasetDB + missing goal_time arg

### DIFF
--- a/application/backend/src/repositories/mappers/dataset_mapper.py
+++ b/application/backend/src/repositories/mappers/dataset_mapper.py
@@ -14,6 +14,7 @@ class DatasetMapper(IBaseMapper):
             name=dataset.name,
             path=dataset.path,
             project_id=str(dataset.project_id),
+            environment_id=str(dataset.environment_id),
         )
 
     @staticmethod

--- a/application/backend/src/workers/robots/commands.py
+++ b/application/backend/src/workers/robots/commands.py
@@ -93,6 +93,7 @@ class SetJointsStateCommand(BaseModel):
 
     command: Literal["set_joints_state"] = "set_joints_state"
     joints: dict[str, float]
+    goal_time: float = 0.0
 
     @field_validator("joints")
     @classmethod
@@ -231,8 +232,8 @@ async def handle_command(  # noqa: PLR0911
         case DisableTorqueCommand():
             return await robot_connection.disable_torque()
 
-        case SetJointsStateCommand(joints=joints):
-            return await robot_connection.set_joints_state(joints)
+        case SetJointsStateCommand(joints=joints, goal_time=goal_time):
+            return await robot_connection.set_joints_state(joints, goal_time)
 
         case ReadStateCommand(normalize=normalize):
             return await robot_connection.read_state(normalize=normalize)


### PR DESCRIPTION
# Pull Request

## Description

Fixes:
- add `environment_id` in dataset mapper (required by DB schema)
- add missing `goal_time` arg in command

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
