### PR TITLE
chore: upgrade `uv` to 0.10.4

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,9 +34,7 @@
   enabledManagers: ["github-actions", "pep621", "dockerfile", "npm"],
 
   // ignore FrameSource dependencies
-  ignoreDeps: [
-    "FrameSource"
-  ],
+  ignoreDeps: ["FrameSource"],
 
   // Set limit to 10
   ignorePresets: [":prHourlyLimit2"],
@@ -122,6 +120,13 @@
       matchDatasources: ["docker"],
       matchPackageNames: ["python"],
       matchUpdateTypes: ["major", "minor"],
+    },
+
+    // Disable upgrades for Dockerfile syntax (docker/dockerfile)
+    {
+      enabled: false,
+      matchDatasources: ["docker"],
+      matchDepNames: ["docker/dockerfile"],
     },
 
     // Disable non-security and lock file upgrades for npm

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
-          version: "0.8.8"
+          version: "0.10.4"
 
       - name: Prepare venv and install Python dependencies
         working-directory: application/backend

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
-          version: "0.8.8"
+          version: "0.10.4"
 
       - name: Verify lock file
         working-directory: library

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
-          version: "0.8.8"
+          version: "0.10.4"
 
       - name: Install OpenCV dependencies
         run: |


### PR DESCRIPTION
# Pull Request

## Description

Following upgrades introduced in https://github.com/open-edge-platform/physical-ai-studio/pull/257 to achieve consistency.
In addition, Renovate config was updated to prevent `uv` upgrades in future as the may introduce some breaking changes.

## Type of Change

- [x] 🔧 `chore` - Maintenance