### PR TITLE
fix: Add clonse so101 and widowx scripts to preinstall

### DIFF
--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -20,7 +20,7 @@
         "format:check": "prettier --check --cache \"./src/**/*.{js,ts,jsx,tsx,css,scss,sass}\"",
         "lint": "eslint \"src/**/*.ts*\" --max-warnings 0",
         "lint:fix": "eslint --fix \"./src/**/*.ts*\"",
-        "preinstall": "npm run clone-geti-ui-packages",
+        "preinstall": "npm run clone-geti-ui-packages && npm run clone-so101 && npm run clone-widowx",
         "preview": "rsbuild preview",
         "test:unit": "vitest --config vitest.config.ts",
         "test:unit:watch": "vitest --config vitest.config.ts --reporter=verbose --watch",
@@ -102,7 +102,5 @@
         "vite-plugin-svgr": "^4.3.0",
         "vitest": "^3.2.4"
     },
-    "workspaces": [
-        "packages/*"
-    ]
+    "workspaces": ["packages/*"]
 }


### PR DESCRIPTION
This PR adds the `npm run clonse-so101` and `npm run clone-widowx` scripts to our preinstall scripts. This way when the user runs `npm install` we will first fetch those (along with our Geti UI package) before installing the other npm packages.

This resolves an issue where otherwise the URDF models won't load and the user won't see visualized robots.

## Type of Change

- [x] 🐞 `fix` - Bug fix
- [x] 📚 `docs` - Documentation