### PR TITLE
fix: don't import rmtree from git

### DIFF
--- a/application/backend/src/internal_datasets/lerobot/lerobot_dataset.py
+++ b/application/backend/src/internal_datasets/lerobot/lerobot_dataset.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 import cv2
 import numpy as np
 import torch
-from git import rmtree
 from lerobot.datasets.dataset_tools import delete_episodes as lerobot_delete_episodes
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.datasets.utils import build_dataset_frame
@@ -85,7 +84,7 @@ class InternalLeRobotDataset(DatasetClient):
             raise ValueError(f"Cannot overwrite lerobot dataset with {source.__class__}")
 
         if self.path.is_dir():
-            rmtree(self.path)
+            shutil.rmtree(self.path)
 
         shutil.copytree(source.path, self.path)
         self.load_dataset()

--- a/application/backend/src/internal_datasets/mutations/delete_episode_mutation.py
+++ b/application/backend/src/internal_datasets/mutations/delete_episode_mutation.py
@@ -1,7 +1,6 @@
 from pathlib import Path
+from shutil import rmtree
 from uuid import uuid4
-
-from git import rmtree
 
 from internal_datasets.dataset_client import DatasetClient
 from settings import get_settings


### PR DESCRIPTION
This fixes an issue when starting up the application in a docker container,

```
physical-ai-studio-1  | Traceback (most recent call last):
physical-ai-studio-1  |   File "/app/application/backend/.venv/lib/python3.12/site-packages/git/__init__.py", line 296, in <module>
physical-ai-studio-1  |     refresh()
physical-ai-studio-1  |   File "/app/application/backend/.venv/lib/python3.12/site-packages/git/__init__.py", line 287, in refresh
physical-ai-studio-1  |     if not Git.refresh(path=path):
physical-ai-studio-1  |            ^^^^^^^^^^^^^^^^^^^^^^
physical-ai-studio-1  |   File "/app/application/backend/.venv/lib/python3.12/site-packages/git/cmd.py", line 860, in refresh
physical-ai-studio-1  |     raise ImportError(err)
physical-ai-studio-1  | ImportError: Bad git executable.
physical-ai-studio-1  | The git executable must be specified in one of the following ways:
physical-ai-studio-1  |     - be included in your $PATH
physical-ai-studio-1  |     - be set via $GIT_PYTHON_GIT_EXECUTABLE
physical-ai-studio-1  |     - explicitly set via git.refresh(<full-path-to-git-executable>)
physical-ai-studio-1  |
physical-ai-studio-1  | All git commands will error until this is rectified.
physical-ai-studio-1  |
physical-ai-studio-1  | This initial message can be silenced or aggravated in the future by setting the
physical-ai-studio-1  | $GIT_PYTHON_REFRESH environment variable. Use one of the following values:
physical-ai-studio-1  |     - quiet|q|silence|s|silent|none|n|0: for no message or exception
physical-ai-studio-1  |     - warn|w|warning|log|l|1: for a warning message (logging level CRITICAL, displayed by default)
physical-ai-studio-1  |     - error|e|exception|raise|r|2: for a raised exception
physical-ai-studio-1  |
physical-ai-studio-1  | Example:
physical-ai-studio-1  |     export GIT_PYTHON_REFRESH=quiet
physical-ai-studio-1  |
physical-ai-studio-1  |
physical-ai-studio-1  | The above exception was the direct cause of the following exception:
physical-ai-studio-1  |
physical-ai-studio-1  | Traceback (most recent call last):
physical-ai-studio-1  |   File "/app/application/backend/src/main.py", line 11, in <module>
physical-ai-studio-1  |     from api.camera import router as camera_router
physical-ai-studio-1  |   File "/app/application/backend/src/api/camera.py", line 9, in <module>
physical-ai-studio-1  |     from api.dependencies import CameraRegistryDep
physical-ai-studio-1  |   File "/app/application/backend/src/api/dependencies.py", line 9, in <module>
physical-ai-studio-1  |     from core.scheduler import Scheduler
physical-ai-studio-1  |   File "/app/application/backend/src/core/__init__.py", line 1, in <module>
physical-ai-studio-1  |     from core.lifecycle import lifespan
physical-ai-studio-1  |   File "/app/application/backend/src/core/lifecycle.py", line 10, in <module>
physical-ai-studio-1  |     from workers.camera_worker_registry import CameraWorkerRegistry
physical-ai-studio-1  |   File "/app/application/backend/src/workers/__init__.py", line 2, in <module>
physical-ai-studio-1  |     from .teleoperate_worker import TeleoperateWorker
physical-ai-studio-1  |   File "/app/application/backend/src/workers/teleoperate_worker.py", line 17, in <module>
physical-ai-studio-1  |     from internal_datasets.lerobot.lerobot_dataset import InternalLeRobotDataset
physical-ai-studio-1  |   File "/app/application/backend/src/internal_datasets/lerobot/lerobot_dataset.py", line 10, in <module>
physical-ai-studio-1  |     from git import rmtree
physical-ai-studio-1  |   File "/app/application/backend/.venv/lib/python3.12/site-packages/git/__init__.py", line 298, in <module>
physical-ai-studio-1  |     raise ImportError("Failed to initialize: {0}".format(_exc)) from _exc
physical-ai-studio-1  | ImportError: Failed to initialize: Bad git executable.
physical-ai-studio-1  | The git executable must be specified in one of the following ways:
physical-ai-studio-1  |     - be included in your $PATH
physical-ai-studio-1  |     - be set via $GIT_PYTHON_GIT_EXECUTABLE
physical-ai-studio-1  |     - explicitly set via git.refresh(<full-path-to-git-executable>)
physical-ai-studio-1  |
physical-ai-studio-1  | All git commands will error until this is rectified.
physical-ai-studio-1  |
physical-ai-studio-1  | This initial message can be silenced or aggravated in the future by setting the
physical-ai-studio-1  | $GIT_PYTHON_REFRESH environment variable. Use one of the following values:
physical-ai-studio-1  |     - quiet|q|silence|s|silent|none|n|0: for no message or exception
physical-ai-studio-1  |     - warn|w|warning|log|l|1: for a warning message (logging level CRITICAL, displayed by default)
physical-ai-studio-1  |     - error|e|exception|raise|r|2: for a raised exception
physical-ai-studio-1  |
physical-ai-studio-1  | Example:
physical-ai-studio-1  |     export GIT_PYTHON_REFRESH=quiet
```

## Type of Change

- [x] 🐞 `fix` - Bug fix