### PR TITLE
fix: training on xpu due to not registering xpu device

### DIFF
--- a/application/backend/src/utils/device.py
+++ b/application/backend/src/utils/device.py
@@ -27,6 +27,8 @@ def get_lightning_strategy() -> str:
     import torch
 
     if torch.xpu.is_available():
+        import physicalai.devices.xpu  # noqa: F401 — registers XPU accelerator/strategy with Lightning
+
         return "xpu_single"
 
     return "auto"

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -151,5 +151,6 @@ class TrainingWorker(BaseProcessWorker):
                 job_id=job.id, status=JobStatus.FAILED, message=f"Training failed: {e}"
             )
         self.interrupt_event.set()
-        dispatcher.join(timeout=10)
+        if dispatcher.is_alive():
+            dispatcher.join(timeout=10)
         self.queue.put((EventType.JOB_UPDATE, job))


### PR DESCRIPTION
The physicalai library provides XPUAccelerator and SingleXPUStrategy that register "xpu" and "xpu_single" with Lightning's registries at import time. However, nothing in the training worker imported physicalai.devices.xpu, so Lightning had no knowledge of these names when the Trainer constructor validated them, causing a ValueError.

Import physicalai.devices.xpu inside get_lightning_strategy() when XPU is detected, ensuring the registry side-effects run before the strategy name is used.

Also guard dispatcher.join() with dispatcher.is_alive() so that when the Trainer constructor (or anything before dispatcher.start()) fails, cleanup does not crash trying to join an unstarted thread.

## Type of Change

- [x] 🐞 `fix` - Bug fix