### PR TITLE
chore: move `dev` into image tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,9 +50,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
-          images: ghcr.io/open-edge-platform/physical-ai-studio-dev-${{ matrix.device }}
+          images: ghcr.io/open-edge-platform/physical-ai-studio-${{ matrix.device }}
           tags: |
-            type=raw,value=${{ steps.version.outputs.version }}-${{ steps.version.outputs.short-sha }}
+            type=raw,value=${{ steps.version.outputs.version }}-dev-${{ steps.version.outputs.short-sha }}
             type=raw,value=${{ github.ref_name }}
 
       - name: Build and push Docker image


### PR DESCRIPTION
This PR moves the `dev` identifier from the container image name to the tag prefix in the nightly Docker publish workflow. This standardizes the image naming convention and prepares for future release types (RC, stable).

## Type of Change

- [x] 🔧 `chore` - Maintenance
