### PR TITLE
feat(docker): use compose profiles for cpu/xpu/cuda and ipc:host for shared memory

### DIFF
--- a/application/docker/.env.example
+++ b/application/docker/.env.example
@@ -12,8 +12,10 @@ IMAGE_TAG=main
 
 PORT=7860
 
-# Hardware target: cpu, xpu, or cuda
-AI_DEVICE=cpu
+# Hardware profile: cpu, xpu, or cuda
+# This is a built-in Docker Compose variable that selects which
+# profiled service to start (see docker-compose.yaml).
+COMPOSE_PROFILES=cpu
 
 # Container user UID/GID — override to match your host user so that
 # bind-mounted volumes (e.g. calibration data) have correct ownership.
@@ -32,3 +34,4 @@ AI_DEVICE=cpu
 # VIDEO_GID=984
 # DIALOUT_GID=985
 # PLUGDEV_GID=46
+# RENDER_GID=989       # Intel GPU render nodes (XPU non-privileged mode)

--- a/application/docker/README.md
+++ b/application/docker/README.md
@@ -21,23 +21,27 @@ All commands should be run from the `application/docker/` directory.
 # 1. Create your local environment file
 cp .env.example .env
 
-# 2. (Optional) Auto-detect host device GIDs for non-Debian systems
+# 2. (Optional) Set your hardware profile in .env
+#    Edit COMPOSE_PROFILES to: cpu (default), xpu, or cuda
+
+# 3. (Optional) Auto-detect host device GIDs for non-Debian systems
 ./setup-devices.sh
 
-# 3. Start Physical AI Studio
+# 4. Start Physical AI Studio
 docker compose up
 ```
 
 Physical AI Studio will be available at **http://localhost:7860**.
 
-To run with a different hardware backend:
+The hardware backend is selected via the `COMPOSE_PROFILES` variable in `.env`.
+To override it on the command line without editing `.env`:
 
 ```bash
 # Intel XPU
-AI_DEVICE=xpu docker compose up
+docker compose --profile xpu up
 
 # NVIDIA CUDA
-AI_DEVICE=cuda docker compose up
+docker compose --profile cuda up
 ```
 
 To run in the background, add the `-d` flag:
@@ -52,31 +56,33 @@ All configuration is done through the `.env` file. Copy `.env.example` to get st
 
 ### Environment Variables
 
-| Variable      | Default                       | Description                                          |
-|---------------|-------------------------------|------------------------------------------------------|
-| `AI_DEVICE`   | `cpu`                         | Hardware backend: `cpu`, `xpu`, or `cuda`            |
-| `PORT`        | `7860`                        | Host port to expose the web UI and API               |
-| `REGISTRY`    | `ghcr.io/open-edge-platform/` | Container image registry                             |
-| `IMAGE_TAG`   | `latest`                      | Image version tag                                    |
-| `APP_UID`     | `1000`                        | UID for the in-container user (match your host user) |
-| `APP_GID`     | `1000`                        | GID for the in-container user (match your host user) |
-| `VIDEO_GID`   | `video` (group name)          | Host GID for the `video` group (cameras)             |
-| `DIALOUT_GID` | `dialout` (group name)        | Host GID for the `dialout` group (serial ports)      |
-| `PLUGDEV_GID` | `plugdev` (group name)        | Host GID for the `plugdev` group (USB devices)       |
-| `HTTP_PROXY`  | *(empty)*                     | HTTP proxy for builds and runtime                    |
-| `HTTPS_PROXY` | *(empty)*                     | HTTPS proxy for builds and runtime                   |
-| `NO_PROXY`    | *(empty)*                     | Proxy exclusion list                                 |
+| Variable           | Default                       | Description                                              |
+|--------------------|-------------------------------|----------------------------------------------------------|
+| `COMPOSE_PROFILES` | `cpu`                         | Hardware profile: `cpu`, `xpu`, or `cuda`                |
+| `PORT`             | `7860`                        | Host port to expose the web UI and API                   |
+| `REGISTRY`         | `ghcr.io/open-edge-platform/` | Container image registry                                 |
+| `IMAGE_TAG`        | `latest`                      | Image version tag                                        |
+| `APP_UID`          | `1000`                        | UID for the in-container user (match your host user)     |
+| `APP_GID`          | `1000`                        | GID for the in-container user (match your host user)     |
+| `VIDEO_GID`        | `video` (group name)          | Host GID for the `video` group (cameras)                 |
+| `DIALOUT_GID`      | `dialout` (group name)        | Host GID for the `dialout` group (serial ports)          |
+| `PLUGDEV_GID`      | `plugdev` (group name)        | Host GID for the `plugdev` group (USB devices)           |
+| `RENDER_GID`       | `render` (group name)         | Host GID for the `render` group (Intel GPU, XPU only)    |
+| `HTTP_PROXY`       | *(empty)*                     | HTTP proxy for builds and runtime                        |
+| `HTTPS_PROXY`      | *(empty)*                     | HTTPS proxy for builds and runtime                       |
+| `NO_PROXY`         | *(empty)*                     | Proxy exclusion list                                     |
 
 ## Hardware Targets
 
 The Docker image is built in multiple variants, one per hardware backend.
-The correct variant is selected automatically based on `AI_DEVICE`.
+The correct variant is selected automatically via Docker Compose profiles
+(`COMPOSE_PROFILES` in `.env` or `--profile` on the command line).
 
-| Build target       | `AI_DEVICE` | Additional system packages                 |
-|--------------------|-------------|--------------------------------------------|
-| `physical-ai-studio-cpu`  | `cpu`       | None                                       |
-| `physical-ai-studio-xpu`  | `xpu`       | Intel GPU runtime (Level Zero, OpenCL, VA) |
-| `physical-ai-studio-cuda` | `cuda`      | CUDA 12.8 runtime (cudart, cuBLAS, cuDNN)  |
+| Profile | Service name                  | Additional system packages                 |
+|---------|-------------------------------|--------------------------------------------|
+| `cpu`   | `physical-ai-studio-cpu`      | None                                       |
+| `xpu`   | `physical-ai-studio-xpu`      | Intel GPU runtime (Level Zero, OpenCL, VA) |
+| `cuda`  | `physical-ai-studio-cuda`     | CUDA 12.8 runtime (cudart, cuBLAS, cuDNN)  |
 
 ## Hardware Access
 
@@ -97,9 +103,9 @@ This is the easiest option and is recommended for development and prototyping.
 ### Option 2: Non-Privileged Mode (more secure)
 
 For production or shared environments, you can restrict the container to only
-the specific devices it needs. Edit `docker-compose.yaml`:
+the specific devices it needs. Edit the relevant service in `docker-compose.yaml`:
 
-1. Comment out `privileged: true`
+1. Comment out `privileged: true` in the `x-common` anchor
 2. Uncomment the `devices` section and adjust the device paths to match your
    hardware:
 
@@ -114,6 +120,20 @@ devices:
    - /dev/video2:/dev/video2
    # Intel RealSense (uncomment if needed)
    # - /dev/bus/usb:/dev/bus/usb
+```
+
+For **Intel XPU** in non-privileged mode, you also need to uncomment the
+`group_add` and `devices` overrides in the `physical-ai-studio-xpu` service
+to grant access to `/dev/dri/renderD*` render nodes:
+
+```yaml
+group_add:
+  - "${DIALOUT_GID:-dialout}"
+  - "${PLUGDEV_GID:-plugdev}"
+  - "${VIDEO_GID:-video}"
+  - "${RENDER_GID:-render}"   # Intel GPU render nodes
+devices:
+  - /dev/dri:/dev/dri         # Intel GPU device nodes
 ```
 
 ### Device Group Setup (non-Debian hosts)
@@ -135,11 +155,12 @@ Run the setup script to auto-detect your host's GIDs and write them to `.env`:
 
 The script detects `VIDEO_GID`, `DIALOUT_GID`, and `PLUGDEV_GID`, checks
 whether your user is a member of each group, and warns you if you need to
-add yourself:
+add yourself. For Intel XPU, also ensure your user is in the `render` group:
 
 ```bash
 sudo usermod -aG video $USER
 sudo usermod -aG dialout $USER
+sudo usermod -aG render $USER   # Intel XPU only
 # Log out and back in for group changes to take effect
 ```
 
@@ -184,20 +205,20 @@ docker compose down -v
 To build the Docker image locally instead of pulling a pre-built image:
 
 ```bash
-# Build for CPU (default)
+# Build for CPU (default profile)
 docker compose build
 
 # Build for Intel XPU
-AI_DEVICE=xpu docker compose build
+docker compose --profile xpu build
 
 # Build for NVIDIA CUDA
-AI_DEVICE=cuda docker compose build
+docker compose --profile cuda build
 ```
 
 The Dockerfile uses a multi-stage build. The build context is the repository
-root, and the image is built with the target `physical-ai-studio-${AI_DEVICE}`.
-Proxy environment variables from `.env` are passed as build arguments
-automatically.
+root. Each profiled service targets the corresponding Dockerfile stage
+(e.g. `physical-ai-studio-cuda`). Proxy environment variables from `.env`
+are passed as build arguments automatically.
 
 ## Troubleshooting
 
@@ -216,17 +237,22 @@ in `.env`.
 
 ### `ERROR: could not select device driver "" with capabilities: [[gpu]]`
 
-The NVIDIA Container Toolkit is not installed or not configured. Follow the
+This error only applies to the `cuda` profile. The NVIDIA Container Toolkit
+is not installed or not configured. Follow the
 [installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
-and restart the Docker daemon.
+and restart the Docker daemon. If you are not using an NVIDIA GPU, make sure
+`COMPOSE_PROFILES` is set to `cpu` or `xpu` in your `.env` file.
 
 ### Out of shared memory (`RuntimeError: DataLoader worker ... is killed`)
 
-The default `shm_size` is set to 2 GB. If you still encounter shared memory
-errors with large datasets, increase it in `docker-compose.yaml`:
+The default configuration uses `ipc: host`, which shares the host's
+`/dev/shm` (typically 50% of system RAM on Linux). This should be sufficient
+for most workloads. If you cannot use `ipc: host` (e.g. in a multi-tenant
+environment), comment it out and set an explicit `shm_size` instead:
 
 ```yaml
-shm_size: 4g  # or higher
+# ipc: host
+shm_size: 16g  # adjust based on available RAM
 ```
 
 ### Proxy issues during build or runtime

--- a/application/docker/docker-compose.yaml
+++ b/application/docker/docker-compose.yaml
@@ -1,10 +1,25 @@
+# ================================================================
+# Physical AI Studio — Docker Compose
+#
+# Uses Docker Compose profiles to select the hardware backend.
+# Set COMPOSE_PROFILES in your .env file (cpu, xpu, or cuda)
+# or pass --profile on the command line:
+#
+#   docker compose --profile cpu up      # CPU (default)
+#   docker compose --profile xpu up      # Intel XPU
+#   docker compose --profile cuda up     # NVIDIA CUDA
+#
+# ================================================================
+
 services:
-  physical-ai-studio:
-    image: ${REGISTRY:-ghcr.io/open-edge-platform/}physical-ai-studio-${AI_DEVICE:-cpu}:${IMAGE_TAG:-main}
+  physical-ai-studio-cpu:
+    profiles: [cpu]
+    container_name: physical-ai-studio
+    image: ${REGISTRY:-ghcr.io/open-edge-platform/}physical-ai-studio-cpu:${IMAGE_TAG:-main}
     build:
       context: ../../
       dockerfile: application/docker/Dockerfile
-      target: physical-ai-studio-${AI_DEVICE:-cpu}
+      target: physical-ai-studio-cpu
       additional_contexts:
         libs: ../../library
       args:
@@ -17,7 +32,7 @@ services:
         - https_proxy=${https_proxy}
         - no_proxy=${no_proxy}
     ports:
-      - "${PORT:-7860}:7860"
+      - "${PORT:-7860}:${PORT:-7860}"
     environment:
       - HOST=${HOST:-0.0.0.0}
       - PORT=${PORT:-7860}
@@ -26,10 +41,25 @@ services:
         required: false
     restart: unless-stopped
     stop_grace_period: 35s
-    # PyTorch DataLoader workers need shared memory (/dev/shm) beyond Docker's 64 MB default
-    shm_size: 2g
+
+    # PyTorch DataLoader workers need shared memory (/dev/shm) beyond
+    # Docker's 64 MB default. Using ipc: host shares the host's /dev/shm
+    # (typically 50% of system RAM on Linux), so it scales automatically
+    # with available memory and works across different hardware configs.
+    #
+    # If you prefer an isolated, fixed-size allocation instead, comment
+    # out "ipc: host" and uncomment the line below:
+    # shm_size: 16g
+    ipc: host
+
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:${PORT:-7860}/api/health')"]
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:${PORT:-7860}/api/health')",
+        ]
       interval: 30s
       timeout: 10s
       start_period: 60s
@@ -50,9 +80,9 @@ services:
     # ============================================================
 
     group_add:
-      - "${DIALOUT_GID:-dialout}"   # serial ports (/dev/ttyACM*)
-      - "${PLUGDEV_GID:-plugdev}"   # pluggable USB devices
-      - "${VIDEO_GID:-video}"       # cameras & video (/dev/video*)
+      - "${DIALOUT_GID:-dialout}" # serial ports (/dev/ttyACM*)
+      - "${PLUGDEV_GID:-plugdev}" # pluggable USB devices
+      - "${VIDEO_GID:-video}" # cameras & video (/dev/video*)
 
     # Persisted data and storage volumes + shared robot calibration
     volumes:
@@ -60,13 +90,13 @@ services:
       - physical-ai-studio-storage:/app/storage
       - ${HOME}/.cache/huggingface/lerobot/calibration:/home/appuser/.cache/huggingface/lerobot/calibration:ro
 
-    # --- Option 1: Privileged mode (active by default) ---
+    # --- Option 1: Privileged mode (active by default)
     # Grants full access to all host devices. Easiest setup, but the
     # container runs with elevated privileges.
     # Also covers Intel RealSense cameras via /dev/bus/usb.
     privileged: true
 
-    # --- Option 2: Non-privileged mode (more secure) ---
+    # --- Option 2: Non-privileged mode (more secure)
     # Map only the specific devices the robot needs. More secure since
     # the container cannot access arbitrary host devices, but you must
     # update the device list whenever hardware changes.
@@ -83,6 +113,41 @@ services:
     #    - /dev/video4:/dev/video4
     #    # Intel RealSense cameras
     #    # - /dev/bus/usb:/dev/bus/usb
+
+  physical-ai-studio-xpu:
+    extends:
+      service: physical-ai-studio-cpu
+    profiles: [xpu]
+    container_name: physical-ai-studio
+    image: ${REGISTRY:-ghcr.io/open-edge-platform/}physical-ai-studio-xpu:${IMAGE_TAG:-main}
+    build:
+      target: physical-ai-studio-xpu
+    # --- Non-privileged XPU additions
+    # When running in non-privileged mode, add these to grant
+    # Intel GPU access via /dev/dri/renderD* nodes:
+    # group_add:
+    #   - "${DIALOUT_GID:-dialout}"
+    #   - "${PLUGDEV_GID:-plugdev}"
+    #   - "${VIDEO_GID:-video}"
+    #   - "${RENDER_GID:-render}"   # Intel GPU render nodes
+    # devices:
+    #   - /dev/dri:/dev/dri         # Intel GPU device nodes
+
+  physical-ai-studio-cuda:
+    extends:
+      service: physical-ai-studio-cpu
+    profiles: [cuda]
+    container_name: physical-ai-studio
+    image: ${REGISTRY:-ghcr.io/open-edge-platform/}physical-ai-studio-cuda:${IMAGE_TAG:-main}
+    build:
+      target: physical-ai-studio-cuda
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
 
 volumes:
   physical-ai-studio-data:


### PR DESCRIPTION
This PR fixes some issues with our compose setup that I found out while deploying the application to some remote servers. The previous docker-compose.yaml had two problems:

1. We did not add `deploy.resources.reservatin` for NVIDIA deployments. Making the container unaware of NVIDIA gpu. Before when testing this on my workstation I didn't encounter this problem as it had setup the NVIDIA container runtime as the default.
2. shm_size was hardcoded to 2g, which was too low: it could prevent us from performing training with high batch sizes.

To fix this we replace the single service with three profiled services (cpu, xpu, cuda) Each profile only includes the hardware-specific settings it needs:
- cpu: no GPU resources
- xpu: commented-out /dev/dri + render group for non-privileged mode
- cuda: NVIDIA GPU reservation via deploy.resources

The AI_DEVICE env var is replaced by COMPOSE_PROFILES, a built-in Docker Compose variable. Users set it once in .env (e.g. COMPOSE_PROFILES=cuda) and all subsequent docker compose commands use the correct profile automatically, without needing to prefix every command.

Replace shm_size: 2g with ipc: host, which shares the host's /dev/shm. This scales automatically with available memory instead of requiring a fixed allocation that may be too large or too small for the host machine.

## Type of Change

- [x] ✨ `feat` - New feature
- [x] ♻️ `refactor` - Code refactoring