### PR TITLE
chore: Run `npm audit fix` to resolve build tools CVE

### DIFF
--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -9527,16 +9527,6 @@
                 "@testing-library/dom": ">=7.21.4"
             }
         },
-        "node_modules/@trysound/sax": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-            "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/@tweenjs/tween.js": {
             "version": "23.1.3",
             "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -14656,9 +14646,9 @@
             "license": "MIT"
         },
         "node_modules/immutable": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-            "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
             "dev": true,
             "license": "MIT"
         },
@@ -18960,6 +18950,16 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/sax": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+            "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
+        },
         "node_modules/saxes": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -19565,19 +19565,19 @@
             "license": "MIT"
         },
         "node_modules/svgo": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-            "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
+            "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
                 "css-select": "^5.1.0",
                 "css-tree": "^2.3.1",
                 "css-what": "^6.1.0",
                 "csso": "^5.0.5",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.0.0",
+                "sax": "^1.5.0"
             },
             "bin": {
                 "svgo": "bin/svgo"


### PR DESCRIPTION
Run `npm audit fix` to resolve a CVE in our build tools that is not applicable to the application.

## Type of Change

- [x] 🔧 `chore` - Maintenance