### PR TITLE
chore(ci): enable npm lock regeneration by Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -129,11 +129,10 @@
       matchDepNames: ["docker/dockerfile"],
     },
 
-    // Disable non-security and lock file upgrades for npm
-    // Lock is updated manually
+    // Disable non-security upgrades for npm, except lock file update
     {
       enabled: false,
-      matchManagers: ["npm"],
+      matchDatasources: ["npm"],
     },
 
     // NPM version in package.json is updated manually


### PR DESCRIPTION
# Pull Request

This PR updates Renovate settings to enable lock file regeneration for NPM.

## Type of Change

- [x] 🔧 `chore` - Maintenance