### PR TITLE
fix: use higher-level import to get trainer in CLI

### DIFF
--- a/library/src/physicalai/cli/cli.py
+++ b/library/src/physicalai/cli/cli.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 r"""Unified CLI for physicalai extending LightningCLI with benchmark support.
@@ -55,7 +55,7 @@ from lightning.pytorch.cli import LightningArgumentParser, LightningCLI
 
 from physicalai.data import DataModule
 from physicalai.policies.base import Policy
-from physicalai.train.trainer import Trainer
+from physicalai.train import Trainer
 
 if TYPE_CHECKING:
     from physicalai.benchmark import Benchmark


### PR DESCRIPTION
# Pull Request

## Description

Trainer should be imported from a higher-level package when text prompts for accelerator and device are used.

## Type of Change

- [x] 🐞 `fix` - Bug fix

## Related Issues

Resolves https://github.com/open-edge-platform/physical-ai-studio/issues/336