### PR TITLE
fix: disable environment form when no robot or cameras

### DIFF
--- a/application/ui/src/features/robots/environment-form/provider.tsx
+++ b/application/ui/src/features/robots/environment-form/provider.tsx
@@ -18,12 +18,8 @@ export type EnvironmentFormState = EnvironmentForm | null;
 export const EnvironmentFormContext = createContext<EnvironmentFormState>(null);
 export const SetEnvironmentFormContext = createContext<Dispatch<SetStateAction<EnvironmentForm>> | null>(null);
 
-export const useEnvironmentFormBody = (environment_id: string): SchemaEnvironmentInput | null => {
+export const useEnvironmentFormBody = (environment_id: string) => {
     const environmentForm = useEnvironmentForm();
-
-    if (environmentForm === undefined) {
-        return null;
-    }
 
     return {
         id: environment_id,
@@ -41,7 +37,7 @@ export const useEnvironmentFormBody = (environment_id: string): SchemaEnvironmen
                         : { type: 'none' },
             };
         }),
-    };
+    } satisfies SchemaEnvironmentInput;
 };
 
 export const EnvironmentFormProvider = ({

--- a/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
+++ b/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
@@ -15,14 +15,15 @@ export const SubmitNewEnvironmentButton = () => {
 
     const environment_id = uuidv4();
     const body = useEnvironmentFormBody(environment_id);
+    const isDisabled = body.name.length === 0 || body.robots.length === 0 || body.camera_ids.length === 0;
 
     return (
         <Button
             variant='accent'
             isPending={addEnvironmentMutation.isPending}
-            isDisabled={body === null}
+            isDisabled={isDisabled}
             onPress={async () => {
-                if (body === null) {
+                if (isDisabled) {
                     return;
                 }
 

--- a/application/ui/src/features/robots/environment-form/update-environment-button.tsx
+++ b/application/ui/src/features/robots/environment-form/update-environment-button.tsx
@@ -15,14 +15,15 @@ export const UpdateEnvironmentButton = () => {
         '/api/projects/{project_id}/environments/{environment_id}'
     );
     const body = useEnvironmentFormBody(environment_id);
+    const isDisabled = body.name.length === 0 || body.robots.length === 0 || body.camera_ids.length === 0;
 
     return (
         <Button
             variant='accent'
             isPending={updateEnvironmentsMutation.isPending}
-            isDisabled={body === null}
+            isDisabled={isDisabled}
             onPress={async () => {
-                if (body === null) {
+                if (isDisabled) {
                     return;
                 }
 


### PR DESCRIPTION
This PR fixes a minor bug where it's possible to configure, and then record, an environment without any robots or cameras.
This mainly was due to a bad UX (that we still have) in that it's not always obvious that you need to press the "Add" button. I'd like to reconsider this UX in a follow up PR.

## Type of Change

- [x] 🐞 `fix` - Bug fix