### PR TITLE
fix: fix elapsed time since model training

### DIFF
--- a/application/ui/src/routes/models/utils.ts
+++ b/application/ui/src/routes/models/utils.ts
@@ -14,5 +14,9 @@ export const durationBetween = (start: string, end: string): string => {
 };
 
 export const elapsedSince = (dateString: string): string => {
-    return formatDuration(new Date().getTime() - new Date(dateString).getTime());
+    const normalized = /Z|[+-]\d\d:\d\d$/.test(dateString) ? dateString : `${dateString}Z`;
+
+    const startDate = new Date(normalized).getTime();
+
+    return formatDuration(new Date().getTime() - startDate);
 };


### PR DESCRIPTION
Previously we didn't take into account the timezone of our `created_at` etc fields. With this change we still don't really do this (the backend isn't sending this info, yet) but we are defaulting to UTC+0 which is the same the server uses.

Long term we should change the return fields of the server to return UTC strings with timezone information (RFC3339 / ISO-8601), however this requires some extra effort that I'd rather do in a separate PR.

## Type of Change

- [x] 🐞 `fix` - Bug fix

## Reproduction steps

Start model training when not in UTC+0 timezone, e.g. UTC+1, and you will see that elapsed time immediately assumes 1 hour has already passed.