### PR TITLE
fix: skip invalidation of queries when loading urdf model

### DIFF
--- a/application/ui/src/features/robots/robot-models-context.tsx
+++ b/application/ui/src/features/robots/robot-models-context.tsx
@@ -128,5 +128,6 @@ export const useLoadModelMutation = () => {
         onSuccess: async (model) => {
             setModel(pathRef.current, model);
         },
+        meta: { skipInvalidation: true },
     });
 };


### PR DESCRIPTION
This fixes an issue where we were too eagerly invalidating cache whenever a robot model was loaded.
Specifically this was also being triggered in the dataset view which then triggered multiple refetches of dataset and video queries.

## Type of Change

- [x] 🐞 `fix` - Bug fix