### PR TITLE
fix: prevent camera canvas from growing outside its container

### DIFF
--- a/application/ui/src/features/cameras/websocket-camera.tsx
+++ b/application/ui/src/features/cameras/websocket-camera.tsx
@@ -5,10 +5,27 @@ import useWebSocket from 'react-use-websocket';
 
 import { fetchClient } from '../../api/client';
 import { SchemaProjectCamera } from '../../api/types';
+import { useContainerSize } from '../../components/zoom/use-container-size';
 
 const CAMERA_WS_URL = fetchClient.PATH('/api/cameras/ws');
 
-export const WebsocketCamera = ({ camera }: { camera: SchemaProjectCamera }) => {
+const calculateCanvasDimensions = (containerSize: { width: number; height: number }, aspectRatio: number) => {
+    const containerAspectRatio = containerSize.width / containerSize.height;
+
+    if (containerAspectRatio > aspectRatio) {
+        return {
+            width: containerSize.height * aspectRatio,
+            height: containerSize.height,
+        };
+    } else {
+        return {
+            width: containerSize.width,
+            height: containerSize.width / aspectRatio,
+        };
+    }
+};
+
+const CameraCanvas = ({ camera, width, height }: { camera: SchemaProjectCamera; width: number; height: number }) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [isLoading, setIsLoading] = useState(true);
     const processingRef = useRef(false);
@@ -89,16 +106,25 @@ export const WebsocketCamera = ({ camera }: { camera: SchemaProjectCamera }) => 
             )}
             <canvas
                 ref={canvasRef}
-                width={Number(camera.payload?.width)}
-                height={Number(camera.payload?.height)}
-                style={{
-                    display: isLoading ? 'none' : 'block',
-                    objectFit: 'contain',
-                    height: '100%',
-                    width: '100%',
-                }}
+                width={width}
+                height={height}
+                style={{ display: isLoading ? 'none' : 'block' }}
                 aria-label={`Camera: ${camera.name}`}
             />
         </>
+    );
+};
+
+export const WebsocketCamera = ({ camera }: { camera: SchemaProjectCamera }) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const containerSize = useContainerSize(ref);
+
+    const cameraAspectRatio = Number(camera.payload?.width) / Number(camera.payload?.height);
+    const { width, height } = calculateCanvasDimensions(containerSize, cameraAspectRatio);
+
+    return (
+        <div ref={ref} style={{ height: '100%', width: '100%' }}>
+            <CameraCanvas camera={camera} width={width} height={height} />
+        </div>
     );
 };

--- a/application/ui/src/features/robots/environment-form/cells/camera-cell.tsx
+++ b/application/ui/src/features/robots/environment-form/cells/camera-cell.tsx
@@ -1,5 +1,3 @@
-import { View } from '@geti/ui';
-
 import { $api } from '../../../../api/client';
 import { WebsocketCamera } from '../../../cameras/websocket-camera';
 import { useProjectId } from '../../../projects/use-project';
@@ -9,11 +7,6 @@ export const CameraCell = ({ camera_id }: { camera_id: string }) => {
     const cameraQuery = $api.useSuspenseQuery('get', '/api/projects/{project_id}/cameras/{camera_id}', {
         params: { path: { project_id, camera_id } },
     });
-    return (
-        <View backgroundColor={'gray-500'}>
-            <View maxHeight='100%' height='100%' position='relative'>
-                <WebsocketCamera camera={cameraQuery.data} />
-            </View>
-        </View>
-    );
+
+    return <WebsocketCamera camera={cameraQuery.data} />;
 };


### PR DESCRIPTION
Use the aspect ratio of the container and the camera to figure out the correct dimensions of the canvas so that it always fits inside of a dockview cell.
This is especially useful after #389 as with that PR we will add these camera views to the dataset recording and inference pages.

## Type of Change

- [x] 🐞 `fix` - Bug fix