### PR TITLE
feat: show total recorded (stored and draft) episodes while recording 

### DIFF
--- a/application/backend/src/workers/robot_control_worker.py
+++ b/application/backend/src/workers/robot_control_worker.py
@@ -30,6 +30,7 @@ class RobotControlState(BaseModel):
     environment_loaded: bool = False
     is_recording: bool = False
     follower_source: Literal["model", "teleoperation"] | None = None
+    episodes_recorded: int = 0
 
 
 class WorkerEvents:
@@ -242,6 +243,7 @@ class RobotControlWorker(BaseThreadWorker):
             self.events.save_episode.clear()
             self.recording_mutation.save_episode()
             self.state.is_recording = False
+            self.state.episodes_recorded += 1
             self._report_state()
 
     async def _handle_discard_episode(self) -> None:

--- a/application/backend/tests/workers/test_robot_control_worker.py
+++ b/application/backend/tests/workers/test_robot_control_worker.py
@@ -137,6 +137,7 @@ class TestRobotControlWorker:
         assert report["data"] == {
             "task": None,
             "model_loaded": False,
+            "episodes_recorded": 0,
             "environment_loaded": False,
             "is_recording": False,
             "dataset_loaded": False,
@@ -274,6 +275,7 @@ class TestRobotControlWorker:
         worker.save_episode()
         report = wait_until_message_from_queue(worker.queue, "state")
         assert not report["data"]["is_recording"]
+        assert report["data"]["episodes_recorded"] == 1
         recording_mutation.save_episode.assert_called()
         worker.disconnect()
         worker.join()

--- a/application/ui/src/features/robots/robot-control-provider.tsx
+++ b/application/ui/src/features/robots/robot-control-provider.tsx
@@ -16,6 +16,7 @@ interface RobotControlState {
     is_recording: boolean;
     dataset_loaded: boolean;
     follower_source: FollowerSource;
+    episodes_recorded: number;
 }
 
 const createRobotControlState = (): RobotControlState => {
@@ -27,6 +28,7 @@ const createRobotControlState = (): RobotControlState => {
         error: false,
         is_recording: false,
         follower_source: null,
+        episodes_recorded: 0,
     };
 };
 

--- a/application/ui/src/routes/datasets/record/index.module.scss
+++ b/application/ui/src/routes/datasets/record/index.module.scss
@@ -9,3 +9,15 @@
     font-size: var(--spectrum-global-dimension-font-size-50);
     color: var(--spectrum-global-color-gray-900);
 }
+
+.episodesText {
+    font-weight: 300;
+    font-size: var(--spectrum-global-dimension-font-size-50);
+    color: var(--spectrum-global-color-gray-700);
+}
+
+.episodesCount {
+    font-size: var(--spectrum-global-dimension-font-size-100);
+    color: var(--spectrum-global-color-gray-900);
+    text-align: right;
+}

--- a/application/ui/src/routes/datasets/record/index.tsx
+++ b/application/ui/src/routes/datasets/record/index.tsx
@@ -1,15 +1,66 @@
 import { Suspense } from 'react';
 
-import { Flex, Grid, Icon, Link, Loading, Text, ToastQueue, View } from '@geti/ui';
+import {
+    Content,
+    ContextualHelp,
+    Flex,
+    Footer,
+    Grid,
+    Heading,
+    Icon,
+    Link,
+    Loading,
+    Text,
+    ToastQueue,
+    View,
+} from '@geti/ui';
 import { ChevronLeft } from '@geti/ui/icons';
 
 import { $api } from '../../../api/client';
 import { useDatasetId } from '../../../features/datasets/use-dataset';
-import { RobotControlProvider } from '../../../features/robots/robot-control-provider';
+import { RobotControlProvider, useRobotControl } from '../../../features/robots/robot-control-provider';
 import { paths } from '../../../router';
 import { RecordingViewer } from './recording-viewer';
 
 import classes from './index.module.scss';
+
+const TotalRecordedEpisodes = () => {
+    const { dataset_id } = useDatasetId();
+    const { state } = useRobotControl();
+
+    const episodeQuery = $api.useSuspenseQuery('get', '/api/dataset/{dataset_id}/episodes', {
+        params: {
+            path: {
+                dataset_id,
+            },
+        },
+    });
+    const totalEpisodes = Number(episodeQuery.data?.length) + state.episodes_recorded;
+
+    if (totalEpisodes === 0 || isNaN(totalEpisodes)) {
+        return null;
+    }
+
+    return (
+        <Flex direction='column' justifyContent={'space-between'} gap='size-50'>
+            <Flex alignItems={'center'} gap='size-50'>
+                <Text UNSAFE_className={classes.episodesText}>Total episodes recorded</Text>
+                <ContextualHelp variant='info'>
+                    <Heading>Recommended amount of episodes</Heading>
+                    <Content>
+                        <Text>We recommend recording at least 50 episodes before training your first model.</Text>
+                    </Content>
+                    <Footer>
+                        <Link href='https://github.com/open-edge-platform/physical-ai-studio/issues/358'>
+                            Learn more about segments
+                        </Link>
+                    </Footer>
+                </ContextualHelp>
+            </Flex>
+            <span className={classes.episodesCount}>{totalEpisodes}</span>
+        </Flex>
+    );
+};
 
 const RecordingPage = () => {
     const { project_id, dataset_id } = useDatasetId();
@@ -34,7 +85,6 @@ const RecordingPage = () => {
             },
         }
     );
-
     return (
         <RobotControlProvider environment={environment} dataset={dataset} onError={ToastQueue.negative}>
             <Grid
@@ -46,7 +96,13 @@ const RecordingPage = () => {
                 height={'100%'}
             >
                 <View backgroundColor={'gray-300'} gridArea={'header'}>
-                    <Flex height='100%' alignItems={'center'} marginX='1rem' gap='size-200'>
+                    <Flex
+                        height='100%'
+                        alignItems={'center'}
+                        marginX='1rem'
+                        gap='size-200'
+                        justifyContent={'space-between'}
+                    >
                         <Link
                             href={paths.project.datasets.show({ project_id, dataset_id })}
                             isQuiet
@@ -64,6 +120,7 @@ const RecordingPage = () => {
                                 </Flex>
                             </Flex>
                         </Link>
+                        <TotalRecordedEpisodes />
                     </Flex>
                 </View>
 


### PR DESCRIPTION
Show the total recorded episodes while recording new episodes. 
A contextual help icon is shown with a recommendation for the amount of episodes to record that also links to #358 as a source of more information.

## Type of Change

- [x] ✨ `feat` - New feature

## Screenshots

| **Recording** | **Help** |
|------------|-----------|
| <img width="1920" height="1080" alt="192 168 2 117_3000_projects_c8f88cf5-20b7-4d82-a5b6-c9e441f336f4_datasets_121a2473-2d65-46b8-9ea0-9976a73ae9ea_record(Full HD)" src="https://github.com/user-attachments/assets/8bb0f63f-18eb-4624-812c-df25c0de4f61" />           |  <img width="1920" height="1080" alt="192 168 2 117_3000_projects_c8f88cf5-20b7-4d82-a5b6-c9e441f336f4_datasets_121a2473-2d65-46b8-9ea0-9976a73ae9ea_record(Full HD) (1)" src="https://github.com/user-attachments/assets/75ea25ba-31ce-4ee3-9158-d99f68db5299" />         |





