### PR TITLE
fix: LR Collapse for SmolVLA and Pi05

### DIFF
--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -455,12 +455,13 @@ class Pi05(ExportablePolicyMixin, Policy):
         drop_steps = self.config.scheduler_decay_steps
         decay_value = self.config.scheduler_decay_lr
 
+        decay_ratio = decay_value / self.config.optimizer_lr
+
         def lr_lambda(step: int) -> float:
-            num_drops = step // drop_steps
-            decay_factor = decay_value**num_drops
             if step < warmup_steps:
                 return step / max(1, warmup_steps)
-            return decay_factor
+            num_drops = (step - warmup_steps) // drop_steps
+            return decay_ratio**num_drops
 
         scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -375,12 +375,13 @@ class SmolVLA(ExportablePolicyMixin, Policy):
         drop_steps = self.config.scheduler_decay_steps
         decay_value = self.config.scheduler_decay_lr
 
+        decay_ratio = decay_value / self.config.optimizer_lr
+
         def lr_lambda(step: int) -> float:
-            num_drops = step // drop_steps
-            decay_factor = decay_value**num_drops
             if step < warmup_steps:
                 return step / max(1, warmup_steps)
-            return decay_factor
+            num_drops = (step - warmup_steps) // drop_steps
+            return decay_ratio**num_drops
 
         scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 


### PR DESCRIPTION
# Pull Request

## Description

With the current code, after warmup, the learning rate instantly drops to 2.5e-6 at step 30,000, then to (2.5e-6)^2 = 6.25e-12 at step 60,000, and so on. After just two drops, the learning rate is essentially zero.

N.B I think the name decay_lr is a bit misleading. In this code I assume it's the target LR? So I calculate a decay factor `decay_factor = decay_value / optimizer_lr` In order to find a reasonable factor. Perhaps we should change this?

Essentially we had an exponent which collapsed the value of the LR after two drops.

```python
optimizer_lr = 2.5e-5
decay_value = 2.5e-6
warmup_steps = 1_000
drop_steps = 30_000
decay_ratio = decay_value / optimizer_lr


def lr_lambda_old(step: int) -> float:
    num_drops = step // drop_steps
    decay_factor = decay_value**num_drops  # <-- after two drops very small
    if step < warmup_steps:
        return step / max(1, warmup_steps)
    return decay_factor


def lr_lambda_new(step: int) -> float:
    if step < warmup_steps:
        return step / max(1, warmup_steps)
    num_drops = (step - warmup_steps) // drop_steps
    return decay_ratio**num_drops
```

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

#403 

## Breaking Changes

-

---

-

## Examples

I can't train 30_000 steps in any reasonable time without a GPU but here is some fake LR code to test the two approaches:

```python
"""
Verifies the fixed lr_lambda produces correct step-decay behaviour.

Config values mirror the pi05/smolvla YAML:
  optimizer_lr       = 2.5e-5
  scheduler_decay_lr = 2.5e-6   (target LR after first drop => ratio 0.1)
  scheduler_decay_steps = 30_000
  scheduler_warmup_steps = 1_000
"""

import torch

optimizer_lr = 2.5e-5
decay_value = 2.5e-6
warmup_steps = 1_000
drop_steps = 30_000
decay_ratio = decay_value / optimizer_lr


def lr_lambda_old(step: int) -> float:
    num_drops = step // drop_steps
    decay_factor = decay_value**num_drops
    if step < warmup_steps:
        return step / max(1, warmup_steps)
    return decay_factor


def lr_lambda_new(step: int) -> float:
    if step < warmup_steps:
        return step / max(1, warmup_steps)
    num_drops = (step - warmup_steps) // drop_steps
    return decay_ratio**num_drops


def make_scheduler(lr_lambda):
    param = torch.nn.Parameter(torch.zeros(1))
    opt = torch.optim.AdamW([param], lr=optimizer_lr)
    return torch.optim.lr_scheduler.LambdaLR(opt, lr_lambda), opt


def get_lr(opt):
    return opt.param_groups[0]["lr"]


def advance(scheduler, opt, to_step, from_step=0):
    for _ in range(to_step - from_step):
        scheduler.step()
    return get_lr(opt)


# test
checkpoints = {
    "step 0 (start)": 0,
    "step 500 (mid-warmup)": 500,
    "step 1000 (end of warmup)": 1_000,
    "step 31000 (after 1st drop)": 31_000,
    "step 61000 (after 2nd drop)": 61_000,
    "step 91000 (after 3rd drop)": 91_000,
}

print(f"{'Step':<35} {'OLD lr':>14} {'NEW lr':>14}  PASS?")
print("-" * 70)

sched_old, opt_old = make_scheduler(lr_lambda_old)
sched_new, opt_new = make_scheduler(lr_lambda_new)

prev = 0
failures = []
for label, step in checkpoints.items():
    lr_old = advance(sched_old, opt_old, step, prev)
    lr_new = advance(sched_new, opt_new, step, prev)
    prev = step

    # Expected new LR
    if step < warmup_steps:
        expected = optimizer_lr * (step / max(1, warmup_steps))
    else:
        n = (step - warmup_steps) // drop_steps
        expected = optimizer_lr * (decay_ratio**n)

    ok = abs(lr_new - expected) < 1e-20
    if not ok:
        failures.append(label)

    print(f"{label:<35} {lr_old:>14.3e} {lr_new:>14.3e}  {'OK' if ok else 'FAIL'}")
```

Output:

```bash
Step                                        OLD lr         NEW lr  PASS?
----------------------------------------------------------------------
step 0 (start)                           0.000e+00      0.000e+00  OK
step 500 (mid-warmup)                    1.250e-05      1.250e-05  OK
step 1000 (end of warmup)                2.500e-05      2.500e-05  OK
step 31000 (after 1st drop)              6.250e-11      2.500e-06  OK
step 61000 (after 2nd drop)              1.563e-16      2.500e-07  OK
step 91000 (after 3rd drop)              3.906e-22      2.500e-08  OK
```

## Screenshots

-