### PR TITLE
fix: Pi0 pad images with zeros

### DIFF
--- a/library/src/physicalai/policies/pi0/preprocessor.py
+++ b/library/src/physicalai/policies/pi0/preprocessor.py
@@ -210,7 +210,7 @@ class Pi0Preprocessor(torch.nn.Module):
         pad_w0, rem_w = divmod(width - new_w, 2)
         pad_w1 = pad_w0 + rem_w
 
-        padded = F.pad(resized, (pad_w0, pad_w1, pad_h0, pad_h1), mode="constant", value=-1.0)
+        padded = F.pad(resized, (pad_w0, pad_w1, pad_h0, pad_h1), mode="constant", value=0.0)
 
         if channels_last:
             padded = padded.permute(0, 2, 3, 1)


### PR DESCRIPTION
# Pull Request

## Description

In the Pi0 preprocessor, padding is applied before the normalization step (img * 2.0 - 1.0). As a result, padded pixels (which have a value of -1.0) are also passed through this transformation, producing -3.0. This pushes those values outside the intended valid range of [-1, 1].

This is in keeping with Pi05 and SmolVLA implementations. Also follows LeRobot implementation: https://github.com/huggingface/lerobot/blob/main/src/lerobot/policies/pi0/modeling_pi0.py#L160-L161.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

#405 

## Breaking Changes

-

---

-

## Examples

-

## Screenshots

-
