### PR TITLE
refactor(inference): nested manifest with dual component resolution

### DIFF
--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -29,6 +29,8 @@ from physicalai.export.backends import (
 from physicalai.inference.manifest import (
     ComponentSpec,
     Manifest,
+    ModelSpec,
+    PolicySource,
     PolicySpec,
 )
 from physicalai.inference.runners.action_chunking import ActionChunking
@@ -112,7 +114,6 @@ class ExportablePolicyMixin:
 
         use_action_queue = metadata.get("use_action_queue", False)
         chunk_size = metadata.get("chunk_size", 1)
-        kind = "action_chunking" if use_action_queue else "single_pass"
 
         if use_action_queue:
             runner = ComponentSpec.from_class(
@@ -128,11 +129,12 @@ class ExportablePolicyMixin:
         return Manifest(
             policy=PolicySpec(
                 name=policy_name,
-                kind=kind,
-                class_path=policy_class,
+                source=PolicySource(class_path=policy_class),
             ),
-            artifacts={str(backend): artifact_filename},
-            runner=runner,
+            model=ModelSpec(
+                runner=runner,
+                artifacts={str(backend): artifact_filename},
+            ),
         )
 
     def _prepare_export_path(self, output_path: PathLike | str, extension: str) -> Path:

--- a/library/src/physicalai/inference/component_factory.py
+++ b/library/src/physicalai/inference/component_factory.py
@@ -7,8 +7,8 @@ The :class:`ComponentRegistry` maps short names (e.g. ``"single_pass"``)
 to fully-qualified class paths so that manifests can use concise
 identifiers instead of full dotted paths.  The :func:`instantiate_component`
 factory resolves a :class:`~physicalai.inference.manifest.ComponentSpec`
-to an object instance, consulting the registry when the ``class_path``
-contains no dot (i.e. is a short name).
+to an object instance, supporting both ``type`` + flat params and
+``class_path`` + ``init_args`` resolution modes.
 """
 
 from __future__ import annotations
@@ -101,6 +101,17 @@ component_registry.register("single_pass", "physicalai.inference.runners.SingleP
 component_registry.register("action_chunking", "physicalai.inference.runners.ActionChunking")
 
 
+def _import_class(class_path: str) -> type:
+    """Import and return a class from a fully-qualified dotted path.
+
+    Returns:
+        The imported class object.
+    """
+    module_path, class_name = class_path.rsplit(".", maxsplit=1)
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+
 def instantiate_component(
     spec: ComponentSpec,
     *,
@@ -108,35 +119,57 @@ def instantiate_component(
 ) -> object:
     """Import the class described by *spec* and return a live instance.
 
-    If ``spec.class_path`` is a registered short name in the *registry*,
-    it is resolved to the full class path before import.
+    Supports two resolution modes:
+
+    1. **class_path + init_args** — ``spec.class_path`` is resolved
+       (via registry if it's a short name) and the class is
+       instantiated with ``spec.init_args``.
+    2. **type + flat params** — ``spec.type`` is resolved via the
+       registry to a class path, and ``spec.flat_params`` are passed
+       as keyword arguments.
+
+    ``class_path`` takes precedence when both are present.
 
     Nested ``ComponentSpec`` dicts in ``init_args`` are instantiated
     recursively.
 
     Args:
-        spec: Component descriptor with class_path and init_args.
+        spec: Component descriptor with type or class_path.
         registry: Optional registry for short-name resolution.
             Defaults to :data:`component_registry`.
 
     Returns:
-        An instance of the class specified by spec.class_path.
+        An instance of the resolved class.
     """
     reg = registry or component_registry
-    class_path = reg.resolve(spec.class_path)
 
-    module_path, class_name = class_path.rsplit(".", maxsplit=1)
-    module = importlib.import_module(module_path)
-    cls_obj = getattr(module, class_name)
+    if spec.class_path:
+        resolved_path = reg.resolve(spec.class_path)
+        cls_obj = _import_class(resolved_path)
 
-    resolved_args: dict[str, object] = {}
-    for key, value in spec.init_args.items():
-        if isinstance(value, dict) and "class_path" in value:
-            resolved_args[key] = instantiate_component(
+        resolved_args: dict[str, object] = {}
+        for key, value in spec.init_args.items():
+            if isinstance(value, dict) and ("class_path" in value or "type" in value):
+                resolved_args[key] = instantiate_component(
+                    type(spec).model_validate(value),
+                    registry=reg,
+                )
+            else:
+                resolved_args[key] = value
+
+        return cls_obj(**resolved_args)
+
+    resolved_path = reg.resolve(spec.type)
+    cls_obj = _import_class(resolved_path)
+
+    resolved_params: dict[str, object] = {}
+    for key, value in spec.flat_params.items():
+        if isinstance(value, dict) and ("class_path" in value or "type" in value):
+            resolved_params[key] = instantiate_component(
                 type(spec).model_validate(value),
                 registry=reg,
             )
         else:
-            resolved_args[key] = value
+            resolved_params[key] = value
 
-    return cls_obj(**resolved_args)
+    return cls_obj(**resolved_params)

--- a/library/src/physicalai/inference/manifest.py
+++ b/library/src/physicalai/inference/manifest.py
@@ -5,12 +5,15 @@
 
 A manifest describes everything needed to reconstruct an inference
 pipeline from a directory of exported artifacts: which runner to
-use, which adapter, what shapes the hardware exposes, etc.
+use, what shapes the hardware exposes, etc.
 
-The on-disk format is ``manifest.json``.  The schema follows the
-``class_path`` + ``init_args`` convention (jsonargparse-style) so that
-domain layers can specify their own components without inferencekit
-needing to know about them.
+The on-disk format is ``manifest.json``.  Components support two
+resolution modes:
+
+1. **type + flat params** — short registry names with flat kwargs,
+   written by LeRobot and readable by both frameworks.
+2. **class_path + init_args** — fully-qualified class paths with nested
+   kwargs (jsonargparse-style), for full-power PhysicalAI usage.
 """
 
 from __future__ import annotations
@@ -20,10 +23,14 @@ import json
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 MANIFEST_VERSION = "1.0"
 MANIFEST_FORMAT = "policy_package"
+
+# Alias builtin ``type`` so it remains accessible inside classes that
+# define a Pydantic field with the same name (e.g. ``ComponentSpec.type``).
+_type = type
 
 
 class TensorSpec(BaseModel):
@@ -111,51 +118,82 @@ class CameraSpec(BaseModel):
         return v
 
 
+class PolicySource(BaseModel):
+    """Origin and training class for a policy.
+
+    Attributes:
+        repo_id: HuggingFace or Git repo identifier, e.g.
+            ``"lerobot/act_aloha_sim_transfer_cube_human"``.
+        class_path: Fully-qualified training class, e.g.
+            ``"physicalai.policies.act.policy.ACT"``.  Informational —
+            the inference runtime does not import this.
+    """
+
+    model_config = ConfigDict(frozen=True)
+    repo_id: str = ""
+    class_path: str = ""
+
+
 class PolicySpec(BaseModel):
     """Policy identity section.
 
     Attributes:
         name: Human-readable policy name, e.g. ``"act"``.
-        kind: Runner kind hint.  Built-in models use ``"single_pass"``
-            or ``"action_chunking"``.  Custom models specify a ``runner``
-            section instead.
-        class_path: Fully-qualified training class, e.g.
-            ``"physicalai.policies.act.ACT"``.  Informational — the
-            inference runtime does not import this.
+        source: Origin and training class reference.
     """
 
     model_config = ConfigDict(frozen=True)
     name: str = ""
-    kind: str = "single_pass"
-    class_path: str = ""
+    source: PolicySource = Field(default_factory=PolicySource)
 
 
 class ComponentSpec(BaseModel):
-    """A ``class_path`` + ``init_args`` pair for dynamic instantiation.
+    """Dual-resolution component descriptor for dynamic instantiation.
 
-    Used for runners, adapters, preprocessors, and postprocessors.
+    Supports two resolution modes:
+
+    1. **type + flat params** (LeRobot-compatible)::
+
+        {"type": "action_chunking", "chunk_size": 100, "n_action_steps": 100}
+
+    2. **class_path + init_args** (full-power PhysicalAI)::
+
+        {"class_path": "physicalai.inference.runners.ActionChunking",
+         "init_args": {"chunk_size": 100}}
+
+    When ``class_path`` is present it takes precedence.  When only
+    ``type`` is present, the :class:`ComponentRegistry` resolves it.
 
     Attributes:
-        class_path: Fully-qualified class path, e.g.
-            ``"physicalai.inference.runners.SinglePass"``, or a
-            registered short name like ``"single_pass"``.
-        init_args: Keyword arguments forwarded to the class constructor.
+        type: Registered short name (e.g. ``"action_chunking"``).
+        class_path: Fully-qualified class path for direct import.
+        init_args: Keyword arguments forwarded to the constructor
+            (used with ``class_path`` mode).
     """
 
-    model_config = ConfigDict(frozen=True)
-    class_path: str
+    model_config = ConfigDict(frozen=True, extra="allow")
+    type: str = ""
+    class_path: str = ""
     init_args: dict[str, Any] = Field(default_factory=dict)
 
-    @field_validator("class_path")
-    @classmethod
-    def _class_path_must_be_nonempty(cls, v: str) -> str:
-        if not v:
-            msg = "class_path must be a non-empty string"
+    @model_validator(mode="after")
+    def _must_have_type_or_class_path(self) -> ComponentSpec:
+        if not self.type and not self.class_path:
+            msg = "ComponentSpec requires either 'type' or 'class_path'"
             raise ValueError(msg)
-        return v
+        return self
+
+    @property
+    def flat_params(self) -> dict[str, Any]:
+        """Return extra fields as flat params (type-based resolution).
+
+        Returns all fields stored in ``model_extra`` — these are the
+        flat kwargs passed alongside ``type`` in LeRobot-style specs.
+        """
+        return dict(self.model_extra) if self.model_extra else {}
 
     @classmethod
-    def from_class(cls, target: type, **overrides: Any) -> ComponentSpec:  # noqa: ANN401
+    def from_class(cls, target: _type, **overrides: Any) -> ComponentSpec:  # noqa: ANN401
         """Build a spec by introspecting a class constructor.
 
         Parameters not present in *overrides* use their default values.
@@ -207,24 +245,68 @@ class ComponentSpec(BaseModel):
         )
 
 
+class ModelSpec(BaseModel):
+    """Model inference specification.
+
+    Groups the runner, artifacts, preprocessors, and postprocessors
+    under a single ``model`` section in the manifest.
+
+    Attributes:
+        n_obs_steps: Number of observation steps the model expects.
+        runner: Runner component specification.
+        artifacts: Mapping of logical name → filename,
+            e.g. ``{"model": "model.onnx"}``.
+        preprocessors: Pipeline stages applied to observations
+            *before* the runner.
+        postprocessors: Pipeline stages applied to runner output
+            *after* inference.
+    """
+
+    model_config = ConfigDict(frozen=True)
+    n_obs_steps: int = 1
+    runner: ComponentSpec | None = None
+    artifacts: dict[str, str] = Field(default_factory=dict)
+    preprocessors: list[ComponentSpec] = Field(default_factory=list)
+    postprocessors: list[ComponentSpec] = Field(default_factory=list)
+
+
+class HardwareSpec(BaseModel):
+    """Hardware configuration for robots and cameras.
+
+    Attributes:
+        robots: Hardware descriptors for robot state/action.
+        cameras: Hardware descriptors for camera inputs.
+    """
+
+    model_config = ConfigDict(frozen=True)
+    robots: list[RobotSpec] = Field(default_factory=list)
+    cameras: list[CameraSpec] = Field(default_factory=list)
+
+
+class MetadataSpec(BaseModel):
+    """Package metadata.
+
+    Attributes:
+        created_at: ISO 8601 timestamp of when the package was created.
+        created_by: Tool or framework that created the package.
+    """
+
+    model_config = ConfigDict(frozen=True)
+    created_at: str = ""
+    created_by: str = ""
+
+
 class Manifest(BaseModel):
     """Parsed manifest for an exported model package.
 
     Attributes:
         format: Always ``"policy_package"`` for this schema.
         version: Schema version string.
-        policy: Policy identity (name, kind, training class).
-        artifacts: Mapping of backend name → filename,
-            e.g. ``{"onnx": "model.onnx"}``.
-        runner: Optional dynamic runner specification.
-        adapter: Optional dynamic adapter specification.
-        robots: Hardware descriptors for robot state/action.
-        cameras: Hardware descriptors for camera inputs.
-        preprocessors: Pipeline stages applied to observations
-            *before* the runner.  Each entry is a ``ComponentSpec``
-            that will be instantiated via ``importlib``.
-        postprocessors: Pipeline stages applied to runner output
-            *after* inference.  Each entry is a ``ComponentSpec``.
+        policy: Policy identity (name, source).
+        model: Inference model specification (runner, artifacts,
+            preprocessors, postprocessors).
+        hardware: Hardware descriptors (robots, cameras).
+        metadata: Package metadata (creation info).
 
     Unknown top-level keys are preserved in ``model_extra`` so that
     domain layers can store additional data without schema changes.
@@ -234,13 +316,9 @@ class Manifest(BaseModel):
     format: str = MANIFEST_FORMAT
     version: str = MANIFEST_VERSION
     policy: PolicySpec = Field(default_factory=PolicySpec)
-    artifacts: dict[str, str] = Field(default_factory=dict)
-    runner: ComponentSpec | None = None
-    adapter: ComponentSpec | None = None
-    robots: list[RobotSpec] = Field(default_factory=list)
-    cameras: list[CameraSpec] = Field(default_factory=list)
-    preprocessors: list[ComponentSpec] = Field(default_factory=list)
-    postprocessors: list[ComponentSpec] = Field(default_factory=list)
+    model: ModelSpec = Field(default_factory=ModelSpec)
+    hardware: HardwareSpec = Field(default_factory=HardwareSpec)
+    metadata: MetadataSpec = Field(default_factory=MetadataSpec)
 
     @classmethod
     def load(cls, path: str | Path) -> Manifest:
@@ -287,7 +365,6 @@ class Manifest(BaseModel):
 
         use_action_queue = metadata.get("use_action_queue", False)
         chunk_size = metadata.get("chunk_size", 1)
-        kind = "action_chunking" if use_action_queue else "single_pass"
 
         from physicalai.inference.runners.action_chunking import ActionChunking  # noqa: PLC0415
         from physicalai.inference.runners.single_pass import SinglePass  # noqa: PLC0415
@@ -304,15 +381,21 @@ class Manifest(BaseModel):
         backend = metadata.get("backend", "")
         artifacts: dict[str, str] = {backend: ""} if backend else {}
 
-        data: dict[str, Any] = {
-            "policy": {"name": policy_name, "kind": kind, "class_path": policy_class},
-            "artifacts": artifacts,
-            "runner": {"class_path": runner.class_path, "init_args": runner.init_args},
-            "robots": [],
-            "cameras": [],
-            **metadata,
-        }
-        return cls.model_validate(data)
+        return cls.model_validate({
+            "policy": {
+                "name": policy_name,
+                "source": {"class_path": policy_class},
+            },
+            "model": {
+                "runner": {"class_path": runner.class_path, "init_args": runner.init_args},
+                "artifacts": artifacts,
+            },
+            **{
+                k: v
+                for k, v in metadata.items()
+                if k not in {"policy_class", "backend", "use_action_queue", "chunk_size"}
+            },
+        })
 
     def save(self, path: str | Path) -> None:
         """Write the manifest as ``manifest.json``.

--- a/library/src/physicalai/inference/model.py
+++ b/library/src/physicalai/inference/model.py
@@ -16,7 +16,7 @@ from physicalai.export.backends import ExportBackend
 from physicalai.inference.adapters import get_adapter
 from physicalai.inference.component_factory import instantiate_component
 from physicalai.inference.constants import ACTION
-from physicalai.inference.manifest import ComponentSpec
+from physicalai.inference.manifest import ComponentSpec, Manifest
 from physicalai.inference.runners import get_runner
 
 if TYPE_CHECKING:
@@ -85,7 +85,7 @@ class InferenceModel:
             policy_name: Policy name (auto-detected if None)
             backend: Backend to use, or 'auto' to detect from metadata/files
             device: Device for inference ('auto', 'cpu', 'cuda', 'CPU', 'GPU', etc.)
-            runner: Execution runner override. If None, auto-selected from metadata.
+            runner: Execution runner override. If None, auto-selected from manifest.
             preprocessors: Pipeline stages applied to observations before the
                 runner.  If ``None``, loaded from manifest (empty if not
                 declared).
@@ -103,14 +103,14 @@ class InferenceModel:
             msg = f"Export directory not found: {export_dir}"
             raise FileNotFoundError(msg)
 
-        self.metadata = self._load_metadata()
+        self.manifest = self._load_manifest()
 
         if policy_name is None:
             policy_name = self._detect_policy_name()
         self.policy_name = policy_name
 
         if backend == "auto":
-            backend = self._detect_backend_from_metadata() or self._detect_backend()
+            backend = self._detect_backend_from_manifest() or self._detect_backend()
         self.backend = ExportBackend(backend) if isinstance(backend, str) else backend
 
         if device == "auto":
@@ -121,13 +121,13 @@ class InferenceModel:
         model_path = self._get_model_path()
         self.adapter.load(model_path)
 
-        self.runner: InferenceRunner = runner if runner is not None else get_runner(self.metadata)
+        self.runner: InferenceRunner = runner if runner is not None else get_runner(self.manifest)
 
         self.preprocessors: list[Preprocessor] = (
-            preprocessors if preprocessors is not None else self._load_processors("preprocessors")
+            preprocessors if preprocessors is not None else self._load_processors(self.manifest.model.preprocessors)
         )
         self.postprocessors: list[Postprocessor] = (
-            postprocessors if postprocessors is not None else self._load_processors("postprocessors")
+            postprocessors if postprocessors is not None else self._load_processors(self.manifest.model.postprocessors)
         )
 
         self.callbacks: list[Callback] = callbacks if callbacks is not None else []
@@ -138,20 +138,26 @@ class InferenceModel:
     @property
     def use_action_queue(self) -> bool:
         """Whether action queuing is enabled (backward compat)."""
-        policy = self.metadata.get("policy", {})
-        if isinstance(policy, dict) and policy.get("kind") == "action_chunking":
-            return True
-        return self.metadata.get("use_action_queue", False)
+        runner_spec = self.manifest.model.runner
+        if runner_spec is not None:
+            if runner_spec.type == "action_chunking":
+                return True
+            if "ActionChunking" in runner_spec.class_path:
+                return True
+        return False
 
     @property
     def chunk_size(self) -> int:
-        """Action chunk size from metadata (backward compat)."""
-        runner_spec = self.metadata.get("runner", {})
-        if isinstance(runner_spec, dict):
-            chunk = runner_spec.get("init_args", {}).get("chunk_size")
+        """Action chunk size from manifest (backward compat)."""
+        runner_spec = self.manifest.model.runner
+        if runner_spec is not None:
+            chunk = runner_spec.init_args.get("chunk_size")
             if chunk is not None:
                 return int(chunk)
-        return self.metadata.get("chunk_size", 1)
+            flat_chunk = runner_spec.flat_params.get("chunk_size")
+            if flat_chunk is not None:
+                return int(flat_chunk)
+        return 1
 
     @classmethod
     def load(
@@ -302,23 +308,18 @@ class InferenceModel:
             return filtered
         return inputs
 
-    def _load_metadata(self) -> dict[str, Any]:
-        """Load export metadata from manifest.json, metadata.yaml, or metadata.json.
+    def _load_manifest(self) -> Manifest:
+        """Load export manifest from manifest.json, metadata.yaml, or metadata.json.
 
         Tries ``manifest.json`` first (new format), then falls back to
         ``metadata.yaml`` and ``metadata.json`` for backward compatibility.
 
-        .. deprecated::
-            Loading from ``metadata.yaml`` or ``metadata.json`` is
-            deprecated.  Re-export models to generate ``manifest.json``.
-
         Returns:
-            Metadata dict, or empty dict if no metadata file is found.
+            Parsed Manifest instance.
         """
         manifest_path = self.export_dir / "manifest.json"
         if manifest_path.exists():
-            with manifest_path.open(encoding="utf-8") as f:
-                return json.load(f)
+            return Manifest.load(manifest_path)
 
         yaml_path = self.export_dir / "metadata.yaml"
         json_path = self.export_dir / "metadata.json"
@@ -334,32 +335,31 @@ class InferenceModel:
             )
             if legacy_path.suffix == ".yaml":
                 with legacy_path.open(encoding="utf-8") as f:
-                    return yaml.safe_load(f) or {}
-            with legacy_path.open(encoding="utf-8") as f:
-                return json.load(f)
+                    raw = yaml.safe_load(f) or {}
+            else:
+                with legacy_path.open(encoding="utf-8") as f:
+                    raw = json.load(f)
+            return Manifest.from_legacy_metadata(raw)
 
-        return {}
+        return Manifest()
 
-    def _load_processors(self, key: str) -> list[Any]:
-        """Instantiate preprocessors or postprocessors from manifest metadata.
+    @staticmethod
+    def _load_processors(specs: list[ComponentSpec]) -> list[Any]:
+        """Instantiate preprocessors or postprocessors from component specs.
 
         Args:
-            key: ``"preprocessors"`` or ``"postprocessors"``.
+            specs: List of component specifications to instantiate.
 
         Returns:
-            List of instantiated processor objects, or empty list if the
-            manifest does not declare any for *key*.
+            List of instantiated processor objects.
         """
-        specs = self.metadata.get(key, [])
-        if not specs:
-            return []
-        return [instantiate_component(ComponentSpec.model_validate(s)) for s in specs]
+        return [instantiate_component(spec) for spec in specs]
 
     def _detect_policy_name(self) -> str:
-        """Auto-detect policy name from files or metadata.
+        """Auto-detect policy name from manifest or file heuristics.
 
         Checks manifest ``policy.name`` first, then falls back to
-        legacy ``policy_class`` extraction, then file-name heuristics.
+        ``policy.source.class_path`` extraction, then file-name heuristics.
 
         Returns:
             Policy name (e.g., 'act', 'diffusion')
@@ -367,16 +367,10 @@ class InferenceModel:
         Raises:
             ValueError: If policy name cannot be determined
         """
-        policy = self.metadata.get("policy", {})
-        if isinstance(policy, dict) and policy.get("name"):
-            return policy["name"]
+        if self.manifest.policy.name:
+            return self.manifest.policy.name
 
-        class_path = ""
-        if isinstance(policy, dict) and policy.get("class_path"):
-            class_path = policy["class_path"]
-        elif "policy_class" in self.metadata:
-            class_path = self.metadata["policy_class"]
-
+        class_path = self.manifest.policy.source.class_path
         if class_path:
             parts = class_path.lower().split(".")
             min_parts_for_module_extraction = 3
@@ -393,19 +387,19 @@ class InferenceModel:
         msg = f"Cannot determine policy name from {self.export_dir}"
         raise ValueError(msg)
 
-    def _detect_backend_from_metadata(self) -> str | None:
-        """Extract backend from manifest artifacts or legacy metadata.
+    def _detect_backend_from_manifest(self) -> str | None:
+        """Extract backend from manifest artifacts or legacy extra data.
 
         Returns:
             Backend string, or ``None`` if not found.
         """
-        artifacts = self.metadata.get("artifacts", {})
-        if isinstance(artifacts, dict) and artifacts:
+        artifacts = self.manifest.model.artifacts
+        if artifacts:
             return next(iter(artifacts))
 
-        backend = self.metadata.get("backend")
-        if backend:
-            return str(backend)
+        legacy_backend = (self.manifest.model_extra or {}).get("backend")
+        if legacy_backend:
+            return str(legacy_backend)
 
         return None
 
@@ -439,7 +433,6 @@ class InferenceModel:
         Returns:
             Device string for the best available device.
         """
-        # Create a lightweight adapter instance to query its preferred device
         adapter = get_adapter(self.backend, device="cpu")
         return adapter.default_device()
 
@@ -452,7 +445,6 @@ class InferenceModel:
         Raises:
             FileNotFoundError: If model file doesn't exist
         """
-        # Map backend to file extension(s)
         extension_map = {
             ExportBackend.OPENVINO: [".xml"],
             ExportBackend.ONNX: [".onnx"],
@@ -462,14 +454,12 @@ class InferenceModel:
 
         extensions = extension_map[self.backend]
 
-        # Try with policy name first
         if self.policy_name:
             for ext in extensions:
                 model_path = self.export_dir / f"{self.policy_name}{ext}"
                 if model_path.exists():
                     return model_path
 
-        # Try finding any file with any of the extensions
         for ext in extensions:
             files = list(self.export_dir.glob(f"*{ext}"))
             if files:

--- a/library/src/physicalai/inference/runners/factory.py
+++ b/library/src/physicalai/inference/runners/factory.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Runner factory for selecting inference runners from metadata."""
+"""Runner factory for selecting inference runners from manifest or metadata."""
 
 from __future__ import annotations
 
@@ -11,35 +11,64 @@ from physicalai.inference.runners.action_chunking import ActionChunking
 from physicalai.inference.runners.single_pass import SinglePass
 
 if TYPE_CHECKING:
+    from physicalai.inference.manifest import Manifest
     from physicalai.inference.runners.base import InferenceRunner
 
 
-def get_runner(metadata: dict[str, Any]) -> InferenceRunner:
-    """Select and instantiate a runner from export metadata or manifest.
+def get_runner(source: Manifest | dict[str, Any]) -> InferenceRunner:
+    """Select and instantiate a runner from a manifest or legacy metadata.
 
-    Supports two formats:
+    Supports three formats:
 
-    1. **Manifest** (``manifest.json``): If ``metadata`` contains a
-       ``"runner"`` key with ``class_path`` + ``init_args``, the runner
-       is instantiated dynamically via :class:`ComponentSpec`.
-    2. **Legacy** (``metadata.yaml``): Falls back to reading flat keys
-       ``use_action_queue`` and ``chunk_size``.
+    1. **Manifest object** — reads ``source.model.runner`` and
+       instantiates via :func:`instantiate_component`.
+    2. **Dict with runner spec** — raw manifest dict containing a
+       ``"model"`` section with a runner component spec.
+    3. **Legacy dict** — falls back to flat ``use_action_queue``
+       and ``chunk_size`` keys.
 
     Args:
-        metadata: Export metadata dict (from ``metadata.yaml`` or
-            ``manifest.json``).
+        source: A :class:`Manifest` instance or a raw metadata dict.
 
     Returns:
         Configured runner instance.
     """
-    runner_spec = metadata.get("runner")
-    if isinstance(runner_spec, dict) and "class_path" in runner_spec:
+    from physicalai.inference.manifest import Manifest  # noqa: PLC0415
+
+    if isinstance(source, Manifest):
+        if source.model.runner is not None:
+            from physicalai.inference.component_factory import instantiate_component  # noqa: PLC0415
+
+            return instantiate_component(source.model.runner)
+        return SinglePass()
+
+    runner_spec = _extract_runner_spec(source)
+    if runner_spec is not None:
         from physicalai.inference.component_factory import instantiate_component  # noqa: PLC0415
         from physicalai.inference.manifest import ComponentSpec  # noqa: PLC0415
 
         return instantiate_component(ComponentSpec.model_validate(runner_spec))
 
-    if metadata.get("use_action_queue"):
-        chunk_size = metadata.get("chunk_size", 1)
+    if source.get("use_action_queue"):
+        chunk_size = source.get("chunk_size", 1)
         return ActionChunking(runner=SinglePass(), chunk_size=chunk_size)
     return SinglePass()
+
+
+def _extract_runner_spec(metadata: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract a runner spec dict from nested or flat metadata.
+
+    Returns:
+        Runner spec dict if found, otherwise ``None``.
+    """
+    model_section = metadata.get("model", {})
+    if isinstance(model_section, dict):
+        runner = model_section.get("runner")
+        if isinstance(runner, dict) and ("class_path" in runner or "type" in runner):
+            return runner
+
+    runner = metadata.get("runner")
+    if isinstance(runner, dict) and ("class_path" in runner or "type" in runner):
+        return runner
+
+    return None

--- a/library/tests/unit/inference/test_manifest.py
+++ b/library/tests/unit/inference/test_manifest.py
@@ -18,8 +18,12 @@ from physicalai.inference.component_factory import (
 from physicalai.inference.manifest import (
     CameraSpec,
     ComponentSpec,
+    HardwareSpec,
     Manifest,
+    MetadataSpec,
+    ModelSpec,
     OrderedTensorSpec,
+    PolicySource,
     PolicySpec,
     RobotSpec,
     TensorSpec,
@@ -126,43 +130,90 @@ class TestCameraSpec:
         assert spec.shape == [3, 480, 640]
 
 
+class TestPolicySource:
+    def test_defaults(self) -> None:
+        source = PolicySource()
+        assert source.repo_id == ""
+        assert source.class_path == ""
+
+    def test_from_dict(self) -> None:
+        source = PolicySource.model_validate({
+            "repo_id": "lerobot/act_aloha",
+            "class_path": "physicalai.policies.act.ACT",
+        })
+        assert source.repo_id == "lerobot/act_aloha"
+        assert source.class_path == "physicalai.policies.act.ACT"
+
+
 class TestPolicySpec:
     def test_from_dict_defaults(self) -> None:
         spec = PolicySpec.model_validate({})
         assert spec.name == ""
-        assert spec.kind == "single_pass"
-        assert spec.class_path == ""
+        assert spec.source.repo_id == ""
+        assert spec.source.class_path == ""
 
     def test_from_dict_full(self) -> None:
         spec = PolicySpec.model_validate({
             "name": "act",
-            "kind": "action_chunking",
-            "class_path": "physicalai.policies.act.ACT",
+            "source": {
+                "repo_id": "lerobot/act_aloha",
+                "class_path": "physicalai.policies.act.ACT",
+            },
         })
         assert spec.name == "act"
-        assert spec.kind == "action_chunking"
-        assert spec.class_path == "physicalai.policies.act.ACT"
+        assert spec.source.repo_id == "lerobot/act_aloha"
+        assert spec.source.class_path == "physicalai.policies.act.ACT"
 
 
 class TestComponentSpec:
-    def test_from_dict(self) -> None:
+    def test_class_path_mode(self) -> None:
         spec = ComponentSpec.model_validate({
             "class_path": "physicalai.inference.runners.SinglePass",
             "init_args": {},
         })
         assert spec.class_path == "physicalai.inference.runners.SinglePass"
         assert spec.init_args == {}
+        assert spec.type == ""
 
-    def test_from_dict_with_init_args(self) -> None:
+    def test_class_path_with_init_args(self) -> None:
         spec = ComponentSpec.model_validate({
             "class_path": "physicalai.inference.runners.ActionChunking",
             "init_args": {"chunk_size": 10},
         })
         assert spec.init_args == {"chunk_size": 10}
 
+    def test_type_mode(self) -> None:
+        spec = ComponentSpec.model_validate({
+            "type": "action_chunking",
+            "chunk_size": 100,
+            "n_action_steps": 100,
+        })
+        assert spec.type == "action_chunking"
+        assert spec.class_path == ""
+        assert spec.flat_params == {"chunk_size": 100, "n_action_steps": 100}
+
+    def test_type_mode_no_extra_params(self) -> None:
+        spec = ComponentSpec.model_validate({"type": "single_pass"})
+        assert spec.type == "single_pass"
+        assert spec.flat_params == {}
+
+    def test_requires_type_or_class_path(self) -> None:
+        with pytest.raises(ValidationError, match="requires either"):
+            ComponentSpec.model_validate({})
+
+    def test_class_path_takes_precedence(self) -> None:
+        spec = ComponentSpec.model_validate({
+            "type": "single_pass",
+            "class_path": "physicalai.inference.runners.SinglePass",
+            "init_args": {"foo": "bar"},
+        })
+        assert spec.class_path == "physicalai.inference.runners.SinglePass"
+        assert spec.type == "single_pass"
+        assert spec.init_args == {"foo": "bar"}
+
 
 class TestInstantiateComponent:
-    def test_instantiate_single_pass(self) -> None:
+    def test_instantiate_single_pass_class_path(self) -> None:
         spec = ComponentSpec(
             class_path="physicalai.inference.runners.SinglePass",
             init_args={},
@@ -170,7 +221,7 @@ class TestInstantiateComponent:
         runner = instantiate_component(spec)
         assert isinstance(runner, SinglePass)
 
-    def test_instantiate_nested(self) -> None:
+    def test_instantiate_nested_class_path(self) -> None:
         spec = ComponentSpec(
             class_path="physicalai.inference.runners.ActionChunking",
             init_args={
@@ -186,6 +237,83 @@ class TestInstantiateComponent:
         assert runner.chunk_size == 5
         assert isinstance(runner.runner, SinglePass)
 
+    def test_instantiate_type_mode(self) -> None:
+        spec = ComponentSpec.model_validate({"type": "single_pass"})
+        runner = instantiate_component(spec)
+        assert isinstance(runner, SinglePass)
+
+    def test_instantiate_type_mode_with_params(self) -> None:
+        spec = ComponentSpec.model_validate({
+            "type": "action_chunking",
+            "runner": {"type": "single_pass"},
+            "chunk_size": 7,
+        })
+        runner = instantiate_component(spec)
+        assert isinstance(runner, ActionChunking)
+        assert runner.chunk_size == 7
+        assert isinstance(runner.runner, SinglePass)
+
+
+class TestModelSpec:
+    def test_defaults(self) -> None:
+        spec = ModelSpec()
+        assert spec.n_obs_steps == 1
+        assert spec.runner is None
+        assert spec.artifacts == {}
+        assert spec.preprocessors == []
+        assert spec.postprocessors == []
+
+    def test_from_dict_full(self) -> None:
+        spec = ModelSpec.model_validate({
+            "n_obs_steps": 2,
+            "runner": {"type": "action_chunking", "chunk_size": 100},
+            "artifacts": {"model": "model.onnx"},
+            "preprocessors": [
+                {"class_path": "myapp.transforms.Normalize", "init_args": {"mean": 0.5}},
+            ],
+            "postprocessors": [
+                {"class_path": "myapp.transforms.Clamp", "init_args": {"low": -1.0, "high": 1.0}},
+            ],
+        })
+        assert spec.n_obs_steps == 2
+        assert spec.runner is not None
+        assert spec.runner.type == "action_chunking"
+        assert spec.artifacts == {"model": "model.onnx"}
+        assert len(spec.preprocessors) == 1
+        assert len(spec.postprocessors) == 1
+
+
+class TestHardwareSpec:
+    def test_defaults(self) -> None:
+        spec = HardwareSpec()
+        assert spec.robots == []
+        assert spec.cameras == []
+
+    def test_from_dict(self) -> None:
+        spec = HardwareSpec.model_validate({
+            "robots": [{"name": "main", "type": "Koch v1.1"}],
+            "cameras": [{"name": "top", "shape": [3, 480, 640]}],
+        })
+        assert len(spec.robots) == 1
+        assert spec.robots[0].name == "main"
+        assert len(spec.cameras) == 1
+        assert spec.cameras[0].name == "top"
+
+
+class TestMetadataSpec:
+    def test_defaults(self) -> None:
+        spec = MetadataSpec()
+        assert spec.created_at == ""
+        assert spec.created_by == ""
+
+    def test_from_dict(self) -> None:
+        spec = MetadataSpec.model_validate({
+            "created_at": "2026-01-01T00:00:00Z",
+            "created_by": "physicalai",
+        })
+        assert spec.created_at == "2026-01-01T00:00:00Z"
+        assert spec.created_by == "physicalai"
+
 
 class TestManifestFromDict:
     @pytest.fixture
@@ -195,31 +323,38 @@ class TestManifestFromDict:
             "version": "1.0",
             "policy": {
                 "name": "act",
-                "kind": "action_chunking",
-                "class_path": "physicalai.policies.act.ACT",
+                "source": {
+                    "repo_id": "lerobot/act_aloha",
+                    "class_path": "physicalai.policies.act.ACT",
+                },
             },
-            "artifacts": {"openvino": "act.xml"},
-            "runner": {
-                "class_path": "physicalai.inference.runners.ActionChunking",
-                "init_args": {
-                    "runner": {
-                        "class_path": "physicalai.inference.runners.SinglePass",
-                        "init_args": {},
+            "model": {
+                "n_obs_steps": 1,
+                "runner": {
+                    "class_path": "physicalai.inference.runners.ActionChunking",
+                    "init_args": {
+                        "runner": {
+                            "class_path": "physicalai.inference.runners.SinglePass",
+                            "init_args": {},
+                        },
+                        "chunk_size": 10,
                     },
-                    "chunk_size": 10,
                 },
+                "artifacts": {"openvino": "act.xml"},
             },
-            "robots": [
-                {
-                    "name": "main",
-                    "type": "Koch v1.1",
-                    "state": {"shape": [14], "dtype": "float32"},
-                    "action": {"shape": [14], "dtype": "float32"},
-                },
-            ],
-            "cameras": [
-                {"name": "top", "shape": [3, 480, 640], "dtype": "uint8"},
-            ],
+            "hardware": {
+                "robots": [
+                    {
+                        "name": "main",
+                        "type": "Koch v1.1",
+                        "state": {"shape": [14], "dtype": "float32"},
+                        "action": {"shape": [14], "dtype": "float32"},
+                    },
+                ],
+                "cameras": [
+                    {"name": "top", "shape": [3, 480, 640], "dtype": "uint8"},
+                ],
+            },
         }
 
     def test_full_manifest(self, full_manifest_data: dict[str, Any]) -> None:
@@ -228,14 +363,14 @@ class TestManifestFromDict:
         assert manifest.format == "policy_package"
         assert manifest.version == "1.0"
         assert manifest.policy.name == "act"
-        assert manifest.policy.kind == "action_chunking"
-        assert manifest.artifacts == {"openvino": "act.xml"}
-        assert manifest.runner is not None
-        assert manifest.runner.class_path == "physicalai.inference.runners.ActionChunking"
-        assert len(manifest.robots) == 1
-        assert manifest.robots[0].name == "main"
-        assert len(manifest.cameras) == 1
-        assert manifest.cameras[0].name == "top"
+        assert manifest.policy.source.class_path == "physicalai.policies.act.ACT"
+        assert manifest.model.artifacts == {"openvino": "act.xml"}
+        assert manifest.model.runner is not None
+        assert manifest.model.runner.class_path == "physicalai.inference.runners.ActionChunking"
+        assert len(manifest.hardware.robots) == 1
+        assert manifest.hardware.robots[0].name == "main"
+        assert len(manifest.hardware.cameras) == 1
+        assert manifest.hardware.cameras[0].name == "top"
 
     def test_minimal_manifest(self) -> None:
         manifest = Manifest.model_validate({})
@@ -243,11 +378,12 @@ class TestManifestFromDict:
         assert manifest.format == "policy_package"
         assert manifest.version == "1.0"
         assert manifest.policy.name == ""
-        assert manifest.runner is None
-        assert manifest.robots == []
-        assert manifest.cameras == []
-        assert manifest.preprocessors == []
-        assert manifest.postprocessors == []
+        assert manifest.model.runner is None
+        assert manifest.model.artifacts == {}
+        assert manifest.model.preprocessors == []
+        assert manifest.model.postprocessors == []
+        assert manifest.hardware.robots == []
+        assert manifest.hardware.cameras == []
 
     def test_unknown_keys_go_to_extra(self) -> None:
         manifest = Manifest.model_validate({
@@ -258,43 +394,47 @@ class TestManifestFromDict:
 
     def test_preprocessors_parsed(self) -> None:
         manifest = Manifest.model_validate({
-            "preprocessors": [
-                {"class_path": "myapp.transforms.Normalize", "init_args": {"mean": 0.5}},
-                {"class_path": "myapp.transforms.Resize", "init_args": {}},
-            ],
+            "model": {
+                "preprocessors": [
+                    {"class_path": "myapp.transforms.Normalize", "init_args": {"mean": 0.5}},
+                    {"class_path": "myapp.transforms.Resize", "init_args": {}},
+                ],
+            },
         })
-        assert len(manifest.preprocessors) == 2
-        assert manifest.preprocessors[0].class_path == "myapp.transforms.Normalize"
-        assert manifest.preprocessors[0].init_args == {"mean": 0.5}
-        assert manifest.preprocessors[1].class_path == "myapp.transforms.Resize"
+        assert len(manifest.model.preprocessors) == 2
+        assert manifest.model.preprocessors[0].class_path == "myapp.transforms.Normalize"
+        assert manifest.model.preprocessors[0].init_args == {"mean": 0.5}
+        assert manifest.model.preprocessors[1].class_path == "myapp.transforms.Resize"
 
     def test_postprocessors_parsed(self) -> None:
         manifest = Manifest.model_validate({
-            "postprocessors": [
-                {"class_path": "myapp.transforms.Clamp", "init_args": {"low": -1.0, "high": 1.0}},
-            ],
+            "model": {
+                "postprocessors": [
+                    {"class_path": "myapp.transforms.Clamp", "init_args": {"low": -1.0, "high": 1.0}},
+                ],
+            },
         })
-        assert len(manifest.postprocessors) == 1
-        assert manifest.postprocessors[0].class_path == "myapp.transforms.Clamp"
-        assert manifest.postprocessors[0].init_args == {"low": -1.0, "high": 1.0}
-
-    def test_preprocessors_postprocessors_not_in_extra(self) -> None:
-        manifest = Manifest.model_validate({
-            "preprocessors": [{"class_path": "a.B", "init_args": {}}],
-            "postprocessors": [{"class_path": "c.D", "init_args": {}}],
-            "custom_key": "val",
-        })
-        assert "preprocessors" not in manifest.model_extra
-        assert "postprocessors" not in manifest.model_extra
-        assert manifest.model_extra == {"custom_key": "val"}
+        assert len(manifest.model.postprocessors) == 1
+        assert manifest.model.postprocessors[0].class_path == "myapp.transforms.Clamp"
+        assert manifest.model.postprocessors[0].init_args == {"low": -1.0, "high": 1.0}
 
     def test_runner_instantiation_from_manifest(self, full_manifest_data: dict[str, Any]) -> None:
         manifest = Manifest.model_validate(full_manifest_data)
-        assert manifest.runner is not None
-        runner = instantiate_component(manifest.runner)
+        assert manifest.model.runner is not None
+        runner = instantiate_component(manifest.model.runner)
         assert isinstance(runner, ActionChunking)
         assert runner.chunk_size == 10
         assert isinstance(runner.runner, SinglePass)
+
+    def test_type_based_runner_in_manifest(self) -> None:
+        manifest = Manifest.model_validate({
+            "model": {
+                "runner": {"type": "action_chunking", "chunk_size": 50},
+            },
+        })
+        assert manifest.model.runner is not None
+        assert manifest.model.runner.type == "action_chunking"
+        assert manifest.model.runner.flat_params == {"chunk_size": 50}
 
 
 class TestManifestFromFile:
@@ -302,8 +442,8 @@ class TestManifestFromFile:
         manifest_data = {
             "format": "policy_package",
             "version": "1.0",
-            "policy": {"name": "act", "kind": "single_pass"},
-            "artifacts": {"onnx": "act.onnx"},
+            "policy": {"name": "act"},
+            "model": {"artifacts": {"onnx": "act.onnx"}},
         }
         manifest_path = tmp_path / "manifest.json"
         with manifest_path.open("w", encoding="utf-8") as f:
@@ -311,14 +451,14 @@ class TestManifestFromFile:
 
         manifest = Manifest.load(manifest_path)
         assert manifest.policy.name == "act"
-        assert manifest.artifacts == {"onnx": "act.onnx"}
+        assert manifest.model.artifacts == {"onnx": "act.onnx"}
 
     def test_load_from_directory(self, tmp_path: Path) -> None:
         manifest_data = {
             "format": "policy_package",
             "version": "1.0",
-            "policy": {"name": "diffusion", "kind": "action_chunking"},
-            "artifacts": {"onnx": "diffusion.onnx"},
+            "policy": {"name": "diffusion"},
+            "model": {"artifacts": {"onnx": "diffusion.onnx"}},
         }
         manifest_path = tmp_path / "manifest.json"
         with manifest_path.open("w", encoding="utf-8") as f:
@@ -347,10 +487,9 @@ class TestManifestFromLegacyMetadata:
         manifest = Manifest.from_legacy_metadata(metadata)
 
         assert manifest.policy.name == "policy"
-        assert manifest.policy.kind == "single_pass"
-        assert manifest.policy.class_path == "physicalai.policies.act.policy.ACT"
-        assert manifest.runner is not None
-        assert "SinglePass" in manifest.runner.class_path
+        assert manifest.policy.source.class_path == "physicalai.policies.act.policy.ACT"
+        assert manifest.model.runner is not None
+        assert "SinglePass" in manifest.model.runner.class_path
 
     def test_action_chunking_policy(self) -> None:
         metadata = {
@@ -361,10 +500,9 @@ class TestManifestFromLegacyMetadata:
         }
         manifest = Manifest.from_legacy_metadata(metadata)
 
-        assert manifest.policy.kind == "action_chunking"
-        assert manifest.runner is not None
-        assert "ActionChunking" in manifest.runner.class_path
-        assert manifest.runner.init_args["chunk_size"] == 10
+        assert manifest.model.runner is not None
+        assert "ActionChunking" in manifest.model.runner.class_path
+        assert manifest.model.runner.init_args["chunk_size"] == 10
 
     def test_legacy_extra_preserved(self) -> None:
         metadata = {
@@ -378,21 +516,27 @@ class TestManifestFromLegacyMetadata:
 
     def test_empty_metadata(self) -> None:
         manifest = Manifest.from_legacy_metadata({})
-        assert manifest.policy.kind == "single_pass"
-        assert manifest.runner is not None
+        assert manifest.model.runner is not None
 
 
 class TestManifestSerialization:
     def test_roundtrip(self, tmp_path: Path) -> None:
         original = Manifest(
-            policy=PolicySpec(name="act", kind="single_pass", class_path="test.ACT"),
-            artifacts={"openvino": "act.xml"},
-            runner=ComponentSpec(
-                class_path="physicalai.inference.runners.SinglePass",
-                init_args={},
+            policy=PolicySpec(
+                name="act",
+                source=PolicySource(class_path="test.ACT"),
             ),
-            robots=[RobotSpec(name="main", type="Koch", state=OrderedTensorSpec(shape=[14]))],
-            cameras=[CameraSpec(name="top", shape=[3, 480, 640])],
+            model=ModelSpec(
+                runner=ComponentSpec(
+                    class_path="physicalai.inference.runners.SinglePass",
+                    init_args={},
+                ),
+                artifacts={"openvino": "act.xml"},
+            ),
+            hardware=HardwareSpec(
+                robots=[RobotSpec(name="main", type="Koch", state=OrderedTensorSpec(shape=[14]))],
+                cameras=[CameraSpec(name="top", shape=[3, 480, 640])],
+            ),
         )
 
         path = tmp_path / "manifest.json"
@@ -400,66 +544,65 @@ class TestManifestSerialization:
 
         loaded = Manifest.load(path)
         assert loaded.policy.name == "act"
-        assert loaded.artifacts == {"openvino": "act.xml"}
-        assert loaded.runner is not None
-        assert loaded.runner.class_path == "physicalai.inference.runners.SinglePass"
-        assert len(loaded.robots) == 1
-        assert loaded.robots[0].name == "main"
-        assert len(loaded.cameras) == 1
-        assert loaded.cameras[0].name == "top"
+        assert loaded.model.artifacts == {"openvino": "act.xml"}
+        assert loaded.model.runner is not None
+        assert loaded.model.runner.class_path == "physicalai.inference.runners.SinglePass"
+        assert len(loaded.hardware.robots) == 1
+        assert loaded.hardware.robots[0].name == "main"
+        assert len(loaded.hardware.cameras) == 1
+        assert loaded.hardware.cameras[0].name == "top"
 
     def test_to_dict_omits_empty_optional_sections(self) -> None:
         manifest = Manifest(policy=PolicySpec(name="test"))
         data = manifest.model_dump(exclude_defaults=True)
 
-        assert "robots" not in data
-        assert "cameras" not in data
-        assert "runner" not in data
-        assert "adapter" not in data
-        assert "preprocessors" not in data
-        assert "postprocessors" not in data
         assert data["policy"]["name"] == "test"
 
     def test_roundtrip_with_preprocessors_postprocessors(self, tmp_path: Path) -> None:
         original = Manifest(
-            policy=PolicySpec(name="act", kind="single_pass"),
-            artifacts={"onnx": "act.onnx"},
-            preprocessors=[
-                ComponentSpec(class_path="myapp.transforms.Normalize", init_args={"mean": 0.5}),
-            ],
-            postprocessors=[
-                ComponentSpec(class_path="myapp.transforms.Clamp", init_args={"low": -1.0, "high": 1.0}),
-                ComponentSpec(class_path="myapp.transforms.Scale", init_args={"factor": 2.0}),
-            ],
+            policy=PolicySpec(name="act"),
+            model=ModelSpec(
+                artifacts={"onnx": "act.onnx"},
+                preprocessors=[
+                    ComponentSpec(class_path="myapp.transforms.Normalize", init_args={"mean": 0.5}),
+                ],
+                postprocessors=[
+                    ComponentSpec(class_path="myapp.transforms.Clamp", init_args={"low": -1.0, "high": 1.0}),
+                    ComponentSpec(class_path="myapp.transforms.Scale", init_args={"factor": 2.0}),
+                ],
+            ),
         )
 
         path = tmp_path / "manifest.json"
         original.save(path)
 
         loaded = Manifest.load(path)
-        assert len(loaded.preprocessors) == 1
-        assert loaded.preprocessors[0].class_path == "myapp.transforms.Normalize"
-        assert loaded.preprocessors[0].init_args == {"mean": 0.5}
-        assert len(loaded.postprocessors) == 2
-        assert loaded.postprocessors[0].class_path == "myapp.transforms.Clamp"
-        assert loaded.postprocessors[1].class_path == "myapp.transforms.Scale"
-        assert loaded.postprocessors[1].init_args == {"factor": 2.0}
+        assert len(loaded.model.preprocessors) == 1
+        assert loaded.model.preprocessors[0].class_path == "myapp.transforms.Normalize"
+        assert loaded.model.preprocessors[0].init_args == {"mean": 0.5}
+        assert len(loaded.model.postprocessors) == 2
+        assert loaded.model.postprocessors[0].class_path == "myapp.transforms.Clamp"
+        assert loaded.model.postprocessors[1].class_path == "myapp.transforms.Scale"
+        assert loaded.model.postprocessors[1].init_args == {"factor": 2.0}
 
     def test_to_dict_includes_nonempty_processors(self) -> None:
         manifest = Manifest(
-            preprocessors=[ComponentSpec(class_path="a.B", init_args={"x": 1})],
-            postprocessors=[ComponentSpec(class_path="c.D", init_args={})],
+            model=ModelSpec(
+                preprocessors=[ComponentSpec(class_path="a.B", init_args={"x": 1})],
+                postprocessors=[ComponentSpec(class_path="c.D", init_args={})],
+            ),
         )
         data = manifest.model_dump(exclude_defaults=True)
 
-        assert "preprocessors" in data
-        assert len(data["preprocessors"]) == 1
-        assert data["preprocessors"][0]["class_path"] == "a.B"
-        assert data["preprocessors"][0]["init_args"] == {"x": 1}
+        model_data = data["model"]
+        assert "preprocessors" in model_data
+        assert len(model_data["preprocessors"]) == 1
+        assert model_data["preprocessors"][0]["class_path"] == "a.B"
+        assert model_data["preprocessors"][0]["init_args"] == {"x": 1}
 
-        assert "postprocessors" in data
-        assert len(data["postprocessors"]) == 1
-        assert data["postprocessors"][0]["class_path"] == "c.D"
+        assert "postprocessors" in model_data
+        assert len(model_data["postprocessors"]) == 1
+        assert model_data["postprocessors"][0]["class_path"] == "c.D"
 
 
 class TestComponentSpecFromClass:
@@ -517,11 +660,15 @@ class TestPydanticValidation:
         with pytest.raises(ValidationError):
             TensorSpec(shape=[3], dtype="")
 
-    def test_component_spec_empty_class_path(self) -> None:
-        with pytest.raises(ValidationError):
-            ComponentSpec(class_path="")
+    def test_component_spec_empty_both_raises(self) -> None:
+        with pytest.raises(ValidationError, match="requires either"):
+            ComponentSpec.model_validate({})
 
-    def test_component_spec_no_dot_class_path_is_valid(self) -> None:
+    def test_component_spec_type_only_is_valid(self) -> None:
+        spec = ComponentSpec.model_validate({"type": "single_pass"})
+        assert spec.type == "single_pass"
+
+    def test_component_spec_class_path_only_is_valid(self) -> None:
         spec = ComponentSpec(class_path="single_pass")
         assert spec.class_path == "single_pass"
 

--- a/library/tests/unit/inference/test_model.py
+++ b/library/tests/unit/inference/test_model.py
@@ -15,6 +15,7 @@ import yaml
 
 from physicalai.export.mixin_policy import ExportBackend
 from physicalai.inference.adapters import RuntimeAdapter
+from physicalai.inference.manifest import ComponentSpec, Manifest, ModelSpec
 from physicalai.inference.model import InferenceModel
 from physicalai.inference.postprocessors.action_normalizer import ActionNormalizer
 from physicalai.inference.postprocessors.base import Postprocessor
@@ -98,9 +99,14 @@ def _make_manifest_export_dir(
     manifest = {
         "format": "policy_package",
         "version": "1.0",
-        "policy": {"name": "act", "kind": kind, "class_path": "physicalai.policies.act.ACT"},
-        "artifacts": {backend: artifact_file},
-        "runner": runner_spec,
+        "policy": {
+            "name": "act",
+            "source": {"class_path": "physicalai.policies.act.ACT"},
+        },
+        "model": {
+            "artifacts": {backend: artifact_file},
+            "runner": runner_spec,
+        },
     }
     with (export_dir / "manifest.json").open("w") as f:
         json.dump(manifest, f)
@@ -231,9 +237,11 @@ class TestManifestModelInit:
         manifest = {
             "format": "policy_package",
             "version": "1.0",
-            "policy": {"name": "new_policy", "kind": "single_pass"},
-            "artifacts": {"openvino": "model.xml"},
-            "runner": {"class_path": "physicalai.inference.runners.SinglePass", "init_args": {}},
+            "policy": {"name": "new_policy"},
+            "model": {
+                "artifacts": {"openvino": "model.xml"},
+                "runner": {"class_path": "physicalai.inference.runners.SinglePass", "init_args": {}},
+            },
         }
         with (export_dir / "manifest.json").open("w") as f:
             json.dump(manifest, f)
@@ -270,7 +278,7 @@ class TestManifestModelInit:
             "format": "policy_package",
             "version": "1.0",
             "policy": {"name": "act"},
-            "artifacts": {"onnx": "act.onnx"},
+            "model": {"artifacts": {"onnx": "act.onnx"}},
         }
         with (export_dir / "manifest.json").open("w") as f:
             json.dump(manifest, f)
@@ -281,38 +289,37 @@ class TestManifestModelInit:
 
 @pytest.mark.usefixtures("_patch_adapter")
 class TestMetadataLoading:
-    @pytest.mark.parametrize(
-        ("format_type", "metadata_content"),
-        [
-            ("yaml", {"policy_class": "physicalai.policies.dummy.Dummy", "chunk_size": 5}),
-            ("json", {"policy_class": "physicalai.policies.act.ACT", "backend": "onnx"}),
-        ],
-    )
-    def test_load_metadata_formats(
-        self,
-        tmp_path: Path,
-        format_type: str,
-        metadata_content: dict,
-    ) -> None:
+    def test_load_legacy_yaml_metadata(self, tmp_path: Path) -> None:
         export_dir = tmp_path / "exports"
         export_dir.mkdir()
+        with (export_dir / "metadata.yaml").open("w") as f:
+            yaml.dump({"policy_class": "physicalai.policies.dummy.Dummy", "chunk_size": 5}, f)
+        (export_dir / "dummy.xml").touch()
 
-        if format_type == "yaml":
-            with (export_dir / "metadata.yaml").open("w") as f:
-                yaml.dump(metadata_content, f)
-            (export_dir / "dummy.xml").touch()
-        else:
-            with (export_dir / "metadata.json").open("w") as f:
-                json.dump(metadata_content, f)
-            (export_dir / "act.onnx").touch()
+        model = InferenceModel(export_dir)
+        assert model.manifest.policy.name == "dummy"
+        assert model.manifest.policy.source.class_path == "physicalai.policies.dummy.Dummy"
 
-        assert InferenceModel(export_dir).metadata == metadata_content
+    def test_load_legacy_json_metadata(self, tmp_path: Path) -> None:
+        export_dir = tmp_path / "exports"
+        export_dir.mkdir()
+        with (export_dir / "metadata.json").open("w") as f:
+            json.dump({"policy_class": "physicalai.policies.act.ACT", "backend": "onnx"}, f)
+        (export_dir / "act.onnx").touch()
+
+        model = InferenceModel(export_dir)
+        assert model.manifest.policy.name == "act"
+        assert model.manifest.policy.source.class_path == "physicalai.policies.act.ACT"
+        assert "onnx" in model.manifest.model.artifacts
 
     def test_no_metadata_fallback(self, tmp_path: Path) -> None:
         export_dir = tmp_path / "exports"
         export_dir.mkdir()
         (export_dir / "model.onnx").touch()
-        assert InferenceModel(export_dir).metadata == {}
+
+        model = InferenceModel(export_dir)
+        assert model.manifest.policy.name == ""
+        assert model.manifest.model.runner is None
 
 
 class TestAutoDetection:
@@ -635,6 +642,54 @@ class TestGetRunnerFactory:
             "runner": {"class_path": "physicalai.inference.runners.SinglePass", "init_args": {}},
         }
         assert isinstance(get_runner(metadata), SinglePass)
+
+    def test_nested_model_runner_spec(self) -> None:
+        metadata = {
+            "model": {
+                "runner": {
+                    "class_path": "physicalai.inference.runners.ActionChunking",
+                    "init_args": {
+                        "runner": {"class_path": "physicalai.inference.runners.SinglePass", "init_args": {}},
+                        "chunk_size": 12,
+                    },
+                },
+            },
+        }
+        runner = get_runner(metadata)
+        assert isinstance(runner, ActionChunking)
+        assert runner.chunk_size == 12
+        assert isinstance(runner.runner, SinglePass)
+
+    def test_nested_model_runner_takes_priority_over_flat(self) -> None:
+        metadata = {
+            "use_action_queue": True,
+            "chunk_size": 99,
+            "model": {
+                "runner": {"class_path": "physicalai.inference.runners.SinglePass", "init_args": {}},
+            },
+        }
+        assert isinstance(get_runner(metadata), SinglePass)
+
+    def test_manifest_object_with_runner(self) -> None:
+        manifest = Manifest.model_validate({
+            "model": {
+                "runner": {
+                    "class_path": "physicalai.inference.runners.ActionChunking",
+                    "init_args": {
+                        "runner": {"class_path": "physicalai.inference.runners.SinglePass", "init_args": {}},
+                        "chunk_size": 7,
+                    },
+                },
+            },
+        })
+        runner = get_runner(manifest)
+        assert isinstance(runner, ActionChunking)
+        assert runner.chunk_size == 7
+        assert isinstance(runner.runner, SinglePass)
+
+    def test_manifest_object_without_runner(self) -> None:
+        manifest = Manifest()
+        assert isinstance(get_runner(manifest), SinglePass)
 
 
 class TestSinglePass:


### PR DESCRIPTION
The manifest moves from a flat metadata dict to nested Pydantic models that mirror the `InferenceModel` class hierarchy. Components now support dual resolution — `type` + flat params for interoperability (LeRobot writes these) or `class_path` + `init_args` for full-power custom components (PhysicalAI writes these). Both resolve identically at runtime.

**Before** — flat dict with string keys:
```python
self.metadata["runner"]           # dict
self.metadata["artifacts"]        # dict
self.metadata["preprocessors"]    # list[dict]
```

**After** — typed nested models:
```python
self.manifest.model.runner        # ComponentSpec
self.manifest.model.artifacts     # dict[str, str]
self.manifest.model.preprocessors # list[ComponentSpec]
self.manifest.policy.name         # str
self.manifest.policy.source       # PolicySource
```

**Dual `ComponentSpec` resolution:**
```json
// type format (LeRobot-compatible, both frameworks read):
{"type": "action_chunking", "chunk_size": 100, "n_action_steps": 100}

// class_path format (PhysicalAI-native, custom/3rd-party components):
{"class_path": "physicalai.inference.runners.ActionChunkingRunner", "init_args": {"chunk_size": 100, "n_action_steps": 100}}

// Both → ActionChunkingRunner(chunk_size=100, n_action_steps=100)
```