### PR TITLE
fix: prevent episode list from growing outside its container

### DIFF
--- a/application/ui/src/routes/datasets/episode-list.module.scss
+++ b/application/ui/src/routes/datasets/episode-list.module.scss
@@ -1,6 +1,13 @@
 .episodePreviewList {
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     width: 250px;
+    position: relative;
+}
+
+.episodePreviewListInner {
+    position: absolute;
+    inset: 0;
 }
 
 .episodeItem {

--- a/application/ui/src/routes/datasets/episode-list.tsx
+++ b/application/ui/src/routes/datasets/episode-list.tsx
@@ -24,52 +24,59 @@ export const EpisodeList = ({ episodes, onSelect, currentEpisode }: EpisodeListP
 
     return (
         <View UNSAFE_className={classes.episodePreviewList}>
-            <VirtualizedListLayout
-                items={episodes}
-                ariaLabel='Episode list'
-                containerHeight='100%'
-                layoutOptions={{ rowHeight: 190 }}
-                idFormatter={(episode) => `${episode.episode_index}`}
-                textValueFormatter={(episode) => `Episode ${episode.episode_index + 1}`}
-                renderItem={(episode) => {
-                    const thumbnailSrc = fetchClient.PATH(
-                        '/api/dataset/{dataset_id}/episodes/{episode_index}/thumbnail',
-                        {
-                            params: {
-                                path: {
-                                    dataset_id,
-                                    episode_index: episode.episode_index,
+            <div className={classes.episodePreviewListInner}>
+                <VirtualizedListLayout
+                    items={episodes}
+                    ariaLabel='Episode list'
+                    containerHeight='100%'
+                    layoutOptions={{ rowHeight: 190 }}
+                    idFormatter={(episode) => `${episode.episode_index}`}
+                    textValueFormatter={(episode) => `Episode ${episode.episode_index + 1}`}
+                    renderItem={(episode) => {
+                        const thumbnailSrc = fetchClient.PATH(
+                            '/api/dataset/{dataset_id}/episodes/{episode_index}/thumbnail',
+                            {
+                                params: {
+                                    path: {
+                                        dataset_id,
+                                        episode_index: episode.episode_index,
+                                    },
+                                    query: { height: 240, width: 320 },
                                 },
-                                query: { height: 240, width: 320 },
-                            },
-                        }
-                    );
+                            }
+                        );
 
-                    return (
-                        <View
-                            UNSAFE_className={clsx({
-                                [classes.episodeItem]: true,
-                                [classes.active]: currentEpisode === episode.episode_index,
-                            })}
-                        >
-                            <img
-                                alt={`Camera frame of ${episode.episode_index}`}
-                                src={thumbnailSrc}
-                                className={classes.episodeImage}
-                                onClick={() => onSelect(episode.episode_index)}
-                            />
-                            <Flex alignItems={'center'} justifyContent={'space-between'} height='size-400' width='100%'>
-                                <EpisodeTag episode={episode} variant='small' />
-                                <Checkbox
-                                    isSelected={selectedEpisodes.includes(episode.episode_index)}
-                                    onPress={() => toggleSelection(episode.episode_index)}
-                                    UNSAFE_className={classes.episodeCheckbox}
+                        return (
+                            <View
+                                UNSAFE_className={clsx({
+                                    [classes.episodeItem]: true,
+                                    [classes.active]: currentEpisode === episode.episode_index,
+                                })}
+                            >
+                                <img
+                                    alt={`Camera frame of ${episode.episode_index}`}
+                                    src={thumbnailSrc}
+                                    className={classes.episodeImage}
+                                    onClick={() => onSelect(episode.episode_index)}
                                 />
-                            </Flex>
-                        </View>
-                    );
-                }}
-            />
+                                <Flex
+                                    alignItems={'center'}
+                                    justifyContent={'space-between'}
+                                    height='size-400'
+                                    width='100%'
+                                >
+                                    <EpisodeTag episode={episode} variant='small' />
+                                    <Checkbox
+                                        isSelected={selectedEpisodes.includes(episode.episode_index)}
+                                        onPress={() => toggleSelection(episode.episode_index)}
+                                        UNSAFE_className={classes.episodeCheckbox}
+                                    />
+                                </Flex>
+                            </View>
+                        );
+                    }}
+                />
+            </div>
         </View>
     );
 };

--- a/application/ui/src/routes/datasets/index.tsx
+++ b/application/ui/src/routes/datasets/index.tsx
@@ -102,7 +102,7 @@ const Datasets = ({ datasets }: DatasetsProps) => {
                         </View>
                     )}
                 </Flex>
-                <TabPanels UNSAFE_style={{ border: 'none' }} marginTop={'size-200'}>
+                <TabPanels UNSAFE_style={{ border: 'none' }} marginTop={'size-200'} minHeight={0}>
                     <Item key={dataset_id}>
                         <Flex height='100%' flex>
                             {dataset_id === undefined ? (


### PR DESCRIPTION
Fix a regression from #411 that made it so that the episode list no longer rendered virtually: instead when having many episodes the list would grow and make the whole screen grow outside of its bounds.
This PR fixes it by wrapping the list in an absolutely positioned inner container, which forces the list to have a fixed height.
For a longer term fix we should migrate the virtualized list component to be replaced by [MediaColumn](https://docs.geti-ui.markredeman.nl/blocks/media/media-column)

## Type of Change

- [x] 🐞 `fix` - Bug fix
