### PR TITLE
chore: don't load alembic plugins at startup of server or processes

### DIFF
--- a/application/backend/src/cli.py
+++ b/application/backend/src/cli.py
@@ -4,8 +4,8 @@ import sys
 
 import click
 
-from db import MigrationManager
 from db.engine import get_sync_db_session
+from db.migration import MigrationManager
 from db.schema import (
     CalibrationValuesDB,
     DatasetDB,

--- a/application/backend/src/db/__init__.py
+++ b/application/backend/src/db/__init__.py
@@ -1,4 +1,3 @@
 from db.engine import get_async_db_session_ctx, sync_engine
-from db.migration import MigrationManager
 
-__all__ = ["MigrationManager", "get_async_db_session_ctx", "sync_engine"]
+__all__ = ["get_async_db_session_ctx", "sync_engine"]


### PR DESCRIPTION
`db/__init__.py` eagerly imported `MigrationManager` from `db.migration`, which in turn imported alembic at the top level.
Alembic registers six autogenerate plugins at import time, each emitting an INFO log line ('setup plugin alembic.autogenerate.*').

Because nearly every service imports from the db package, this caused alembic to load in every process: the main server, the training
worker, and all PyTorch DataLoader workers, producing noisy log output, and probably making the startup time of the processes slower.

Only `cli.py` actually uses `MigrationManager`, so import it directly from db.migration there and remove it from `db/__init__.py` entirely.

## Type of Change

- [x] 🔧 `chore` - Maintenance
