### PR TITLE
feat: enable auto-reload server for development

### DIFF
--- a/application/backend/run.sh
+++ b/application/backend/run.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 # Usage:
 #   SEED_DB=true ./run.sh       # Seed database before launching server
 #   ./run.sh                    # Run server without seeding
+#   ./run.sh --dev              # Force dev mode (hot reload enabled)
 #
 # Environment variables:
 #   SEED_DB       If set to "true", runs database seeding before starting.
@@ -29,6 +30,12 @@ UV_CMD=${UV_CMD:-uv run --no-sync}
 
 export PYTHONUNBUFFERED=1
 export PYTHONPATH=src
+
+if [[ "${1:-}" == "--dev" ]]; then
+    export ENVIRONMENT=dev
+    export DEBUG=true
+    echo "Dev mode enabled: hot reload is on"
+fi
 
 # Always run migrations — Alembic is idempotent and will skip
 # already-applied migrations. This ensures the persistent volume

--- a/application/backend/run.sh
+++ b/application/backend/run.sh
@@ -28,7 +28,7 @@ APP_MODULE=${APP_MODULE:-src/main.py}
 UV_CMD=${UV_CMD:-uv run --no-sync}
 
 export PYTHONUNBUFFERED=1
-export PYTHONPATH=.
+export PYTHONPATH=src
 
 # Always run migrations — Alembic is idempotent and will skip
 # already-applied migrations. This ensures the persistent volume

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -82,4 +82,11 @@ if __name__ == "__main__":
     if get_torch_device() == "xpu" and mp.get_start_method(allow_none=True) != "spawn":
         mp.set_start_method("spawn", force=True)
     uvicorn_port = int(os.environ.get("HTTP_SERVER_PORT", settings.port))
-    uvicorn.run(app, host=settings.host, port=uvicorn_port)
+    reload = settings.environment == "dev"
+    uvicorn.run(
+        "main:app",
+        host=settings.host,
+        port=uvicorn_port,
+        reload=reload,
+        reload_dirs=["src"] if reload else None,
+    )


### PR DESCRIPTION
This PR allows us to run `./run.sh --development` so that the server automatically reloads when making code changes to the server code.
One caveat with this is that currently the server is a bit slow to startup. PR #433 will resolve part of this, but there are more improvements we can make here: I have one branch where I added some aggressive lazy loading of imports and reduced the startup time to 1s-2s. However I need to spend some more time on testing that branch to make sure there are no regressions.

One other thing to take note about is that when using this `--dev` mode we will also restart our training workers. This means that if you have running training jobs and then reload the server this will cancel any training jobs.
This is something we will need to spend a bit more time on. I think it would be better if we could make sure that we don't reload training workers.

## Type of Change

- [x] ✨ `feat` - New feature