### PR TITLE
fix: fit camera and video cells while keeping aspect ratio

### DIFF
--- a/application/ui/src/features/cameras/media-fit.ts
+++ b/application/ui/src/features/cameras/media-fit.ts
@@ -1,0 +1,31 @@
+export type ContainerSize = { width: number; height: number };
+
+export const calculateMediaFit = (
+    containerSize: ContainerSize,
+    aspectRatio: number
+): { width: number; height: number } => {
+    if (
+        containerSize.width <= 0 ||
+        !Number.isFinite(containerSize.width) ||
+        containerSize.height <= 0 ||
+        !Number.isFinite(containerSize.height)
+    ) {
+        return { width: 0, height: 0 };
+    }
+
+    const safeAspectRatio = aspectRatio > 0 && Number.isFinite(aspectRatio) ? aspectRatio : 1;
+
+    const containerAspectRatio = containerSize.width / containerSize.height;
+
+    if (containerAspectRatio > safeAspectRatio) {
+        return {
+            width: containerSize.height * safeAspectRatio,
+            height: containerSize.height,
+        };
+    } else {
+        return {
+            width: containerSize.width,
+            height: containerSize.width / safeAspectRatio,
+        };
+    }
+};

--- a/application/ui/src/features/cameras/use-fitted-media-size.ts
+++ b/application/ui/src/features/cameras/use-fitted-media-size.ts
@@ -1,0 +1,17 @@
+import { useRef } from 'react';
+
+import { useContainerSize } from '../../components/zoom/use-container-size';
+import { calculateMediaFit } from './media-fit';
+
+export const useFittedMediaSize = (intrinsicWidth?: number, intrinsicHeight?: number) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const containerSize = useContainerSize(containerRef);
+
+    const w = Number(intrinsicWidth);
+    const h = Number(intrinsicHeight);
+    const aspectRatio = w > 0 && Number.isFinite(w) && h > 0 && Number.isFinite(h) ? w / h : 1;
+
+    const { width, height } = calculateMediaFit(containerSize, aspectRatio);
+
+    return { containerRef, width, height };
+};

--- a/application/ui/src/features/cameras/websocket-camera.tsx
+++ b/application/ui/src/features/cameras/websocket-camera.tsx
@@ -5,25 +5,9 @@ import useWebSocket from 'react-use-websocket';
 
 import { fetchClient } from '../../api/client';
 import { SchemaProjectCamera } from '../../api/types';
-import { useContainerSize } from '../../components/zoom/use-container-size';
+import { useFittedMediaSize } from './use-fitted-media-size';
 
 const CAMERA_WS_URL = fetchClient.PATH('/api/cameras/ws');
-
-const calculateCanvasDimensions = (containerSize: { width: number; height: number }, aspectRatio: number) => {
-    const containerAspectRatio = containerSize.width / containerSize.height;
-
-    if (containerAspectRatio > aspectRatio) {
-        return {
-            width: containerSize.height * aspectRatio,
-            height: containerSize.height,
-        };
-    } else {
-        return {
-            width: containerSize.width,
-            height: containerSize.width / aspectRatio,
-        };
-    }
-};
 
 const CameraCanvas = ({ camera, width, height }: { camera: SchemaProjectCamera; width: number; height: number }) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -116,14 +100,13 @@ const CameraCanvas = ({ camera, width, height }: { camera: SchemaProjectCamera; 
 };
 
 export const WebsocketCamera = ({ camera }: { camera: SchemaProjectCamera }) => {
-    const ref = useRef<HTMLDivElement>(null);
-    const containerSize = useContainerSize(ref);
-
-    const cameraAspectRatio = Number(camera.payload?.width) / Number(camera.payload?.height);
-    const { width, height } = calculateCanvasDimensions(containerSize, cameraAspectRatio);
+    const { containerRef, width, height } = useFittedMediaSize(
+        Number(camera.payload?.width),
+        Number(camera.payload?.height)
+    );
 
     return (
-        <div ref={ref} style={{ height: '100%', width: '100%' }}>
+        <div ref={containerRef} style={{ height: '100%', width: '100%' }}>
             <CameraCanvas camera={camera} width={width} height={height} />
         </div>
     );

--- a/application/ui/src/features/datasets/episodes/episode-video-cell.component.tsx
+++ b/application/ui/src/features/datasets/episodes/episode-video-cell.component.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef } from 'react';
 
-import { Flex } from '@geti-ui/ui';
-
 import { fetchClient } from '../../../api/client';
 import { SchemaEpisodeVideo } from '../../../api/openapi-spec';
+import { useFittedMediaSize } from '../../cameras/use-fitted-media-size';
 import { useEpisodeViewer } from './episode-viewer-provider.component';
 
 export const EpisodeVideoCell = ({
@@ -39,10 +38,15 @@ export const EpisodeVideoCell = ({
         video.currentTime = time + start;
     }, [time, episodeVideo?.start]);
 
+    const { containerRef, width, height } = useFittedMediaSize(
+        videoRef.current?.videoWidth,
+        videoRef.current?.videoHeight
+    );
+
     /* eslint-disable jsx-a11y/media-has-caption */
     return (
-        <Flex>
-            <video ref={videoRef} src={url} />
-        </Flex>
+        <div ref={containerRef} style={{ height: '100%', width: '100%' }}>
+            <video ref={videoRef} src={url} width={width} height={height} />
+        </div>
     );
 };

--- a/application/ui/src/features/robots/robot-control/camera-cell.component.tsx
+++ b/application/ui/src/features/robots/robot-control/camera-cell.component.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
-import { Flex, ProgressCircle, View } from '@geti-ui/ui';
+import { Flex, ProgressCircle } from '@geti-ui/ui';
 
+import { useFittedMediaSize } from '../../../features/cameras/use-fitted-media-size';
 import { useInterval } from '../../../routes/datasets/use-interval';
 import { useRobotControl } from '../robot-control-provider';
 
@@ -17,27 +18,30 @@ export const CameraCell = ({ camera_id, camera_name }: { camera_id: string; came
         }
     }, 1000 / 30);
 
-    const aspectRatio = 640 / 480;
+    const imageRef = useRef<HTMLImageElement>(null);
+    const { containerRef, width, height } = useFittedMediaSize(
+        imageRef.current?.naturalWidth,
+        imageRef.current?.naturalHeight
+    );
 
     return (
-        <Flex UNSAFE_style={{ aspectRatio }}>
-            <View height={'100%'} position={'relative'}>
-                {img === undefined ? (
-                    <Flex width='100%' height='100%' justifyContent={'center'} alignItems={'center'}>
-                        <ProgressCircle isIndeterminate />
-                    </Flex>
-                ) : (
-                    <img
-                        alt={`Camera frame of ${camera_name}`}
-                        src={`data:image/jpg;base64,${img}`}
-                        style={{
-                            objectFit: 'contain',
-                            height: '100%',
-                            width: '100%',
-                        }}
-                    />
-                )}
-            </View>
-        </Flex>
+        <div ref={containerRef} style={{ height: '100%', width: '100%' }}>
+            {img === undefined ? (
+                <Flex width='100%' height='100%' justifyContent={'center'} alignItems={'center'}>
+                    <ProgressCircle isIndeterminate />
+                </Flex>
+            ) : (
+                <img
+                    ref={imageRef}
+                    alt={`Camera frame of ${camera_name}`}
+                    src={`data:image/jpg;base64,${img}`}
+                    style={{
+                        objectFit: 'contain',
+                        height,
+                        width,
+                    }}
+                />
+            )}
+        </div>
     );
 };


### PR DESCRIPTION
This improves the camera and video cells used by the dataset viewer and recording/inference so that the camera feed always fits into its parent container.
The aspect ratio of the camera feed is conserved.

## Type of Change

- [x] 🐞 `fix` - Bug fix