### PR TITLE
refactor: make job a descriminator type

### DIFF
--- a/application/backend/src/api/job.py
+++ b/application/backend/src/api/job.py
@@ -8,7 +8,8 @@ from loguru import logger
 from api.dependencies import get_event_processor_ws, get_job_id, get_job_service, get_scheduler
 from core.scheduler import Scheduler
 from schemas import Job
-from schemas.job import JobStatus, TrainJobPayload
+from schemas.base_job import JobStatus
+from schemas.job import TrainJobPayload
 from services.event_processor import EventProcessor, EventType
 from services.job_service import JobService
 

--- a/application/backend/src/api/job.py
+++ b/application/backend/src/api/job.py
@@ -23,6 +23,15 @@ async def list_jobs(
     return await job_service.get_job_list()
 
 
+@router.get("/{job_id}")
+async def get_job(
+    job_id: Annotated[UUID, Depends(get_job_id)],
+    job_service: Annotated[JobService, Depends(get_job_service)],
+) -> Job:
+    """Fetch one job by id."""
+    return await job_service.get_job_by_id(job_id)
+
+
 @router.delete("/{job_id}")
 async def delete_job(
     job_id: Annotated[UUID, Depends(get_job_id)],

--- a/application/backend/src/repositories/job_repo.py
+++ b/application/backend/src/repositories/job_repo.py
@@ -7,7 +7,8 @@ from db.schema import JobDB
 from repositories.base import BaseRepository
 from repositories.mappers import JobMapper
 from schemas import Job
-from schemas.job import JobStatus, JobType, TrainJobPayload
+from schemas.base_job import JobStatus, JobType
+from schemas.job import TrainJobPayload
 
 
 class JobRepository(BaseRepository):

--- a/application/backend/src/repositories/mappers/job_mapper.py
+++ b/application/backend/src/repositories/mappers/job_mapper.py
@@ -1,6 +1,10 @@
+from pydantic import TypeAdapter
+
 from db.schema import JobDB
 from repositories.mappers.base_mapper_interface import IBaseMapper
 from schemas import Job
+
+JOB_ADAPTER = TypeAdapter(Job)
 
 
 class JobMapper(IBaseMapper):
@@ -10,4 +14,4 @@ class JobMapper(IBaseMapper):
 
     @staticmethod
     def from_schema(model: JobDB) -> Job:
-        return Job.model_validate(model, from_attributes=True)
+        return JOB_ADAPTER.validate_python(model, from_attributes=True)

--- a/application/backend/src/schemas/__init__.py
+++ b/application/backend/src/schemas/__init__.py
@@ -1,7 +1,8 @@
+from .base_job import JobStatus, JobType
 from .calibration import CalibrationConfig
 from .camera import Camera, CameraProfile
 from .dataset import Dataset, Episode, EpisodeInfo, EpisodeVideo, LeRobotDatasetInfo, Snapshot
-from .job import Job
+from .job import Job, TrainJob
 from .model import Model
 from .project import Project
 from .robot import LeRobotConfig, NetworkIpRobotConfig, Robot, SerialPortInfo
@@ -15,6 +16,8 @@ __all__ = [
     "EpisodeInfo",
     "EpisodeVideo",
     "Job",
+    "JobStatus",
+    "JobType",
     "LeRobotConfig",
     "LeRobotDatasetInfo",
     "Model",
@@ -23,4 +26,5 @@ __all__ = [
     "Robot",
     "SerialPortInfo",
     "Snapshot",
+    "TrainJob",
 ]

--- a/application/backend/src/schemas/base_job.py
+++ b/application/backend/src/schemas/base_job.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+from uuid import UUID
+
+from pydantic import Field, field_serializer
+
+from schemas.base import BaseIDModel
+
+
+class JobType(StrEnum):
+    TRAINING = "training"
+
+
+class JobStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+
+class BaseJob(BaseIDModel):
+    project_id: UUID
+    progress: int = Field(default=0, ge=0, le=100, description="Progress percentage from 0 to 100")
+    status: JobStatus = JobStatus.PENDING
+    # Optional telemetry/debug details only.
+    # Contract: data in `extra_info` must never be required for workflow decisions.
+    # If deleting this field would break execution or UI behavior, that data belongs in typed payload.
+    extra_info: dict | None = None
+    message: str = "Job created"
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+    created_at: datetime | None = Field(None)
+
+    @field_serializer("project_id")
+    def serialize_project_id(self, project_id: UUID, _info: Any) -> str:
+        return str(project_id)

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -1,44 +1,13 @@
-from datetime import datetime
-from enum import StrEnum
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_serializer
 
-from schemas.base import BaseIDModel
-
-
-class JobType(StrEnum):
-    TRAINING = "training"
-
-
-class JobStatus(StrEnum):
-    PENDING = "pending"
-    RUNNING = "running"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    CANCELED = "canceled"
-
-
-class Job(BaseIDModel):
-    project_id: UUID
-    type: JobType = JobType.TRAINING
-    progress: int = Field(default=0, ge=0, le=100, description="Progress percentage from 0 to 100")
-    status: JobStatus = JobStatus.PENDING
-    payload: dict
-    extra_info: dict | None = None
-    message: str = "Job created"
-    start_time: datetime | None = None
-    end_time: datetime | None = None
-    created_at: datetime | None = Field(None)
-
-    @field_serializer("project_id")
-    def serialize_project_id(self, project_id: UUID, _info: Any) -> str:
-        return str(project_id)
+from schemas.base_job import BaseJob, JobType
 
 
 class JobList(BaseModel):
-    jobs: list[Job]
+    jobs: list["Job"]
 
 
 class TrainJobPayload(BaseModel):
@@ -65,3 +34,18 @@ class TrainJobPayload(BaseModel):
     @field_serializer("base_model_id")
     def serialize_base_model_id(self, base_model_id: UUID | None, _info: Any) -> str | None:
         return str(base_model_id) if base_model_id else None
+
+
+class TrainJob(BaseJob):
+    type: Literal[JobType.TRAINING] = JobType.TRAINING  # type: ignore[valid-type]
+    payload: TrainJobPayload
+
+
+JobPayload = TrainJobPayload
+
+Job = Annotated[
+    TrainJob,
+    Field(discriminator="type"),
+]
+
+JobList.model_rebuild()

--- a/application/backend/src/services/job_service.py
+++ b/application/backend/src/services/job_service.py
@@ -8,7 +8,8 @@ from db.schema import JobDB
 from exceptions import DuplicateJobException, ResourceInUseError, ResourceNotFoundError, ResourceType
 from repositories import JobRepository
 from schemas import Job
-from schemas.job import JobStatus, JobType, TrainJobPayload
+from schemas.base_job import JobStatus, JobType
+from schemas.job import TrainJob, TrainJobPayload
 
 
 class JobService:
@@ -45,10 +46,9 @@ class JobService:
                 raise DuplicateJobException
 
             try:
-                job = Job(
+                job = TrainJob(
                     project_id=payload.project_id,
-                    type=JobType.TRAINING,
-                    payload=payload.model_dump(),
+                    payload=payload,
                     message="Training job submitted",
                 )
                 return await repo.save(job)
@@ -94,7 +94,7 @@ class JobService:
             if job is None:
                 raise ResourceNotFoundError(ResourceType.JOB, str(job_id))
 
-            if job.status != "failed":
+            if job.status not in {JobStatus.FAILED, JobStatus.CANCELED}:
                 raise ResourceInUseError(ResourceType.JOB, str(job_id))
 
             await repo.delete_by_id(job_id)

--- a/application/backend/src/services/log_service.py
+++ b/application/backend/src/services/log_service.py
@@ -14,7 +14,8 @@ from loguru import logger
 from sse_starlette import ServerSentEvent
 
 from core.logging.utils import get_job_logs_path
-from schemas.job import JobType, TrainJobPayload
+from schemas.base_job import JobType
+from schemas.job import TrainJobPayload
 from schemas.logs import LogSource
 from services.job_service import JobService
 from settings import Settings

--- a/application/backend/src/services/training_service.py
+++ b/application/backend/src/services/training_service.py
@@ -12,7 +12,7 @@ from lightning.pytorch.callbacks import Callback, ProgressBar
 from lightning.pytorch.utilities.types import STEP_OUTPUT
 from loguru import logger
 
-from schemas.job import JobStatus, JobType
+from schemas.base_job import JobStatus, JobType
 from services.event_processor import EventType
 from services.job_service import JobService
 from workers.base import BaseThreadWorker

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -27,7 +27,8 @@ from physicalai.export import ExportablePolicyMixin
 from physicalai.train import Trainer
 
 from schemas import Job, Model, Snapshot
-from schemas.job import JobStatus, TrainJobPayload
+from schemas.base_job import JobStatus
+from schemas.job import TrainJobPayload
 from services import DatasetService, ModelService
 from services.event_processor import EventType
 from services.job_service import JobService

--- a/application/ui/src/routes/models/index.tsx
+++ b/application/ui/src/routes/models/index.tsx
@@ -17,7 +17,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import useWebSocket from 'react-use-websocket';
 
 import { $api, fetchClient } from '../../api/client';
-import { SchemaJob, SchemaModel } from '../../api/openapi-spec';
+import { SchemaTrainJob as SchemaJob, SchemaModel } from '../../api/openapi-spec';
 import { LogsDialog } from '../../features/logs/logs-dialog';
 import { useProjectId } from '../../features/projects/use-project';
 import { ReactComponent as EmptyIllustration } from './../../assets/illustration.svg';

--- a/application/ui/src/routes/models/model-table.component.tsx
+++ b/application/ui/src/routes/models/model-table.component.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { ActionButton, Button, DialogTrigger, Flex, Grid, Item, Key, Menu, MenuTrigger, Text, View } from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
 
-import { SchemaJob, SchemaModel } from '../../api/openapi-spec';
+import { SchemaModel, SchemaTrainJob } from '../../api/openapi-spec';
 import { GRID_COLUMNS } from './constants';
 import { ModelDownloadDialog } from './model-download-dialog.component';
 import { StartInferenceDialog } from './start-model-modal.component';
@@ -32,7 +32,7 @@ export const ModelRow = ({
     onViewLogs,
 }: {
     model: SchemaModel;
-    trainingJob?: SchemaJob;
+    trainingJob?: SchemaTrainJob;
     onDelete: () => void;
     onRetrain: () => void;
     onViewLogs?: () => void;

--- a/application/ui/src/routes/models/train-model-dialog.tsx
+++ b/application/ui/src/routes/models/train-model-dialog.tsx
@@ -24,13 +24,13 @@ import {
 } from '@geti-ui/ui';
 
 import { $api } from '../../api/client';
-import { SchemaJob, SchemaModel, SchemaTrainJobPayload } from '../../api/openapi-spec';
+import { SchemaTrainJob as SchemaJob, SchemaModel } from '../../api/openapi-spec';
 import { useProject } from '../../features/projects/use-project';
 
 import classes from './train-model-dialog.module.scss';
 
 export type SchemaTrainJob = Omit<SchemaJob, 'payload'> & {
-    payload: SchemaTrainJobPayload;
+    payload: SchemaJob['payload'];
 };
 
 const GB = 1024 ** 3;
@@ -261,7 +261,7 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: 
             return;
         }
 
-        const payload: SchemaTrainJobPayload = {
+        const payload: SchemaJob['payload'] = {
             dataset_id,
             project_id: projectId,
             model_name: name,


### PR DESCRIPTION
This PR makes preparations for us to enable both dataset and model import jobs.
There are two things this PR does:
1. Expose a new `GET /api/jobs/{job_id}` endpoint that we can use to poll the status of one specific job
2. Change the `Job` model to be a based on a discriminator type, similarly to how the `Camera` model behaves

This will then allow us to have a `DatasetImportJob`, `ModelImportJob` etc.

## Type of Change

- [x] ♻️ `refactor` - Code refactoring