### PR TITLE
feat: add training device information to train model dialog

### DIFF
--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -22,6 +22,7 @@ from services.event_processor import EventProcessor
 from services.job_service import JobService
 from services.log_service import LogService
 from services.robot_calibration_service import RobotCalibrationService
+from services.system_service import SystemService
 from settings import get_settings
 from utils.serial_robot_tools import RobotConnectionManager
 from workers.camera_worker_registry import CameraWorkerRegistry
@@ -40,6 +41,12 @@ def is_valid_uuid(identifier: str) -> bool:
     except ValueError:
         return False
     return True
+
+
+@lru_cache
+def get_system_service() -> SystemService:
+    """Provide a SystemService instance for querying system hardware."""
+    return SystemService()
 
 
 @lru_cache

--- a/application/backend/src/api/system.py
+++ b/application/backend/src/api/system.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""System information endpoints for hardware discovery."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from api.dependencies import get_system_service
+from schemas.hardware import DeviceInfo
+from services.system_service import SystemService
+
+system_router = APIRouter(prefix="/api/system", tags=["System"])
+
+
+@system_router.get("/devices/training")
+async def get_training_devices(
+    system_service: Annotated[SystemService, Depends(get_system_service)],
+) -> list[DeviceInfo]:
+    """Returns the list of available training devices (CPU, Intel XPU, NVIDIA CUDA, Apple MPS)."""
+    return system_service.get_training_devices()

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -88,3 +88,15 @@ class ResourceAlreadyExistsError(BaseException):
             error_code=f"{resource_name}_already_exists",
             http_status=http.HTTPStatus.CONFLICT,
         )
+
+
+class UnsupportedDeviceError(BaseException):
+    """Exception raised when a requested training device is not available on the system."""
+
+    def __init__(self, device_type: str, supported: list[str]) -> None:
+        supported_str = ", ".join(supported) if supported else "none"
+        super().__init__(
+            message=f"Device type '{device_type}' is not available for training. Supported devices: {supported_str}.",
+            error_code="unsupported_device",
+            http_status=http.HTTPStatus.BAD_REQUEST,
+        )

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -24,6 +24,7 @@ from api.robot_control import router as robot_control_router
 from api.robot_setup import router as robot_setup_router
 from api.robots import router as project_robots_router
 from api.settings import router as settings_router
+from api.system import system_router
 from api.webui import SPAStaticFiles
 from core import lifespan
 from exception_handlers import register_application_exception_handlers
@@ -54,6 +55,7 @@ app.include_router(settings_router)
 app.include_router(models_router)
 app.include_router(job_router)
 app.include_router(logs_router)
+app.include_router(system_router)
 
 register_application_exception_handlers(app)
 

--- a/application/backend/src/schemas/__init__.py
+++ b/application/backend/src/schemas/__init__.py
@@ -2,6 +2,7 @@ from .base_job import JobStatus, JobType
 from .calibration import CalibrationConfig
 from .camera import Camera, CameraProfile
 from .dataset import Dataset, Episode, EpisodeInfo, EpisodeVideo, LeRobotDatasetInfo, Snapshot
+from .hardware import DeviceInfo, DeviceType
 from .job import Job, TrainJob
 from .model import Model
 from .project import Project
@@ -12,6 +13,8 @@ __all__ = [
     "Camera",
     "CameraProfile",
     "Dataset",
+    "DeviceInfo",
+    "DeviceType",
     "Episode",
     "EpisodeInfo",
     "EpisodeVideo",

--- a/application/backend/src/schemas/hardware.py
+++ b/application/backend/src/schemas/hardware.py
@@ -14,14 +14,13 @@ class DeviceType(StrEnum):
     CPU = auto()
     XPU = auto()
     CUDA = auto()
-    MPS = auto()
     NPU = auto()
 
 
 class DeviceInfo(BaseModel):
     """Information about a compute device available for training."""
 
-    type: DeviceType = Field(..., description="Device type (cpu, xpu, cuda, mps, npu)")
+    type: DeviceType = Field(..., description="Device type (cpu, xpu, cuda, npu)")
     name: str = Field(..., description="Human-readable device name")
-    memory: int | None = Field(None, description="Total device memory in bytes (null for CPU/MPS)")
-    index: int | None = Field(None, description="Device index among those of the same type (null for CPU/MPS)")
+    memory: int | None = Field(None, description="Total device memory in bytes (null for CPU)")
+    index: int | None = Field(None, description="Device index among those of the same type (null for CPU)")

--- a/application/backend/src/schemas/hardware.py
+++ b/application/backend/src/schemas/hardware.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Schemas for hardware and device information."""
+
+from enum import StrEnum, auto
+
+from pydantic import BaseModel, Field
+
+
+class DeviceType(StrEnum):
+    """Enumeration of supported device types."""
+
+    CPU = auto()
+    XPU = auto()
+    CUDA = auto()
+    MPS = auto()
+    NPU = auto()
+
+
+class DeviceInfo(BaseModel):
+    """Information about a compute device available for training."""
+
+    type: DeviceType = Field(..., description="Device type (cpu, xpu, cuda, mps, npu)")
+    name: str = Field(..., description="Human-readable device name")
+    memory: int | None = Field(None, description="Total device memory in bytes (null for CPU/MPS)")
+    index: int | None = Field(None, description="Device index among those of the same type (null for CPU/MPS)")

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -16,18 +16,18 @@ class TrainingDevice(BaseModel):
     """Device specification for training."""
 
     type: DeviceType = Field(..., description="Device type, e.g. 'cpu', 'xpu', 'cuda'")
-    index: int | None = Field(default=None, ge=0, description="Device index (null for CPU/MPS/NPU)")
+    index: int | None = Field(default=None, ge=0, description="Device index (null for CPU/NPU)")
 
     @model_validator(mode="after")
     def validate_index_for_device_type(self) -> "TrainingDevice":
         """Ensure index is consistent with the device type.
 
         Indexed types (cuda, xpu) default to index 0 when omitted.
-        Non-indexed types (cpu, mps, npu) ignore a supplied index with a warning.
+        Non-indexed types (cpu, npu) ignore a supplied index with a warning.
         """
         device_type_str = str(self.type).lower()
         indexed_types = {"cuda", "xpu"}
-        non_indexed_types = {"cpu", "mps", "npu"}
+        non_indexed_types = {"cpu", "npu"}
 
         if device_type_str in non_indexed_types:
             if self.index is not None:

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -1,13 +1,49 @@
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_serializer
+from loguru import logger
+from pydantic import BaseModel, Field, field_serializer, model_validator
 
 from schemas.base_job import BaseJob, JobType
+from schemas.hardware import DeviceType
 
 
 class JobList(BaseModel):
     jobs: list["Job"]
+
+
+class TrainingDevice(BaseModel):
+    """Device specification for training."""
+
+    type: DeviceType = Field(..., description="Device type, e.g. 'cpu', 'xpu', 'cuda'")
+    index: int | None = Field(default=None, ge=0, description="Device index (null for CPU/MPS/NPU)")
+
+    @model_validator(mode="after")
+    def validate_index_for_device_type(self) -> "TrainingDevice":
+        """Ensure index is consistent with the device type.
+
+        Indexed types (cuda, xpu) default to index 0 when omitted.
+        Non-indexed types (cpu, mps, npu) ignore a supplied index with a warning.
+        """
+        device_type_str = str(self.type).lower()
+        indexed_types = {"cuda", "xpu"}
+        non_indexed_types = {"cpu", "mps", "npu"}
+
+        if device_type_str in non_indexed_types:
+            if self.index is not None:
+                logger.warning(
+                    "Device type '{}' does not support an index. Got index={}. Disregarding index.",
+                    self.type,
+                    self.index,
+                )
+                self.index = None
+        elif device_type_str in indexed_types and self.index is None:
+            logger.warning(
+                "Device type '{}' requires an index (e.g., 'cuda:0', 'xpu:0'). Using default index 0.",
+                device_type_str,
+            )
+            self.index = 0
+        return self
 
 
 class TrainJobPayload(BaseModel):
@@ -22,6 +58,7 @@ class TrainJobPayload(BaseModel):
         default=False, description="Run batch-size finder before training (power scaling)"
     )
     base_model_id: UUID | None = Field(default=None, description="Model ID to resume training from")
+    device: TrainingDevice | None = Field(default=None, description="Target training device (auto-detected if null)")
 
     @field_serializer("project_id")
     def serialize_project_id(self, project_id: UUID, _info: Any) -> str:

--- a/application/backend/src/services/__init__.py
+++ b/application/backend/src/services/__init__.py
@@ -7,6 +7,7 @@ from .model_download_service import ModelDownloadService
 from .model_service import ModelService
 from .project_camera_service import ProjectCameraService
 from .project_service import ProjectService
+from .system_service import SystemService
 
 __all__ = [
     "DatasetDownloadService",
@@ -17,4 +18,5 @@ __all__ = [
     "ProjectCameraService",
     "ProjectService",
     "RobotService",
+    "SystemService",
 ]

--- a/application/backend/src/services/job_service.py
+++ b/application/backend/src/services/job_service.py
@@ -5,11 +5,18 @@ from sqlalchemy.exc import IntegrityError
 
 from db import get_async_db_session_ctx
 from db.schema import JobDB
-from exceptions import DuplicateJobException, ResourceInUseError, ResourceNotFoundError, ResourceType
+from exceptions import (
+    DuplicateJobException,
+    ResourceInUseError,
+    ResourceNotFoundError,
+    ResourceType,
+    UnsupportedDeviceError,
+)
 from repositories import JobRepository
 from schemas import Job
 from schemas.base_job import JobStatus, JobType
 from schemas.job import TrainJob, TrainJobPayload
+from services.system_service import SystemService
 
 
 class JobService:
@@ -40,6 +47,13 @@ class JobService:
 
     @staticmethod
     async def submit_train_job(payload: TrainJobPayload) -> Job:
+        # Validate the requested training device before persisting the job
+        if payload.device is not None and not SystemService.is_device_supported_for_training(payload.device.type):
+            raise UnsupportedDeviceError(
+                device_type=payload.device.type,
+                supported=SystemService.supported_training_device_types(),
+            )
+
         async with get_async_db_session_ctx() as session:
             repo = JobRepository(session)
             if await repo.is_job_duplicate(project_id=payload.project_id, payload=payload):

--- a/application/backend/src/services/system_service.py
+++ b/application/backend/src/services/system_service.py
@@ -63,3 +63,21 @@ class SystemService:
             logger.debug("Detected MPS device")
 
         return devices
+
+    @classmethod
+    def is_device_supported_for_training(cls, device_type: str) -> bool:
+        """Check whether a device type is available for training.
+
+        Args:
+            device_type: Device type string, e.g. 'cpu', 'cuda', 'xpu'.
+
+        Returns:
+            True if at least one device of the given type is available.
+        """
+        device_type_lower = device_type.lower()
+        return any(d.type == device_type_lower for d in cls.get_training_devices())
+
+    @classmethod
+    def supported_training_device_types(cls) -> list[str]:
+        """Return the distinct device type strings available for training."""
+        return sorted({d.type for d in cls.get_training_devices()})

--- a/application/backend/src/services/system_service.py
+++ b/application/backend/src/services/system_service.py
@@ -16,7 +16,7 @@ class SystemService:
     def get_training_devices() -> list[DeviceInfo]:
         """Get available compute devices for training.
 
-        Enumerates CPU, Intel XPU, NVIDIA CUDA, and Apple MPS devices
+        Enumerates CPU, Intel XPU and NVIDIA CUDA
         that PyTorch can use for model training.
 
         Returns:
@@ -64,13 +64,6 @@ class SystemService:
                     cuda_props.name,
                     cuda_props.total_memory,
                 )
-
-        # Apple MPS
-        if torch.mps.is_available():
-            devices.append(
-                DeviceInfo(type=DeviceType.MPS, name="MPS", memory=None, index=None),
-            )
-            logger.debug("Detected MPS device")
 
         return devices
 

--- a/application/backend/src/services/system_service.py
+++ b/application/backend/src/services/system_service.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Service for querying system hardware information."""
+
+import torch
+from loguru import logger
+
+from schemas.hardware import DeviceInfo, DeviceType
+
+
+class SystemService:
+    """Service to discover and report available compute hardware."""
+
+    @staticmethod
+    def get_training_devices() -> list[DeviceInfo]:
+        """Get available compute devices for training.
+
+        Enumerates CPU, Intel XPU, NVIDIA CUDA, and Apple MPS devices
+        that PyTorch can use for model training.
+
+        Returns:
+            list[DeviceInfo]: Available training devices with name, type,
+                memory (where available), and device index.
+        """
+        devices: list[DeviceInfo] = [
+            DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None),
+        ]
+
+        # Intel XPU devices
+        if torch.xpu.is_available():
+            for device_idx in range(torch.xpu.device_count()):
+                props = torch.xpu.get_device_properties(device_idx)
+                devices.append(
+                    DeviceInfo(
+                        type=DeviceType.XPU,
+                        name=props.name,
+                        memory=props.total_memory,
+                        index=device_idx,
+                    ),
+                )
+                logger.debug("Detected XPU device {}: {} ({} bytes)", device_idx, props.name, props.total_memory)
+
+        # NVIDIA CUDA devices
+        if torch.cuda.is_available():
+            for device_idx in range(torch.cuda.device_count()):
+                props = torch.cuda.get_device_properties(device_idx)
+                devices.append(
+                    DeviceInfo(
+                        type=DeviceType.CUDA,
+                        name=props.name,
+                        memory=props.total_memory,
+                        index=device_idx,
+                    ),
+                )
+                logger.debug("Detected CUDA device {}: {} ({} bytes)", device_idx, props.name, props.total_memory)
+
+        # Apple MPS
+        if torch.mps.is_available():
+            devices.append(
+                DeviceInfo(type=DeviceType.MPS, name="MPS", memory=None, index=None),
+            )
+            logger.debug("Detected MPS device")
+
+        return devices

--- a/application/backend/src/services/system_service.py
+++ b/application/backend/src/services/system_service.py
@@ -30,30 +30,40 @@ class SystemService:
         # Intel XPU devices
         if torch.xpu.is_available():
             for device_idx in range(torch.xpu.device_count()):
-                props = torch.xpu.get_device_properties(device_idx)
+                xpu_props = torch.xpu.get_device_properties(device_idx)
                 devices.append(
                     DeviceInfo(
                         type=DeviceType.XPU,
-                        name=props.name,
-                        memory=props.total_memory,
+                        name=xpu_props.name,
+                        memory=xpu_props.total_memory,
                         index=device_idx,
                     ),
                 )
-                logger.debug("Detected XPU device {}: {} ({} bytes)", device_idx, props.name, props.total_memory)
+                logger.debug(
+                    "Detected XPU device {}: {} ({} bytes)",
+                    device_idx,
+                    xpu_props.name,
+                    xpu_props.total_memory,
+                )
 
         # NVIDIA CUDA devices
         if torch.cuda.is_available():
             for device_idx in range(torch.cuda.device_count()):
-                props = torch.cuda.get_device_properties(device_idx)
+                cuda_props = torch.cuda.get_device_properties(device_idx)
                 devices.append(
                     DeviceInfo(
                         type=DeviceType.CUDA,
-                        name=props.name,
-                        memory=props.total_memory,
+                        name=cuda_props.name,
+                        memory=cuda_props.total_memory,
                         index=device_idx,
                     ),
                 )
-                logger.debug("Detected CUDA device {}: {} ({} bytes)", device_idx, props.name, props.total_memory)
+                logger.debug(
+                    "Detected CUDA device {}: {} ({} bytes)",
+                    device_idx,
+                    cuda_props.name,
+                    cuda_props.total_memory,
+                )
 
         # Apple MPS
         if torch.mps.is_available():

--- a/application/backend/src/utils/device.py
+++ b/application/backend/src/utils/device.py
@@ -9,7 +9,7 @@ def get_torch_device(device: str | None = None) -> str:
 
     When *device* is provided it is returned as-is, allowing the caller to
     override auto-detection.  When ``None``, the best available accelerator
-    is chosen automatically (XPU > CUDA > MPS > CPU).
+    is chosen automatically (XPU > CUDA > CPU).
     """
     if device is not None:
         return device

--- a/application/backend/src/utils/device.py
+++ b/application/backend/src/utils/device.py
@@ -4,10 +4,16 @@
 """Utility functions for device management."""
 
 
-def get_torch_device() -> str:
-    """Get the appropriate torch device string based on availability.
-    Checks for XPU, CUDA, MPS, and falls back to CPU if none are available.
+def get_torch_device(device: str | None = None) -> str:
+    """Get the torch device string to use for training.
+
+    When *device* is provided it is returned as-is, allowing the caller to
+    override auto-detection.  When ``None``, the best available accelerator
+    is chosen automatically (XPU > CUDA > MPS > CPU).
     """
+    if device is not None:
+        return device
+
     import torch
 
     if torch.xpu.is_available():
@@ -20,10 +26,20 @@ def get_torch_device() -> str:
     return "cpu"
 
 
-def get_lightning_strategy() -> str:
-    """Get the appropriate lightning strategy string based on available hardware.
+def get_lightning_strategy(device: str | None = None) -> str:
+    """Get the Lightning strategy string for the given device.
 
-    XPU device requires a specific strategy, while others are covered by 'auto' strategy."""
+    XPU requires a specific strategy; all other devices are covered by
+    ``'auto'``.  When *device* is ``None`` the decision is based on
+    hardware auto-detection.
+    """
+    if device is not None:
+        if device == "xpu":
+            import physicalai.devices.xpu
+
+            return "xpu_single"
+        return "auto"
+
     import torch
 
     if torch.xpu.is_available():

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -116,6 +116,10 @@ class TrainingWorker(BaseProcessWorker):
         try:
             path = Path(model.path)
 
+            # Resolve training device -- explicit from payload or auto-detected
+            device_type = payload.device.type if payload.device else None
+            device_index = payload.device.index if payload.device else None
+
             l_dm = LeRobotDataModule(
                 repo_id="snapshot",  # doesnt matter for loading the data.
                 root=snapshot.path,
@@ -148,8 +152,9 @@ class TrainingWorker(BaseProcessWorker):
                     ),
                     TrainingLogCallback(),
                 ],
-                accelerator=get_torch_device(),
-                strategy=get_lightning_strategy(),
+                accelerator=get_torch_device(device_type),
+                strategy=get_lightning_strategy(device_type),
+                devices=[device_index] if device_index is not None else "auto",
                 max_steps=payload.max_steps,
                 auto_scale_batch_size=payload.auto_scale_batch_size,
             )

--- a/application/ui/src/routes/models/train-model-dialog.tsx
+++ b/application/ui/src/routes/models/train-model-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
     Button,
@@ -19,13 +19,16 @@ import {
     Key,
     NumberField,
     Picker,
+    StatusLight,
     Text,
     TextField,
+    View,
 } from '@geti-ui/ui';
 
 import { $api } from '../../api/client';
-import { SchemaTrainJob as SchemaJob, SchemaModel } from '../../api/openapi-spec';
+import { SchemaDeviceInfo, SchemaTrainJob as SchemaJob, SchemaModel } from '../../api/openapi-spec';
 import { useProject } from '../../features/projects/use-project';
+import { InlineAlert } from '../../features/robots/setup-wizard/shared/inline-alert';
 
 import classes from './train-model-dialog.module.scss';
 
@@ -91,6 +94,12 @@ interface PolicySelectionProps {
 }
 
 const PolicySelection = ({ selectedPolicy, onSelectionChange, isDisabled }: PolicySelectionProps) => {
+    const bestDevice = useBestTrainingDevice();
+    const availableVram = bestDevice?.memory ?? 0;
+
+    const selectedModel = MODELS.find((m) => m.id === selectedPolicy) ?? null;
+    const hasInsufficientVram = selectedModel !== null && availableVram > 0 && selectedModel.minVRAM > availableVram;
+
     return (
         <Flex direction='column' gap='size-100'>
             <Text UNSAFE_style={{ fontSize: 12 }}>Policy</Text>
@@ -129,14 +138,54 @@ const PolicySelection = ({ selectedPolicy, onSelectionChange, isDisabled }: Poli
                                     </Flex>
                                 </Flex>
                                 <Divider size='S' />
-                                <Text UNSAFE_style={{ fontSize: 12 }} marginTop='size-50'>
-                                    {model.description}
-                                </Text>
+                                <Text UNSAFE_style={{ fontSize: 12 }}>{model.description}</Text>
                             </Flex>
                         </Card>
                     );
                 })}
             </div>
+
+            {hasInsufficientVram && (
+                <View marginTop='size-100'>
+                    <InlineAlert variant='warning'>
+                        {selectedModel.name} requires at least {formatBytes(selectedModel!.minVRAM)} VRAM but your
+                        device has {formatBytes(availableVram)}. Training may fail or be very slow.
+                    </InlineAlert>
+                </View>
+            )}
+        </Flex>
+    );
+};
+
+const useBestTrainingDevice = (): SchemaDeviceInfo | null => {
+    const { data: trainingDevices = [] } = $api.useQuery('get', '/api/system/devices/training');
+
+    // Pick the GPU with the most VRAM (if any)
+    return useMemo(() => {
+        return trainingDevices
+            .filter((d) => d.type !== 'cpu' && d.memory != null)
+            .reduce((best, device): SchemaDeviceInfo | null => {
+                if (best === null || (device.memory ?? 0) > (best.memory ?? 0)) {
+                    return device;
+                }
+
+                return best;
+            }, null);
+    }, [trainingDevices]);
+};
+
+const TrainingDeviceInfo = () => {
+    const bestDevice = useBestTrainingDevice();
+
+    return (
+        <Flex UNSAFE_style={{ textAlign: 'right' }} direction='column' gap='size-75'>
+            {bestDevice ? (
+                <StatusLight variant='positive'>
+                    {bestDevice.name}, {formatBytes(bestDevice.memory!)} VRAM
+                </StatusLight>
+            ) : (
+                <StatusLight variant='neutral'>CPU only (no GPU detected)</StatusLight>
+            )}
         </Flex>
     );
 };
@@ -282,6 +331,8 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: 
             <Heading>
                 <Flex justifyContent={'space-between'}>
                     <Text> Train model</Text>
+
+                    <TrainingDeviceInfo />
                 </Flex>
             </Heading>
             <Divider />


### PR DESCRIPTION
This PR adds a new `GET /api/system/devices/training` endpoint (taken anomalib studio's implementation as a reference). The training devices information is then used to determine if the user has enough VRAM to train amodel. If they don't then we show a warning message.
One open for this implementation is that for iGPU the memory that is reported to be used is the same as the system memory, but it is not realistic that the iGPU has access to all of this.

## Type of Change

- [x] ✨ `feat` - New feature

## Screenshots

| **Enough (V)RAM** | **Not enough VRAM** |
|------------|-----------|
| <img width="1920" height="1080" alt="192 168 2 101_3000_projects(Full HD)" src="https://github.com/user-attachments/assets/12d35fd0-ddf5-4087-9e42-fccb8ab3c91b" />           | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c3da2535-ef80-4b2e-aaa1-70cbce5f3c3b" />          |



