### PR TITLE
refactor: Start Model worker processes on init

### DIFF
--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -25,6 +25,7 @@ from services.robot_calibration_service import RobotCalibrationService
 from settings import get_settings
 from utils.serial_robot_tools import RobotConnectionManager
 from workers.camera_worker_registry import CameraWorkerRegistry
+from workers.model_worker_registry import ModelWorkerRegistry
 from workers.robot_worker_registry import RobotWorkerRegistry
 
 
@@ -226,3 +227,14 @@ def get_robot_registry(request: HTTPConnection) -> RobotWorkerRegistry:
 
 CameraRegistryDep = Annotated[CameraWorkerRegistry, Depends(get_camera_registry)]
 RobotRegistryDep = Annotated[RobotWorkerRegistry, Depends(get_robot_registry)]
+
+
+def get_model_registry(request: HTTPConnection) -> ModelWorkerRegistry:
+    """Dependency to get model worker registry."""
+    registry = getattr(request.app.state, "model_registry", None)
+    if registry is None:
+        raise RuntimeError("Model worker registry not initialized")
+    return registry
+
+
+ModelRegistryDep = Annotated[ModelWorkerRegistry, Depends(get_model_registry)]

--- a/application/backend/src/api/record.py
+++ b/application/backend/src/api/record.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, WebSocket
 from fastapi.responses import Response
 from loguru import logger
 
-from api.dependencies import RobotCalibrationServiceDep, RobotConnectionManagerDep, get_scheduler_ws
+from api.dependencies import ModelRegistryDep, RobotCalibrationServiceDep, RobotConnectionManagerDep, get_scheduler_ws
 from core.scheduler import Scheduler
 from robots.robot_client_factory import RobotClientFactory
 from schemas import Dataset, Model
@@ -77,6 +77,7 @@ async def robot_control_websocket(
     robot_manager: RobotConnectionManagerDep,
     calibration_service: RobotCalibrationServiceDep,
     scheduler: Annotated[Scheduler, Depends(get_scheduler_ws)],
+    model_registry: ModelRegistryDep,
 ) -> None:
     """Robot control websocket."""
     await websocket.accept()
@@ -88,6 +89,7 @@ async def robot_control_websocket(
             calibration_service=calibration_service,
         ),
         queue=queue,
+        model_worker_registry=model_registry,
     )
     process.start()
 

--- a/application/backend/src/control/sync_mixed_model_integration.py
+++ b/application/backend/src/control/sync_mixed_model_integration.py
@@ -1,10 +1,7 @@
-from multiprocessing.synchronize import Event as EventClass
-
 from physicalai.data import Observation
 
 from control.inference_poller import InferencePoller
 from control.queue_mixer import QueueMixer
-from schemas import Model
 from workers.model_worker import ModelWorker
 
 
@@ -14,12 +11,8 @@ class SyncMixedModelIntegration:
     inference_poller: InferencePoller
     fps: int
 
-    def __init__(self, model: Model, backend: str, stop_event: EventClass, fps: int):
-        self.model_worker = ModelWorker(
-            model=model,
-            backend=backend,
-            stop_event=stop_event,
-        )
+    def __init__(self, model_worker: ModelWorker, fps: int):
+        self.model_worker = model_worker
         self.fps = fps
 
         # Communication layer to model worker. It ensures no queue.
@@ -33,7 +26,7 @@ class SyncMixedModelIntegration:
             inference_result = self.inference_poller.get_result()
             offset = int(inference_result.time * self.fps)
             self.queue_mixer.add(inference_result.data, offset)
-            self.queue_mixer.lerp_duration = max(offset, 1)  # inference time should be a good guide for now.
+            self.queue_mixer.lerp_duration = max(offset, 1)
 
         if not self.inference_poller.busy:
             self.inference_poller.run_inference(observation)
@@ -47,9 +40,8 @@ class SyncMixedModelIntegration:
         self.inference_poller.reset()
 
     async def setup(self) -> None:
-        self.model_worker.start()
+        # Worker is already running (pre-spawned); just wait for model to load.
         await self.model_worker.wait_for_loading_to_complete()
 
     def teardown(self) -> None:
-        self.model_worker.stop()
-        self.model_worker.join(timeout=5)
+        self.inference_poller.reset()

--- a/application/backend/src/core/lifecycle.py
+++ b/application/backend/src/core/lifecycle.py
@@ -9,6 +9,7 @@ from services.event_processor import EventProcessor
 from settings import get_settings
 from utils.serial_robot_tools import RobotConnectionManager
 from workers.camera_worker_registry import CameraWorkerRegistry
+from workers.model_worker_registry import ModelWorkerRegistry
 from workers.robot_worker_registry import RobotWorkerRegistry
 
 from .scheduler import Scheduler
@@ -36,6 +37,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     logger.info("Starting %s application...", settings.app_name)
     app_scheduler = Scheduler()
     app_scheduler.start_workers()
+
+    app.state.model_registry = ModelWorkerRegistry(
+        max_workers=1,
+        stop_event=app_scheduler.mp_stop_event,
+    )
     app.state.scheduler = app_scheduler
     app.state.event_processor = EventProcessor(app_scheduler.event_queue)
     logger.info("Application startup completed")
@@ -54,6 +60,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     robot_registry: RobotWorkerRegistry = app.state.robot_registry
     await robot_registry.shutdown_all()
+
+    model_registry: ModelWorkerRegistry = app.state.model_registry
+    await model_registry.shutdown_all()
 
     # We might want to shutdown the hardware manager too, though releasing workers should handle it.
     # But a global cleanup is safe.

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -79,7 +79,7 @@ if (
     app.mount("/", static_files, name="webui")
 
 if __name__ == "__main__":
-    #if get_torch_device() == "xpu" and mp.get_start_method(allow_none=True) != "spawn":
-    mp.set_start_method("spawn", force=True)
+    if get_torch_device() == "xpu" and mp.get_start_method(allow_none=True) != "spawn":
+        mp.set_start_method("spawn", force=True)
     uvicorn_port = int(os.environ.get("HTTP_SERVER_PORT", settings.port))
     uvicorn.run(app, host=settings.host, port=uvicorn_port)

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -79,7 +79,7 @@ if (
     app.mount("/", static_files, name="webui")
 
 if __name__ == "__main__":
-    if get_torch_device() == "xpu" and mp.get_start_method(allow_none=True) != "spawn":
-        mp.set_start_method("spawn", force=True)
+    #if get_torch_device() == "xpu" and mp.get_start_method(allow_none=True) != "spawn":
+    mp.set_start_method("spawn", force=True)
     uvicorn_port = int(os.environ.get("HTTP_SERVER_PORT", settings.port))
     uvicorn.run(app, host=settings.host, port=uvicorn_port)

--- a/application/backend/src/workers/model_worker.py
+++ b/application/backend/src/workers/model_worker.py
@@ -17,55 +17,76 @@ from .base import BaseProcessWorker
 class ModelWorker(BaseProcessWorker):
     ROLE: str = "ModelWorker"
 
-    backend: str
-    model: Model
     inference_model: InferenceModel
+    command_queue: mp.Queue
     observation_queue: mp.Queue
     output_queue: mp.Queue
     model_loaded_event: EventClass
+    unload_event: EventClass
 
-    def __init__(self, model: Model, backend: str, stop_event: EventClass):
+    def __init__(self, stop_event: EventClass):
+        self.command_queue = mp.Queue()
         self.observation_queue = mp.Queue()
         self.output_queue = mp.Queue()
-        super().__init__(stop_event=stop_event, queues_to_cancel=[self.observation_queue, self.output_queue])
-        self.model = model
-        self.backend = backend
-        self.close_event = mp.Event()
+        super().__init__(
+            stop_event=stop_event,
+            queues_to_cancel=[self.command_queue, self.observation_queue, self.output_queue],
+        )
         self.model_loaded_event = mp.Event()
+        self.unload_event = mp.Event()
 
-    async def setup(self) -> None:
-        """Load model."""
-        self.inference_model = load_inference_model(self.model, backend=self.backend)
-        logger.info("Model loaded.")
-        self.model_loaded_event.set()
+    @property
+    def is_loaded(self) -> bool:
+        return self.model_loaded_event.is_set()
+
+    def load_model(self, model: Model, backend: str) -> None:
+        """Send a load command to the worker process."""
+        self.command_queue.put(("load", model, backend))
+
+    def unload_model(self) -> None:
+        """Signal the worker to stop inference and return to idle."""
+        self.unload_event.set()
 
     async def wait_for_loading_to_complete(self) -> None:
         await asyncio.to_thread(self.model_loaded_event.wait)
 
-    def stop(self) -> None:
-        """Stop model worker."""
-        self.close_event.set()
-
     async def run_loop(self) -> None:
-        """Run inference."""
-        logger.info("Inference-Run loop")
-        # Should stop is a check for global shutdown, close event for worker shutdown.
-        while not self.should_stop() and not self.close_event.is_set():
+        """Idle → load → inference → idle cycle."""
+        while not self.should_stop():
+            # Wait for a load command
             try:
-                observation = self.observation_queue.get(timeout=1)
-                start_time = time.perf_counter()
-                # batch size is 1, so taking first batch 0
-                output = self.inference_model.select_action(observation)[0]
-                end_time = time.perf_counter()
-                elapsed_time = end_time - start_time
-                logger.debug(f"Inference: ({elapsed_time}): {output.shape}")
-                self.output_queue.put(InferenceResult(time=elapsed_time, data=output))
+                cmd = self.command_queue.get(timeout=1)
             except queue.Empty:
                 continue
 
-        logger.info("Inference stopped")
+            if cmd[0] != "load":
+                continue
+
+            _, model, backend = cmd
+            logger.info(f"Loading model: {model.name} ({backend})")
+            self.inference_model = load_inference_model(model, backend=backend)
+            logger.info("Model loaded.")
+            self.model_loaded_event.set()
+
+            # Inference loop until unload is requested
+            while not self.should_stop() and not self.unload_event.is_set():
+                try:
+                    observation = self.observation_queue.get(timeout=1)
+                    start_time = time.perf_counter()
+                    output = self.inference_model.select_action(observation)[0]
+                    elapsed_time = time.perf_counter() - start_time
+                    logger.debug(f"Inference: ({elapsed_time}): {output.shape}")
+                    self.output_queue.put(InferenceResult(time=elapsed_time, data=output))
+                except queue.Empty:
+                    continue
+
+            logger.info("Inference stopped, unloading model.")
+            self.unload_event.clear()
+            self.model_loaded_event.clear()
+            del self.inference_model
 
     async def teardown(self) -> None:
+        self.command_queue.close()
         self.observation_queue.close()
         self.output_queue.close()
         await super().teardown()

--- a/application/backend/src/workers/model_worker_registry.py
+++ b/application/backend/src/workers/model_worker_registry.py
@@ -59,9 +59,7 @@ class ModelWorkerRegistry:
         """
         async with self._lock:
             if not self._idle:
-                raise ValueError(
-                    f"No idle model workers available (all {self._max_workers} are busy)"
-                )
+                raise ValueError(f"No idle model workers available (all {self._max_workers} are busy)")
             worker_id = next(iter(self._idle))
             self._idle.discard(worker_id)
             self._busy.add(worker_id)

--- a/application/backend/src/workers/model_worker_registry.py
+++ b/application/backend/src/workers/model_worker_registry.py
@@ -1,0 +1,139 @@
+"""Registry for managing pre-spawned model worker processes."""
+
+import asyncio
+import time
+from multiprocessing.synchronize import Event as EventClass
+from types import TracebackType
+from typing import Self
+from uuid import UUID, uuid4
+
+from loguru import logger
+
+from schemas import Model
+
+from .model_worker import ModelWorker
+
+
+class ModelWorkerRegistry:
+    """
+    Manages a pool of pre-spawned idle ModelWorker processes.
+
+    Workers are spawned at startup (not on demand) to avoid Python's spawn
+    overhead mid-lifetime. When a model is requested, an idle worker receives
+    a load command and transitions to LOADED state. On release it returns to
+    idle, ready to accept the next model.
+    """
+
+    def __init__(
+        self,
+        max_workers: int,
+        stop_event: EventClass,
+        shutdown_timeout_s: float = 10.0,
+    ) -> None:
+        self._stop_event = stop_event
+        self._max_workers = max_workers
+        self._shutdown_timeout_s = shutdown_timeout_s
+        self._lock = asyncio.Lock()
+
+        self._workers: dict[UUID, ModelWorker] = {}
+        self._idle: set[UUID] = set()
+        self._busy: set[UUID] = set()
+
+        self._spawn_workers()
+
+    def _spawn_workers(self) -> None:
+        """Pre-spawn all worker processes at registry creation time."""
+        for _ in range(self._max_workers):
+            worker_id = uuid4()
+            worker = ModelWorker(stop_event=self._stop_event)
+            worker.start()
+            self._workers[worker_id] = worker
+            self._idle.add(worker_id)
+            logger.info(f"Model worker pre-spawned: {worker_id} (pid={worker.pid})")
+
+    async def acquire(self, model: Model, backend: str) -> tuple[UUID, ModelWorker]:
+        """
+        Assign an idle worker to load the given model.
+
+        Returns (worker_id, worker). Raises ValueError if no idle workers.
+        """
+        async with self._lock:
+            if not self._idle:
+                raise ValueError(
+                    f"No idle model workers available (all {self._max_workers} are busy)"
+                )
+            worker_id = next(iter(self._idle))
+            self._idle.discard(worker_id)
+            self._busy.add(worker_id)
+
+        worker = self._workers[worker_id]
+        worker.load_model(model, backend)
+        logger.info(f"Model worker {worker_id} acquired for model '{model.name}' ({backend})")
+        return worker_id, worker
+
+    async def release(self, worker_id: UUID) -> None:
+        """
+        Unload the model from a worker and return it to the idle pool.
+        """
+        async with self._lock:
+            if worker_id not in self._busy:
+                return
+            worker = self._workers.get(worker_id)
+
+        if worker is None:
+            return
+
+        worker.unload_model()
+        # Poll until the worker clears model_loaded_event (signals unload complete)
+        deadline = time.monotonic() + self._shutdown_timeout_s
+
+        def _wait_for_unload() -> None:
+            while worker.model_loaded_event.is_set():
+                if time.monotonic() > deadline:
+                    logger.warning(f"Timed out waiting for worker {worker_id} to unload")
+                    break
+                time.sleep(0.05)
+
+        await asyncio.to_thread(_wait_for_unload)
+
+        async with self._lock:
+            self._busy.discard(worker_id)
+            if worker_id in self._workers:
+                self._idle.add(worker_id)
+
+        logger.info(f"Model worker {worker_id} released and returned to idle pool")
+
+    def get(self, worker_id: UUID) -> ModelWorker | None:
+        return self._workers.get(worker_id)
+
+    async def shutdown_all(self) -> None:
+        """Terminate all worker processes."""
+        logger.info(f"Shutting down {len(self._workers)} model workers...")
+
+        async with self._lock:
+            workers = list(self._workers.values())
+            self._workers.clear()
+            self._idle.clear()
+            self._busy.clear()
+
+        def _terminate_all() -> None:
+            for worker in workers:
+                try:
+                    worker.terminate()
+                    worker.join(timeout=self._shutdown_timeout_s)
+                except Exception as e:
+                    logger.error(f"Error terminating model worker: {e}")
+
+        await asyncio.to_thread(_terminate_all)
+        logger.info("All model workers shut down")
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        await self.shutdown_all()

--- a/application/backend/src/workers/model_worker_registry.py
+++ b/application/backend/src/workers/model_worker_registry.py
@@ -59,7 +59,7 @@ class ModelWorkerRegistry:
         """
         async with self._lock:
             if not self._idle:
-                raise ValueError(f"No idle model workers available (all {self._max_workers} are busy)")
+                raise ValueError(f"No idle model workers available (all {self._max_workers} workers are busy)")
             worker_id = next(iter(self._idle))
             self._idle.discard(worker_id)
             self._busy.add(worker_id)

--- a/application/backend/src/workers/robot_control_worker.py
+++ b/application/backend/src/workers/robot_control_worker.py
@@ -6,6 +6,7 @@ from multiprocessing import Event, Queue
 from multiprocessing.synchronize import Event as EventClass
 from pathlib import Path
 from typing import Literal
+from uuid import UUID
 
 from loguru import logger
 from pydantic import BaseModel
@@ -21,6 +22,7 @@ from schemas.dataset import Dataset, Episode
 from schemas.environment import EnvironmentWithRelations
 
 from .base import BaseThreadWorker
+from .model_worker_registry import ModelWorkerRegistry
 
 
 class RobotControlState(BaseModel):
@@ -68,12 +70,17 @@ class RobotControlWorker(BaseThreadWorker):
         stop_event: EventClass,
         queue: Queue,
         robot_client_factory: RobotClientFactory,
+        model_worker_registry: ModelWorkerRegistry,
     ):
         super().__init__(stop_event=stop_event)
         self.queue = queue
         self.state = RobotControlState()
         self.robot_client_factory = robot_client_factory
         self.events = WorkerEvents()
+        self._model_worker_registry = model_worker_registry
+        self._model_worker_id: UUID | None = None
+        self._pending_model: Model | None = None
+        self._pending_backend: str | None = None
 
     def start_task(self, task: str) -> None:
         if self.state.model_loaded and self.state.environment_loaded:
@@ -112,19 +119,11 @@ class RobotControlWorker(BaseThreadWorker):
         self._report_state()
 
     def load_model(self, model: Model, backend: str) -> None:
-        try:
-            self.model_integration = SyncMixedModelIntegration(
-                model=model,
-                backend=backend,
-                stop_event=self._stop_event,
-                fps=self.fps,
-            )
-            self.state.model_loaded = False
-            self.events.new_model.set()
-            self._report_state()
-        except Exception as e:
-            self.model_integration = None
-            self._report_error(e)
+        self._pending_model = model
+        self._pending_backend = backend
+        self.state.model_loaded = False
+        self.events.new_model.set()
+        self._report_state()
 
     def load_environment(self, environment: EnvironmentWithRelations) -> None:
         """Setup environment."""
@@ -219,11 +218,28 @@ class RobotControlWorker(BaseThreadWorker):
             self._report_error(e)
 
     async def _handle_new_model_load(self) -> None:
-        if self.model_integration and self.events.new_model.is_set():
+        if self._pending_model is not None and self.events.new_model.is_set():
             self.events.new_model.clear()
-            await self.model_integration.setup()
-            self.state.model_loaded = True
-            self._report_state()
+            try:
+                # Release any previously held worker slot
+                if self._model_worker_id is not None:
+                    await self._model_worker_registry.release(self._model_worker_id)
+                    self._model_worker_id = None
+
+                worker_id, worker = await self._model_worker_registry.acquire(
+                    self._pending_model, self._pending_backend or "torch"
+                )
+                self._model_worker_id = worker_id
+                self.model_integration = SyncMixedModelIntegration(model_worker=worker, fps=self.fps)
+                await self.model_integration.setup()
+                self.state.model_loaded = True
+                self._report_state()
+            except Exception as e:
+                self.model_integration = None
+                self._report_error(e)
+            finally:
+                self._pending_model = None
+                self._pending_backend = None
 
     async def _handle_setup_environment(self) -> None:
         if self.environment_integration and self.events.new_environment.is_set():
@@ -280,6 +296,10 @@ class RobotControlWorker(BaseThreadWorker):
 
         if self.model_integration is not None:
             self.model_integration.teardown()
+
+        if self._model_worker_id is not None:
+            await self._model_worker_registry.release(self._model_worker_id)
+            self._model_worker_id = None
 
         if self.recording_mutation:
             self.recording_mutation.teardown()

--- a/application/backend/src/workers/robot_control_worker.py
+++ b/application/backend/src/workers/robot_control_worker.py
@@ -6,7 +6,7 @@ from multiprocessing import Event, Queue
 from multiprocessing.synchronize import Event as EventClass
 from pathlib import Path
 from typing import Literal
-from uuid import UUID
+from uuid import UUID  # noqa: TC003
 
 from loguru import logger
 from pydantic import BaseModel

--- a/application/backend/tests/workers/test_model_worker.py
+++ b/application/backend/tests/workers/test_model_worker.py
@@ -1,0 +1,79 @@
+import multiprocessing as mp
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from workers.model_worker import ModelWorker
+
+
+@pytest.fixture
+def stop_event():
+    return mp.Event()
+
+
+class TestModelWorker:
+    def test_worker_starts_idle(self, stop_event):
+        worker = ModelWorker(stop_event=stop_event)
+        assert not worker.is_loaded
+
+    def test_load_model_puts_command_on_queue(self, stop_event, test_model):
+        worker = ModelWorker(stop_event=stop_event)
+        worker.load_model(test_model, backend="torch")
+
+        cmd = worker.command_queue.get(timeout=2)
+        assert cmd[0] == "load"
+        assert cmd[1].name == test_model.name
+        assert cmd[2] == "torch"
+
+        worker.command_queue.cancel_join_thread()
+        worker.observation_queue.cancel_join_thread()
+        worker.output_queue.cancel_join_thread()
+
+    def test_unload_model_sets_unload_event(self, stop_event):
+        worker = ModelWorker(stop_event=stop_event)
+        assert not worker.unload_event.is_set()
+        worker.unload_model()
+        assert worker.unload_event.is_set()
+
+    def test_is_loaded_reflects_model_loaded_event(self, stop_event):
+        worker = ModelWorker(stop_event=stop_event)
+        assert not worker.is_loaded
+        worker.model_loaded_event.set()
+        assert worker.is_loaded
+        worker.model_loaded_event.clear()
+        assert not worker.is_loaded
+
+    def test_full_load_unload_cycle(self, stop_event, test_model):
+        """Worker process loads a model, signals loaded, then unloads on request."""
+        fake_output = MagicMock()
+        fake_output.shape = (6,)
+        fake_inference_model = MagicMock()
+        fake_inference_model.select_action.return_value = [fake_output]
+
+        with patch("workers.model_worker.load_inference_model", return_value=fake_inference_model):
+            worker = ModelWorker(stop_event=stop_event)
+            worker.start()
+
+            try:
+                worker.load_model(test_model, backend="torch")
+                loaded = worker.model_loaded_event.wait(timeout=10)
+                assert loaded, "Model did not load within timeout"
+                assert worker.is_loaded
+
+                worker.unload_model()
+                # Wait for worker to process unload (model_loaded_event cleared)
+                for _ in range(50):
+                    time.sleep(0.1)
+                    if not worker.model_loaded_event.is_set():
+                        break
+                else:
+                    pytest.fail("Worker did not clear model_loaded_event after unload")
+
+                assert not worker.is_loaded
+            finally:
+                stop_event.set()
+                worker.join(timeout=5)
+                worker.command_queue.cancel_join_thread()
+                worker.observation_queue.cancel_join_thread()
+                worker.output_queue.cancel_join_thread()

--- a/application/backend/tests/workers/test_model_worker_registry.py
+++ b/application/backend/tests/workers/test_model_worker_registry.py
@@ -1,0 +1,134 @@
+import asyncio
+import multiprocessing as mp
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from workers.model_worker_registry import ModelWorkerRegistry
+
+
+def _make_mock_worker() -> MagicMock:
+    """Return a mock ModelWorker with a real mp.Event for model_loaded_event."""
+    worker = MagicMock()
+    worker.model_loaded_event = mp.Event()
+    return worker
+
+
+@pytest.fixture
+def stop_event():
+    return mp.Event()
+
+
+@pytest.fixture
+def registry(stop_event):
+    """Registry with 2 pre-spawned mock workers (no real processes)."""
+    with patch("workers.model_worker_registry.ModelWorker", side_effect=lambda **_: _make_mock_worker()):
+        reg = ModelWorkerRegistry(max_workers=2, stop_event=stop_event)
+    return reg
+
+
+@pytest.fixture
+def single_worker_registry(stop_event):
+    with patch("workers.model_worker_registry.ModelWorker", side_effect=lambda **_: _make_mock_worker()):
+        reg = ModelWorkerRegistry(max_workers=1, stop_event=stop_event)
+    return reg
+
+
+class TestModelWorkerRegistryInit:
+    def test_pre_spawns_correct_number_of_workers(self, registry):
+        assert len(registry._workers) == 2
+
+    def test_all_workers_start_idle(self, registry):
+        assert len(registry._idle) == 2
+        assert len(registry._busy) == 0
+
+    def test_workers_are_started(self, registry):
+        for worker in registry._workers.values():
+            worker.start.assert_called_once()
+
+
+class TestModelWorkerRegistryAcquire:
+    def test_acquire_returns_worker_id_and_worker(self, registry, test_model):
+        worker_id, worker = asyncio.run(registry.acquire(test_model, "torch"))
+        assert isinstance(worker_id, UUID)
+        assert worker is registry._workers[worker_id]
+
+    def test_acquire_moves_worker_to_busy(self, registry, test_model):
+        worker_id, _ = asyncio.run(registry.acquire(test_model, "torch"))
+        assert worker_id in registry._busy
+        assert worker_id not in registry._idle
+
+    def test_acquire_calls_load_model_on_worker(self, registry, test_model):
+        _, worker = asyncio.run(registry.acquire(test_model, "torch"))
+        worker.load_model.assert_called_once_with(test_model, "torch")
+
+    def test_acquire_two_workers_exhausts_pool(self, registry, test_model):
+        asyncio.run(registry.acquire(test_model, "torch"))
+        asyncio.run(registry.acquire(test_model, "torch"))
+        assert len(registry._idle) == 0
+        assert len(registry._busy) == 2
+
+    def test_acquire_raises_when_no_idle_workers(self, single_worker_registry, test_model):
+        asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+        with pytest.raises(ValueError, match="No idle model workers available"):
+            asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+
+
+class TestModelWorkerRegistryRelease:
+    def test_release_returns_worker_to_idle(self, single_worker_registry, test_model):
+        worker_id, _ = asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+        asyncio.run(single_worker_registry.release(worker_id))
+        assert worker_id in single_worker_registry._idle
+        assert worker_id not in single_worker_registry._busy
+
+    def test_release_calls_unload_model(self, single_worker_registry, test_model):
+        worker_id, worker = asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+        asyncio.run(single_worker_registry.release(worker_id))
+        worker.unload_model.assert_called_once()
+
+    def test_released_worker_can_be_acquired_again(self, single_worker_registry, test_model):
+        worker_id, _ = asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+        asyncio.run(single_worker_registry.release(worker_id))
+        new_id, _ = asyncio.run(single_worker_registry.acquire(test_model, "onnx"))
+        assert new_id == worker_id
+
+    def test_release_unknown_id_is_noop(self, registry):
+        from uuid import uuid4
+        asyncio.run(registry.release(uuid4()))  # should not raise
+
+
+class TestModelWorkerRegistryGet:
+    def test_get_returns_correct_worker(self, registry):
+        worker_id = next(iter(registry._workers))
+        assert registry.get(worker_id) is registry._workers[worker_id]
+
+    def test_get_unknown_id_returns_none(self, registry):
+        from uuid import uuid4
+        assert registry.get(uuid4()) is None
+
+
+class TestModelWorkerRegistryShutdown:
+    def test_shutdown_all_terminates_workers(self, registry):
+        workers = list(registry._workers.values())
+        asyncio.run(registry.shutdown_all())
+        for worker in workers:
+            worker.terminate.assert_called_once()
+
+    def test_shutdown_all_clears_state(self, registry):
+        asyncio.run(registry.shutdown_all())
+        assert len(registry._workers) == 0
+        assert len(registry._idle) == 0
+        assert len(registry._busy) == 0
+
+    def test_context_manager_calls_shutdown_all(self, stop_event):
+        with patch("workers.model_worker_registry.ModelWorker", side_effect=lambda **_: _make_mock_worker()):
+            async def run():
+                async with ModelWorkerRegistry(max_workers=1, stop_event=stop_event) as reg:
+                    workers = list(reg._workers.values())
+                return workers
+
+            workers = asyncio.run(run())
+
+        for worker in workers:
+            worker.terminate.assert_called_once()

--- a/application/backend/tests/workers/test_model_worker_registry.py
+++ b/application/backend/tests/workers/test_model_worker_registry.py
@@ -24,15 +24,13 @@ def stop_event():
 def registry(stop_event):
     """Registry with 2 pre-spawned mock workers (no real processes)."""
     with patch("workers.model_worker_registry.ModelWorker", side_effect=lambda **_: _make_mock_worker()):
-        reg = ModelWorkerRegistry(max_workers=2, stop_event=stop_event)
-    return reg
+        return ModelWorkerRegistry(max_workers=2, stop_event=stop_event)
 
 
 @pytest.fixture
 def single_worker_registry(stop_event):
     with patch("workers.model_worker_registry.ModelWorker", side_effect=lambda **_: _make_mock_worker()):
-        reg = ModelWorkerRegistry(max_workers=1, stop_event=stop_event)
-    return reg
+        return ModelWorkerRegistry(max_workers=1, stop_event=stop_event)
 
 
 class TestModelWorkerRegistryInit:
@@ -95,6 +93,7 @@ class TestModelWorkerRegistryRelease:
 
     def test_release_unknown_id_is_noop(self, registry):
         from uuid import uuid4
+
         asyncio.run(registry.release(uuid4()))  # should not raise
 
 
@@ -105,6 +104,7 @@ class TestModelWorkerRegistryGet:
 
     def test_get_unknown_id_returns_none(self, registry):
         from uuid import uuid4
+
         assert registry.get(uuid4()) is None
 
 
@@ -123,10 +123,10 @@ class TestModelWorkerRegistryShutdown:
 
     def test_context_manager_calls_shutdown_all(self, stop_event):
         with patch("workers.model_worker_registry.ModelWorker", side_effect=lambda **_: _make_mock_worker()):
+
             async def run():
                 async with ModelWorkerRegistry(max_workers=1, stop_event=stop_event) as reg:
-                    workers = list(reg._workers.values())
-                return workers
+                    return list(reg._workers.values())
 
             workers = asyncio.run(run())
 

--- a/application/backend/tests/workers/test_robot_control_worker.py
+++ b/application/backend/tests/workers/test_robot_control_worker.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from multiprocessing import Event, Queue
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from tests.queue_utils import clear_queue, thread_flush, wait_until_message_from_queue
@@ -91,11 +92,15 @@ def test_dataset_impl(recording_mutation):
 def robot_control_worker(mock_robot_client_factory):
     stop_event = Event()
     queue = Queue()
+    mock_registry = MagicMock()
+    mock_registry.acquire = AsyncMock(return_value=(uuid4(), MagicMock()))
+    mock_registry.release = AsyncMock()
 
     process = RobotControlWorker(
         stop_event=stop_event,
         robot_client_factory=mock_robot_client_factory,
         queue=queue,
+        model_worker_registry=mock_registry,
     )
     process.start()
 
@@ -111,13 +116,12 @@ def loaded_inference_worker(
 ):
     with patch("workers.robot_control_worker.SyncMixedModelIntegration", return_value=model_integration):
         robot_control_worker.load_model(test_model, "torch")
+        with patch("workers.robot_control_worker.EnvironmentIntegration", return_value=environment_integration):
+            robot_control_worker.load_environment(test_environment)
+        model_integration.allow_setup()
+        environment_integration.allow_setup()
+        state = _wait_until_state(robot_control_worker.queue, model_loaded=True, environment_loaded=True)
 
-    with patch("workers.robot_control_worker.EnvironmentIntegration", return_value=environment_integration):
-        robot_control_worker.load_environment(test_environment)
-    model_integration.allow_setup()
-    environment_integration.allow_setup()
-
-    state = _wait_until_state(robot_control_worker.queue, model_loaded=True, environment_loaded=True)
     assert state["model_loaded"]
     assert state["environment_loaded"]
     clear_queue(robot_control_worker.queue)
@@ -192,14 +196,17 @@ class TestRobotControlWorker:
         report = wait_until_message_from_queue(robot_control_worker.queue, "state")
         assert report["event"] == "state"
 
+        # Keep patch active until after allow_setup(): _handle_new_model_load creates
+        # SyncMixedModelIntegration asynchronously, so the patch must outlive load_model().
         with patch("workers.robot_control_worker.SyncMixedModelIntegration", return_value=model_integration):
             robot_control_worker.load_model(test_model, "torch")
-        report = wait_until_message_from_queue(robot_control_worker.queue, "state")
-        assert report["event"] == "state"
-        assert not report["data"]["model_loaded"]
+            report = wait_until_message_from_queue(robot_control_worker.queue, "state")
+            assert report["event"] == "state"
+            assert not report["data"]["model_loaded"]
 
-        model_integration.allow_setup()
-        report = robot_control_worker.queue.get()
+            model_integration.allow_setup()
+            report = robot_control_worker.queue.get()
+
         assert report["event"] == "state"
         assert report["data"]["model_loaded"]
 


### PR DESCRIPTION
ModelWorker, a process, should be spawned at startup. 
The model worker registry follows the robot and camera worker registry pattern in that it keeps track of the available processes and allows for reserving a model worker.

Currently allowing only one model at a time since keeping track of vram and stability is pretty hard.