### PR TITLE
refactor: make query invalidation opt in instead of opt out

### DIFF
--- a/application/ui/src/features/datasets/delete-dataset-dialog.tsx
+++ b/application/ui/src/features/datasets/delete-dataset-dialog.tsx
@@ -9,7 +9,11 @@ type Dataset = SchemaDatasetOutput;
 
 export const DeleteDatasetDialog = ({ dataset, onDone }: { dataset: Dataset; onDone: () => void }) => {
     const [removeFiles, setRemoveFiles] = useState(false);
-    const deleteMutation = $api.useMutation('delete', '/api/dataset/{dataset_id}');
+    const deleteMutation = $api.useMutation('delete', '/api/dataset/{dataset_id}', {
+        meta: {
+            invalidates: [['get', '/api/projects']],
+        },
+    });
 
     const onDelete = async () => {
         if (dataset.id === undefined) {

--- a/application/ui/src/features/datasets/episodes/use-episodes.ts
+++ b/application/ui/src/features/datasets/episodes/use-episodes.ts
@@ -6,6 +6,12 @@ export const useDeleteEpisodeQuery = (dataset_id: string) => {
     const queryClient = useQueryClient();
 
     const mutation = $api.useMutation('delete', '/api/dataset/{dataset_id}/episodes', {
+        meta: {
+            invalidates: [
+                ['get', '/api/dataset/{dataset_id}/episodes', { params: { path: { dataset_id } } }],
+                ['get', '/api/dataset/{dataset_id}', { params: { path: { dataset_id } } }],
+            ],
+        },
         onSuccess: (data) => {
             const query_key = [
                 'get',

--- a/application/ui/src/features/datasets/rename-dataset-dialog.tsx
+++ b/application/ui/src/features/datasets/rename-dataset-dialog.tsx
@@ -15,7 +15,14 @@ export const RenameDatasetDialog = ({
     onDone: (dataset: SchemaDatasetOutput | undefined) => void;
 }) => {
     const [name, setName] = useState(dataset.name);
-    const renameMutation = $api.useMutation('put', '/api/dataset/{dataset_id}');
+    const renameMutation = $api.useMutation('put', '/api/dataset/{dataset_id}', {
+        meta: {
+            invalidates: [
+                ['get', '/api/dataset/{dataset_id}', { params: { path: { dataset_id: dataset.id! } } }],
+                ['get', '/api/projects'],
+            ],
+        },
+    });
 
     const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();

--- a/application/ui/src/features/projects/list/new-project-link.component.tsx
+++ b/application/ui/src/features/projects/list/new-project-link.component.tsx
@@ -23,7 +23,11 @@ import classes from './project-list.module.scss';
 
 export const NewProjectLink = ({ className }: { className?: string }) => {
     const navigate = useNavigate();
-    const saveMutation = $api.useMutation('post', '/api/projects');
+    const saveMutation = $api.useMutation('post', '/api/projects', {
+        meta: {
+            invalidates: [['get', '/api/projects']],
+        },
+    });
     const [name, setName] = useState<string>('');
 
     const save = (e: React.FormEvent<HTMLFormElement>) => {

--- a/application/ui/src/features/projects/list/project-card.tsx
+++ b/application/ui/src/features/projects/list/project-card.tsx
@@ -28,7 +28,11 @@ type ProjectCardProps = {
 //};
 
 export const ProjectCard = ({ item, isActive }: ProjectCardProps) => {
-    const deleteMutation = $api.useMutation('delete', '/api/projects/{project_id}');
+    const deleteMutation = $api.useMutation('delete', '/api/projects/{project_id}', {
+        meta: {
+            invalidates: [['get', '/api/projects']],
+        },
+    });
 
     const onAction = (key: Key) => {
         switch (key.toString()) {

--- a/application/ui/src/features/robots/camera-form/submit-new-camera-button.tsx
+++ b/application/ui/src/features/robots/camera-form/submit-new-camera-button.tsx
@@ -11,7 +11,11 @@ export const SubmitNewCameraButton = () => {
     const navigate = useNavigate();
     const { project_id } = useProjectId();
 
-    const addCameraMutation = $api.useMutation('post', '/api/projects/{project_id}/cameras');
+    const addCameraMutation = $api.useMutation('post', '/api/projects/{project_id}/cameras', {
+        meta: {
+            invalidates: [['get', '/api/projects/{project_id}/cameras', { params: { path: { project_id } } }]],
+        },
+    });
 
     const body = useCameraFormBody(uuidv4());
 

--- a/application/ui/src/features/robots/camera-form/update-camera-button.tsx
+++ b/application/ui/src/features/robots/camera-form/update-camera-button.tsx
@@ -10,7 +10,18 @@ export const UpdateCameraButton = () => {
     const navigate = useNavigate();
     const { project_id, camera_id } = useCameraId();
 
-    const updateCameraMutation = $api.useMutation('put', '/api/projects/{project_id}/cameras/{camera_id}');
+    const updateCameraMutation = $api.useMutation('put', '/api/projects/{project_id}/cameras/{camera_id}', {
+        meta: {
+            invalidates: [
+                ['get', '/api/projects/{project_id}/cameras', { params: { path: { project_id } } }],
+                [
+                    'get',
+                    '/api/projects/{project_id}/cameras/{camera_id}',
+                    { params: { path: { project_id, camera_id } } },
+                ],
+            ],
+        },
+    });
     const body = useCameraFormBody(camera_id);
 
     return (

--- a/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
+++ b/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
@@ -11,7 +11,11 @@ export const SubmitNewEnvironmentButton = () => {
     const navigate = useNavigate();
     const { project_id } = useProjectId();
 
-    const addEnvironmentMutation = $api.useMutation('post', '/api/projects/{project_id}/environments');
+    const addEnvironmentMutation = $api.useMutation('post', '/api/projects/{project_id}/environments', {
+        meta: {
+            invalidates: [['get', '/api/projects/{project_id}/environments', { params: { path: { project_id } } }]],
+        },
+    });
 
     const environment_id = uuidv4();
     const body = useEnvironmentFormBody(environment_id);

--- a/application/ui/src/features/robots/environment-form/update-environment-button.tsx
+++ b/application/ui/src/features/robots/environment-form/update-environment-button.tsx
@@ -12,7 +12,19 @@ export const UpdateEnvironmentButton = () => {
 
     const updateEnvironmentsMutation = $api.useMutation(
         'put',
-        '/api/projects/{project_id}/environments/{environment_id}'
+        '/api/projects/{project_id}/environments/{environment_id}',
+        {
+            meta: {
+                invalidates: [
+                    ['get', '/api/projects/{project_id}/environments', { params: { path: { project_id } } }],
+                    [
+                        'get',
+                        '/api/projects/{project_id}/environments/{environment_id}',
+                        { params: { path: { project_id, environment_id } } },
+                    ],
+                ],
+            },
+        }
     );
     const body = useEnvironmentFormBody(environment_id);
     const isDisabled = body.name.length === 0 || body.robots.length === 0 || body.camera_ids.length === 0;

--- a/application/ui/src/features/robots/robot-control-provider.tsx
+++ b/application/ui/src/features/robots/robot-control-provider.tsx
@@ -181,6 +181,7 @@ export const RobotControlProvider = (props: useRobotControlProps) => {
             ),
     });
 
+    // TODO: verify invalidation needs for WebSocket-only mutations
     const startEpisode = useMutation({
         meta: { skipInvalidation: true },
         mutationFn: async (task: string) => {

--- a/application/ui/src/features/robots/robot-control-provider.tsx
+++ b/application/ui/src/features/robots/robot-control-provider.tsx
@@ -181,7 +181,6 @@ export const RobotControlProvider = (props: useRobotControlProps) => {
             ),
     });
 
-    // TODO: verify invalidation needs for WebSocket-only mutations
     const startEpisode = useMutation({
         meta: { skipInvalidation: true },
         mutationFn: async (task: string) => {

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -82,7 +82,9 @@ const RefreshRobotsButton = () => {
 
 const IdentifyRobot = () => {
     const robotForm = useRobotForm();
-    const identifyMutation = $api.useMutation('post', '/api/hardware/identify');
+    const identifyMutation = $api.useMutation('post', '/api/hardware/identify', {
+        meta: { skipInvalidation: true },
+    });
 
     const isDisabled = identifyMutation.isPending || !robotForm.name || !robotForm.type || !robotForm.connection_string;
 

--- a/application/ui/src/features/robots/robot-form/submit-new-robot-button.tsx
+++ b/application/ui/src/features/robots/robot-form/submit-new-robot-button.tsx
@@ -11,7 +11,14 @@ export const SubmitNewRobotButton = () => {
     const navigate = useNavigate();
     const { project_id } = useProjectId();
 
-    const addRobotMutation = $api.useMutation('post', '/api/projects/{project_id}/robots');
+    const addRobotMutation = $api.useMutation('post', '/api/projects/{project_id}/robots', {
+        meta: {
+            invalidates: [
+                ['get', '/api/projects/{project_id}/robots', { params: { path: { project_id } } }],
+                ['get', '/api/projects/{project_id}/robots/online', { params: { path: { project_id } } }],
+            ],
+        },
+    });
 
     const body = useRobotFormBody(uuidv4());
 

--- a/application/ui/src/features/robots/robot-form/update-robot-button.tsx
+++ b/application/ui/src/features/robots/robot-form/update-robot-button.tsx
@@ -10,7 +10,14 @@ export const UpdateRobotButton = () => {
     const navigate = useNavigate();
     const { project_id, robot_id } = useRobotId();
 
-    const updateRobotMutation = $api.useMutation('put', '/api/projects/{project_id}/robots/{robot_id}');
+    const updateRobotMutation = $api.useMutation('put', '/api/projects/{project_id}/robots/{robot_id}', {
+        meta: {
+            invalidates: [
+                ['get', '/api/projects/{project_id}/robots', { params: { path: { project_id } } }],
+                ['get', '/api/projects/{project_id}/robots/{robot_id}', { params: { path: { project_id, robot_id } } }],
+            ],
+        },
+    });
     const body = useRobotFormBody(robot_id);
 
     return (

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -13,7 +13,14 @@ import classes from './robots-list.module.scss';
 
 const MenuActions = ({ robot_id }: { robot_id: string }) => {
     const { project_id } = useProjectId();
-    const deleteRobotMutation = $api.useMutation('delete', '/api/projects/{project_id}/robots/{robot_id}');
+    const deleteRobotMutation = $api.useMutation('delete', '/api/projects/{project_id}/robots/{robot_id}', {
+        meta: {
+            invalidates: [
+                ['get', '/api/projects/{project_id}/robots', { params: { path: { project_id } } }],
+                ['get', '/api/projects/{project_id}/robots/online', { params: { path: { project_id } } }],
+            ],
+        },
+    });
 
     return (
         <MenuTrigger>

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -113,12 +113,28 @@ export const VerificationStep = () => {
     // Sync live joint positions to the 3D model
     useSyncJointState(wsState.jointState);
 
-    const addRobotMutation = $api.useMutation('post', '/api/projects/{project_id}/robots');
+    const addRobotMutation = $api.useMutation('post', '/api/projects/{project_id}/robots', {
+        meta: {
+            invalidates: [
+                ['get', '/api/projects/{project_id}/robots', { params: { path: { project_id } } }],
+                ['get', '/api/projects/{project_id}/robots/online', { params: { path: { project_id } } }],
+            ],
+        },
+    });
     const saveCalibrationMutation = $api.useMutation(
         'post',
-        '/api/projects/{project_id}/robots/{robot_id}/calibrations'
+        '/api/projects/{project_id}/robots/{robot_id}/calibrations',
+        {
+            meta: {
+                invalidates: [['get', '/api/projects/{project_id}/robots', { params: { path: { project_id } } }]],
+            },
+        }
     );
-    const updateRobotMutation = $api.useMutation('put', '/api/projects/{project_id}/robots/{robot_id}');
+    const updateRobotMutation = $api.useMutation('put', '/api/projects/{project_id}/robots/{robot_id}', {
+        meta: {
+            invalidates: [['get', '/api/projects/{project_id}/robots', { params: { path: { project_id } } }]],
+        },
+    });
 
     const robotBody: SchemaRobot | null =
         robotForm.type !== null && robotForm.name

--- a/application/ui/src/providers.tsx
+++ b/application/ui/src/providers.tsx
@@ -1,31 +1,13 @@
 import { ReactNode } from 'react';
 
 import { ThemeProvider, ToastContainer } from '@geti-ui/ui';
-import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouterProps, RouterProvider } from 'react-router';
 import { MemoryRouter as Router } from 'react-router-dom';
 
 import { ZoomProvider } from './components/zoom/zoom';
+import { queryClient } from './query-client/query-client';
 import { router } from './router';
-
-const queryClient = new QueryClient({
-    defaultOptions: {
-        queries: {
-            gcTime: 30 * 60 * 1000,
-            staleTime: 5 * 60 * 1000,
-            networkMode: 'always',
-        },
-        mutations: {
-            networkMode: 'always',
-        },
-    },
-    mutationCache: new MutationCache({
-        onSuccess: (_data, _variables, _context, mutation) => {
-            if (mutation.options.meta?.skipInvalidation) return;
-            queryClient.invalidateQueries();
-        },
-    }),
-});
 
 export const Providers = () => {
     return (

--- a/application/ui/src/query-client/query-client.interface.ts
+++ b/application/ui/src/query-client/query-client.interface.ts
@@ -1,0 +1,45 @@
+/**
+ * This file contains types for query keys and mutation metadata used in the API client.
+ * It leverages the OpenAPI specification to ensure type safety and consistency.
+ * The QueryKey type constructs query keys based on the API paths and their parameters.
+ * The MutationMeta type defines metadata for mutations, including which queries to invalidate or await.
+ * These types are used to enhance the functionality of the query client, particularly in managing cache invalidation
+ * and ensuring data consistency after mutations.
+ *
+ * Be careful when modifying these types, as they are integral to the query client's operation.
+ */
+
+import type { HttpMethod } from 'openapi-typescript-helpers';
+
+import { type paths } from '../api/openapi-spec';
+
+type OperationFor<Paths extends paths, P extends keyof Paths, Method extends HttpMethod> = Method extends keyof Paths[P]
+    ? Paths[P][Method]
+    : never;
+
+type PathParamsFor<Paths extends paths, P extends keyof Paths, Method extends HttpMethod> =
+    OperationFor<Paths, P, Method> extends { parameters: { path: infer PP } } ? PP : never;
+
+type MethodsForPath<Paths extends paths, P extends keyof Paths> = Extract<keyof Paths[P], HttpMethod>;
+
+export type QueryKey<Paths extends paths> = {
+    [P in keyof Paths]: {
+        [M in MethodsForPath<Paths, P>]: PathParamsFor<Paths, P, M> extends never
+            ? [M, P]
+            : [
+                  M,
+                  P,
+                  {
+                      params: {
+                          path: PathParamsFor<Paths, P, M>;
+                      };
+                  },
+              ];
+    }[MethodsForPath<Paths, P>];
+}[keyof Paths];
+
+export type MutationMeta = {
+    skipInvalidation?: boolean;
+    invalidates?: QueryKey<paths>[];
+    awaits?: QueryKey<paths>[];
+};

--- a/application/ui/src/query-client/query-client.ts
+++ b/application/ui/src/query-client/query-client.ts
@@ -1,0 +1,52 @@
+import { matchQuery, MutationCache, Query, QueryClient } from '@tanstack/react-query';
+
+import { MutationMeta } from './query-client.interface';
+
+declare module '@tanstack/react-query' {
+    interface Register {
+        mutationMeta: MutationMeta;
+    }
+}
+
+export const queryClient: QueryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            gcTime: 30 * 60 * 1000,
+            staleTime: 5 * 60 * 1000,
+            networkMode: 'always',
+        },
+        mutations: {
+            networkMode: 'always',
+        },
+    },
+    mutationCache: new MutationCache({
+        onSuccess: (_data, _variables, _context, mutation): void | Promise<void> => {
+            if (mutation.meta?.skipInvalidation) return;
+
+            // Fire-and-forget invalidation
+            queryClient.invalidateQueries({
+                predicate: (query: Query): boolean => {
+                    return (
+                        mutation.meta?.invalidates?.some((queryKey) => {
+                            return matchQuery({ queryKey }, query);
+                        }) ?? false
+                    );
+                },
+            });
+
+            // Optionally await specific query invalidations
+            if (mutation.meta?.awaits && mutation.meta.awaits.length > 0) {
+                return queryClient.invalidateQueries(
+                    {
+                        predicate: (query) => {
+                            return (
+                                mutation.meta?.awaits?.some((queryKey) => matchQuery({ queryKey }, query), {}) ?? false
+                            );
+                        },
+                    },
+                    { cancelRefetch: false }
+                );
+            }
+        },
+    }),
+});

--- a/application/ui/src/routes/cameras/layout.tsx
+++ b/application/ui/src/routes/cameras/layout.tsx
@@ -30,7 +30,11 @@ import classes from './../../features/robots/robots-list.module.scss';
 
 const MenuActions = ({ camera_id }: { camera_id: string }) => {
     const { project_id } = useProjectId();
-    const deleteCameraMutation = $api.useMutation('delete', '/api/projects/{project_id}/cameras/{camera_id}');
+    const deleteCameraMutation = $api.useMutation('delete', '/api/projects/{project_id}/cameras/{camera_id}', {
+        meta: {
+            invalidates: [['get', '/api/projects/{project_id}/cameras', { params: { path: { project_id } } }]],
+        },
+    });
 
     return (
         <MenuTrigger>

--- a/application/ui/src/routes/datasets/new-dataset.component.tsx
+++ b/application/ui/src/routes/datasets/new-dataset.component.tsx
@@ -25,7 +25,11 @@ interface NewDatasetFormProps {
     onDone: (dataset: SchemaDatasetOutput | undefined) => void;
 }
 export const NewDatasetForm = ({ project_id, onDone }: NewDatasetFormProps) => {
-    const saveMutation = $api.useMutation('post', '/api/dataset');
+    const saveMutation = $api.useMutation('post', '/api/dataset', {
+        meta: {
+            invalidates: [['get', '/api/projects/{project_id}', { params: { path: { project_id } } }]],
+        },
+    });
     const [name, setName] = useState<string>('');
     const [defaultTask, setDefaultTask] = useState<string>('');
     const { geti_action_dataset_path } = useSettings();

--- a/application/ui/src/routes/environments/layout.tsx
+++ b/application/ui/src/routes/environments/layout.tsx
@@ -30,7 +30,12 @@ const MenuActions = ({ environment_id }: { environment_id: string }) => {
     const { project_id } = useProjectId();
     const deleteEnvironmentMutation = $api.useMutation(
         'delete',
-        '/api/projects/{project_id}/environments/{environment_id}'
+        '/api/projects/{project_id}/environments/{environment_id}',
+        {
+            meta: {
+                invalidates: [['get', '/api/projects/{project_id}/environments', { params: { path: { project_id } } }]],
+            },
+        }
     );
 
     return (

--- a/application/ui/src/routes/models/index.tsx
+++ b/application/ui/src/routes/models/index.tsx
@@ -42,7 +42,12 @@ const ModelList = ({
 
     const jobsById = new Map(jobs.map((j) => [j.id, j]));
 
-    const deleteModelMutation = $api.useMutation('delete', '/api/models/{model_id}');
+    const { project_id } = useProjectId();
+    const deleteModelMutation = $api.useMutation('delete', '/api/models/{model_id}', {
+        meta: {
+            invalidates: [['get', '/api/projects/{project_id}/models', { params: { path: { project_id } } }]],
+        },
+    });
 
     const deleteModel = (model: SchemaModel) => {
         deleteModelMutation.mutate({ params: { path: { model_id: model.id! } } });
@@ -70,7 +75,11 @@ const JobList = ({ jobs, onViewLogs }: { jobs: SchemaTrainJob[]; onViewLogs: (jo
         .filter((m) => m.status !== 'completed')
         .toSorted((a, b) => new Date(b.created_at!).getTime() - new Date(a.created_at!).getTime());
 
-    const interruptMutation = $api.useMutation('post', '/api/jobs/{job_id}:interrupt');
+    const interruptMutation = $api.useMutation('post', '/api/jobs/{job_id}:interrupt', {
+        meta: {
+            invalidates: [['get', '/api/jobs']],
+        },
+    });
     const onInterrupt = (job: SchemaTrainJob) => {
         if (job.id !== undefined) {
             interruptMutation.mutate({

--- a/application/ui/src/routes/models/job-table.component.tsx
+++ b/application/ui/src/routes/models/job-table.component.tsx
@@ -58,7 +58,11 @@ const TrainJobStatus = ({ job }: { job: SchemaTrainJob }) => {
 };
 
 const JobMenu = ({ trainJob, onViewLogs }: { trainJob: SchemaTrainJob; onViewLogs: () => void }) => {
-    const deleteJobMutation = $api.useMutation('delete', '/api/jobs/{job_id}');
+    const deleteJobMutation = $api.useMutation('delete', '/api/jobs/{job_id}', {
+        meta: {
+            invalidates: [['get', '/api/jobs']],
+        },
+    });
     const onAction = (key: Key) => {
         const action = key.toString();
         if (action === 'logs') {

--- a/application/ui/src/routes/models/train-model-dialog.tsx
+++ b/application/ui/src/routes/models/train-model-dialog.tsx
@@ -252,7 +252,11 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: 
     const [numWorkers, setNumWorkers] = useState<Key | null>('auto');
     const [autoScaleBatchSize, setAutoScaleBatchSize] = useState<boolean>(true);
 
-    const trainMutation = $api.useMutation('post', '/api/jobs:train');
+    const trainMutation = $api.useMutation('post', '/api/jobs:train', {
+        meta: {
+            invalidates: [['get', '/api/jobs']],
+        },
+    });
 
     const save = () => {
         const dataset_id = selectedDataset?.toString();

--- a/application/ui/src/routes/robots/robot.tsx
+++ b/application/ui/src/routes/robots/robot.tsx
@@ -11,7 +11,9 @@ import { useRobot } from '../../features/robots/use-robot';
 export const Robot = () => {
     const robot = useRobot();
 
-    const identifyMutation = $api.useMutation('post', '/api/hardware/identify');
+    const identifyMutation = $api.useMutation('post', '/api/hardware/identify', {
+        meta: { skipInvalidation: true },
+    });
 
     const onIdentify = identifyMutation.isPending
         ? undefined


### PR DESCRIPTION
This is a follow up of #467 as it updates our query client settings so that query invalidation becomes opt in.
This follows what we also are using now on the other Geti apps.

The first commit of this PR contains the necessary configuration.
The second commit contains changes so that we invalidate specific queries (instead of all) when making mutations.

## Type of Change

- [x] ♻️ `refactor` - Code refactoring
