### PR TITLE
fix: delete project from list or menu

### DIFF
--- a/application/ui/src/features/datasets/delete-dataset-dialog.tsx
+++ b/application/ui/src/features/datasets/delete-dataset-dialog.tsx
@@ -4,14 +4,19 @@ import { AlertDialog, Checkbox, Flex, Text } from '@geti-ui/ui';
 
 import { $api } from '../../api/client';
 import { SchemaDatasetOutput } from '../../api/openapi-spec';
+import { useProjectId } from '../projects/use-project';
 
 type Dataset = SchemaDatasetOutput;
 
 export const DeleteDatasetDialog = ({ dataset, onDone }: { dataset: Dataset; onDone: () => void }) => {
     const [removeFiles, setRemoveFiles] = useState(false);
+    const { project_id } = useProjectId();
     const deleteMutation = $api.useMutation('delete', '/api/dataset/{dataset_id}', {
         meta: {
-            invalidates: [['get', '/api/projects']],
+            invalidates: [
+                ['get', '/api/projects'],
+                ['get', '/api/projects/{project_id}', { params: { path: { project_id } } }],
+            ],
         },
     });
 

--- a/application/ui/src/features/projects/list/menu-actions.component.tsx
+++ b/application/ui/src/features/projects/list/menu-actions.component.tsx
@@ -11,8 +11,6 @@ export const MenuActions = ({ onAction }: MenuActionsProps) => {
                 <MoreMenu />
             </ActionButton>
             <Menu onAction={onAction}>
-                <Item key={'export'}>Export</Item>
-                <Item key={'duplicate'}>Duplicate</Item>
                 <Item key={'delete'}>Delete</Item>
             </Menu>
         </MenuTrigger>

--- a/application/ui/src/features/projects/list/project-card.tsx
+++ b/application/ui/src/features/projects/list/project-card.tsx
@@ -15,18 +15,6 @@ type ProjectCardProps = {
     isActive: boolean;
 };
 
-//const robotNameFromTypeMap: { [key: string]: string } = {
-//    so100_follower: 'SO-100',
-//    so101_follower: 'SO-101',
-//    koch_follower: 'Koch',
-//    stretch3: 'Stretch 3',
-//    lekiwi: 'LeKiwi',
-//    viperx: 'ViperX',
-//    hope_jr_arm: 'HopeJrArm',
-//    bi_so100_follower: 'Bi SO-100',
-//    reachy2: 'Reachy2 Robot',
-//};
-
 export const ProjectCard = ({ item, isActive }: ProjectCardProps) => {
     const deleteMutation = $api.useMutation('delete', '/api/projects/{project_id}', {
         meta: {

--- a/application/ui/src/features/projects/menu/projects-list-panel.component.tsx
+++ b/application/ui/src/features/projects/menu/projects-list-panel.component.tsx
@@ -40,6 +40,12 @@ interface ProjectListProps {
 }
 
 export const ProjectsList = ({ menuWidth = '100%', projects }: ProjectListProps) => {
+    const deleteMutation = $api.useMutation('delete', '/api/projects/{project_id}', {
+        meta: {
+            invalidates: [['get', '/api/projects']],
+        },
+    });
+
     return (
         <Menu UNSAFE_className={styles.projectMenu} width={menuWidth} items={projects}>
             {(item) => (
@@ -47,8 +53,16 @@ export const ProjectsList = ({ menuWidth = '100%', projects }: ProjectListProps)
                     <Text>
                         <Flex justifyContent='space-between' alignItems='center' marginX={'size-200'}>
                             {item.name}
-                            <ActionMenu isQuiet>
-                                <Item>Rename</Item>
+                            <ActionMenu
+                                isQuiet
+                                onAction={(key) => {
+                                    if (key === 'delete' && item.id) {
+                                        deleteMutation.mutate({
+                                            params: { path: { project_id: item.id } },
+                                        });
+                                    }
+                                }}
+                            >
                                 <Item>Delete</Item>
                             </ActionMenu>
                         </Flex>


### PR DESCRIPTION
Fix deleting (and invalidating) projects from list and menu.
Also fix invalidation when deleting datasets
I've also removed the rename, export and duplicate options as these haven't been implemented yet.

## Type of Change

- [x] 🐞 `fix` - Bug fix