### PR TITLE
feat: export with OV tokenizer for VLAs

### DIFF
--- a/library/src/physicalai/inference/component_factory.py
+++ b/library/src/physicalai/inference/component_factory.py
@@ -106,6 +106,7 @@ component_registry.register("normalize", "physicalai.inference.preprocessors.Sta
 component_registry.register("smolvla_resize", "physicalai.inference.preprocessors.ResizeSmolVLA")
 component_registry.register("new_line", "physicalai.inference.preprocessors.NewLinePreprocessor")
 component_registry.register("hf_tokenizer", "physicalai.inference.preprocessors.HFTokenizer")
+component_registry.register("ov_tokenizer", "physicalai.inference.preprocessors.OVTokenizer")
 component_registry.register("pi05", "physicalai.inference.preprocessors.Pi05Preprocessor")
 
 # Postprocessors

--- a/library/src/physicalai/inference/preprocessors/__init__.py
+++ b/library/src/physicalai/inference/preprocessors/__init__.py
@@ -11,6 +11,7 @@ from physicalai.inference.preprocessors.base import Preprocessor
 from physicalai.inference.preprocessors.hf_tokenizer import HFTokenizer
 from physicalai.inference.preprocessors.lambda_processor import LambdaPreprocessor
 from physicalai.inference.preprocessors.new_line import NewLinePreprocessor
+from physicalai.inference.preprocessors.ov_tokenizer import OVTokenizer
 from physicalai.inference.preprocessors.pi05 import Pi05Preprocessor
 from physicalai.inference.preprocessors.smolvla import ResizeSmolVLA
 from physicalai.inference.preprocessors.stats_normalizer import StatsNormalizer
@@ -19,6 +20,7 @@ __all__ = [
     "HFTokenizer",
     "LambdaPreprocessor",
     "NewLinePreprocessor",
+    "OVTokenizer",
     "Pi05Preprocessor",
     "Preprocessor",
     "ResizeSmolVLA",

--- a/library/src/physicalai/inference/preprocessors/ov_tokenizer.py
+++ b/library/src/physicalai/inference/preprocessors/ov_tokenizer.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 import numpy as np
 
-from physicalai.inference.preprocessors import Preprocessor
 from physicalai.inference.adapters import OpenVINOAdapter
 from physicalai.inference.constants import TASK, TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
+from physicalai.inference.preprocessors import Preprocessor
 
 
 class OVTokenizer(Preprocessor):
@@ -26,6 +26,9 @@ class OVTokenizer(Preprocessor):
 
         Args:
             artifact: Path to the OpenVINO tokenizer artifact.
+
+        Raises:
+            ValueError: If the adapter does not have exactly one input.
         """
         super().__init__()
         self._artifact = Path(artifact)
@@ -35,8 +38,8 @@ class OVTokenizer(Preprocessor):
         self._adapter.load(self._artifact)
 
         if len(self._adapter.input_names) != 1:
-            raise ValueError("Expected exactly one input for the OV tokenizer, "
-                             f"but got {len(self._adapter.input_names)}")
+            msg = f"Expected exactly one input for the OV tokenizer, but got {len(self._adapter.input_names)}"
+            raise ValueError(msg)
         self._input_name = self._adapter.input_names[0]
 
     def __call__(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
@@ -47,6 +50,9 @@ class OVTokenizer(Preprocessor):
 
         Returns:
             Dictionary with tokenized outputs.
+
+        Raises:
+            TypeError: If `TASK` is not a list of strings.
         """
         batch_tasks = inputs[TASK]
         outputs = dict(inputs)

--- a/library/src/physicalai/inference/preprocessors/ov_tokenizer.py
+++ b/library/src/physicalai/inference/preprocessors/ov_tokenizer.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenVINO tokenizer inference preprocessor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from physicalai.inference.preprocessors import Preprocessor
+from physicalai.inference.adapters import OpenVINOAdapter
+from physicalai.inference.constants import TASK, TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
+
+
+class OVTokenizer(Preprocessor):
+    """Preprocessor that wraps an OpenVINO tokenizer.
+
+    Args:
+        artifact: Path to the OpenVINO tokenizer artifact.
+    """
+
+    def __init__(self, artifact: str | Path) -> None:
+        """Initialize the OVTokenizer.
+
+        Args:
+            artifact: Path to the OpenVINO tokenizer artifact.
+        """
+        super().__init__()
+        self._artifact = Path(artifact)
+        # OV Tokenizers support CPU only:
+        # https://github.com/openvinotoolkit/openvino_tokenizers?tab=readme-ov-file#usage
+        self._adapter = OpenVINOAdapter(device="CPU")
+        self._adapter.load(self._artifact)
+
+        if len(self._adapter.input_names) != 1:
+            raise ValueError("Expected exactly one input for the OV tokenizer, "
+                             f"but got {len(self._adapter.input_names)}")
+        self._input_name = self._adapter.input_names[0]
+
+    def __call__(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Tokenize inputs using the OpenVINO tokenizer.
+
+        Args:
+            inputs: Dictionary of input arrays containing the key `TASK`.
+
+        Returns:
+            Dictionary with tokenized outputs.
+        """
+        batch_tasks = inputs[TASK]
+        outputs = dict(inputs)
+        outputs.pop(TASK)
+
+        if not isinstance(batch_tasks, list):
+            msg = f"Expected TASK to be a list of strings, got {type(batch_tasks)}"
+            raise TypeError(msg)
+
+        adapter_output = self._adapter.predict({self._input_name: batch_tasks})
+        outputs[TOKENIZED_PROMPT] = adapter_output["input_ids"]
+        outputs[TOKENIZED_PROMPT_MASK] = adapter_output["attention_mask"].astype(np.bool)
+
+        return outputs
+
+    def __repr__(self) -> str:
+        """Return a developer-friendly representation."""
+        return f"{self.__class__.__name__}(artifact={self._artifact!r})"

--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -164,7 +164,7 @@ def _clone_kv_cache(past_key_values: DynamicCache) -> DynamicCache:
         Cloned DynamicCache instance.
     """
     cloned = DynamicCache()
-    for layer_idx, (key_states, value_states) in enumerate(past_key_values):
+    for layer_idx, (key_states, value_states, _) in enumerate(past_key_values):
         cloned.update(key_states.clone(), value_states.clone(), layer_idx)
     return cloned
 
@@ -675,14 +675,8 @@ class Pi05Model(ExportableModelMixin, Model):
             >>> print(onnx_args.exporter_kwargs)
             {'output_names': ['action']}
         """
-        preproc_specs = [
+        base_preproc_specs = [
             ComponentSpec(type="pi05", image_resolution=self._image_resolution),
-            ComponentSpec(
-                type="hf_tokenizer",
-                tokenizer_name="google/paligemma-3b-pt-224",
-                revision="35e4f46485b4d07967e7e9935bc3786aad50687c",
-                max_token_len=self._tokenizer_max_length,
-            ),
         ]
         postproc_specs = [
             ComponentSpec(
@@ -694,19 +688,33 @@ class Pi05Model(ExportableModelMixin, Model):
         extra_args: dict[str, ExportParameters] = {}
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
-                "output_names": ["action"],
+                "output_names": [ACTION],
             },
             export_tokenizer=False,
-            preprocessors_specs=preproc_specs,
+            preprocessors_specs=[
+                *base_preproc_specs,
+                ComponentSpec(
+                    type="hf_tokenizer",
+                    tokenizer_name="google/paligemma-3b-pt-224",
+                    revision="35e4f46485b4d07967e7e9935bc3786aad50687c",
+                    max_token_len=self._tokenizer_max_length,
+                ),
+            ],
             postprocessors_specs=postproc_specs,
         )
         extra_args["openvino"] = OpenVINOExportParameters(
-            outputs=["action"],
+            outputs=[ACTION],
             compress_to_fp16=True,
             via_onnx=True,
-            export_tokenizer=False,
+            export_tokenizer=True,
             exporter_kwargs={},
-            preprocessors_specs=preproc_specs,
+            preprocessors_specs=[
+                *base_preproc_specs,
+                ComponentSpec(
+                    type="ov_tokenizer",
+                    artifact="tokenizer.xml",
+                ),
+            ],
             postprocessors_specs=postproc_specs,
         )
         extra_args["torch"] = TorchExportParameters()

--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -359,7 +359,7 @@ class SmolVLAModel(ExportableModelMixin, Model):
         ]
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
-                "output_names": ["action"],
+                "output_names": [ACTION],
             },
             preprocessors_specs=[
                 *base_preproc_specs,
@@ -374,7 +374,7 @@ class SmolVLAModel(ExportableModelMixin, Model):
             export_tokenizer=False,
         )
         extra_args["openvino"] = OpenVINOExportParameters(
-            outputs=["action"],
+            outputs=[ACTION],
             compress_to_fp16=False,
             export_tokenizer=True,
             exporter_kwargs={},

--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -346,15 +346,9 @@ class SmolVLAModel(ExportableModelMixin, Model):
             {'output_names': ['action']}
         """
         extra_args: dict[str, ExportParameters] = {}
-        preproc_specs = [
+        base_preproc_specs = [
             ComponentSpec(type="smolvla_resize", image_resolution=self._resize_imgs_with_padding),
             ComponentSpec(type="new_line"),
-            ComponentSpec(
-                type="hf_tokenizer",
-                tokenizer_name=self._vlm_model_name,
-                revision="7b375e1b73b11138ff12fe22c8f2822d8fe03467",
-                max_token_len=self._tokenizer_max_length,
-            ),
         ]
         postproc_specs = [
             ComponentSpec(
@@ -367,16 +361,30 @@ class SmolVLAModel(ExportableModelMixin, Model):
             exporter_kwargs={
                 "output_names": ["action"],
             },
-            preprocessors_specs=preproc_specs,
+            preprocessors_specs=[
+                *base_preproc_specs,
+                ComponentSpec(
+                    type="hf_tokenizer",
+                    tokenizer_name=self._vlm_model_name,
+                    revision="7b375e1b73b11138ff12fe22c8f2822d8fe03467",
+                    max_token_len=self._tokenizer_max_length,
+                ),
+            ],
             postprocessors_specs=postproc_specs,
             export_tokenizer=False,
         )
         extra_args["openvino"] = OpenVINOExportParameters(
             outputs=["action"],
             compress_to_fp16=False,
-            export_tokenizer=False,
+            export_tokenizer=True,
             exporter_kwargs={},
-            preprocessors_specs=preproc_specs,
+            preprocessors_specs=[
+                *base_preproc_specs,
+                ComponentSpec(
+                    type="ov_tokenizer",
+                    artifact="tokenizer.xml",
+                ),
+            ],
             postprocessors_specs=postproc_specs,
         )
         extra_args["torch"] = TorchExportParameters()

--- a/library/tests/unit/inference/preprocessors/test_ov_tokenizer.py
+++ b/library/tests/unit/inference/preprocessors/test_ov_tokenizer.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for OVTokenizer preprocessor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from physicalai.inference.constants import TASK, TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
+from physicalai.inference.preprocessors import Preprocessor
+
+
+@pytest.fixture
+def mock_adapter():
+    """Create a mock OpenVINOAdapter."""
+    adapter = MagicMock()
+    adapter.input_names = ["string_input"]
+    adapter.output_names = ["input_ids", "attention_mask"]
+
+    def _predict(inputs):
+        # Simulate tokenizer output based on batch size
+        batch_size = len(inputs["string_input"])
+        return {
+            "input_ids": np.ones((batch_size, 64), dtype=np.int64),
+            "attention_mask": np.ones((batch_size, 64), dtype=np.int64),
+        }
+
+    adapter.predict.side_effect = _predict
+    return adapter
+
+
+@pytest.fixture
+def ov_tokenizer(mock_adapter):
+    """Create an OVTokenizer with mocked adapter."""
+    with patch(
+        "physicalai.inference.preprocessors.ov_tokenizer.OpenVINOAdapter",
+        return_value=mock_adapter,
+    ):
+        from physicalai.inference.preprocessors.ov_tokenizer import OVTokenizer
+
+        return OVTokenizer(artifact="tokenizer.xml")
+
+
+class TestOVTokenizerInit:
+    """Tests for OVTokenizer initialization."""
+
+    def test_is_preprocessor(self, ov_tokenizer) -> None:
+        """OVTokenizer should be a Preprocessor instance."""
+        assert isinstance(ov_tokenizer, Preprocessor)
+
+    def test_loads_adapter_on_init(self, mock_adapter) -> None:
+        """Adapter should be loaded with the artifact path during init."""
+        with patch(
+            "physicalai.inference.preprocessors.ov_tokenizer.OpenVINOAdapter",
+            return_value=mock_adapter,
+        ):
+            from physicalai.inference.preprocessors.ov_tokenizer import OVTokenizer
+
+            OVTokenizer(artifact=Path("my_tokenizer.xml"))
+
+        mock_adapter.load.assert_called_once_with(Path("my_tokenizer.xml"))
+
+    def test_raises_when_multiple_inputs(self) -> None:
+        """Should raise ValueError if adapter has more than one input."""
+        bad_adapter = MagicMock()
+        bad_adapter.input_names = ["input1", "input2"]
+
+        with patch(
+            "physicalai.inference.preprocessors.ov_tokenizer.OpenVINOAdapter",
+            return_value=bad_adapter,
+        ):
+            from physicalai.inference.preprocessors.ov_tokenizer import OVTokenizer
+
+            with pytest.raises(ValueError, match="Expected exactly one input"):
+                OVTokenizer(artifact="tokenizer.xml")
+
+
+class TestOVTokenizerCall:
+    """Tests for OVTokenizer __call__ method."""
+
+    def test_tokenizes_batch(self, ov_tokenizer) -> None:
+        """Should tokenize a batch of tasks and return correct keys."""
+        inputs = {TASK: ["task one", "task two"]}
+        result = ov_tokenizer(inputs)
+
+        assert TOKENIZED_PROMPT in result
+        assert TOKENIZED_PROMPT_MASK in result
+        assert TASK not in result
+        assert result[TOKENIZED_PROMPT].shape == (2, 64)
+        assert result[TOKENIZED_PROMPT_MASK].dtype == np.bool_
+
+    def test_raises_when_task_not_list(self, ov_tokenizer) -> None:
+        """Should raise TypeError if TASK is not a list."""
+        inputs = {TASK: "not a list"}
+
+        with pytest.raises(TypeError, match="Expected TASK to be a list"):
+            ov_tokenizer(inputs)


### PR DESCRIPTION
# Pull Request

## Description

- Utilize OV tokenizers library when exporting supported VLA policies: a tokenizer is exported as a standalone OV model and later used by `OVTokenizer` inference preprocessor. That allows to avoid loading anything from hf storage, like it happens when using hf tokenizers

## Type of Change

- [x] ✨ `feat` - New feature

