### PR TITLE
fix: SmolVLA condition inverted for expert VLM layers

### DIFF
--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -1280,15 +1280,16 @@ class _SmolVLMWithExpertModel(nn.Module):
         lm_expert_config.hidden_size = int(hidden_size * expert_width_multiplier)  # hidden_size // 2
         lm_expert_config.intermediate_size = _get_intermediate_size(int(hidden_size * expert_width_multiplier))
         lm_expert_config.num_hidden_layers = self.num_vlm_layers
-        if num_expert_layers > 0 and len(self.get_vlm_model().text_model.layers) % num_expert_layers == 0:
+        if num_expert_layers > 0:
+            if len(self.get_vlm_model().text_model.layers) % num_expert_layers != 0:
+                msg = (
+                    f"Number of layers in the VLM {len(self.get_vlm_model().text_model.layers)} are "
+                    f"not multiple of num_expert_layers {num_expert_layers}"
+                )
+                raise RuntimeError(msg)
             lm_expert_config.num_hidden_layers = num_expert_layers
-            msg = (
-                f"Number of layers in the VLM {len(self.get_vlm_model().text_model.layers)} are "
-                f"not multiple of num_expert_layers {num_expert_layers}"
-            )
-            raise RuntimeError(msg)
-        self.lm_expert = auto_model_cls.from_config(lm_expert_config)
 
+        self.lm_expert = auto_model_cls.from_config(lm_expert_config)
         self.num_expert_layers = len(self.lm_expert.layers)
         self.self_attn_every_n_layers = self_attn_every_n_layers
         if "cross" in attention_mode:


### PR DESCRIPTION
# Pull Request

## Description

The condition is inverted. It raises when len(layers) is divisible by num_expert_layers which is the valid case. When the config is invalid (not divisible), the condition is false, the assignment is skipped, num_hidden_layers is set incorrectly, and no error is raised.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

#482 

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
