### PR TITLE
fix: SmolVLA pad language differs between API and config

### DIFF
--- a/library/src/physicalai/policies/smolvla/config.py
+++ b/library/src/physicalai/policies/smolvla/config.py
@@ -112,6 +112,8 @@ class SmolVLAConfig(Config):
 
     prefix_length: int = -1
 
+    # NOTE max_length is fixed for export compatibility (avoids dynamic input shapes).
+    # It should not impact performance since masking ignores unused tokens.
     pad_language_to: str = "max_length"  # "longest"
 
     num_expert_layers: int = -1


### PR DESCRIPTION
# Pull Request

## Description

Unify default arg of `pad_language_length` between config and api. Config defaults to "longest". API training and all inference constructs via SmolVLA.init uses "longest".

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

#483 

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
