### PR TITLE
fix: restore delta_timestamps callback flow for lerobot 0.5.1

### DIFF
--- a/library/src/physicalai/data/lerobot/dataset.py
+++ b/library/src/physicalai/data/lerobot/dataset.py
@@ -227,17 +227,19 @@ class _LeRobotDatasetAdapter(Dataset):
     @property
     def delta_indices(self) -> dict[str, list[int]]:
         """Expose delta_indices from the DatasetReader (lerobot >=0.5.1)."""
-        reader = self._lerobot_dataset.reader
-        if reader is None:
-            return {}
-        return reader.delta_indices or {}
+        reader = getattr(self._lerobot_dataset, "reader", None)
+        if reader is not None:
+            return reader.delta_indices or {}
+        return getattr(self._lerobot_dataset, "delta_indices", None) or {}
 
     @delta_indices.setter
     def delta_indices(self, indices: dict[str, list[int]]) -> None:
         """Set delta_indices on DatasetReader so the training callback can inject them post-construction."""
-        reader = self._lerobot_dataset.reader
+        reader = getattr(self._lerobot_dataset, "reader", None)
         if reader is not None:
             reader.delta_indices = indices
+        else:
+            self._lerobot_dataset.delta_indices = indices
 
 
 __all__ = ["_LeRobotDatasetAdapter"]

--- a/library/src/physicalai/data/lerobot/dataset.py
+++ b/library/src/physicalai/data/lerobot/dataset.py
@@ -226,14 +226,18 @@ class _LeRobotDatasetAdapter(Dataset):
 
     @property
     def delta_indices(self) -> dict[str, list[int]]:
-        """Expose delta_indices from the dataset."""
-        indices = self._lerobot_dataset.delta_indices
-        return indices if indices is not None else {}
+        """Expose delta_indices from the DatasetReader (lerobot >=0.5.1)."""
+        reader = self._lerobot_dataset.reader
+        if reader is None:
+            return {}
+        return reader.delta_indices or {}
 
     @delta_indices.setter
     def delta_indices(self, indices: dict[str, list[int]]) -> None:
-        """Allow setting delta_indices on the dataset."""
-        self._lerobot_dataset.delta_indices = indices
+        """Set delta_indices on DatasetReader so the training callback can inject them post-construction."""
+        reader = self._lerobot_dataset.reader
+        if reader is not None:
+            reader.delta_indices = indices
 
 
 __all__ = ["_LeRobotDatasetAdapter"]

--- a/library/tests/integration/test_first_party_e2e.py
+++ b/library/tests/integration/test_first_party_e2e.py
@@ -17,7 +17,6 @@ import pytest
 import torch
 
 from physicalai.data import LeRobotDataModule
-from physicalai.data.lerobot.utils.delta_timestamps import get_delta_timestamps_from_policy
 from physicalai.inference import InferenceModel
 from physicalai.policies import get_policy
 from physicalai.policies.base.policy import Policy
@@ -262,12 +261,10 @@ class TestE2E(CoreE2ETests, ExportE2ETests):
     """E2E tests for policies with export support (ACT, etc.)."""
 
     @pytest.fixture(scope="class")
-    def datamodule(self, policy_name: str) -> LeRobotDataModule:
-        """Create datamodule for first-party policies with delta timestamps."""
-        delta_timestamps = get_delta_timestamps_from_policy(policy_name, fps=10)
+    def datamodule(self) -> LeRobotDataModule:
+        """Create datamodule for first-party policies."""
         return LeRobotDataModule(
             repo_id="lerobot/pusht",
             train_batch_size=8,
             episodes=list(range(10)),
-            delta_timestamps=delta_timestamps,
         )


### PR DESCRIPTION
## Summary

- Fix `_LeRobotDatasetAdapter.delta_indices` getter/setter to target `DatasetReader` instead of the (now non-existent) dataset-level attribute in lerobot >=0.5.1

## Problem

In lerobot 0.5.1, `delta_indices` moved from `LeRobotDataset` to `DatasetReader` as part of the dataset reader/writer split. The adapter's getter/setter was writing to a dangling attribute on the dataset object, so the `PolicyDatasetInteraction` callback (`on_fit_start`) had no effect. 

## Solution

The adapter layer absorbs the lerobot API change — the getter/setter now targets `reader.delta_indices` directly. This restores the original flow:

1. User creates `LeRobotDataModule(repo_id=...)` — **no delta_timestamps needed**
2. User creates policy
3. `trainer.fit()` triggers `PolicyDatasetInteraction` callback
4. Callback reads delta indices from policy and sets them on the dataset via the adapter