### PR TITLE
feat(upload): add a upload size guard middleware

### DIFF
--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -100,3 +100,14 @@ class UnsupportedDeviceError(BaseException):
             error_code="unsupported_device",
             http_status=http.HTTPStatus.BAD_REQUEST,
         )
+
+
+class UploadTooLargeError(BaseException):
+    """Raised when the HTTP upload exceeds the configured maximum size."""
+
+    def __init__(self, message: str = "Uploaded file exceeds the maximum allowed size") -> None:
+        super().__init__(
+            message=message,
+            error_code="upload_too_large",
+            http_status=http.HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+        )

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -6,7 +6,9 @@ import os
 from pathlib import Path
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import Response
+from starlette.middleware.base import RequestResponseEndpoint
 
 from api.camera import router as camera_router
 from api.dataset import router as dataset_router
@@ -28,6 +30,7 @@ from api.system import system_router
 from api.webui import SPAStaticFiles
 from core import lifespan
 from exception_handlers import register_application_exception_handlers
+from middleware.upload_size_guard import upload_size_guard_middleware
 from settings import get_settings
 from utils.device import get_torch_device
 
@@ -58,6 +61,11 @@ app.include_router(logs_router)
 app.include_router(system_router)
 
 register_application_exception_handlers(app)
+
+
+@app.middleware("http")
+async def _upload_size_guard(request: Request, call_next: RequestResponseEndpoint) -> Response:
+    return await upload_size_guard_middleware(request, call_next)
 
 
 @app.get("/api/health")

--- a/application/backend/src/middleware/upload_size_guard.py
+++ b/application/backend/src/middleware/upload_size_guard.py
@@ -1,0 +1,38 @@
+from fastapi import Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse, Response
+from starlette.middleware.base import RequestResponseEndpoint
+
+from exceptions import UploadTooLargeError
+from settings import get_settings
+
+
+async def upload_size_guard_middleware(request: Request, call_next: RequestResponseEndpoint) -> Response:
+    """Reject oversized dataset-upload requests before body processing."""
+    raw = request.headers.get("content-length")
+
+    if raw is not None:
+        try:
+            content_length = int(raw)
+        except ValueError as error:
+            raise UploadTooLargeError("Invalid Content-Length header") from error
+
+        settings = get_settings()
+        if content_length > settings.data_import_max_upload_bytes:
+            upload_error = UploadTooLargeError(
+                f"Upload size ({content_length} bytes) exceeds the maximum allowed upload size "
+                f"({settings.data_import_max_upload_bytes} bytes)"
+            )
+            return JSONResponse(
+                content=jsonable_encoder(
+                    {
+                        "error_code": upload_error.error_code,
+                        "message": upload_error.message,
+                        "http_status": upload_error.http_status,
+                    }
+                ),
+                status_code=int(upload_error.http_status),
+                headers={"Cache-Control": "no-cache"},
+            )
+
+    return await call_next(request)

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -33,6 +33,24 @@ class Settings(BaseSettings):
 
     supported_backends: list[str] = ["torch"]
 
+    # Data import/upload safety (shared for dataset/model/project imports)
+    data_import_max_uncompressed_bytes: int = Field(
+        default=200 * 1024 * 1024 * 1024,
+        alias="DATA_IMPORT_MAX_UNCOMPRESSED_BYTES",
+    )
+    # Maximum raw upload size (Content-Length) accepted before any processing.
+    # Default: 100 GiB - supports large dataset imports while still guarding abuse.
+    data_import_max_upload_bytes: int = Field(
+        default=100 * 1024 * 1024 * 1024,
+        alias="DATA_IMPORT_MAX_UPLOAD_BYTES",
+    )
+    # Minimum free bytes that must remain on the target filesystem after the
+    # upload / extraction lands.  Default: 1 GiB headroom.
+    data_import_min_free_bytes: int = Field(
+        default=1 * 1024 * 1024 * 1024,
+        alias="DATA_IMPORT_MIN_FREE_BYTES",
+    )
+
     @property
     def datasets_dir(self) -> Path:
         """Storage directory for datasets."""


### PR DESCRIPTION
This middleware allows us to configure a max size of an upload allowed by studio.
While ideally we should not need this in practice having a max size will allow us to give better error handling (instead of having very long running load times).

Note: this PR is a small extraction of the dataset import PR that I'm preparing.

## Type of Change

- [x] 🔧 `chore` - Maintenance