### PR TITLE
fix: restore PI0 and GROOT compatibility with transformers 5.3

### DIFF
--- a/library/src/physicalai/policies/groot/components/backbone.py
+++ b/library/src/physicalai/policies/groot/components/backbone.py
@@ -557,7 +557,7 @@ class EagleProcessor:
             str(cache_dir),
             trust_remote_code=True,
         )
-        # Set left padding for decoder-style models
+
         processor.tokenizer.padding_side = "left"
         return processor
 
@@ -599,13 +599,13 @@ class EagleProcessor:
         eagle_inputs = self.processor(
             text=text_list,
             images=image_inputs,
+            text_kwargs={"padding": True, "return_tensors": return_tensors},
             images_kwargs={
                 "min_dynamic_tiles": self.min_dynamic_tiles,
                 "max_dynamic_tiles": self.max_dynamic_tiles,
                 "use_thumbnail": self.use_thumbnail,
+                "return_tensors": return_tensors,
             },
-            return_tensors=return_tensors,
-            padding=True,
         )
 
         # Prefix keys with eagle_
@@ -650,13 +650,13 @@ class EagleProcessor:
         eagle_inputs = self.processor(
             text=all_text,
             images=all_images,
+            text_kwargs={"padding": True, "return_tensors": return_tensors},
             images_kwargs={
                 "min_dynamic_tiles": self.min_dynamic_tiles,
                 "max_dynamic_tiles": self.max_dynamic_tiles,
                 "use_thumbnail": self.use_thumbnail,
+                "return_tensors": return_tensors,
             },
-            return_tensors=return_tensors,
-            padding=True,
         )
 
         return {f"eagle_{k}": v for k, v in eagle_inputs.items()}

--- a/library/src/physicalai/policies/pi0/components/gemma.py
+++ b/library/src/physicalai/policies/pi0/components/gemma.py
@@ -206,14 +206,14 @@ class PaliGemmaWithExpert(nn.Module):
         """Embed images using PaliGemma's vision encoder."""  # noqa: DOC201
         self._ensure_loaded()
         pixel_values = pixel_values.to(dtype=self.dtype)
-        vision_outputs = self.paligemma.vision_tower(pixel_values)
+        vision_outputs = self.paligemma.model.vision_tower(pixel_values)
         image_features = vision_outputs.last_hidden_state
-        return self.paligemma.multi_modal_projector(image_features)
+        return self.paligemma.model.multi_modal_projector(image_features)
 
     def embed_language_tokens(self, input_ids: torch.Tensor) -> torch.Tensor:
         """Embed language tokens using PaliGemma's embedding layer."""  # noqa: DOC201
         self._ensure_loaded()
-        return self.paligemma.language_model.embed_tokens(input_ids)
+        return self.paligemma.model.language_model.embed_tokens(input_ids)
 
     def forward(
         self,
@@ -241,7 +241,7 @@ class PaliGemmaWithExpert(nn.Module):
         if prefix_embeds is not None:
             prefix_position_ids = position_ids[:, :prefix_len]
             prefix_attention_mask = attention_mask[:, :, :prefix_len, :prefix_len]
-            pali_outputs = self.paligemma.language_model(
+            pali_outputs = self.paligemma.model.language_model(
                 inputs_embeds=prefix_embeds,
                 attention_mask=prefix_attention_mask,
                 position_ids=prefix_position_ids,
@@ -258,7 +258,8 @@ class PaliGemmaWithExpert(nn.Module):
         if suffix_embeds is not None:
             suffix_cond = adarms_cond[1] if adarms_cond is not None else None
             suffix_position_ids = position_ids[:, prefix_len : prefix_len + suffix_len]
-            suffix_attention_mask = attention_mask[:, :, prefix_len:, :]
+            kv_offset = 0 if past_key_values is not None else prefix_len
+            suffix_attention_mask = attention_mask[:, :, prefix_len:, kv_offset:]
 
             if self.use_adarms and suffix_cond is not None:
                 suffix_output = self._forward_action_expert_with_adarms(
@@ -322,13 +323,13 @@ class PaliGemmaWithExpert(nn.Module):
         """Set which parameters are trainable."""
         self._ensure_loaded()
 
-        for param in self.paligemma.language_model.parameters():
+        for param in self.paligemma.model.language_model.parameters():
             param.requires_grad = tune_paligemma
 
-        for param in self.paligemma.vision_tower.parameters():
+        for param in self.paligemma.model.vision_tower.parameters():
             param.requires_grad = tune_vision_encoder
 
-        for param in self.paligemma.multi_modal_projector.parameters():
+        for param in self.paligemma.model.multi_modal_projector.parameters():
             param.requires_grad = tune_paligemma
 
         for param in self.action_expert.parameters():


### PR DESCRIPTION
## Summary
- restore PI0 compatibility with transformers 5.3 by updating PaliGemma component access to the nested `model` layout and fixing the suffix attention mask used by the action expert
- restore GROOT compatibility with transformers 5.3 by routing `return_tensors` through `text_kwargs` and `images_kwargs` so the vendored Eagle processor returns tensors without runtime monkey-patching
- validate the hotfix with targeted unit and first-party integration coverage for both PI0 and GROOT