### PR TITLE
fix: show error message on identify robot error

### DIFF
--- a/application/backend/src/exception_handlers.py
+++ b/application/backend/src/exception_handlers.py
@@ -8,6 +8,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from loguru import logger
+from serial.serialutil import SerialException
 
 from exceptions import BaseException
 
@@ -130,6 +131,38 @@ async def pydantic_validation_exception_handler(_request: Request, exception: Ex
     )
 
 
+async def connection_error_exception_handler(_request: Request, exception: Exception) -> JSONResponse:
+    """Convert serial connection errors to a client-facing 4xx response."""
+    if not isinstance(exception, ConnectionError):
+        raise exception
+
+    cause = exception.__cause__ or exception.__context__
+    is_permission_denied = isinstance(cause, PermissionError) or (
+        isinstance(cause, SerialException) and getattr(cause, "errno", None) == 13
+    )
+
+    if is_permission_denied:
+        payload = {
+            "error_code": "serial_permission_denied",
+            "message": (
+                "Permission denied while opening the serial device. "
+                "Grant your user access to the serial port and try again."
+            ),
+            "http_status": http.HTTPStatus.FORBIDDEN.value,
+        }
+        status_code = status.HTTP_403_FORBIDDEN
+    else:
+        payload = {
+            "error_code": "serial_connection_error",
+            "message": "Could not connect to the robot on the requested serial port.",
+            "http_status": http.HTTPStatus.BAD_REQUEST.value,
+        }
+        status_code = status.HTTP_400_BAD_REQUEST
+
+    headers = {"Cache-Control": "no-cache"}
+    return JSONResponse(status_code=status_code, content=jsonable_encoder(payload), headers=headers)
+
+
 def register_application_exception_handlers(app: FastAPI) -> None:
     """
     Register application exception handlers
@@ -141,3 +174,4 @@ def register_application_exception_handlers(app: FastAPI) -> None:
 
     app.add_exception_handler(RequestValidationError, validation_exception_handler)
     app.add_exception_handler(pydantic.ValidationError, pydantic_validation_exception_handler)
+    app.add_exception_handler(ConnectionError, connection_error_exception_handler)

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -20,6 +20,7 @@ import { $api } from '../../../api/client';
 import { SchemaRobot } from '../../../api/openapi-spec';
 import { useProjectId } from '../../../features/projects/use-project';
 import { paths } from '../../../router';
+import { PermissionDeniedError } from '../setup-wizard/so101/diagnostics-step-error';
 import { useRobotForm, useSetRobotForm } from './provider';
 import { SubmitNewRobotButton } from './submit-new-robot-button';
 
@@ -80,11 +81,14 @@ const RefreshRobotsButton = () => {
     );
 };
 
-const IdentifyRobot = () => {
-    const robotForm = useRobotForm();
-    const identifyMutation = $api.useMutation('post', '/api/hardware/identify', {
+const useIdentifyMutation = () => {
+    return $api.useMutation('post', '/api/hardware/identify', {
         meta: { skipInvalidation: true },
     });
+};
+
+const IdentifyRobot = ({ identifyMutation }: { identifyMutation: ReturnType<typeof useIdentifyMutation> }) => {
+    const robotForm = useRobotForm();
 
     const isDisabled = identifyMutation.isPending || !robotForm.name || !robotForm.type || !robotForm.connection_string;
 
@@ -119,6 +123,8 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
 
     const robotForm = useRobotForm();
     const setRobotForm = useSetRobotForm();
+
+    const identifyMutation = useIdentifyMutation();
 
     // Since project won't save connection_string for Serial devices;
     // we need to populate this value; so the identify button works.
@@ -192,7 +198,7 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
                                         placeholder='192.168.1.2'
                                     />
                                     <Flex gap='size-100'>
-                                        <IdentifyRobot />
+                                        <IdentifyRobot identifyMutation={identifyMutation} />
                                     </Flex>
                                 </>
                             ) : null}
@@ -230,11 +236,14 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
 
                                     <Flex gap='size-100'>
                                         <RefreshRobotsButton />
-                                        <IdentifyRobot />
+                                        <IdentifyRobot identifyMutation={identifyMutation} />
                                     </Flex>
                                 </>
                             ) : null}
                         </Flex>
+                        {robotForm.type?.toLowerCase().startsWith('so101') && identifyMutation.isError && (
+                            <PermissionDeniedError port={robotForm.connection_string} />
+                        )}
                     </Flex>
                     <Divider orientation='horizontal' size='S' />
                     <View>{submitButton}</View>

--- a/application/ui/src/features/robots/setup-wizard/so101/diagnostics-step-error.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/diagnostics-step-error.tsx
@@ -7,7 +7,7 @@ import classes from '../shared/setup-wizard.module.scss';
 
 const LEROBOT_DOCS_URL = 'https://huggingface.co/docs/lerobot/so101';
 
-const PermissionDeniedError = ({ port }: { port: string | null }) => {
+export const PermissionDeniedError = ({ port }: { port: string | null }) => {
     const portDisplay = port ?? '/dev/ttyACM*';
 
     return (


### PR DESCRIPTION
This PR catches the permission error that the backend raises when it's unable to write to (and therefore connect0 a SO101 robot.
Based on this error we then show a inline alert to the user informing them how to possibly fix this.

## Type of Change

- [x] 🐞 `fix` - Bug fix
## Related Issues

Fixes #496

## Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c0952f36-804a-4e2a-a663-6c2291b9aae2" />

