### PR TITLE
fix: fix unable to load episode thumbnail after lerobot update

### DIFF
--- a/application/backend/src/internal_datasets/lerobot/lerobot_dataset.py
+++ b/application/backend/src/internal_datasets/lerobot/lerobot_dataset.py
@@ -366,7 +366,10 @@ class InternalLeRobotDataset(DatasetClient):
 
         from_idx = int(episode["dataset_from_index"])
         try:
-            image = self._dataset[from_idx][image_key].permute(1, 2, 0).detach().numpy()
+            reader = self._dataset._ensure_reader()
+            if reader.hf_dataset is None:
+                reader.load_and_activate()
+            image = reader.get_item(from_idx)[image_key].permute(1, 2, 0).detach().numpy()
         except Exception:
             return None
 


### PR DESCRIPTION
After updating to lerboto v0.5.1 the studio's thumbnails broke due to the endpoint raising,
```
RuntimeError: Cannot read from a dataset that is being recorded. Call finalize() first, then access items.
````

This is because Lerobot's dataset refactor blocks `LeRobotDataset.__getitem__` while a writer is active, which made thumbnail generation fail on dataset frame access.

Read thumbnail frames through the dataset reader directly so thumbnail extraction still works without requiring `finalize()`.

## Type of Change

- [x] 🐞 `fix` - Bug fix
