### PR TITLE
fix: handle ACT VAE latents during validation

### DIFF
--- a/library/src/physicalai/policies/act/model.py
+++ b/library/src/physicalai/policies/act/model.py
@@ -750,10 +750,7 @@ class _ACT(nn.Module):
 
             # Sample the latent with the reparameterization trick during training.
             # In eval/validation mode use the mean directly for deterministic behavior.
-            if self.training:
-                latent_sample = mu + log_sigma_x2.div(2).exp() * torch.randn_like(mu)
-            else:
-                latent_sample = mu
+            latent_sample = mu + log_sigma_x2.div(2).exp() * torch.randn_like(mu) if self.training else mu
         else:
             # When not using the VAE encoder, we set the latent to be all zeros.
             mu = log_sigma_x2 = None

--- a/library/src/physicalai/policies/act/model.py
+++ b/library/src/physicalai/policies/act/model.py
@@ -703,7 +703,7 @@ class _ACT(nn.Module):
         batch_size = batch[STATE].shape[0]
 
         # Prepare the latent for input to the transformer encoder.
-        if self.config.use_vae and ACTION in batch and self.training:
+        if self.config.use_vae and ACTION in batch:
             # Prepare the input to the VAE encoder: [cls, *joint_space_configuration, *action_sequence].
             cls_embed = einops.repeat(
                 self.vae_encoder_cls_embed.weight,
@@ -748,8 +748,12 @@ class _ACT(nn.Module):
             # This is 2log(sigma). Done this way to match the original implementation.
             log_sigma_x2 = latent_pdf_params[:, self.config.latent_dim :]
 
-            # Sample the latent with the reparameterization trick.
-            latent_sample = mu + log_sigma_x2.div(2).exp() * torch.randn_like(mu)
+            # Sample the latent with the reparameterization trick during training.
+            # In eval/validation mode use the mean directly for deterministic behavior.
+            if self.training:
+                latent_sample = mu + log_sigma_x2.div(2).exp() * torch.randn_like(mu)
+            else:
+                latent_sample = mu
         else:
             # When not using the VAE encoder, we set the latent to be all zeros.
             mu = log_sigma_x2 = None

--- a/library/tests/unit/policies/test_act.py
+++ b/library/tests/unit/policies/test_act.py
@@ -121,6 +121,7 @@ class TestACTolicy:
         input_batch = copy.deepcopy(batch).to_dict()
         input_batch["images"] = input_batch["images"].to(dtype)
         input_batch["state"] = input_batch["state"].to(dtype)
+        input_batch["action"] = input_batch["action"].to(dtype)
 
         actions = eval_policy.model(input_batch)
         assert isinstance(actions, torch.Tensor)


### PR DESCRIPTION
> [!WARNING]
> I fixed this bug with AI and don't have a strong understanding of what impact the change could have on the produced model, so please check this carefully

Validation computes KL loss via compute_loss, but _ACT.forward previously only produced mu/log_sigma_x2 in training mode.

In eval mode this returned None latents, causing a TypeError when validation KL did 1 + log_sigma_x2.
Compute latent params whenever actions are available and use deterministic latent=mu in eval while keeping reparameterized sampling in training.

## Type of Change

- [x] 🐞 `fix` - Bug fix