### PR TITLE
fix: delete model snapshot during model removal

### DIFF
--- a/application/backend/src/repositories/__init__.py
+++ b/application/backend/src/repositories/__init__.py
@@ -2,10 +2,12 @@ from .dataset_repo import DatasetRepository
 from .job_repo import JobRepository
 from .model_repo import ModelRepository
 from .project_repo import ProjectRepository
+from .snapshot_repo import SnapshotRepository
 
 __all__ = [
     "DatasetRepository",
     "JobRepository",
     "ModelRepository",
     "ProjectRepository",
+    "SnapshotRepository",
 ]

--- a/application/backend/src/services/model_service.py
+++ b/application/backend/src/services/model_service.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from db import get_async_db_session_ctx
 from exceptions import ResourceNotFoundError, ResourceType
-from repositories import ModelRepository
+from repositories import ModelRepository, SnapshotRepository
 from schemas import Model
 
 
@@ -40,10 +40,17 @@ class ModelService:
     @staticmethod
     async def delete_model(model: Model) -> None:
         async with get_async_db_session_ctx() as session:
-            repo = ModelRepository(session)
-            await repo.delete_by_id(model.id)
-            model_path = Path(model.path).expanduser()
-            shutil.rmtree(model_path)
+            model_repo = ModelRepository(session)
+            snapshot_repo = SnapshotRepository(session)
+
+            await model_repo.delete_by_id(model.id)
+
+            # Remove the associated snapshot row to avoid stale FK references
+            if model.snapshot_id is not None:
+                await snapshot_repo.delete_by_id(model.snapshot_id)
+
+        model_path = Path(model.path).expanduser()
+        shutil.rmtree(model_path)
 
     @staticmethod
     async def get_project_models(project_id: UUID) -> list[Model]:

--- a/application/backend/tests/services/test_model_service.py
+++ b/application/backend/tests/services/test_model_service.py
@@ -1,0 +1,73 @@
+"""Unit tests for ModelService focusing on the delete_model behaviour."""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from schemas.model import Model
+from services.model_service import ModelService
+
+
+def _make_model(snapshot_id=None) -> Model:
+    return Model.model_validate(
+        {
+            "id": str(uuid4()),
+            "name": "test-model",
+            "policy": "act",
+            "path": "/tmp/test-model",
+            "project_id": str(uuid4()),
+            "dataset_id": str(uuid4()),
+            "snapshot_id": str(snapshot_id) if snapshot_id else None,
+            "properties": {},
+        }
+    )
+
+
+@pytest.mark.anyio
+async def test_delete_model_deletes_snapshot_when_snapshot_id_set() -> None:
+    """When model.snapshot_id is set, delete_model should also delete the snapshot row."""
+    snapshot_id = uuid4()
+    model = _make_model(snapshot_id=snapshot_id)
+
+    mock_model_repo = AsyncMock()
+    mock_snapshot_repo = AsyncMock()
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("services.model_service.get_async_db_session_ctx", return_value=mock_session),
+        patch("services.model_service.ModelRepository", return_value=mock_model_repo),
+        patch("services.model_service.SnapshotRepository", return_value=mock_snapshot_repo),
+        patch("services.model_service.shutil.rmtree"),
+    ):
+        await ModelService.delete_model(model)
+
+    mock_model_repo.delete_by_id.assert_awaited_once_with(model.id)
+    mock_snapshot_repo.delete_by_id.assert_awaited_once_with(model.snapshot_id)
+
+
+@pytest.mark.anyio
+async def test_delete_model_skips_snapshot_delete_when_no_snapshot_id() -> None:
+    """When model.snapshot_id is None, snapshot repo delete should NOT be called."""
+    model = _make_model(snapshot_id=None)
+
+    mock_model_repo = AsyncMock()
+    mock_snapshot_repo = AsyncMock()
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("services.model_service.get_async_db_session_ctx", return_value=mock_session),
+        patch("services.model_service.ModelRepository", return_value=mock_model_repo),
+        patch("services.model_service.SnapshotRepository", return_value=mock_snapshot_repo),
+        patch("services.model_service.shutil.rmtree"),
+    ):
+        await ModelService.delete_model(model)
+
+    mock_model_repo.delete_by_id.assert_awaited_once_with(model.id)
+    mock_snapshot_repo.delete_by_id.assert_not_awaited()


### PR DESCRIPTION
This PR fixes an issue where deleting a model wasn't deleting its associated dataset snapshot. Now this isn't a huge deal since it's only a single row in the database, but it prevents the user from deleting their datasets if they had any trained model on it (due to foreign key constraints).

This is an initial fix for #504, as without it users will never be able to delete datasets if they used it to train a model.


## Type of Change

- [x] 🐞 `fix` - Bug fix