### PR TITLE
docs: add a note about requiring HF_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ docker compose --profile xpu up # or use --profile cuda, --profile cpu
 Application runs at http://localhost:7860. See the [Docker README](./application/docker/README.md) for
 hardware configuration (Intel XPU, NVIDIA CUDA) and device setup.
 
+If you plan to train Hugging Face Hub-backed policies (for example, SmolVLA, Pi0,
+and others), configure `HF_TOKEN` to avoid unauthenticated Hub access warnings. See
+[Hugging Face Integration](./application/backend/docs/huggingface_integration.md).
+
 #### Native: installation & running
 
 Run the application in development mode, using [uv package manager](https://docs.astral.sh/uv/getting-started/installation/) and [node v24](https://nodejs.org/en/download) (we recommend using nvm)
@@ -87,6 +91,10 @@ npm run build:api:download && npm run build:api && npm run start
 ```
 
 Open http://localhost:3000 in your browser.
+
+If you plan to train Hugging Face Hub-backed policies (for example, SmolVLA, Pi0,
+and others), configure `HF_TOKEN` in your backend environment. See
+[Hugging Face Integration](./application/backend/docs/huggingface_integration.md).
 
 ### Library (Python/CLI)
 

--- a/application/README.md
+++ b/application/README.md
@@ -45,6 +45,10 @@ docker compose up
 Application runs at http://localhost:7860. See the [Docker README](./docker/README.md) for
 hardware configuration (Intel XPU, NVIDIA CUDA) and device setup.
 
+If you plan to train Hugging Face Hub-backed policies (for example, SmolVLA, Pi0,
+and others), configure `HF_TOKEN` to avoid unauthenticated Hub access warnings. See
+[Hugging Face Integration](./backend/docs/huggingface_integration.md).
+
 ### Native
 
 Or run the application natively in development mode.
@@ -60,6 +64,10 @@ uv sync --extra xpu # or `--extra cpu` or `--extra cuda`
 ```
 
 Backend runs at http://localhost:7860
+
+If you plan to train Hugging Face Hub-backed policies (for example, SmolVLA, Pi0,
+and others), configure `HF_TOKEN` in `backend/.env`. See
+[Hugging Face Integration](./backend/docs/huggingface_integration.md).
 
 #### Frontend
 

--- a/application/backend/docs/huggingface_integration.md
+++ b/application/backend/docs/huggingface_integration.md
@@ -1,0 +1,77 @@
+# Hugging Face Integration
+
+Several policies download assets from Hugging Face Hub (for example, SmolVLA, Pi0,
+and other Hub-backed models).
+
+If `HF_TOKEN` is not set, the backend logs a warning and Hub access is
+unauthenticated.
+
+Set `HF_TOKEN` for any workflow that depends on Hugging Face-hosted assets.
+Without a token, model downloads may fail (for example, due to anonymous rate
+limits or access restrictions on gated/private repositories).
+
+## Required token permissions
+
+For model download in Physical AI Studio, use a token with **read-only** Hub
+access:
+
+- **Required:** `Read` permission for model repositories.
+- **Not required:** `Write` or admin permissions.
+- **If using gated/private models:** the token must belong to a Hugging Face
+  account that has been granted access to those repositories.
+
+If you use a fine-grained token, grant read access to the specific model repos
+you plan to train from.
+
+## Create a Hugging Face token
+
+1. Sign in to [huggingface.co](https://huggingface.co/).
+2. Open **Settings** -> **Access Tokens**.
+3. Create a new token.
+4. Set permissions to read-only model access (see required permissions above).
+5. Copy the token value.
+
+## Configure `HF_TOKEN`
+
+Set `HF_TOKEN` in the environment used by the backend.
+
+### Native backend
+
+Add the token to `application/backend/.env`:
+
+```env
+HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Then start the backend as usual:
+
+```bash
+cd application/backend
+./run.sh
+```
+
+### Docker deployment
+
+Add the token to `application/docker/.env`:
+
+```env
+HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Then run Docker Compose as usual:
+
+```bash
+cd application/docker
+docker compose up
+```
+
+## Verify setup
+
+- Start a training job for a Hub-backed policy (for example, SmolVLA or Pi0).
+- Confirm there is no warning about missing `HF_TOKEN`.
+
+## Security notes
+
+- Never commit real tokens to source control.
+- Store tokens in local `.env` files or your secret manager.
+- Rotate the token immediately if it is exposed.

--- a/application/docker/.env.example
+++ b/application/docker/.env.example
@@ -35,3 +35,6 @@ COMPOSE_PROFILES=cpu
 # DIALOUT_GID=985
 # PLUGDEV_GID=46
 # RENDER_GID=989       # Intel GPU render nodes (XPU non-privileged mode)
+
+# Hugging Face token for Hub-backed model downloads (for example, SmolVLA, Pi0)
+HF_TOKEN=

--- a/application/docker/README.md
+++ b/application/docker/README.md
@@ -68,9 +68,15 @@ All configuration is done through the `.env` file. Copy `.env.example` to get st
 | `DIALOUT_GID`      | `dialout` (group name)        | Host GID for the `dialout` group (serial ports)          |
 | `PLUGDEV_GID`      | `plugdev` (group name)        | Host GID for the `plugdev` group (USB devices)           |
 | `RENDER_GID`       | `render` (group name)         | Host GID for the `render` group (Intel GPU, XPU only)    |
+| `HF_TOKEN`         | *(empty)*                     | Hugging Face access token for Hub-backed model downloads     |
 | `HTTP_PROXY`       | *(empty)*                     | HTTP proxy for builds and runtime                        |
 | `HTTPS_PROXY`      | *(empty)*                     | HTTPS proxy for builds and runtime                       |
 | `NO_PROXY`         | *(empty)*                     | Proxy exclusion list                                     |
+
+If you plan to train Hugging Face Hub-backed policies (for example, SmolVLA, Pi0,
+and others), set `HF_TOKEN` in `.env` to avoid unauthenticated Hub access warnings.
+See [Hugging Face Integration](../backend/docs/huggingface_integration.md) for token
+creation and setup details.
 
 ## Hardware Targets
 


### PR DESCRIPTION
Training Pi0 requires a HF_TOKEN so that we can download pre trained weights. This PR updates the readme files with references to setting this up for development.
The new huggingface integration document explains what token permissions are needed though I haven't done a full check on this yet.

Later we should also allow users to set this token from the UI.

## Type of Change

- [x] 📚 `docs` - Documentation