### PR TITLE
fix: enable sycl cache

### DIFF
--- a/application/docker/.env.example
+++ b/application/docker/.env.example
@@ -17,6 +17,12 @@ PORT=7860
 # profiled service to start (see docker-compose.yaml).
 COMPOSE_PROFILES=cpu
 
+# Persist the SYCL kernel cache across container restarts so the first
+# model inference (which compiles hundreds of SYCL kernels) only pays
+# the full ~minutes-long compile cost once.
+SYCL_CACHE_PERSISTENT=1
+SYCL_CACHE_DIR=/app/storage/.sycl-cache
+
 # Container user UID/GID — override to match your host user so that
 # bind-mounted volumes (e.g. calibration data) have correct ownership.
 # Run `id -u` and `id -g` to find your host values.

--- a/application/docker/docker-compose.yaml
+++ b/application/docker/docker-compose.yaml
@@ -131,6 +131,9 @@ services:
     build:
       <<: *common-build
       target: physical-ai-studio-xpu
+    environment:
+      - SYCL_CACHE_PERSISTENT=${SYCL_CACHE_PERSISTENT:-1}
+      - SYCL_CACHE_DIR=${SYCL_CACHE_DIR:-'/app/storage/.sycl-cache'}
     # --- Non-privileged XPU additions
     # When running in non-privileged mode, add these to grant
     # Intel GPU access via /dev/dri/renderD* nodes:


### PR DESCRIPTION
Enable sycl cache for model loading, resolve SmolVLA and others too loading slow on subsequent restarts

Fix #516 