### PR TITLE
feat(import): import job schema

### DIFF
--- a/application/backend/src/schemas/__init__.py
+++ b/application/backend/src/schemas/__init__.py
@@ -3,7 +3,7 @@ from .calibration import CalibrationConfig
 from .camera import Camera, CameraProfile
 from .dataset import Dataset, Episode, EpisodeInfo, EpisodeVideo, LeRobotDatasetInfo, Snapshot
 from .hardware import DeviceInfo, DeviceType
-from .job import Job, TrainJob
+from .job import DatasetImportJob, Job, TrainJob
 from .model import Model
 from .project import Project
 from .robot import LeRobotConfig, NetworkIpRobotConfig, Robot, SerialPortInfo
@@ -13,6 +13,7 @@ __all__ = [
     "Camera",
     "CameraProfile",
     "Dataset",
+    "DatasetImportJob",
     "DeviceInfo",
     "DeviceType",
     "Episode",

--- a/application/backend/src/schemas/base_job.py
+++ b/application/backend/src/schemas/base_job.py
@@ -10,6 +10,7 @@ from schemas.base import BaseIDModel
 
 class JobType(StrEnum):
     TRAINING = "training"
+    DATASET_IMPORT = "dataset_import"
 
 
 class JobStatus(StrEnum):

--- a/application/backend/src/schemas/dataset_import_job.py
+++ b/application/backend/src/schemas/dataset_import_job.py
@@ -1,0 +1,118 @@
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_serializer
+from pydantic_core.core_schema import SerializationInfo
+
+
+class ManifestCameraEntry(BaseModel):
+    """Recording schema entry describing a single camera stream."""
+
+    name: str
+    width: int | None = None
+    height: int | None = None
+    fps: int | None = None
+
+
+class ManifestRobotEntry(BaseModel):
+    """Recording schema entry describing a robot and its controllable joints."""
+
+    name: str
+    type: str | None = None
+    joints: list[str] = Field(default_factory=list)
+
+
+class DatasetManifestRecordingSchema(BaseModel):
+    """Cameras and robots inferred from dataset source metadata."""
+
+    cameras: list[ManifestCameraEntry] = Field(default_factory=list)
+    robots: list[ManifestRobotEntry] = Field(default_factory=list)
+
+
+class ImportStep(StrEnum):
+    AWAITING_UPLOAD = "awaiting_upload"
+    UPLOADED = "uploaded"
+    DETECTING_SOURCE = "detecting_source"
+    GENERATING_DRAFT_MANIFEST = "generating_draft_manifest"
+    WAITING_FOR_USER_INPUT = "waiting_for_user_input"
+    READY_TO_COMMIT = "ready_to_commit"
+    REGISTERING_RESOURCE = "registering_resource"
+    IMPORTING_RESOURCE = "importing_resource"
+    COMPLETED = "completed"
+
+
+class DatasetImportSource(StrEnum):
+    LEROBOT_V3 = "lerobot_v3"
+    UNKNOWN = "unknown"
+
+
+class ImportValidationSeverity(StrEnum):
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class ImportValidationMessage(BaseModel):
+    severity: ImportValidationSeverity
+    message: str
+
+
+class ImportValidationReport(BaseModel):
+    messages: list[ImportValidationMessage] = Field(default_factory=list)
+
+    def add(self, severity: ImportValidationSeverity, message: str) -> None:
+        self.messages.append(ImportValidationMessage(severity=severity, message=message))
+
+    def add_error(self, message: str) -> None:
+        self.messages.append(ImportValidationMessage(severity=ImportValidationSeverity.ERROR, message=message))
+
+    def add_warning(self, message: str) -> None:
+        self.messages.append(ImportValidationMessage(severity=ImportValidationSeverity.WARNING, message=message))
+
+    @computed_field(return_type=bool)
+    def is_valid(self) -> bool:
+        return not any(message.severity == ImportValidationSeverity.ERROR for message in self.messages)
+
+
+class DatasetManifestStatistics(BaseModel):
+    episode_count: int = Field(default=0, ge=0)
+    frame_count: int = Field(default=0, ge=0)
+
+
+class DatasetManifest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    source_type: DatasetImportSource = DatasetImportSource.UNKNOWN
+    suggested_name: str | None = None
+    statistics: DatasetManifestStatistics = Field(default_factory=DatasetManifestStatistics)
+    dataset_schema: DatasetManifestRecordingSchema = Field(default_factory=DatasetManifestRecordingSchema)
+
+
+class DatasetImportFinalizeInput(BaseModel):
+    dataset_name: str
+    environment_id: UUID
+    default_task: str = ""
+
+    @field_serializer("environment_id")
+    def serialize_environment_id(self, environment_id: UUID, _info: SerializationInfo) -> str:
+        return str(environment_id)
+
+
+class DatasetImportJobPayload(BaseModel):
+    step: ImportStep = ImportStep.AWAITING_UPLOAD
+    result_dataset_id: UUID | None = None
+
+    # Opaque staging identifier - resolve the archive path via resolve_payload_archive_path().
+    archive_staging_id: UUID
+    uploaded_archive_name: str | None = None
+    source_hint: str = "auto"
+    dataset_manifest_draft: DatasetManifest | None = None
+    validation_report: ImportValidationReport | None = None
+    finalize_input: DatasetImportFinalizeInput | None = None
+
+    @field_serializer("result_dataset_id")
+    def serialize_result_dataset_id(self, result_dataset_id: UUID | None, _info: SerializationInfo) -> str | None:
+        return str(result_dataset_id) if result_dataset_id else None
+
+    @field_serializer("archive_staging_id")
+    def serialize_archive_staging_id(self, archive_staging_id: UUID, _info: SerializationInfo) -> str:
+        return str(archive_staging_id)

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -5,6 +5,7 @@ from loguru import logger
 from pydantic import BaseModel, Field, field_serializer, model_validator
 
 from schemas.base_job import BaseJob, JobType
+from schemas.dataset_import_job import DatasetImportJobPayload
 from schemas.hardware import DeviceType
 
 
@@ -84,10 +85,15 @@ class TrainJob(BaseJob):
     payload: TrainJobPayload
 
 
-JobPayload = TrainJobPayload
+class DatasetImportJob(BaseJob):
+    type: Literal[JobType.DATASET_IMPORT] = JobType.DATASET_IMPORT  # type: ignore[valid-type]
+    payload: DatasetImportJobPayload
+
+
+JobPayload = TrainJobPayload | DatasetImportJobPayload
 
 Job = Annotated[
-    TrainJob,
+    TrainJob | DatasetImportJob,
     Field(discriminator="type"),
 ]
 

--- a/application/backend/tests/services/test_log_service.py
+++ b/application/backend/tests/services/test_log_service.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import pytest
 
-from schemas.job import Job, JobType
+from schemas.job import Job, TrainJob
 from services.log_service import LogService
 
 
@@ -42,10 +42,9 @@ async def test_discover_job_sources_includes_training_name_and_created_at(tmp_pa
     file_path = jobs_dir / f"{job_id}.log"
     file_path.write_text("hello")
 
-    job = Job(
+    job = TrainJob(
         id=job_id,
         project_id=uuid4(),
-        type=JobType.TRAINING,
         payload={
             "project_id": str(uuid4()),
             "dataset_id": str(uuid4()),

--- a/application/ui/src/routes/models/index.tsx
+++ b/application/ui/src/routes/models/index.tsx
@@ -115,10 +115,12 @@ const JobList = ({ jobs, onViewLogs }: { jobs: SchemaTrainJob[]; onViewLogs: (jo
     );
 };
 
-const useProjectJobs = (project_id: string): SchemaJob[] => {
-    const { data: allJobs } = $api.useQuery('get', '/api/jobs');
+const useProjectTrainingJobs = (project_id: string): SchemaJob[] => {
+    const { data: allJobs = [] } = $api.useQuery('get', '/api/jobs');
 
-    return allJobs?.filter((j) => j.project_id === project_id) ?? [];
+    return allJobs
+        .filter((job) => job.project_id === project_id)
+        .filter((job): job is SchemaJob => job.type === 'training');
 };
 
 export const Index = () => {
@@ -127,7 +129,7 @@ export const Index = () => {
         params: { path: { project_id } },
     });
 
-    const jobs = useProjectJobs(project_id);
+    const jobs = useProjectTrainingJobs(project_id);
     const [retrainModel, setRetrainModel] = useState<SchemaModel | null>(null);
     const [logsSourceId, setLogsSourceId] = useState<string | undefined>();
 


### PR DESCRIPTION
This PR sets up new schemas that will be used by dataset import jobs. 
My intention for this PR is to outline the full import workflow but keep the review focus on the actual schemas that get stored to the database and send to the UI.
From a user point of view importing a dataset has the following steps:
1. Click import dataset
2. Upload dataset zip file
3. Wait for upload to finish
4. Provide additional metadata: dataset name, environment, default task
5. Wait for dataset import to finish

Under the hood though this flow is split up in a few more steps so that we can provide more detailed progress reports.
Below is a full example of how the import flow is expected to work from an API/backend perspective.

<details>
<summary>
<h3>Import flow (click for details)</h3>
</summary>

Dataset import runs as an async job with these payload step transitions:
1. `awaiting_upload`: job prepared
7. `uploaded`: archive uploaded
8. `detecting_source`: worker selecting adapter
9. `generating_draft_manifest`: worker building draft + assessment
10. `waiting_for_user_input`: UI can inspect draft and submit finalize input
11. `ready_to_commit`: finalize input accepted
12. `importing_resource`: adapter commit in progress
13. `registering_resource`: dataset registration in progress
14. `completed`: import done, `result_dataset_id` set

---

### 1) `awaiting_upload`
**Endpoint called:**
`POST {BASE_URL}/api/projects/{project_id}/imports/datasets:prepare`

**Payload observed via:**
`GET {BASE_URL}/api/jobs/{job_id}`

```json
{
  "step": "awaiting_upload",
  "archive_staging_id": "a4bc8f6b-5f8f-4f76-94f9-2f4e8444f1b1",
  "uploaded_archive_name": null,
  "source_hint": "auto",
  "dataset_manifest_draft": null,
  "validation_report": null,
  "finalize_input": null,
  "result_dataset_id": null
}
```

### 2) `uploaded`
**Endpoint called:**
`PUT {BASE_URL}/api/projects/{project_id}/imports/datasets/{job_id}:upload`

**Payload observed via:**
`GET {BASE_URL}/api/jobs/{job_id}`

```json
{
  "step": "uploaded",
  "archive_staging_id": "a4bc8f6b-5f8f-4f76-94f9-2f4e8444f1b1",
  "uploaded_archive_name": "warehouse-run-01.zip",
  "source_hint": "auto"
}
```

### 3) `detecting_source` (worker)
**No direct endpoint call (worker transition).**
**Observe via:**
`GET {BASE_URL}/api/jobs/{job_id}` 

```json
{
  "step": "detecting_source"
}
```

### 4) `generating_draft_manifest` (worker)
**No direct endpoint call (worker transition).**
**Observe via:**
`GET {BASE_URL}/api/jobs/{job_id}`

```json
{
  "step": "generating_draft_manifest"
}
```

### 5) `waiting_for_user_input`
**No direct endpoint call (worker transition).**
**Observe via:**
`GET {BASE_URL}/api/jobs/{job_id}`

```json
{
  "step": "waiting_for_user_input",
  "dataset_manifest_draft": {
    "source_type": "lerobot_v3",
    "suggested_name": "warehouse-run-01",
    "statistics": { "episode_count": 52, "frame_count": 208000 },
    "dataset_schema": { "cameras": [], "robots": [] }
  },
  "validation_report": {
    "messages": [
      { "severity": "warning", "message": "No global stats metadata found in 'meta/stats.json'." }
    ],
    "is_valid": true
  }
}
```

### 6) `ready_to_commit`
**Endpoint called:**
`POST {BASE_URL}/api/projects/{project_id}/imports/datasets/{job_id}:finalize`

**Payload observed via:**
`GET {BASE_URL}/api/jobs/{job_id}`

```json
{
  "step": "ready_to_commit",
  "finalize_input": {
    "dataset_name": "warehouse-run-01",
    "environment_id": "f8e945f2-b7fd-4ed1-b9d8-cac8a4fd4f38",
    "default_task": ""
  }
}
```

### 7) `importing_resource` (worker)
**No direct endpoint call (worker transition).**
**Observe via:**
`GET {BASE_URL}/api/jobs/{job_id}`

```json
{
  "step": "importing_resource"
}
```

### 8) `registering_resource` (worker)
**No direct endpoint call (worker transition).**
**Observe via:**
`GET {BASE_URL}/api/jobs/{job_id}`

```json
{
  "step": "registering_resource",
  "result_dataset_id": "8f3f52a8-64d4-4a24-a95e-fcce92774b7c"
}
```

### 9) `completed`
**No direct endpoint call (worker transition).**
**Observe via:**
`GET {BASE_URL}/api/jobs/{job_id}`

```json
{
  "step": "completed",
  "result_dataset_id": "8f3f52a8-64d4-4a24-a95e-fcce92774b7c"
}
```

</details>


## Type of Change

- [x] ✨ `feat` - New feature