### PR TITLE
fix: missing state normalization on VLA OV inference

### DIFF
--- a/library/src/physicalai/inference/preprocessors/stats_normalizer.py
+++ b/library/src/physicalai/inference/preprocessors/stats_normalizer.py
@@ -16,12 +16,11 @@ Supports two normalization modes:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, override
+from typing import override
+
+import numpy as np
 
 from physicalai.inference.preprocessors.base import Preprocessor
-
-if TYPE_CHECKING:
-    import numpy as np
 
 _EPS = 1e-8
 
@@ -69,6 +68,7 @@ class StatsNormalizer(Preprocessor):
         features: list[str] | None = None,
         *,
         artifact: str | None = None,
+        stats: dict[str, dict[str, np.ndarray]] | None = None,
     ) -> None:
         """Initialize with stats file path and normalization config.
 
@@ -80,6 +80,8 @@ class StatsNormalizer(Preprocessor):
                 all features present in the stats file are normalized.
             artifact: Alias for *stats_path*, used when the path is
                 supplied via manifest ``artifact`` resolution.
+            stats: Optional pre-loaded stats dict.  If provided, skips
+                lazy loading from file.
 
         Raises:
             ValueError: If *mode* is not a recognized normalization mode
@@ -91,14 +93,14 @@ class StatsNormalizer(Preprocessor):
             raise ValueError(msg)
 
         resolved_path = stats_path or artifact
-        if resolved_path is None:
-            msg = "Either stats_path or artifact must be provided"
+        if resolved_path is None and stats is None:
+            msg = "Either stats_path, artifact, or stats must be provided"
             raise ValueError(msg)
 
         self._stats_path = resolved_path
         self._mode = mode
         self._features: set[str] = set(features) if features else set()
-        self._stats: dict[str, dict[str, np.ndarray]] | None = None
+        self._stats: dict[str, dict[str, np.ndarray]] | None = stats
 
     def load_stats(self) -> None:
         """Eagerly load stats from the safetensors file.
@@ -167,7 +169,7 @@ def _normalize(
     if mode == "mean_std":
         mean = stats["mean"]
         std = stats["std"]
-        return (tensor - mean) / (std + _EPS)
+        return (tensor - mean) / (std + np.array(_EPS))
 
     if mode == "min_max":
         min_val = stats["min"]

--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -677,6 +677,11 @@ class Pi05Model(ExportableModelMixin, Model):
         """
         base_preproc_specs = [
             ComponentSpec(type="pi05", image_resolution=self._image_resolution),
+            ComponentSpec(
+                type="normalize",
+                stats={STATE: self._dataset_stats[f"observation.{STATE}"]},
+                mode="mean_std",
+            ),
         ]
         postproc_specs = [
             ComponentSpec(

--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -349,6 +349,11 @@ class SmolVLAModel(ExportableModelMixin, Model):
         base_preproc_specs = [
             ComponentSpec(type="smolvla_resize", image_resolution=self._resize_imgs_with_padding),
             ComponentSpec(type="new_line"),
+            ComponentSpec(
+                type="normalize",
+                stats={STATE: self._dataset_stats[f"observation.{STATE}"]},
+                mode="mean_std",
+            ),
         ]
         postproc_specs = [
             ComponentSpec(

--- a/library/tests/unit/inference/preprocessors/test_stats_normalizer.py
+++ b/library/tests/unit/inference/preprocessors/test_stats_normalizer.py
@@ -46,7 +46,7 @@ class TestStatsNormalizerInit:
         assert isinstance(normalizer, Preprocessor)
 
     def test_neither_stats_path_nor_artifact_raises(self) -> None:
-        with pytest.raises(ValueError, match="Either stats_path or artifact must be provided"):
+        with pytest.raises(ValueError, match="Either stats_path, artifact, or stats must be provided"):
             StatsNormalizer()
 
     def test_artifact_param_accepted(self, stats_dir: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Description

- Missing state normalization step was added to pi05 and SmolVLA preprocessing lists on export

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] 🐞 `fix` - Bug fix

Numerical tolerance vs torch reference was improved, but the numbers (especially relative error) didn't change much. Apparently, robot state doesn't contribute to the model outputs if it's not yet fine-tuned.