### PR TITLE
refactor: move extra export args from internal model to policy

### DIFF
--- a/library/src/physicalai/export/mixin_model.py
+++ b/library/src/physicalai/export/mixin_model.py
@@ -7,8 +7,6 @@ from abc import ABC, abstractmethod
 
 import torch
 
-from .backends import ExportParameters
-
 
 class ExportableModelMixin(torch.nn.Module, ABC):
     """Mixin class for exportable PyTorch models.
@@ -28,17 +26,4 @@ class ExportableModelMixin(torch.nn.Module, ABC):
 
         Returns:
             A dictionary mapping input names to example torch.Tensor objects.
-        """
-
-    @property
-    @abstractmethod
-    def extra_export_args(self) -> dict[str, ExportParameters]:
-        """Return extra arguments for the export process.
-
-        This method can be overridden to provide additional arguments that may be required by specific
-        export formats or tools. The returned dictionary can include any relevant information that
-        should be considered during export.
-
-        Returns:
-            A dictionary of extra arguments for the export process.
         """

--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -50,6 +50,17 @@ class ExportablePolicyMixin:
     model: ExportableModelMixin
     _preprocessor: torch.nn.Module
 
+    @property
+    def extra_export_args(self) -> dict[str, ExportParameters]:
+        """Return extra arguments for the export process.
+
+        Override in subclasses to provide backend-specific export parameters.
+
+        Returns:
+            A dictionary mapping backend names to their export parameters.
+        """
+        return {}
+
     def _create_metadata(
         self,
         export_dir: Path,
@@ -631,8 +642,8 @@ class ExportablePolicyMixin:
             ExportParameters: Extra export arguments for the specified backend.
                 Returns an empty ExportParameters instance if no extra arguments are found.
         """
-        if backend in self.model.extra_export_args:
-            return self.model.extra_export_args[backend]
+        if backend in self.extra_export_args:
+            return self.extra_export_args[backend]
         return ExportBackend(backend).parameter_class()
 
     def _get_forward_arg_name(self) -> str:

--- a/library/src/physicalai/inference/adapters/torch.py
+++ b/library/src/physicalai/inference/adapters/torch.py
@@ -79,9 +79,8 @@ class TorchAdapter(RuntimeAdapter):
 
             self._policy = policy_class.load_from_checkpoint(model_path, map_location="cpu").to(self.device).eval()
 
-            policy_model: Any = self._policy.model
-            if hasattr(policy_model, "extra_export_args") and "torch" in policy_model.extra_export_args:
-                torch_export_args: TorchExportParameters = policy_model.extra_export_args["torch"]
+            if hasattr(self._policy, "extra_export_args") and "torch" in self._policy.extra_export_args:
+                torch_export_args: TorchExportParameters = self._policy.extra_export_args["torch"]
             else:
                 torch_export_args = TorchExportParameters()
 

--- a/library/src/physicalai/inference/postprocessors/stats_denormalizer.py
+++ b/library/src/physicalai/inference/postprocessors/stats_denormalizer.py
@@ -16,7 +16,7 @@ Supports two denormalization modes:
 
 from __future__ import annotations
 
-from typing import override
+from typing import Any, override
 
 import numpy as np
 
@@ -103,7 +103,22 @@ class StatsDenormalizer(Postprocessor):
         self._stats_path = resolved_path
         self._mode = mode
         self._features: set[str] = set(features) if features else set()
-        self._stats: dict[str, dict[str, np.ndarray]] | None = stats
+        self._stats: dict[str, dict[str, np.ndarray]] | None = self._enforce_numpy(stats) if stats else None
+
+    @staticmethod
+    def _enforce_numpy(stats: dict[str, dict[str, Any]]) -> dict[str, dict[str, np.ndarray]]:
+        """Convert every value in a nested stats dict to a numpy array.
+
+        Args:
+            stats: Nested dict mapping feature names to stat-name → value dicts.
+                Values may be lists, scalars, or already numpy arrays.
+
+        Returns:
+            A copy of the dict with all leaf values as ``np.ndarray``.
+        """
+        return {
+            feature: {stat: np.asarray(val) for stat, val in stat_dict.items()} for feature, stat_dict in stats.items()
+        }
 
     def load_stats(self) -> None:
         """Eagerly load stats from the safetensors file.

--- a/library/src/physicalai/inference/preprocessors/stats_normalizer.py
+++ b/library/src/physicalai/inference/preprocessors/stats_normalizer.py
@@ -17,7 +17,7 @@ Supports two normalization modes:
 
 from __future__ import annotations
 
-from typing import override
+from typing import Any, override
 
 import numpy as np
 
@@ -101,7 +101,22 @@ class StatsNormalizer(Preprocessor):
         self._stats_path = resolved_path
         self._mode = mode
         self._features: set[str] = set(features) if features else set()
-        self._stats: dict[str, dict[str, np.ndarray]] | None = stats
+        self._stats: dict[str, dict[str, np.ndarray]] | None = self._enforce_numpy(stats) if stats else None
+
+    @staticmethod
+    def _enforce_numpy(stats: dict[str, dict[str, Any]]) -> dict[str, dict[str, np.ndarray]]:
+        """Convert every value in a nested stats dict to a numpy array.
+
+        Args:
+            stats: Nested dict mapping feature names to stat-name → value dicts.
+                Values may be lists, scalars, or already numpy arrays.
+
+        Returns:
+            A copy of the dict with all leaf values as ``np.ndarray``.
+        """
+        return {
+            feature: {stat: np.asarray(val) for stat, val in stat_dict.items()} for feature, stat_dict in stats.items()
+        }
 
     def load_stats(self) -> None:
         """Eagerly load stats from the safetensors file.
@@ -170,7 +185,7 @@ def _normalize(
     if mode == "mean_std":
         mean = stats["mean"]
         std = stats["std"]
-        return (tensor - mean) / (std + np.array(_EPS))
+        return (tensor - mean) / (std + _EPS)
 
     if mode == "min_max":
         min_val = stats["min"]

--- a/library/src/physicalai/policies/act/model.py
+++ b/library/src/physicalai/policies/act/model.py
@@ -29,13 +29,6 @@ from torchvision.ops.misc import FrozenBatchNorm2d
 from physicalai.data import Feature, FeatureType
 from physicalai.data.observation import ACTION, EXTRA, IMAGES, STATE, Observation
 from physicalai.export import ExportableModelMixin
-from physicalai.export.backends import (
-    ExecuTorchExportParameters,
-    ExportParameters,
-    ONNXExportParameters,
-    OpenVINOExportParameters,
-    TorchExportParameters,
-)
 from physicalai.policies.base import Model
 from physicalai.policies.utils.normalization import FeatureNormalizeTransform, NormalizationType
 
@@ -238,41 +231,6 @@ class ACT(ExportableModelMixin, Model):
                 sample_input[IMAGES + "." + key] = torch.randn(1, *visual_feature.shape, device=device)
 
         return sample_input
-
-    @property
-    def extra_export_args(self) -> dict[str, ExportParameters]:
-        """Additional export arguments for model conversion.
-
-        This property provides extra configuration parameters needed when exporting
-        the model to different formats (ONNX, OpenVINO, and PyTorch).
-
-        Returns:
-            dict[str, ExportParameters]: A dictionary mapping format names to their export parameters.
-            Supported formats: 'onnx', 'openvino', 'executorch', 'torch'.
-
-        Example:
-            >>> model = ACT(input_features, output_features)
-            >>> export_args = model.extra_export_args
-            >>> onnx_args = export_args['onnx']
-            >>> print(onnx_args.exporter_kwargs)
-            {'output_names': ['action']}
-        """
-        extra_args: dict[str, ExportParameters] = {}
-        extra_args["onnx"] = ONNXExportParameters(
-            exporter_kwargs={
-                "output_names": ["action"],
-            },
-        )
-        extra_args["openvino"] = OpenVINOExportParameters(
-            outputs=["action"],
-            export_tokenizer=False,
-            compress_to_fp16=False,
-            exporter_kwargs={},
-        )
-        extra_args["executorch"] = ExecuTorchExportParameters()
-        extra_args["torch"] = TorchExportParameters()
-
-        return extra_args
 
     def forward(self, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, float]] | torch.Tensor:
         """Forward pass through the ACT model.

--- a/library/src/physicalai/policies/act/policy.py
+++ b/library/src/physicalai/policies/act/policy.py
@@ -8,6 +8,13 @@ from typing import Any, cast
 import torch
 
 from physicalai.data import Dataset, Feature, FeatureType, NormalizationParameters, Observation
+from physicalai.export.backends import (
+    ExecuTorchExportParameters,
+    ExportParameters,
+    ONNXExportParameters,
+    OpenVINOExportParameters,
+    TorchExportParameters,
+)
 from physicalai.export.mixin_policy import ExportablePolicyMixin, ExportBackend
 from physicalai.gyms import Gym
 from physicalai.policies.act.config import ACTConfig
@@ -440,3 +447,27 @@ class ACT(ExportablePolicyMixin, Policy):
             ExportBackend.ONNX,
             ExportBackend.EXECUTORCH,
         ]
+
+    @property
+    def extra_export_args(self) -> dict[str, ExportParameters]:
+        """Additional export arguments for model conversion.
+
+        Returns:
+            dict[str, ExportParameters]: A dictionary mapping format names to their export parameters.
+        """
+        extra_args: dict[str, ExportParameters] = {}
+        extra_args["onnx"] = ONNXExportParameters(
+            exporter_kwargs={
+                "output_names": ["action"],
+            },
+        )
+        extra_args["openvino"] = OpenVINOExportParameters(
+            outputs=["action"],
+            export_tokenizer=False,
+            compress_to_fp16=False,
+            exporter_kwargs={},
+        )
+        extra_args["executorch"] = ExecuTorchExportParameters()
+        extra_args["torch"] = TorchExportParameters()
+
+        return extra_args

--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -20,13 +20,6 @@ from transformers.cache_utils import DynamicCache
 from physicalai.data.constants import IMAGE_MASKS, TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
 from physicalai.data.observation import ACTION, IMAGES, STATE, TASK
 from physicalai.export import ExportableModelMixin
-from physicalai.export.backends import (
-    ExportParameters,
-    ONNXExportParameters,
-    OpenVINOExportParameters,
-    TorchExportParameters,
-)
-from physicalai.inference.manifest import ComponentSpec
 from physicalai.policies.base import Model
 
 from .pi_gemma import (
@@ -659,75 +652,6 @@ class Pi05Model(ExportableModelMixin, Model):
     def set_dataset_stats(self, dataset_stats: dict) -> None:
         """Update dataset statistics used for normalization."""
         self._dataset_stats = dataset_stats
-
-    @property
-    def extra_export_args(self) -> dict[str, ExportParameters]:
-        """Additional export arguments for model conversion.
-
-        This property provides extra configuration parameters needed when exporting
-        the model to different formats (ONNX, OpenVINO, and PyTorch).
-
-        Returns:
-            dict[str, ExportParameters]: A dictionary mapping format names to their export parameters.
-            Supported formats: 'onnx', 'openvino', 'torch'.
-
-        Example:
-            >>> model = Pi05(input_features, output_features)
-            >>> export_args = model.extra_export_args
-            >>> onnx_args = export_args['onnx']
-            >>> print(onnx_args.exporter_kwargs)
-            {'output_names': ['action']}
-        """
-        base_preproc_specs = [
-            ComponentSpec(type="pi05", image_resolution=self._image_resolution),
-            ComponentSpec(
-                type="normalize",
-                stats={STATE: self._dataset_stats[f"observation.{STATE}"]},
-                mode="mean_std",
-            ),
-        ]
-        postproc_specs = [
-            ComponentSpec(
-                type="denormalize",
-                stats={ACTION: self._dataset_stats[ACTION]},
-                mode=self._normalization_mode,
-            ),
-        ]
-        extra_args: dict[str, ExportParameters] = {}
-        extra_args["onnx"] = ONNXExportParameters(
-            exporter_kwargs={
-                "output_names": [ACTION],
-            },
-            export_tokenizer=False,
-            preprocessors_specs=[
-                *base_preproc_specs,
-                ComponentSpec(
-                    type="hf_tokenizer",
-                    tokenizer_name="google/paligemma-3b-pt-224",
-                    revision="35e4f46485b4d07967e7e9935bc3786aad50687c",
-                    max_token_len=self._tokenizer_max_length,
-                ),
-            ],
-            postprocessors_specs=postproc_specs,
-        )
-        extra_args["openvino"] = OpenVINOExportParameters(
-            outputs=[ACTION],
-            compress_to_fp16=True,
-            via_onnx=True,
-            export_tokenizer=True,
-            exporter_kwargs={},
-            preprocessors_specs=[
-                *base_preproc_specs,
-                ComponentSpec(
-                    type="ov_tokenizer",
-                    artifact="tokenizer.xml",
-                ),
-            ],
-            postprocessors_specs=postproc_specs,
-        )
-        extra_args["torch"] = TorchExportParameters()
-
-        return extra_args
 
     @property
     def sample_input(self) -> dict[str, torch.Tensor | str]:

--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -564,7 +564,6 @@ class Pi05Model(ExportableModelMixin, Model):
         gradient_checkpointing: bool = False,
         compile_model: bool = False,
         use_random_input_noise: bool = False,
-        normalization_mode: str = "quantiles",
     ) -> None:
         """Initialize Pi05Model.
 
@@ -592,7 +591,6 @@ class Pi05Model(ExportableModelMixin, Model):
             compile_model: Whether to use torch.compile.
             use_random_input_noise: Whether to use random noise as the initial input for the denoising
                 process during inference. If False, zeros are used instead.
-            normalization_mode: Normalization mode for action/state features (e.g. "quantiles", "mean_std").
 
         Raises:
             ValueError: If image resolution is not square.
@@ -612,13 +610,12 @@ class Pi05Model(ExportableModelMixin, Model):
         self._image_resolution = image_resolution
         self._tokenizer_max_length = tokenizer_max_length
         self._use_random_input_noise = use_random_input_noise
-        self._normalization_mode = normalization_mode
 
         paligemma_config = get_gemma_config(paligemma_variant)
         action_expert_config = get_gemma_config(action_expert_variant)
 
-        if image_resolution[0] != image_resolution[1]:
-            msg = f"PaliGemma expects square image resolution, invalid: {image_resolution}"
+        if self._image_resolution[0] != self._image_resolution[1]:
+            msg = f"PaliGemma expects square image resolution, invalid: {self._image_resolution}"
             raise ValueError(msg)
 
         self.paligemma_with_expert = PaliGemmaWithExpertModel(
@@ -626,7 +623,7 @@ class Pi05Model(ExportableModelMixin, Model):
             action_expert_config,
             use_adarms=[False, True],
             precision=dtype,
-            image_size=image_resolution[0],
+            image_size=self._image_resolution[0],
             freeze_vision_encoder=freeze_vision_encoder,
             train_expert_only=train_expert_only,
         )

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -671,7 +671,10 @@ class Pi05(ExportablePolicyMixin, Policy):
             ValueError: If dataset stats are not available for export.
         """
         if self._dataset_stats is None:
-            msg = "Dataset stats are required for export. Initialize the policy with dataset_stats or train for at least one epoch to populate them."
+            msg = (
+                "Dataset stats are required for export. Initialize the policy with dataset_stats"
+                " or train for at least one epoch to populate them."
+            )
             raise ValueError(msg)
 
         base_preproc_specs = [

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -17,8 +17,15 @@ from huggingface_hub import hf_hub_download
 from safetensors.torch import load_file
 
 from physicalai.data.dataset import Dataset
-from physicalai.data.observation import ACTION
+from physicalai.data.observation import ACTION, STATE
 from physicalai.export import ExportablePolicyMixin, ExportBackend
+from physicalai.export.backends import (
+    ExportParameters,
+    ONNXExportParameters,
+    OpenVINOExportParameters,
+    TorchExportParameters,
+)
+from physicalai.inference.manifest import ComponentSpec
 from physicalai.policies.base import Policy
 from physicalai.train.schedulers import cosine_decay_with_warmup_scheduler
 from physicalai.train.utils import reformat_dataset_to_match_policy
@@ -652,3 +659,61 @@ class Pi05(ExportablePolicyMixin, Policy):
             list[str | ExportBackend]: A list of supported export backends.
         """
         return [ExportBackend.TORCH, ExportBackend.OPENVINO]
+
+    @property
+    def extra_export_args(self) -> dict[str, ExportParameters]:
+        """Additional export arguments for model conversion.
+
+        Returns:
+            dict[str, ExportParameters]: A dictionary mapping format names to their export parameters.
+        """
+        base_preproc_specs = [
+            ComponentSpec(type="pi05", image_resolution=self.model._image_resolution),
+            ComponentSpec(
+                type="normalize",
+                stats={STATE: self.model._dataset_stats[f"observation.{STATE}"]},
+                mode="mean_std",
+            ),
+        ]
+        postproc_specs = [
+            ComponentSpec(
+                type="denormalize",
+                stats={ACTION: self.model._dataset_stats[ACTION]},
+                mode=self.model._normalization_mode,
+            ),
+        ]
+        extra_args: dict[str, ExportParameters] = {}
+        extra_args["onnx"] = ONNXExportParameters(
+            exporter_kwargs={
+                "output_names": [ACTION],
+            },
+            export_tokenizer=False,
+            preprocessors_specs=[
+                *base_preproc_specs,
+                ComponentSpec(
+                    type="hf_tokenizer",
+                    tokenizer_name="google/paligemma-3b-pt-224",
+                    revision="35e4f46485b4d07967e7e9935bc3786aad50687c",
+                    max_token_len=self.model._tokenizer_max_length,
+                ),
+            ],
+            postprocessors_specs=postproc_specs,
+        )
+        extra_args["openvino"] = OpenVINOExportParameters(
+            outputs=[ACTION],
+            compress_to_fp16=True,
+            via_onnx=True,
+            export_tokenizer=True,
+            exporter_kwargs={},
+            preprocessors_specs=[
+                *base_preproc_specs,
+                ComponentSpec(
+                    type="ov_tokenizer",
+                    artifact="tokenizer.xml",
+                ),
+            ],
+            postprocessors_specs=postproc_specs,
+        )
+        extra_args["torch"] = TorchExportParameters()
+
+        return extra_args

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -666,20 +666,31 @@ class Pi05(ExportablePolicyMixin, Policy):
 
         Returns:
             dict[str, ExportParameters]: A dictionary mapping format names to their export parameters.
+
+        Raises:
+            ValueError: If dataset stats are not available for export.
         """
+        if self._dataset_stats is None:
+            msg = "Dataset stats are required for export. Initialize the policy with dataset_stats or train for at least one epoch to populate them."
+            raise ValueError(msg)
+
         base_preproc_specs = [
-            ComponentSpec(type="pi05", image_resolution=self.model._image_resolution),
+            ComponentSpec(
+                type="pi05",
+                image_resolution=self.config.image_resolution,
+                empty_cameras=self.config.empty_cameras,
+            ),
             ComponentSpec(
                 type="normalize",
-                stats={STATE: self.model._dataset_stats[f"observation.{STATE}"]},
-                mode="mean_std",
+                stats={STATE: self._dataset_stats[f"observation.{STATE}"]},
+                mode=self.config.normalization_mode,
             ),
         ]
         postproc_specs = [
             ComponentSpec(
                 type="denormalize",
-                stats={ACTION: self.model._dataset_stats[ACTION]},
-                mode=self.model._normalization_mode,
+                stats={ACTION: self._dataset_stats[ACTION]},
+                mode=self.config.normalization_mode,
             ),
         ]
         extra_args: dict[str, ExportParameters] = {}
@@ -694,7 +705,7 @@ class Pi05(ExportablePolicyMixin, Policy):
                     type="hf_tokenizer",
                     tokenizer_name="google/paligemma-3b-pt-224",
                     revision="35e4f46485b4d07967e7e9935bc3786aad50687c",
-                    max_token_len=self.model._tokenizer_max_length,
+                    max_token_len=self.config.tokenizer_max_length,
                 ),
             ],
             postprocessors_specs=postproc_specs,

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -264,7 +264,6 @@ class Pi05(ExportablePolicyMixin, Policy):
             gradient_checkpointing=self.config.gradient_checkpointing,
             compile_model=self.config.compile_model,
             use_random_input_noise=self.config.use_random_input_noise,
-            normalization_mode=self.config.normalization_mode.lower(),
         )
         if weights_file is not None:
             # load raw state dict
@@ -686,14 +685,14 @@ class Pi05(ExportablePolicyMixin, Policy):
             ComponentSpec(
                 type="normalize",
                 stats={STATE: self._dataset_stats[f"observation.{STATE}"]},
-                mode=self.config.normalization_mode,
+                mode=self.config.normalization_mode.lower(),
             ),
         ]
         postproc_specs = [
             ComponentSpec(
                 type="denormalize",
                 stats={ACTION: self._dataset_stats[ACTION]},
-                mode=self.config.normalization_mode,
+                mode=self.config.normalization_mode.lower(),
             ),
         ]
         extra_args: dict[str, ExportParameters] = {}

--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -20,13 +20,6 @@ from torch import nn
 from physicalai.data.constants import IMAGE_MASKS, TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
 from physicalai.data.observation import ACTION, EXTRA, IMAGES, STATE, TASK, FeatureType
 from physicalai.export import ExportableModelMixin
-from physicalai.export.backends import (
-    ExportParameters,
-    ONNXExportParameters,
-    OpenVINOExportParameters,
-    TorchExportParameters,
-)
-from physicalai.inference.manifest import ComponentSpec
 from physicalai.policies.base import Model
 
 if TYPE_CHECKING:
@@ -326,75 +319,6 @@ class SmolVLAModel(ExportableModelMixin, Model):
         sample_input[TASK] = ["sample_task"]
 
         return sample_input
-
-    @property
-    def extra_export_args(self) -> dict[str, ExportParameters]:
-        """Additional export arguments for model conversion.
-
-        This property provides extra configuration parameters needed when exporting
-        the model to different formats (ONNX, OpenVINO, and PyTorch).
-
-        Returns:
-            dict[str, ExportParameters]: A dictionary mapping format names to their export parameters.
-            Supported formats: 'onnx', 'openvino', 'torch'.
-
-        Example:
-            >>> model = SmolVLA(input_features, output_features)
-            >>> export_args = model.extra_export_args
-            >>> onnx_args = export_args['onnx']
-            >>> print(onnx_args.exporter_kwargs)
-            {'output_names': ['action']}
-        """
-        extra_args: dict[str, ExportParameters] = {}
-        base_preproc_specs = [
-            ComponentSpec(type="smolvla_resize", image_resolution=self._resize_imgs_with_padding),
-            ComponentSpec(type="new_line"),
-            ComponentSpec(
-                type="normalize",
-                stats={STATE: self._dataset_stats[f"observation.{STATE}"]},
-                mode="mean_std",
-            ),
-        ]
-        postproc_specs = [
-            ComponentSpec(
-                type="denormalize",
-                stats={ACTION: self._dataset_stats[ACTION]},
-                mode="mean_std",
-            ),
-        ]
-        extra_args["onnx"] = ONNXExportParameters(
-            exporter_kwargs={
-                "output_names": [ACTION],
-            },
-            preprocessors_specs=[
-                *base_preproc_specs,
-                ComponentSpec(
-                    type="hf_tokenizer",
-                    tokenizer_name=self._vlm_model_name,
-                    revision="7b375e1b73b11138ff12fe22c8f2822d8fe03467",
-                    max_token_len=self._tokenizer_max_length,
-                ),
-            ],
-            postprocessors_specs=postproc_specs,
-            export_tokenizer=False,
-        )
-        extra_args["openvino"] = OpenVINOExportParameters(
-            outputs=[ACTION],
-            compress_to_fp16=False,
-            export_tokenizer=True,
-            exporter_kwargs={},
-            preprocessors_specs=[
-                *base_preproc_specs,
-                ComponentSpec(
-                    type="ov_tokenizer",
-                    artifact="tokenizer.xml",
-                ),
-            ],
-            postprocessors_specs=postproc_specs,
-        )
-        extra_args["torch"] = TorchExportParameters()
-
-        return extra_args
 
     @property
     def reward_delta_indices(self) -> None:

--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -64,7 +64,6 @@ class SmolVLAModel(ExportableModelMixin, Model):
         chunk_size: int = 50,
         max_state_dim: int = 32,
         max_action_dim: int = 32,
-        resize_imgs_with_padding: tuple[int, int] | None = (512, 512),
         adapt_to_pi_aloha: bool = False,
         num_steps: int = 10,
         use_cache: bool = True,
@@ -83,7 +82,6 @@ class SmolVLAModel(ExportableModelMixin, Model):
         min_period: float = 4e-3,
         max_period: float = 4.0,
         use_random_input_noise: bool = True,
-        tokenizer_max_length: int = 48,
     ) -> None:
         """Initialize the SmolVLA model.
 
@@ -94,7 +92,6 @@ class SmolVLAModel(ExportableModelMixin, Model):
             chunk_size: Size of action chunks for prediction.
             max_state_dim: Maximum dimension for state vectors; shorter vectors will be padded.
             max_action_dim: Maximum dimension for action vectors; shorter vectors will be padded.
-            resize_imgs_with_padding: Target size (height, width) for image preprocessing with padding.
             adapt_to_pi_aloha: Whether to convert joint and gripper values from standard Aloha space
                 to pi internal runtime space.
             num_steps: Number of decoding steps for flow matching.
@@ -115,15 +112,12 @@ class SmolVLAModel(ExportableModelMixin, Model):
             max_period: Maximum period for sine-cosine positional encoding of timesteps.
             use_random_input_noise: Whether to use random noise as the initial input for the
                 denoising process during inference. If False, zeros are used instead.
-            tokenizer_max_length: Maximum token length for the tokenizer. Default: 48.
         """
         super().__init__()
         self._chunk_size = chunk_size
         self._max_state_dim = max_state_dim
         self._max_action_dim = max_action_dim
-        self._resize_imgs_with_padding = resize_imgs_with_padding
         self._adapt_to_pi_aloha = adapt_to_pi_aloha
-        self._tokenizer_max_length = tokenizer_max_length
         self._vlm_model_name = vlm_model_name
         self._model = VLAFlowMatching(
             chunk_size=chunk_size,

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -12,8 +12,15 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
-from physicalai.data.observation import ACTION
+from physicalai.data.observation import ACTION, STATE
 from physicalai.export import ExportablePolicyMixin, ExportBackend
+from physicalai.export.backends import (
+    ExportParameters,
+    ONNXExportParameters,
+    OpenVINOExportParameters,
+    TorchExportParameters,
+)
+from physicalai.inference.manifest import ComponentSpec
 from physicalai.policies.base import Policy
 from physicalai.train.schedulers import cosine_decay_with_warmup_scheduler
 from physicalai.train.utils import reformat_dataset_to_match_policy
@@ -452,3 +459,61 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             list[str | ExportBackend]: A list of supported export backends.
         """
         return [ExportBackend.TORCH, ExportBackend.OPENVINO]
+
+    @property
+    def extra_export_args(self) -> dict[str, ExportParameters]:
+        """Additional export arguments for model conversion.
+
+        Returns:
+            dict[str, ExportParameters]: A dictionary mapping format names to their export parameters.
+        """
+        extra_args: dict[str, ExportParameters] = {}
+        base_preproc_specs = [
+            ComponentSpec(type="smolvla_resize", image_resolution=self.model._resize_imgs_with_padding),
+            ComponentSpec(type="new_line"),
+            ComponentSpec(
+                type="normalize",
+                stats={STATE: self.model._dataset_stats[f"observation.{STATE}"]},
+                mode="mean_std",
+            ),
+        ]
+        postproc_specs = [
+            ComponentSpec(
+                type="denormalize",
+                stats={ACTION: self.model._dataset_stats[ACTION]},
+                mode="mean_std",
+            ),
+        ]
+        extra_args["onnx"] = ONNXExportParameters(
+            exporter_kwargs={
+                "output_names": [ACTION],
+            },
+            preprocessors_specs=[
+                *base_preproc_specs,
+                ComponentSpec(
+                    type="hf_tokenizer",
+                    tokenizer_name=self.model._vlm_model_name,
+                    revision="7b375e1b73b11138ff12fe22c8f2822d8fe03467",
+                    max_token_len=self.model._tokenizer_max_length,
+                ),
+            ],
+            postprocessors_specs=postproc_specs,
+            export_tokenizer=False,
+        )
+        extra_args["openvino"] = OpenVINOExportParameters(
+            outputs=[ACTION],
+            compress_to_fp16=False,
+            export_tokenizer=True,
+            exporter_kwargs={},
+            preprocessors_specs=[
+                *base_preproc_specs,
+                ComponentSpec(
+                    type="ov_tokenizer",
+                    artifact="tokenizer.xml",
+                ),
+            ],
+            postprocessors_specs=postproc_specs,
+        )
+        extra_args["torch"] = TorchExportParameters()
+
+        return extra_args

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -470,7 +470,10 @@ class SmolVLA(ExportablePolicyMixin, Policy):
         """
         extra_args: dict[str, ExportParameters] = {}
         if self._dataset_stats is None:
-            msg = "Dataset stats are required for export. Initialize the policy with dataset_stats or train for at least one epoch to populate them."
+            msg = (
+                "Dataset stats are required for export. Initialize the policy with dataset_stats"
+                " or train for at least one epoch to populate them."
+            )
             raise ValueError(msg)
 
         base_preproc_specs = [

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -219,7 +219,6 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             chunk_size=self.config.chunk_size,
             max_state_dim=self.config.max_state_dim,
             max_action_dim=self.config.max_action_dim,
-            resize_imgs_with_padding=self.config.resize_imgs_with_padding,
             adapt_to_pi_aloha=self.config.adapt_to_pi_aloha,
             num_steps=self.config.num_steps,
             use_cache=self.config.use_cache,
@@ -238,7 +237,6 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             min_period=self.config.min_period,
             max_period=self.config.max_period,
             use_random_input_noise=self.config.use_random_input_noise,
-            tokenizer_max_length=self.config.tokenizer_max_length,
         )
 
         self._update_preprocessor_stats(dataset_stats)
@@ -466,21 +464,28 @@ class SmolVLA(ExportablePolicyMixin, Policy):
 
         Returns:
             dict[str, ExportParameters]: A dictionary mapping format names to their export parameters.
+
+        Raises:
+            ValueError: If dataset_stats is not available for export argument construction.
         """
         extra_args: dict[str, ExportParameters] = {}
+        if self._dataset_stats is None:
+            msg = "Dataset stats are required for export. Initialize the policy with dataset_stats or train for at least one epoch to populate them."
+            raise ValueError(msg)
+
         base_preproc_specs = [
-            ComponentSpec(type="smolvla_resize", image_resolution=self.model._resize_imgs_with_padding),
+            ComponentSpec(type="smolvla_resize", image_resolution=self.config.resize_imgs_with_padding),
             ComponentSpec(type="new_line"),
             ComponentSpec(
                 type="normalize",
-                stats={STATE: self.model._dataset_stats[f"observation.{STATE}"]},
+                stats={STATE: self._dataset_stats[f"observation.{STATE}"]},
                 mode="mean_std",
             ),
         ]
         postproc_specs = [
             ComponentSpec(
                 type="denormalize",
-                stats={ACTION: self.model._dataset_stats[ACTION]},
+                stats={ACTION: self._dataset_stats[ACTION]},
                 mode="mean_std",
             ),
         ]
@@ -492,9 +497,9 @@ class SmolVLA(ExportablePolicyMixin, Policy):
                 *base_preproc_specs,
                 ComponentSpec(
                     type="hf_tokenizer",
-                    tokenizer_name=self.model._vlm_model_name,
+                    tokenizer_name=self.config.vlm_model_name,
                     revision="7b375e1b73b11138ff12fe22c8f2822d8fe03467",
-                    max_token_len=self.model._tokenizer_max_length,
+                    max_token_len=self.config.tokenizer_max_length,
                 ),
             ],
             postprocessors_specs=postproc_specs,

--- a/library/tests/unit/export/test_executorch_integration.py
+++ b/library/tests/unit/export/test_executorch_integration.py
@@ -43,8 +43,6 @@ class _ExportWrapper(ExportablePolicyMixin):
 
     def __init__(self, model: torch.nn.Module) -> None:
         self.model = model
-        if not hasattr(model, "extra_export_args"):
-            model.extra_export_args = {}
 
     @property
     def metadata_extra(self) -> dict[str, Any]:

--- a/library/tests/unit/export/test_mixin_export.py
+++ b/library/tests/unit/export/test_mixin_export.py
@@ -139,11 +139,14 @@ class ExportWrapper(ExportablePolicyMixin):
     def __init__(self, model: torch.nn.Module):
         self.model = model
         self._preprocessor = IdentityPreprocessor()
-        if not hasattr(model, "extra_export_args"):
-            model.extra_export_args = {
-                ExportBackend.ONNX: ONNXExportParameters(),
-                ExportBackend.OPENVINO: OpenVINOExportParameters(),
-            }
+        self._extra_export_args = {
+            ExportBackend.ONNX: ONNXExportParameters(),
+            ExportBackend.OPENVINO: OpenVINOExportParameters(),
+        }
+
+    @property
+    def extra_export_args(self):
+        return self._extra_export_args
 
     def _get_default_export_input_sample(self) -> dict[str, torch.Tensor] | None:
         if not hasattr(self.model, "sample_input"):
@@ -307,8 +310,8 @@ class TestToOpenVINO:
         """Test that provided kwargs override model's extra_export_args."""
         model = ModelWithSampleInput(input_dim=10, output_dim=5)
 
-        model.extra_export_args = {}
         wrapper = ExportWrapper(model)
+        wrapper._extra_export_args = {}
         output_path = tmp_path / "model.xml"
         wrapper.to_openvino(output_path)
 
@@ -379,12 +382,12 @@ class TestToOpenVINO:
     def test_to_openvino_via_export_method(self, tmp_path, fp16):
         """Test OpenVINO export using the generic export method."""
         model = ModelWithSampleInput(input_dim=10, output_dim=5)
-        model.extra_export_args = {
+        wrapper = ExportWrapper(model)
+        wrapper._extra_export_args = {
             "openvino": OpenVINOExportParameters(
                 compress_to_fp16=fp16,
             ),
         }
-        wrapper = ExportWrapper(model)
 
         output_path = tmp_path / "model.xml"
         wrapper.export(backend="openvino", output_path=output_path)
@@ -395,12 +398,12 @@ class TestToOpenVINO:
     def test_to_openvino_via_onnx(self, tmp_path):
         """Test OpenVINO export via ONNX intermediate model."""
         model = ModelWithSampleInput(input_dim=10, output_dim=5)
-        model.extra_export_args = {
+        wrapper = ExportWrapper(model)
+        wrapper._extra_export_args = {
             ExportBackend.OPENVINO: OpenVINOExportParameters(
                 via_onnx=True,
             ),
         }
-        wrapper = ExportWrapper(model)
 
         output_path = tmp_path / "model.xml"
         wrapper.to_openvino(output_path)

--- a/library/tests/unit/inference/test_adapters.py
+++ b/library/tests/unit/inference/test_adapters.py
@@ -179,7 +179,7 @@ class TestTorchAdapter:
         mock_model.return_value = torch.tensor([[1.0, 2.0]])
         mock_model.eval.return_value = mock_model
         mock_model.to.return_value = mock_model
-        mock_model.model.extra_export_args = {"torch": TorchExportParameters()}
+        mock_model.extra_export_args = {"torch": TorchExportParameters()}
 
         with patch("physicalai.policies.act.ACT.load_from_checkpoint", return_value=mock_model):
             adapter = TorchAdapter(device="cpu")
@@ -210,7 +210,7 @@ class TestTorchAdapter:
         mock_model.eval.return_value = mock_model
         mock_model.to.return_value = mock_model
         mock_model.model.sample_input = {"state": torch.zeros(1, 2), "images": torch.zeros(1, 3, 96, 96)}
-        mock_model.model.extra_export_args = {"torch": TorchExportParameters()}
+        mock_model.extra_export_args = {"torch": TorchExportParameters()}
 
         with patch("physicalai.policies.act.ACT.load_from_checkpoint", return_value=mock_model):
             adapter = TorchAdapter(device="cpu")
@@ -237,7 +237,7 @@ class TestTorchAdapter:
         mock_model.to.return_value = mock_model
         if hasattr(mock_model.model, "sample_input"):
             del mock_model.model.sample_input
-        mock_model.model.extra_export_args = {"torch": TorchExportParameters()}
+        mock_model.extra_export_args = {"torch": TorchExportParameters()}
 
         with patch("physicalai.policies.act.ACT.load_from_checkpoint", return_value=mock_model):
             adapter = TorchAdapter(device="cpu")


### PR DESCRIPTION
# Pull Request

## Description

- `extra_export_args` property was moved from torch model to lightning policy. The reason is that the property is more related to the whole policy now, as it contains full pre/post processing parameters, which the model is not aware of.
- forward empty cameras to pi05 numpy preprocessing

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] ♻️ `refactor` - Code refactoring
