### PR TITLE
refactor(backend): model robots as discriminated union with payload configs

### DIFF
--- a/application/backend/src/alembic/versions/a1b2c3d4e5f6_robot_payload_json_column.py
+++ b/application/backend/src/alembic/versions/a1b2c3d4e5f6_robot_payload_json_column.py
@@ -1,0 +1,89 @@
+"""robot payload json column
+
+Revision ID: a1b2c3d4e5f6
+Revises: 96ebe046cb09
+Create Date: 2026-04-22 00:00:00.000000
+
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "96ebe046cb09"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema: replace connection_string + serial_number with payload JSON."""
+    conn = op.get_bind()
+
+    # Step 1: add nullable payload column
+    with op.batch_alter_table("project_robots", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("payload", sa.JSON(), nullable=True))
+
+    # Step 2: backfill payload from existing columns
+    rows = conn.execute(sa.text("SELECT id, type, connection_string, serial_number FROM project_robots")).fetchall()
+
+    for row in rows:
+        robot_id, robot_type, connection_string, serial_number = row
+
+        payload = (
+            {
+                "serial_number": serial_number or "",
+            }
+            if robot_type in ("SO101_Follower", "SO101_LEADER")
+            else {
+                "connection_string": connection_string or "",
+            }
+        )
+
+        conn.execute(
+            sa.text("UPDATE project_robots SET payload = :payload WHERE id = :id"),
+            {"payload": json.dumps(payload), "id": str(robot_id)},
+        )
+
+    # Step 3: set payload NOT NULL and drop old columns
+    with op.batch_alter_table("project_robots", schema=None) as batch_op:
+        batch_op.alter_column("payload", nullable=False)
+        batch_op.drop_column("connection_string")
+        batch_op.drop_column("serial_number")
+
+
+def downgrade() -> None:
+    """Downgrade schema: restore connection_string + serial_number from payload JSON."""
+    conn = op.get_bind()
+
+    # Step 1: re-add old columns as nullable
+    with op.batch_alter_table("project_robots", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("connection_string", sa.String(255), nullable=True))
+        batch_op.add_column(sa.Column("serial_number", sa.String(255), nullable=True))
+
+    # Step 2: repopulate from payload
+    rows = conn.execute(sa.text("SELECT id, payload FROM project_robots")).fetchall()
+
+    for row in rows:
+        robot_id, payload_raw = row
+        try:
+            payload = json.loads(payload_raw) if isinstance(payload_raw, str) else (payload_raw or {})
+        except (ValueError, TypeError):
+            payload = {}
+
+        conn.execute(
+            sa.text("UPDATE project_robots SET connection_string = :cs, serial_number = :sn WHERE id = :id"),
+            {
+                "cs": payload.get("connection_string", ""),
+                "sn": payload.get("serial_number", ""),
+                "id": str(robot_id),
+            },
+        )
+
+    # Step 3: drop payload column
+    with op.batch_alter_table("project_robots", schema=None) as batch_op:
+        batch_op.drop_column("payload")

--- a/application/backend/src/db/schema.py
+++ b/application/backend/src/db/schema.py
@@ -56,9 +56,8 @@ class ProjectRobotDB(Base):
     id: Mapped[UUID] = mapped_column(Text, primary_key=True, default=uuid4)
     project_id: Mapped[str] = mapped_column(ForeignKey("projects.id", ondelete="CASCADE"))
     name: Mapped[str] = mapped_column(String(255))
-    connection_string: Mapped[str] = mapped_column(String(255))
-    serial_number: Mapped[str] = mapped_column(String(255))
     type: Mapped[RobotType] = mapped_column(Enum(RobotType))
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 

--- a/application/backend/src/repositories/mappers/project_robot_mapper.py
+++ b/application/backend/src/repositories/mappers/project_robot_mapper.py
@@ -1,6 +1,6 @@
 from db.schema import ProjectRobotDB
 from repositories.mappers.base_mapper_interface import IBaseMapper
-from schemas.robot import Robot
+from schemas.robot import Robot, RobotAdapter, RobotType
 
 
 class ProjectRobotMapper(IBaseMapper):
@@ -12,22 +12,22 @@ class ProjectRobotMapper(IBaseMapper):
         return ProjectRobotDB(
             id=str(db_schema.id),
             name=db_schema.name,
-            serial_number=db_schema.serial_number,
-            connection_string=db_schema.connection_string,
             type=db_schema.type,
+            payload=db_schema.payload.model_dump(),
             active_calibration_id=str(db_schema.active_calibration_id) if db_schema.active_calibration_id else None,
         )
 
     @staticmethod
     def from_schema(model: ProjectRobotDB) -> Robot:
         """Convert Robot db entity to schema."""
-        return Robot(
-            id=model.id,
-            name=model.name,
-            connection_string=model.connection_string,
-            serial_number=model.serial_number,
-            type=model.type,
-            active_calibration_id=model.active_calibration_id,
-            created_at=model.created_at,
-            updated_at=model.updated_at,
+        return RobotAdapter.validate_python(
+            {
+                "id": model.id,
+                "name": model.name,
+                "type": RobotType(model.type),
+                "payload": model.payload,
+                "active_calibration_id": model.active_calibration_id,
+                "created_at": model.created_at,
+                "updated_at": model.updated_at,
+            }
         )

--- a/application/backend/src/robots/discovery/ip.py
+++ b/application/backend/src/robots/discovery/ip.py
@@ -21,6 +21,6 @@ class IPDiscovery:
         return (await proc.wait()) == 0
 
     async def is_reachable(self, robot: Robot) -> bool:
-        if not robot.connection_string:
+        if not robot.payload.connection_string:
             return False
-        return await self.ping(robot.connection_string)
+        return await self.ping(robot.payload.connection_string)

--- a/application/backend/src/robots/discovery/manager.py
+++ b/application/backend/src/robots/discovery/manager.py
@@ -16,7 +16,7 @@ class DiscoveryManager:
 
     async def is_robot_online(self, robot: Robot) -> bool:
         if robot.type in {RobotType.SO101_LEADER, RobotType.SO101_FOLLOWER}:
-            return robot.serial_number in [cs.serial_number for cs in self.serial_manager.robots]
+            return robot.payload.serial_number in [cs.serial_number for cs in self.serial_manager.robots]
         if robot.type in {RobotType.TROSSEN_WIDOWXAI_LEADER, RobotType.TROSSEN_WIDOWXAI_FOLLOWER}:
             return await self.ip.is_reachable(robot)
         return False

--- a/application/backend/src/robots/discovery/serial.py
+++ b/application/backend/src/robots/discovery/serial.py
@@ -6,4 +6,4 @@ from schemas import Robot
 class SerialDiscovery:
     async def is_reachable(self, robot: Robot) -> bool:
         ports = {p.device for p in list_ports.comports()}
-        return robot.connection_string in ports
+        return robot.payload.connection_string in ports

--- a/application/backend/src/robots/robot_client_factory.py
+++ b/application/backend/src/robots/robot_client_factory.py
@@ -29,14 +29,14 @@ class RobotClientFactory:
                 config = NetworkIpRobotConfig(
                     type="follower",
                     robot_type=RobotType.TROSSEN_WIDOWXAI_FOLLOWER,
-                    connection_string=robot.connection_string,
+                    connection_string=robot.payload.connection_string,
                 )
                 return TrossenWidowXAIFollower(config=config)
             case RobotType.TROSSEN_WIDOWXAI_LEADER:
                 config = NetworkIpRobotConfig(
                     type="leader",
                     robot_type=RobotType.TROSSEN_WIDOWXAI_LEADER,
-                    connection_string=robot.connection_string,
+                    connection_string=robot.payload.connection_string,
                 )
                 return TrossenWidowXAILeader(config=config)
             case RobotType.SO101_FOLLOWER:
@@ -51,9 +51,9 @@ class RobotClientFactory:
         calibration = await self._get_robot_calibration(robot)
 
         if calibration is None:
-            raise ResourceNotFoundError(ResourceType.ROBOT_CALIBRATION, robot.serial_number)
+            raise ResourceNotFoundError(ResourceType.ROBOT_CALIBRATION, robot.payload.serial_number)
         if port is None:
-            raise ResourceNotFoundError(ResourceType.ROBOT, robot.serial_number)
+            raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
 
         mode = "follower" if robot.type == RobotType.SO101_FOLLOWER else "teleoperator"
         role = "follower" if mode == "follower" else "leader"
@@ -77,7 +77,7 @@ class RobotClientFactory:
     async def _find_robot_port(self, robot: Robot) -> str:
         port = await find_robot_port(self.robot_manager, robot)
         if port is None:
-            raise ResourceNotFoundError(ResourceType.ROBOT, robot.serial_number)
+            raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
 
         return port
 

--- a/application/backend/src/robots/robot_service.py
+++ b/application/backend/src/robots/robot_service.py
@@ -4,7 +4,7 @@ from db import get_async_db_session_ctx
 from exceptions import ResourceNotFoundError, ResourceType
 from repositories.project_robot_repo import ProjectRobotRepository
 from robots.discovery.manager import DiscoveryManager
-from schemas.robot import Robot, RobotType, RobotWithConnectionState
+from schemas.robot import Robot, RobotWithConnectionState, RobotWithConnectionStateAdapter
 
 
 class RobotService:
@@ -26,9 +26,11 @@ class RobotService:
             is_online = await discovery.is_robot_online(robot)
 
             results.append(
-                RobotWithConnectionState(
-                    **robot.model_dump(),
-                    connection_status="online" if is_online else "offline",
+                RobotWithConnectionStateAdapter.validate_python(
+                    {
+                        **robot.model_dump(),
+                        "connection_status": "online" if is_online else "offline",
+                    }
                 )
             )
 
@@ -49,20 +51,12 @@ class RobotService:
     async def create_robot(project_id: UUID, robot: Robot) -> Robot:
         async with get_async_db_session_ctx() as session:
             repo = ProjectRobotRepository(session, project_id)
-
-            if robot.type in {RobotType.SO101_LEADER, RobotType.SO101_FOLLOWER}:
-                robot.connection_string = ""
-
             return await repo.save(robot)
 
     @staticmethod
     async def update_robot(project_id: UUID, robot: Robot) -> Robot:
         async with get_async_db_session_ctx() as session:
             repo = ProjectRobotRepository(session, project_id)
-
-            if robot.type in {RobotType.SO101_LEADER, RobotType.SO101_FOLLOWER}:
-                robot.connection_string = ""
-
             return await repo.update(robot, partial_update=robot.model_dump(exclude={"id"}))
 
     @staticmethod

--- a/application/backend/src/schemas/robot.py
+++ b/application/backend/src/schemas/robot.py
@@ -1,10 +1,11 @@
-from abc import ABC
 from datetime import datetime
 from enum import StrEnum
 from typing import Annotated, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+
+from schemas.base import BaseIDModel
 
 
 class SerialPortInfo(BaseModel):
@@ -39,27 +40,61 @@ class RobotType(StrEnum):
     TROSSEN_WIDOWXAI_FOLLOWER = "Trossen_WidowXAI_Follower"
 
 
-class Robot(ABC, BaseModel):
-    id: Annotated[UUID, Field(description="Unique identifier")]
+# ============================================================================
+# Payload Models (Configuration Only)
+# ============================================================================
 
+
+class SO101RobotPayload(BaseModel):
+    """Connection configuration for SO-101 serial robots."""
+
+    connection_string: str = Field(
+        default="",
+        description="Serial port path; leave empty to auto-discover via serial_number",
+    )
+    serial_number: str = Field(..., description="Unique serial number for the robot")
+
+
+class TrossenSingleArmPayload(BaseModel):
+    """Connection configuration for Trossen single-arm robots."""
+
+    connection_string: str = Field(..., description="IP address of the robot")
+    serial_number: str = Field(default="", description="Serial number (unused for IP robots)")
+
+
+# ============================================================================
+# Concrete Robot Models
+# ============================================================================
+
+
+_SO101Types = Literal[RobotType.SO101_FOLLOWER, RobotType.SO101_LEADER]
+_TrossenTypes = Literal[RobotType.TROSSEN_WIDOWXAI_LEADER, RobotType.TROSSEN_WIDOWXAI_FOLLOWER]
+
+
+class BaseRobot(BaseIDModel):
     created_at: datetime | None = Field(None)
     updated_at: datetime | None = Field(None)
 
     name: str = Field(..., description="Human-readable robot name")
-    connection_string: str = Field(
-        ..., description="Connection string to device, keep empty to automatically find using serial number"
-    )
-    serial_number: str = Field(..., description="Unique serial number for the robot")
-    type: RobotType = Field(..., description="Type of robot configuration")
     active_calibration_id: UUID | None = Field(default=None, description="The ID of the active calibration")
+
+
+class SO101Robot(BaseRobot):
+    """SO-101 follower or leader robot using a serial connection."""
+
+    type: _SO101Types = Field(..., description="Type of robot configuration")
+    payload: SO101RobotPayload = Field(..., description="SO-101 connection configuration")
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "id": "a5e2cde6-936b-4a9e-a213-08dda0afa453",
                 "name": "Assembly Line Robot 1",
-                "connection_string": "SO101-2024-001",
-                "robot_type": "SO101_Leader",
+                "type": "SO101_Follower",
+                "payload": {
+                    "connection_string": "",
+                    "serial_number": "SO101-2024-001",
+                },
                 "active_calibration_id": "b7f3d9e2-1a2b-4c3d-8e9f-0a1b2c3d4e5f",
                 "created_at": "2024-01-15T10:30:00Z",
                 "updated_at": "2024-01-15T10:30:00Z",
@@ -68,5 +103,57 @@ class Robot(ABC, BaseModel):
     )
 
 
-class RobotWithConnectionState(Robot):
-    connection_status: Literal["online", "offline", "unknown"] = "unknown"
+class TrossenSingleArmRobot(BaseRobot):
+    """Trossen WidowX AI follower or leader robot using an IP connection."""
+
+    type: _TrossenTypes = Field(..., description="Type of robot configuration")
+    payload: TrossenSingleArmPayload = Field(..., description="Trossen single-arm connection configuration")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "a5e2cde6-936b-4a9e-a213-08dda0afa453",
+                "name": "WidowX AI Robot 1",
+                "type": "Trossen_WidowXAI_Follower",
+                "payload": {
+                    "connection_string": "192.168.1.100",
+                    "serial_number": "",
+                },
+                "active_calibration_id": None,
+                "created_at": "2024-01-15T10:30:00Z",
+                "updated_at": "2024-01-15T10:30:00Z",
+            },
+        },
+    )
+
+
+# Discriminated union of all robot types
+Robot = Annotated[
+    SO101Robot | TrossenSingleArmRobot,
+    Field(discriminator="type"),
+]
+
+RobotAdapter: TypeAdapter[Robot] = TypeAdapter(Robot)
+
+
+# ============================================================================
+# RobotWithConnectionState variants
+# ============================================================================
+
+_ConnectionStatus = Literal["online", "offline", "unknown"]
+
+
+class SO101RobotWithConnectionState(SO101Robot):
+    connection_status: _ConnectionStatus = "unknown"
+
+
+class TrossenSingleArmRobotWithConnectionState(TrossenSingleArmRobot):
+    connection_status: _ConnectionStatus = "unknown"
+
+
+RobotWithConnectionState = Annotated[
+    SO101RobotWithConnectionState | TrossenSingleArmRobotWithConnectionState,
+    Field(discriminator="type"),
+]
+
+RobotWithConnectionStateAdapter: TypeAdapter[RobotWithConnectionState] = TypeAdapter(RobotWithConnectionState)

--- a/application/backend/src/schemas/robot.py
+++ b/application/backend/src/schemas/robot.py
@@ -72,6 +72,7 @@ _TrossenTypes = Literal[RobotType.TROSSEN_WIDOWXAI_LEADER, RobotType.TROSSEN_WID
 
 
 class BaseRobot(BaseIDModel):
+    id: Annotated[UUID, Field(description="Unique identifier")]
     created_at: datetime | None = Field(None)
     updated_at: datetime | None = Field(None)
 

--- a/application/backend/src/services/robot_calibration_service.py
+++ b/application/backend/src/services/robot_calibration_service.py
@@ -18,7 +18,7 @@ from utils.serial_robot_tools import RobotConnectionManager
 async def find_robot_port(manager: RobotConnectionManager, robot: Robot) -> str | None:
     """Find the port associated with a robot."""
     for managed_robot in manager.robots:
-        if managed_robot.serial_number == robot.serial_number:
+        if managed_robot.serial_number == robot.payload.serial_number:
             return managed_robot.connection_string
 
     return None
@@ -98,7 +98,7 @@ class RobotCalibrationService:
         port = await find_robot_port(self.robot_manager, robot)
 
         if port is None:
-            raise ResourceNotFoundError(ResourceType.ROBOT, robot.serial_number)
+            raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
 
         # TODO: make this depend on the robot type
         # Assume follower since leader shares same FeetechMotorBus layout

--- a/application/backend/src/utils/serial_robot_tools.py
+++ b/application/backend/src/utils/serial_robot_tools.py
@@ -102,13 +102,16 @@ async def identify_so101_robot_visually(robot: Robot, joint: str | None = None) 
     if joint is None:
         joint = "gripper"
 
-    if robot.connection_string == "" and robot.serial_number != "":
-        robot.connection_string = find_port_for_serial(robot.serial_number)
+    connection_string = robot.payload.connection_string
+    serial_number = robot.payload.serial_number
 
-    if robot.connection_string == "":
-        raise ValueError(f"Could not find the serial port for serial number {robot.serial_number}")
+    if connection_string == "" and serial_number != "":
+        connection_string = find_port_for_serial(serial_number)
+
+    if connection_string == "":
+        raise ValueError(f"Could not find the serial port for serial number {serial_number}")
     # Assume follower since leader shares same FeetechMotorBus layout
-    connection = SOFollower(SOFollowerRobotConfig(port=robot.connection_string))
+    connection = SOFollower(SOFollowerRobotConfig(port=connection_string))
     connection.bus.connect()
 
     PRESENT_POSITION_KEY = "Present_Position"

--- a/application/backend/src/utils/trossen_robot_tools.py
+++ b/application/backend/src/utils/trossen_robot_tools.py
@@ -15,7 +15,7 @@ async def identify_trossen_robot_visually(robot: Robot) -> None:
     driver.configure(
         trossen_arm.Model.wxai_v0,
         trossen_arm.StandardEndEffector.wxai_v0_leader,
-        robot.connection_string,
+        robot.payload.connection_string,
         True,
         timeout=5,
     )

--- a/application/backend/tests/api/test_robot_calibration.py
+++ b/application/backend/tests/api/test_robot_calibration.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from api.dependencies import get_robot_calibration_service, get_robot_service
 from main import app
 from schemas.calibration import Calibration
-from schemas.robot import Robot
+from schemas.robot import Robot, SO101Robot, SO101RobotPayload
 
 # ---------------------------------------------------------------------------
 # Minimal service stubs
@@ -61,12 +61,11 @@ def test_set_active_calibration_id_returns_updated_robot() -> None:
     calibration_id = str(uuid4())
 
     robot_stub = _StubRobotService()
-    robot_stub._robots[robot_id] = Robot(
+    robot_stub._robots[robot_id] = SO101Robot(
         id=robot_id,
         name="Test Robot",
-        connection_string="",
-        serial_number="SN-TEST-001",
         type="SO101_Follower",
+        payload=SO101RobotPayload(connection_string="", serial_number="SN-TEST-001"),
         active_calibration_id=None,
     )
 
@@ -80,9 +79,11 @@ def test_set_active_calibration_id_returns_updated_robot() -> None:
             json={
                 "id": str(robot_id),
                 "name": "Test Robot",
-                "connection_string": "",
-                "serial_number": "SN-TEST-001",
                 "type": "SO101_Follower",
+                "payload": {
+                    "connection_string": "",
+                    "serial_number": "SN-TEST-001",
+                },
                 "active_calibration_id": calibration_id,
             },
         )
@@ -102,12 +103,11 @@ def test_update_robot_without_calibration_returns_null_active_calibration() -> N
     robot_id = uuid4()
 
     robot_stub = _StubRobotService()
-    robot_stub._robots[robot_id] = Robot(
+    robot_stub._robots[robot_id] = SO101Robot(
         id=robot_id,
         name="Robot Without Calibration",
-        connection_string="",
-        serial_number="SN-TEST-002",
         type="SO101_Follower",
+        payload=SO101RobotPayload(connection_string="", serial_number="SN-TEST-002"),
         active_calibration_id=None,
     )
 
@@ -121,9 +121,11 @@ def test_update_robot_without_calibration_returns_null_active_calibration() -> N
             json={
                 "id": str(robot_id),
                 "name": "Renamed Robot",
-                "connection_string": "",
-                "serial_number": "SN-TEST-002",
                 "type": "SO101_Follower",
+                "payload": {
+                    "connection_string": "",
+                    "serial_number": "SN-TEST-002",
+                },
                 "active_calibration_id": None,
             },
         )

--- a/application/backend/tests/conftest.py
+++ b/application/backend/tests/conftest.py
@@ -56,9 +56,11 @@ def test_environment():
                     "robot": {
                         "id": "c3f3f886-8813-4b3b-ba48-165cdaa39995",
                         "name": "Khaos",
-                        "connection_string": "",
-                        "serial_number": "5AA9017083",
                         "type": "SO101_Follower",
+                        "payload": {
+                            "connection_string": "",
+                            "serial_number": "5AA9017083",
+                        },
                     },
                     "tele_operator": {"type": "none"},
                 }

--- a/application/ui/src/features/robots/controller/robot-viewer.tsx
+++ b/application/ui/src/features/robots/controller/robot-viewer.tsx
@@ -8,8 +8,8 @@ import * as THREE from 'three';
 import { degToRad } from 'three/src/math/MathUtils.js';
 import { URDFRobot } from 'urdf-loader';
 
-import { SchemaRobot, SchemaRobotType } from '../../../api/openapi-spec';
 import { useContainerSize } from '../../../components/zoom/use-container-size';
+import { SchemaRobot, SchemaRobotType } from '../robot-types';
 import { urdfPathForType, useLoadModelMutation, useRobotModels } from './../robot-models-context';
 
 /** Material name used by the dark parts in the Trossen URDF. */

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -17,9 +17,9 @@ import {
 import { ChevronLeft, Refresh } from '@geti-ui/ui/icons';
 
 import { $api } from '../../../api/client';
-import { SchemaRobot } from '../../../api/openapi-spec';
 import { useProjectId } from '../../../features/projects/use-project';
 import { paths } from '../../../router';
+import { SchemaRobotInput } from '../robot-types';
 import { PermissionDeniedError } from '../setup-wizard/so101/diagnostics-step-error';
 import { useRobotForm, useSetRobotForm } from './provider';
 import { SubmitNewRobotButton } from './submit-new-robot-button';
@@ -97,14 +97,16 @@ const IdentifyRobot = ({ identifyMutation }: { identifyMutation: ReturnType<type
             return;
         }
 
-        const body: SchemaRobot = {
+        const body: SchemaRobotInput = {
             id: crypto.randomUUID(), // required by schema, not used by backend
             name: robotForm.name,
             type: robotForm.type,
-            connection_string: robotForm.connection_string ?? '',
-            serial_number: robotForm.serial_number ?? '',
+            payload: {
+                connection_string: robotForm.connection_string ?? '',
+                serial_number: robotForm.serial_number ?? '',
+            },
             active_calibration_id: null,
-        };
+        } as SchemaRobotInput;
 
         identifyMutation.mutate({ body });
     };

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -1,6 +1,6 @@
 import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
 
-import { SchemaRobot, SchemaRobotType } from '../../../api/openapi-spec';
+import { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../robot-types';
 
 type RobotForm = {
     name: string;
@@ -14,7 +14,7 @@ export type RobotFormState = RobotForm | null;
 export const RobotFormContext = createContext<RobotFormState>(null);
 export const SetRobotFormContext = createContext<Dispatch<SetStateAction<RobotForm>> | null>(null);
 
-export const useRobotFormBody = (robot_id: string): SchemaRobot | null => {
+export const useRobotFormBody = (robot_id: string): SchemaRobotInput | null => {
     const robotForm = useRobotForm();
 
     if (robotForm === undefined) {
@@ -33,17 +33,19 @@ export const useRobotFormBody = (robot_id: string): SchemaRobot | null => {
         id: robot_id,
         name: robotForm.name,
         type: robotForm.type,
-        connection_string: robotForm.connection_string ?? '',
-        serial_number: robotForm.serial_number ?? '',
-    };
+        payload: {
+            connection_string: robotForm.connection_string ?? '',
+            serial_number: robotForm.serial_number ?? '',
+        },
+    } as SchemaRobotInput;
 };
 
 export const RobotFormProvider = ({ children, robot }: { children: ReactNode; robot?: SchemaRobot }) => {
     const [value, setValue] = useState<RobotForm>({
         name: robot?.name ?? '',
         type: robot?.type ?? 'SO101_Follower',
-        connection_string: robot?.connection_string ?? '',
-        serial_number: robot?.serial_number ?? '',
+        connection_string: robot?.payload?.connection_string ?? '',
+        serial_number: robot?.payload?.serial_number ?? '',
     });
 
     return (

--- a/application/ui/src/features/robots/robot-form/submit-new-robot-button.tsx
+++ b/application/ui/src/features/robots/robot-form/submit-new-robot-button.tsx
@@ -38,8 +38,8 @@ export const SubmitNewRobotButton = () => {
                         body,
                     },
                     {
-                        onSuccess: ({}, { body: { id: robot_id } }) => {
-                            navigate(paths.project.robots.show({ project_id, robot_id }));
+                        onSuccess: (createdRobot) => {
+                            navigate(paths.project.robots.show({ project_id, robot_id: createdRobot.id }));
                         },
                     }
                 );

--- a/application/ui/src/features/robots/robot-models-context.tsx
+++ b/application/ui/src/features/robots/robot-models-context.tsx
@@ -4,7 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import * as THREE from 'three';
 import URDFLoader, { URDFRobot } from 'urdf-loader';
 
-import { SchemaRobotType } from '../../api/openapi-spec';
+import { SchemaRobotType } from './robot-types';
 
 // ---------------------------------------------------------------------------
 // Path resolution

--- a/application/ui/src/features/robots/robot-types.ts
+++ b/application/ui/src/features/robots/robot-types.ts
@@ -1,0 +1,15 @@
+import {
+    SchemaSo101RobotInput,
+    SchemaSo101RobotOutput,
+    SchemaTrossenSingleArmRobotInput,
+    SchemaTrossenSingleArmRobotOutput,
+} from '../../api/openapi-spec';
+
+/** Union of all concrete robot output schemas (as returned by the API). */
+export type SchemaRobot = SchemaSo101RobotOutput | SchemaTrossenSingleArmRobotOutput;
+
+/** Union of all concrete robot input schemas (for create/update requests). */
+export type SchemaRobotInput = SchemaSo101RobotInput | SchemaTrossenSingleArmRobotInput;
+
+/** All possible robot type discriminators. */
+export type SchemaRobotType = SchemaRobot['type'];

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -174,8 +174,8 @@ export const RobotsList = () => {
                                 <RobotListItem
                                     id={robot.id}
                                     name={robot.name}
-                                    connectionString={robot.connection_string}
-                                    serialNumber={robot.serial_number}
+                                    connectionString={robot.payload.connection_string}
+                                    serialNumber={robot.payload.serial_number}
                                     type={robot.type}
                                     status={onlineProjectRobots === undefined ? 'unknown' : status}
                                     isActive={isActive}

--- a/application/ui/src/features/robots/setup-wizard/shared/setup-robot-viewer.tsx
+++ b/application/ui/src/features/robots/setup-wizard/shared/setup-robot-viewer.tsx
@@ -9,9 +9,9 @@ import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
 import { degToRad } from 'three/src/math/MathUtils.js';
 import { URDFRobot } from 'urdf-loader';
 
-import { SchemaRobotType } from '../../../../api/openapi-spec';
 import { useContainerSize } from '../../../../components/zoom/use-container-size';
 import { urdfPathForType, useLoadModelMutation, useRobotModels } from '../../robot-models-context';
+import { SchemaRobotType } from '../../robot-types';
 import { JointHighlight, useJointHighlight } from './use-joint-highlight';
 
 // ---------------------------------------------------------------------------

--- a/application/ui/src/features/robots/setup-wizard/so101/setup-wizard.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/setup-wizard.tsx
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 
 import { Divider, Grid, Heading, View } from '@geti-ui/ui';
 
-import { SchemaRobotType } from '../../../../api/openapi-spec';
 import { useRobotForm } from '../../robot-form/provider';
+import { SchemaRobotType } from '../../robot-types';
 import { SetupRobotViewer } from '../shared/setup-robot-viewer';
 import { Stepper } from '../shared/stepper';
 import { JointHighlight } from '../shared/use-joint-highlight';

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -6,11 +6,12 @@ import { degToRad } from 'three/src/math/MathUtils.js';
 import { v4 as uuidv4 } from 'uuid';
 
 import { $api } from '../../../../api/client';
-import { SchemaCalibration, SchemaRobot } from '../../../../api/openapi-spec';
+import { SchemaCalibration } from '../../../../api/openapi-spec';
 import { paths } from '../../../../router';
 import { useProjectId } from '../../../projects/use-project';
 import { useRobotForm } from '../../robot-form/provider';
 import { useRobotModels } from '../../robot-models-context';
+import { SchemaRobotInput } from '../../robot-types';
 import { InlineAlert } from '../shared/inline-alert';
 import { CalibrationResult } from './use-setup-websocket';
 import { useSetupActions, useSetupState } from './wizard-provider';
@@ -136,16 +137,18 @@ export const VerificationStep = () => {
         },
     });
 
-    const robotBody: SchemaRobot | null =
+    const robotBody: SchemaRobotInput | null =
         robotForm.type !== null && robotForm.name
-            ? {
+            ? ({
                   id: robotId,
                   name: robotForm.name,
                   type: robotForm.type,
-                  connection_string: robotForm.connection_string ?? '',
-                  serial_number: robotForm.serial_number ?? '',
+                  payload: {
+                      connection_string: robotForm.connection_string ?? '',
+                      serial_number: robotForm.serial_number ?? '',
+                  },
                   active_calibration_id: null,
-              }
+              } as SchemaRobotInput)
             : null;
 
     const hasCalibration = wsState.calibrationResult !== null;

--- a/application/ui/src/features/robots/use-robot.ts
+++ b/application/ui/src/features/robots/use-robot.ts
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router';
 
 import { $api } from '../../api/client';
-import { SchemaRobot } from '../../api/openapi-spec';
+import { SchemaRobot } from './robot-types';
 
 export function useRobotId() {
     const { robot_id, project_id } = useParams<{ robot_id: string; project_id: string }>();

--- a/application/ui/src/routes/environments/show.tsx
+++ b/application/ui/src/routes/environments/show.tsx
@@ -2,7 +2,7 @@ import { Button, Flex, View } from '@geti-ui/ui';
 
 import { useProjectId } from '../../features/projects/use-project';
 import { Preview } from '../../features/robots/environment-form/preview';
-import { EnvironmentFormProvider, EnvironmentFormState } from '../../features/robots/environment-form/provider';
+import { EnvironmentForm, EnvironmentFormProvider } from '../../features/robots/environment-form/provider';
 import { useEnvironment } from '../../features/robots/use-environment';
 import { paths } from '../../router';
 
@@ -33,7 +33,7 @@ const Header = () => {
 export const EnvironmentShow = () => {
     const environment = useEnvironment();
 
-    const environmentForm: EnvironmentFormState = {
+    const environmentForm: EnvironmentForm = {
         name: environment.name,
         camera_ids: environment.cameras?.map(({ id }) => id!) ?? [],
         robots:


### PR DESCRIPTION
This PR refactors our robot schema so that it will be easier for us to add new robots in the future.
There's two main changes:
1. The `Robot` schema is changed so that it is a discriminated union
2. The `connection_string` and `serial_number` are moved into a generic `payload` that is stored as json

The second point makes it all a bit more generic so it loses some robustness (no database verification that connection string exists etc), but it will make it a lot easier for us to enable new robots like a bimanual robot that needs two connection strings.
If we do want more database guarantees than we could consider to change the json payload to be based on pivot tables (e.g. `so101_configuration` table with `robot_id`, `serial_number` and `widowx_configuration` with `robot_id` and `connection_string` etc), but I think at the moment that would be premature optimization without much benefit.

The alembic migration contains both up and down migrations and will convert the original robots' `connection_string` and `serial_number` to a payload representation.

## Type of Change

- [x] ♻️ `refactor` - Code refactoring
