### PR TITLE
refactor: synchronize robot joint state with urdf model

### DIFF
--- a/application/ui/src/features/robots/controller/joint-controls.tsx
+++ b/application/ui/src/features/robots/controller/joint-controls.tsx
@@ -83,7 +83,7 @@ const useRobotJointsState = (): JointsState => {
 
     const { project_id, robot_id } = useRobotId();
     const { joints } = useJointState(project_id, robot_id);
-    useSynchronizeModelJoints(joints, urdfPathForType(robot.type));
+    useSynchronizeModelJoints(joints, robot.type);
 
     return joints.map((joint) => {
         const modelJoint = modelJoints.find(({ name }) => name === joint.name);

--- a/application/ui/src/features/robots/controller/robot-viewer.tsx
+++ b/application/ui/src/features/robots/controller/robot-viewer.tsx
@@ -10,7 +10,7 @@ import { URDFRobot } from 'urdf-loader';
 
 import { useContainerSize } from '../../../components/zoom/use-container-size';
 import { SchemaRobot, SchemaRobotType } from '../robot-types';
-import { urdfPathForType, useLoadModelMutation, useRobotModels } from './../robot-models-context';
+import { mapJointToURDFJoint, urdfPathForType, useLoadModelMutation, useRobotModels } from './../robot-models-context';
 
 /** Material name used by the dark parts in the Trossen URDF. */
 const TROSSEN_DARK_MATERIAL = 'trossen_black';
@@ -127,19 +127,18 @@ export const RobotViewer = ({ robot = { type: 'SO101_Follower' }, featureValues,
 
     useEffect(() => {
         if (featureValues !== undefined && featureNames !== undefined && model !== undefined) {
-            featureNames.forEach((name, index) => {
-                if (index < featureValues.length && name.endsWith('.pos')) {
-                    const joint_name = name.replace('.pos', '');
-
-                    if (joint_name === 'gripper' && model.robotName == 'wxai') {
-                        model.setJointValue('left_carriage_joint', featureValues[index]); // meters
-                    } else if (model.joints[joint_name] != undefined) {
-                        model.joints[joint_name].setJointValue(degToRad(featureValues[index]));
-                    }
-                }
+            featureNames.forEach((_, index) => {
+                mapJointToURDFJoint(
+                    {
+                        name: featureNames[index],
+                        value: featureValues[index],
+                    },
+                    model,
+                    robot.type
+                );
             });
         }
-    }, [featureValues, featureNames, model]);
+    }, [featureValues, featureNames, model, robot.type]);
 
     return (
         <div ref={ref} style={{ width: '100%', height: '100%' }}>

--- a/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
+++ b/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
@@ -3,7 +3,7 @@ import { View } from '@geti-ui/ui';
 import { $api } from '../../../../api/client';
 import { useProjectId } from '../../../projects/use-project';
 import { RobotViewer } from '../../controller/robot-viewer';
-import { RobotModelsProvider, urdfPathForType } from '../../robot-models-context';
+import { RobotModelsProvider } from '../../robot-models-context';
 import { useJointState, useSynchronizeModelJoints } from '../../use-joint-state';
 
 const InnerCell = ({ robot_id }: { robot_id: string }) => {
@@ -14,7 +14,7 @@ const InnerCell = ({ robot_id }: { robot_id: string }) => {
     });
 
     const { joints } = useJointState(project_id, robot_id);
-    useSynchronizeModelJoints(joints, urdfPathForType(robot.type));
+    useSynchronizeModelJoints(joints, robot.type);
 
     return (
         <View minWidth='size-4000' minHeight='size-4000' width='100%' height='100%' backgroundColor={'gray-600'}>

--- a/application/ui/src/features/robots/robot-models-context.tsx
+++ b/application/ui/src/features/robots/robot-models-context.tsx
@@ -2,6 +2,7 @@ import { createContext, ReactNode, useCallback, useContext, useRef, useState } f
 
 import { useMutation } from '@tanstack/react-query';
 import * as THREE from 'three';
+import { degToRad } from 'three/src/math/MathUtils.js';
 import URDFLoader, { URDFRobot } from 'urdf-loader';
 
 import { SchemaRobotType } from './robot-types';
@@ -16,6 +17,49 @@ export const urdfPathForType = (robotType: SchemaRobotType): string => {
         return '/widowx/urdf/generated/wxai/wxai_follower.urdf';
     }
     return '/SO101/so101_new_calib.urdf';
+};
+
+const SO101_TO_URDF = {
+    'shoulder_pan.pos': ['shoulder_pan'],
+    'shoulder_lift.pos': ['shoulder_lift'],
+    'elbow_flex.pos': ['elbow_flex'],
+    'wrist_flex.pos': ['wrist_flex'],
+    'wrist_roll.pos': ['wrist_roll'],
+    'gripper.pos': ['gripper'],
+};
+const TROSSEN_TO_URDF = {
+    'shoulder_pan.pos': ['joint_0'],
+    'shoulder_lift.pos': ['joint_1'],
+    'elbow_flex.pos': ['joint_2'],
+    'wrist_flex.pos': ['joint_3'],
+    'wrist_yaw.pos': ['joint_4'],
+    'wrist_roll.pos': ['joint_5'],
+    'gripper.pos': ['left_carriage_joint', 'right_carriage_joint'],
+};
+
+const ROBOT_TYPE_TO_URDF_MAP: Record<SchemaRobotType, Record<string, string[]>> = {
+    SO101_Follower: SO101_TO_URDF,
+    SO101_Leader: SO101_TO_URDF,
+    Trossen_WidowXAI_Leader: TROSSEN_TO_URDF,
+    Trossen_WidowXAI_Follower: TROSSEN_TO_URDF,
+};
+
+export const mapJointToURDFJoint = (
+    joint: { name: string; value: number },
+    model: URDFRobot,
+    robotType: SchemaRobotType
+) => {
+    if (!joint.name.endsWith('.pos')) {
+        return;
+    }
+    const modelJointMap = ROBOT_TYPE_TO_URDF_MAP[robotType];
+    const modelJoints = modelJointMap[joint.name] ?? [];
+
+    modelJoints.forEach((modelJointName) => {
+        const isRevolute = model.joints[modelJointName].jointType === 'revolute';
+
+        model.setJointValue(modelJointName, isRevolute ? degToRad(joint.value) : joint.value); // meters
+    });
 };
 
 /**

--- a/application/ui/src/features/robots/use-joint-state.ts
+++ b/application/ui/src/features/robots/use-joint-state.ts
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import useWebSocket from 'react-use-websocket';
-import { degToRad } from 'three/src/math/MathUtils.js';
 
 import { fetchClient } from '../../api/client';
-import { useRobotModels } from './robot-models-context';
+import { mapJointToURDFJoint, urdfPathForType, useRobotModels } from './robot-models-context';
+import { SchemaRobotType } from './robot-types';
 
 type JointsState = Array<{
     name: string;
@@ -27,30 +27,18 @@ const getNewJointState = (newJoints: StateWasUpdatedEvent['state']) => {
     });
 };
 
-export const useSynchronizeModelJoints = (joints: JointsState, urdfPath: string) => {
+export const useSynchronizeModelJoints = (joints: JointsState, robotType: SchemaRobotType) => {
     const { getModel } = useRobotModels();
+    const urdfPath = urdfPathForType(robotType);
     const model = getModel(urdfPath);
-
-    function removeSuffix(str: string, suffix: string): string {
-        return str.endsWith(suffix) ? str.slice(0, -suffix.length) : str;
-    }
 
     useEffect(() => {
         if (!model) return;
 
         joints.forEach((joint) => {
-            const name = removeSuffix(joint.name, '.pos');
-
-            if (name === 'gripper' && model.robotName == 'wxai') {
-                model.setJointValue('left_carriage_joint', joint.value); // meters
-                return;
-            }
-
-            if (model.joints[name]) {
-                model.setJointValue(name, degToRad(joint.value));
-            }
+            mapJointToURDFJoint(joint, model, robotType);
         });
-    }, [model, joints]);
+    }, [model, joints, robotType]);
 };
 
 export const useJointState = (project_id: string, robot_id: string) => {


### PR DESCRIPTION
This PR refactors how we sync a robot's joint states to its respective URDF model. Before we were doing this in two different places and had some hardcoded logic for how to handle the gripper. Now we are using a check on the joint type to determine if we need to do a conversion to radians.

Additionally now both the logic to determine the urdf path as well as the mappings are all in the same place, which should make documenting how to add new robots into the UI a bit easier.

## Type of Change

- [x] ♻️ `refactor` - Code refactoring