### PR TITLE
refactor: restore support of InferenceModel in benchmark

### DIFF
--- a/library/src/physicalai/benchmark/benchmark.py
+++ b/library/src/physicalai/benchmark/benchmark.py
@@ -42,13 +42,17 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+import torch
+
 from physicalai.benchmark.results import BenchmarkResults, TaskResult
 from physicalai.eval.rollout import evaluate_policy
+from physicalai.inference.model import InferenceModel
+from physicalai.policies.base import Policy
 
 if TYPE_CHECKING:
+    from physicalai.data import Observation
     from physicalai.eval.video import VideoRecorder
     from physicalai.gyms import Gym
-    from physicalai.policies.base import Policy
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +116,7 @@ class Benchmark:
 
     def evaluate(
         self,
-        policy: Policy,
+        policy: Policy | InferenceModel,
         *,
         continue_on_error: bool = True,
     ) -> BenchmarkResults:
@@ -120,11 +124,12 @@ class Benchmark:
 
         Supports both PyTorch `Policy` objects and exported `InferenceModel`
         objects, enabling benchmarking of production inference performance.
+        Only select_action() is used during gym rollout, as it represents
+        the expected inference behavior.
 
         Args:
             policy: Policy or model to evaluate. Accepts Policy (PyTorch),
-                InferenceModel (exported), or any object implementing the
-                Policy protocol (select_action, reset).
+                InferenceModel (exported).
             continue_on_error: Whether to continue if a task fails.
 
         Returns:
@@ -148,6 +153,7 @@ class Benchmark:
         Raises:
             RuntimeError: If all tasks fail during evaluation.
         """
+        policy = _wrap_policy(policy)
         metadata = self._build_metadata(policy)
         results = BenchmarkResults(metadata=metadata)
         failed_tasks: list[str] = []
@@ -271,7 +277,7 @@ class Benchmark:
 
     def _create_video_recorder(
         self,
-        policy: Policy,
+        policy: Policy | InferenceModel,
         task_id: str,
     ) -> VideoRecorder | None:
         """Create a VideoRecorder for the current task if video recording is enabled.
@@ -388,3 +394,45 @@ def _get_policy_name(policy: Policy, _index: int = 0) -> str:
         # InferenceModel uses policy_name attribute
         return str(policy.policy_name)
     return type(policy).__name__
+
+
+def _wrap_policy(policy: Policy | InferenceModel) -> Policy:
+    """Wrap an InferenceModel in a Policy interface if needed.
+
+    This allows evaluate_policy to work with both Policy and InferenceModel
+    objects seamlessly.
+
+    Inference model interface doesn't match 1:1 with Policy,
+    so the wrapper uses select_action() everywhere.
+    That's not an issue for evaluation: only select_action()
+    is used during rollout.
+
+    Returns:
+        A Policy object that can be used for evaluation.
+    """
+
+    class InferenceModelPolicyWrapper(Policy):
+        def __init__(self, inf_model: InferenceModel) -> None:
+            super().__init__()
+            self._inf_model = inf_model
+            self.name = inf_model.policy_name
+
+        def forward(self, batch: Observation) -> torch.Tensor:
+            return self.select_action(batch)
+
+        def predict_action_chunk(self, batch: Observation) -> torch.Tensor:
+            return self.select_action(batch)
+
+        def select_action(self, observation: Observation) -> torch.Tensor:
+            np_inputs = observation.to_numpy().to_dict(flatten=False)
+            action = self._inf_model.select_action(np_inputs)
+            return torch.from_numpy(action)
+
+        def reset(self) -> None:
+            """Reset policy state for new episode."""
+            self._inf_model.reset()
+
+    if isinstance(policy, InferenceModel):
+        return InferenceModelPolicyWrapper(policy)
+
+    return policy

--- a/library/src/physicalai/benchmark/benchmark.py
+++ b/library/src/physicalai/benchmark/benchmark.py
@@ -48,7 +48,7 @@ from physicalai.eval.rollout import evaluate_policy
 if TYPE_CHECKING:
     from physicalai.eval.video import VideoRecorder
     from physicalai.gyms import Gym
-    from physicalai.policies.base import PolicyLike
+    from physicalai.policies.base import Policy
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ class Benchmark:
 
     def evaluate(
         self,
-        policy: PolicyLike,
+        policy: Policy,
         *,
         continue_on_error: bool = True,
     ) -> BenchmarkResults:
@@ -124,7 +124,7 @@ class Benchmark:
         Args:
             policy: Policy or model to evaluate. Accepts Policy (PyTorch),
                 InferenceModel (exported), or any object implementing the
-                PolicyLike protocol (select_action, reset).
+                Policy protocol (select_action, reset).
             continue_on_error: Whether to continue if a task fails.
 
         Returns:
@@ -203,7 +203,7 @@ class Benchmark:
         gym: Gym,
         gym_idx: int,
         total_gyms: int,
-        policy: PolicyLike,
+        policy: Policy,
         failed_tasks: list[str],
         *,
         continue_on_error: bool,
@@ -271,7 +271,7 @@ class Benchmark:
 
     def _create_video_recorder(
         self,
-        policy: PolicyLike,
+        policy: Policy,
         task_id: str,
     ) -> VideoRecorder | None:
         """Create a VideoRecorder for the current task if video recording is enabled.
@@ -297,7 +297,7 @@ class Benchmark:
             record_mode=self.record_mode,  # type: ignore[arg-type]
         )
 
-    def _build_metadata(self, policy: PolicyLike) -> dict[str, Any]:
+    def _build_metadata(self, policy: Policy) -> dict[str, Any]:
         """Build metadata dict for results.
 
         Returns:
@@ -374,7 +374,7 @@ def _get_task_name(gym: Gym) -> str:
     return ""
 
 
-def _get_policy_name(policy: PolicyLike, _index: int = 0) -> str:
+def _get_policy_name(policy: Policy, _index: int = 0) -> str:
     """Extract policy name for results dict key.
 
     Handles both Policy objects and InferenceModel objects.

--- a/library/src/physicalai/eval/rollout/functional.py
+++ b/library/src/physicalai/eval/rollout/functional.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from physicalai.data import Observation
     from physicalai.eval.video import VideoRecorder
     from physicalai.gyms import Gym
-    from physicalai.policies.base import PolicyLike
+    from physicalai.policies.base import Policy
 
 
 @dataclass
@@ -230,7 +230,7 @@ def _collect_frame(
 
 def setup_rollout(
     env: Gym,
-    policy: PolicyLike,
+    policy: Policy,
     seed: int | None,
     max_steps: int | None,
 ) -> tuple[Observation, int]:
@@ -238,7 +238,7 @@ def setup_rollout(
 
     Args:
         env (Gym): environment to probe max_steps and init.
-        policy (PolicyLike): policy to reset if it has attribute.
+        policy (Policy): policy to reset if it has attribute.
         seed (int | None): seed to init reset.
         max_steps (int | None): maximum number of steps
 
@@ -259,7 +259,7 @@ def setup_rollout(
 
 def run_rollout_loop(  # noqa: PLR0914
     env: Gym,
-    policy: PolicyLike,
+    policy: Policy,
     initial_observation: Observation,
     max_steps: int,
     *,
@@ -412,7 +412,7 @@ def finalize_rollout(
 
 def rollout(
     env: Gym,
-    policy: PolicyLike,
+    policy: Policy,
     *,
     seed: int | None = None,
     max_steps: int | None = None,
@@ -436,9 +436,9 @@ def rollout(
 
     Args:
         env (Gym): Environment to interact with.
-        policy (PolicyLike): Policy or inference model used to select actions.
+        policy (Policy): Policy or inference model used to select actions.
             Accepts Policy (PyTorch), InferenceModel (exported), or any
-            object implementing the PolicyLike protocol (select_action, reset).
+            object implementing the Policy protocol (select_action, reset).
         seed (int | None, optional): RNG seed for the environment. Defaults to None.
         max_steps (int | None, optional): Maximum number of steps before termination.
             If None, runs until the episode ends. Defaults to None.
@@ -556,7 +556,7 @@ def _extract_episode_records(
 
 def evaluate_policy(
     env: Gym,
-    policy: PolicyLike,
+    policy: Policy,
     n_episodes: int,
     *,
     start_seed: int | None = None,
@@ -571,9 +571,9 @@ def evaluate_policy(
 
     Args:
         env (Gym): Environment used for evaluation.
-        policy (PolicyLike): Policy or inference model to evaluate.
+        policy (Policy): Policy or inference model to evaluate.
             Accepts Policy (PyTorch), InferenceModel (exported), or any
-            object implementing the PolicyLike protocol (select_action, reset).
+            object implementing the Policy protocol (select_action, reset).
         n_episodes (int): Number of episodes to run.
         start_seed (int | None, optional): Initial seed; incremented per episode
             if provided. Defaults to None.

--- a/library/src/physicalai/policies/__init__.py
+++ b/library/src/physicalai/policies/__init__.py
@@ -5,19 +5,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from . import lerobot
 from .act import ACT, ACTConfig, ACTModel
-from .base import PolicyLike
+from .base import Policy
 from .groot import Groot, GrootConfig, GrootModel
 from .lerobot import get_lerobot_policy
 from .pi0 import Pi0, Pi0Config, Pi0Model
 from .pi05 import Pi05, Pi05Config, Pi05Model
 from .smolvla import SmolVLA, SmolVLAConfig, SmolVLAModel
-
-if TYPE_CHECKING:
-    from .base import Policy
 
 __all__ = [
     # ACT
@@ -35,8 +30,8 @@ __all__ = [
     "Pi05",
     "Pi05Config",
     "Pi05Model",
-    # Protocol
-    "PolicyLike",
+    # Base
+    "Policy",
     # SmolVLA
     "SmolVLA",
     "SmolVLAConfig",

--- a/library/src/physicalai/policies/base/__init__.py
+++ b/library/src/physicalai/policies/base/__init__.py
@@ -4,6 +4,6 @@
 """Base classes for policies."""
 
 from .model import Model
-from .policy import Policy, PolicyLike
+from .policy import Policy
 
-__all__ = ["Model", "Policy", "PolicyLike"]
+__all__ = ["Model", "Policy"]

--- a/library/src/physicalai/policies/base/policy.py
+++ b/library/src/physicalai/policies/base/policy.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import deque
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any
 
 import lightning as L  # noqa: N812
 
@@ -20,34 +20,6 @@ if TYPE_CHECKING:
     from physicalai.gyms import Gym
 
     from .model import Model
-
-
-@runtime_checkable
-class PolicyLike(Protocol):
-    """Protocol for policy-like objects that can be used for inference.
-
-    This protocol defines the minimal interface required for evaluation
-    and benchmarking. Both `Policy` (PyTorch/Lightning) and `InferenceModel`
-    (exported models) satisfy this protocol.
-
-    The protocol enables using exported models for benchmarking production
-    performance without requiring the full PyTorch training infrastructure.
-    """
-
-    def select_action(self, observation: Observation) -> torch.Tensor:
-        """Select action for given observation.
-
-        Args:
-            observation: Robot observation (images, states, etc.)
-
-        Returns:
-            Action tensor to execute.
-        """
-        ...
-
-    def reset(self) -> None:
-        """Reset policy state for new episode."""
-        ...
 
 
 class Policy(L.LightningModule, ABC):

--- a/library/tests/conftest.py
+++ b/library/tests/conftest.py
@@ -396,7 +396,7 @@ def dummy_policy():
     so existing tests that pass ``dummy_policy`` directly as a policy still work.
 
     Satisfies:
-    - PolicyLike protocol (select_action, reset) for evaluate_policy / Rollout
+    - Policy interface (select_action, reset) for evaluate_policy / Rollout
     - LightningModule interface (forward, training_step, configure_optimizers) for trainer.fit
     """
     from physicalai.policies.base import Policy

--- a/library/tests/unit/benchmark/test_benchmark.py
+++ b/library/tests/unit/benchmark/test_benchmark.py
@@ -11,7 +11,6 @@ import pytest
 import torch
 
 from physicalai.benchmark import Benchmark, BenchmarkResults, LiberoBenchmark, TaskResult
-from physicalai.policies.base import PolicyLike
 
 
 @pytest.fixture
@@ -107,50 +106,8 @@ class TestLiberoBenchmark:
             assert "libero_10" in repr(LiberoBenchmark(task_suite="libero_10"))
 
 
-class TestPolicyLikeProtocol:
-    """Tests for PolicyLike protocol compatibility."""
-
-    def test_policy_like_protocol_with_mock(self):
-        """Test that mock objects satisfying PolicyLike work with benchmark."""
-
-        class MockInferenceModel:
-            """Mock class mimicking InferenceModel interface."""
-
-            def __init__(self):
-                self.policy_name = "mock_inference_model"
-
-            def select_action(self, observation):
-                """Return dummy action tensor."""
-                return torch.zeros(1, 7)
-
-            def reset(self):
-                """Reset internal state."""
-                pass
-
-        model = MockInferenceModel()
-        assert isinstance(model, PolicyLike), "Mock should satisfy PolicyLike protocol"
-
-    def test_benchmark_accepts_policy_like(self, mock_gym, eval_result):
-        """Test that Benchmark.evaluate accepts PolicyLike objects."""
-
-        class MockInferenceModel:
-            def __init__(self):
-                self.policy_name = "test_model"
-
-            def select_action(self, observation):
-                return torch.zeros(1, 7)
-
-            def reset(self):
-                pass
-
-        model = MockInferenceModel()
-        benchmark = Benchmark(gyms=[mock_gym], num_episodes=5, max_steps=100)
-
-        with patch("physicalai.benchmark.benchmark.evaluate_policy", return_value=eval_result):
-            results = benchmark.evaluate(model)
-
-        assert results.n_tasks == 1
-        assert results.overall_success_rate == 80.0
+class TestPolicyNameExtraction:
+    """Tests for policy name extraction."""
 
     def test_policy_name_extraction_from_inference_model(self):
         """Test that _get_policy_name extracts policy_name from InferenceModel-like objects."""

--- a/library/tests/unit/benchmark/test_benchmark.py
+++ b/library/tests/unit/benchmark/test_benchmark.py
@@ -106,6 +106,38 @@ class TestLiberoBenchmark:
             assert "libero_10" in repr(LiberoBenchmark(task_suite="libero_10"))
 
 
+class TestWrapPolicy:
+    """Tests for _wrap_policy with InferenceModel input."""
+
+    def test_wraps_inference_model_into_policy(self):
+        """Test that _wrap_policy wraps an InferenceModel into a Policy-compatible object."""
+        import numpy as np
+
+        from physicalai.benchmark.benchmark import _wrap_policy
+        from physicalai.inference.model import InferenceModel
+        from physicalai.policies.base import Policy
+
+        mock_model = MagicMock(spec=InferenceModel)
+        mock_model.policy_name = "test_policy"
+        mock_model.select_action.return_value = np.array([1.0, 2.0, 3.0])
+
+        wrapped = _wrap_policy(mock_model)
+
+        assert isinstance(wrapped, Policy)
+        assert wrapped.name == "test_policy"
+
+        obs = MagicMock()
+        np_obs = MagicMock()
+        np_obs.to_dict.return_value = {"image": np.zeros((3, 224, 224))}
+        obs.to_numpy.return_value = np_obs
+
+        action = wrapped.select_action(obs)
+
+        mock_model.select_action.assert_called_once()
+        assert isinstance(action, torch.Tensor)
+        assert torch.equal(action, torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64))
+
+
 class TestPolicyNameExtraction:
     """Tests for policy name extraction."""
 


### PR DESCRIPTION
# Pull Request

## Description

- Remove `PolicyLike` interface, as it doesn't generalize to both policy and exported policy anymore.
- Refactor `InferenceModel` support in benchmark

## Type of Change

- [x] ♻️ `refactor` - Code refactoring

## Breaking Changes

`PolicyLike` protocol is deleted


## Examples

```python
from physicalai.benchmark import LiberoBenchmark
from physicalai.inference import InferenceModel

ov_model = InferenceModel("pi05_libero_finetuned_hf_ov", runner=ActionChunking(SinglePass()))
benchmark = LiberoBenchmark(
        task_suite="libero_10",
        task_ids=[6],             
        num_episodes=5,     
        max_steps=500,       
        video_dir="fail_videos"
    )
results = benchmark.evaluate(ov_model)
```