### PR TITLE
feat: add compute_val_loss method for validation loss calculation in ACT model

### DIFF
--- a/library/src/physicalai/policies/act/model.py
+++ b/library/src/physicalai/policies/act/model.py
@@ -290,6 +290,45 @@ class ACT(ExportableModelMixin, Model):
         return loss, loss_dict
 
     @torch.no_grad()
+    def compute_val_loss(self, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, float]]:
+        """Compute validation loss (L1 + optional KL divergence).
+
+        Temporarily sets the inner model to training mode so the VAE encoder
+        runs and produces latent distribution parameters (mu, log_sigma_x2).
+        The model is restored to eval mode afterwards.  Dropout and batch-norm
+        behaviour during this call will follow training-mode semantics, but
+        gradients are still disabled by the ``@torch.no_grad()`` decorator.
+
+        Args:
+            batch: Preprocessed batch dict.
+
+        Returns:
+            Tuple of (loss tensor, loss dict with ``"l1_loss"`` and optionally ``"kld_loss"``).
+        """
+        batch = self._input_normalizer(batch)
+
+        self._model.train()
+        try:
+            actions_hat, (mu_hat, log_sigma_x2_hat) = self._model(batch)
+        finally:
+            self._model.eval()
+
+        l1_loss = (
+            F.l1_loss(batch[ACTION], actions_hat, reduction="none") * ~batch[EXTRA + ".action_is_pad"].unsqueeze(-1)
+        ).mean()
+
+        loss_dict: dict[str, float] = {"l1_loss": l1_loss.item()}
+        if self._config.use_vae:
+            mean_kld = (-0.5 * (1 + log_sigma_x2_hat - mu_hat.pow(2) - (log_sigma_x2_hat).exp())).sum(-1).mean()
+            loss_dict["kld_loss"] = mean_kld.item()
+            loss = l1_loss + mean_kld * self._config.kl_weight
+        else:
+            loss = l1_loss
+
+        loss_dict["loss"] = loss.item()
+        return loss, loss_dict
+
+    @torch.no_grad()
     def predict_action_chunk(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
         """Predicts a chunk of actions from a batch of observations.
 


### PR DESCRIPTION
# Pull Request

## Description

During validation, PyTorch Lightning sets the model to eval mode (`self.training = False`). The ACT model's `_ACT.forward()` gates the VAE encoder behind `self.training`, so during validation loss computation `mu` and `log_sigma_x2` are `None`. This causes a `TypeError` in the KL divergence calculation: `unsupported operand type(s) for +: 'int' and 'NoneType'`.

This PR adds a dedicated `compute_val_loss` method to the `ACT` model that temporarily sets the inner `_ACT` module to training mode so the VAE encoder runs and produces valid latent distribution parameters. The model is restored to eval mode via `try/finally`, and `@torch.no_grad()` ensures no gradients are computed.

## Type of Change

- [x] 🐞 `fix` - Bug fix

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

None. The base class `Model.compute_val_loss` already delegates to `compute_loss` by default. This override only affects the ACT policy's validation path.

---

## Examples

**Before:** Training with `use_vae=True` crashes at the first validation epoch:
```
File "library/src/physicalai/policies/act/model.py", line 283, in compute_loss
    mean_kld = (-0.5 * (1 + log_sigma_x2_hat - mu_hat.pow(2) - ...
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

**After:** Validation loss is computed correctly, reporting both `l1_loss` and `kld_loss` in the loss dict.