### PR TITLE
docs: replace `cp .env.example .env` with `./setup-devices.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cd physical-ai-studio
 
 # Setup and run docker services
 cd application/docker
-cp .env.example .env
+./setup-devices.sh
 docker compose --profile xpu up # or use --profile cuda, --profile cpu
 ```
 


### PR DESCRIPTION
Without this docker may raise an error when staring the services with `docker compose up` if the default group in our docker compose file is not available.

## Type of Change

- [x] 📚 `docs` - Documentation
