### PR TITLE
fix: remove calibration volume mount from docker compose

### DIFF
--- a/application/docker/docker-compose.yaml
+++ b/application/docker/docker-compose.yaml
@@ -70,7 +70,6 @@ x-common: &common
     volumes:
       - physical-ai-studio-data:/app/data
       - physical-ai-studio-storage:/app/storage
-      - ${HOME}/.cache/huggingface/lerobot/calibration:/home/appuser/.cache/huggingface/lerobot/calibration:ro
 
     # --- Option 1: Privileged mode (active by default)
     # Grants full access to all host devices. Easiest setup, but the


### PR DESCRIPTION
Previously we needed this to load robot calibration, but we've since moved to storing calibration data into our own storage folder.

By removing this we avoid a bug where docker will create the calibration folder possibly with user `root:root`. If a user then uses `run.sh` to start the server instead of docker then they will get a permission error when trying to connect to robots.

Note that this issue does not happen with the physicalai storage and data folders due to these being volumes managed by docker.

## Type of Change

- [x] 🐞 fix - Bug fix
