### PR TITLE
fix: fix robot payload migration due to inconsistent capitalization

### DIFF
--- a/application/backend/src/alembic/versions/a1b2c3d4e5f6_robot_payload_json_column.py
+++ b/application/backend/src/alembic/versions/a1b2c3d4e5f6_robot_payload_json_column.py
@@ -38,7 +38,7 @@ def upgrade() -> None:
             {
                 "serial_number": serial_number or "",
             }
-            if robot_type in ("SO101_Follower", "SO101_LEADER")
+            if robot_type in ("SO101_FOLLOWER", "SO101_LEADER", "SO101_Leader", "SO101_Follower")
             else {
                 "connection_string": connection_string or "",
             }


### PR DESCRIPTION
The database migration was using an inconsistent capitalization check on the robot type, leading to a mismatch when converting our previous robot schema to the new payload based one.

One thing that to me was unexpected is that in SQLite the robot type was in all uppercase even though the enum used a mix of lower and uppercase. I've updated the migration so that it should be able to handle both. Though it would be good to also figure out if we can make this more consistent.

This fixes one part of the issues mentioned in #316 (the project page was no longer loading after this migration was applied)

## Type of Change

- [x] 🐞 `fix` - Bug fix
