### PR TITLE
refactor: move logs to footer to make them more visible

### DIFF
--- a/application/ui/src/features/jobs/footer/job-status.tsx
+++ b/application/ui/src/features/jobs/footer/job-status.tsx
@@ -4,32 +4,7 @@ import { Flex, ProgressCircle, Text, View } from '@geti-ui/ui';
 import useWebSocket from 'react-use-websocket';
 
 import { fetchClient } from '../../../api/client';
-import { SchemaDatasetImportJob, SchemaTrainJob } from '../../../api/openapi-spec';
-
-const DatasetImportJobStatus = ({ job }: { job: SchemaDatasetImportJob }) => {
-    if (job?.status !== 'pending' && job?.status !== 'running') {
-        return null;
-    }
-
-    return (
-        <Flex gap='size-100'>
-            <Text
-                UNSAFE_style={{
-                    color: 'var(--spectrum-global-color-gray-700)',
-                }}
-            >
-                Status:
-            </Text>
-            <Text
-                UNSAFE_style={{
-                    color: 'var(--spectrum-global-color-gray-800)',
-                }}
-            >
-                Importing dataset
-            </Text>
-        </Flex>
-    );
-};
+import { SchemaTrainJob } from '../../../api/openapi-spec';
 
 const TrainingJobStatus = ({ job }: { job: SchemaTrainJob }) => {
     if (job?.status !== 'pending' && job?.status !== 'running') {
@@ -67,13 +42,13 @@ const TrainingJobStatus = ({ job }: { job: SchemaTrainJob }) => {
 };
 
 export const JobStatus = () => {
-    const [job, setJob] = useState<null | SchemaTrainJob | SchemaDatasetImportJob>(null);
+    const [job, setJob] = useState<null | SchemaTrainJob>(null);
 
     const onMessage = ({ data }: WebSocketEventMap['message']) => {
         const message_data = JSON.parse(data);
 
         if (message_data.event === 'JOB_UPDATE') {
-            setJob(message_data.data as SchemaTrainJob | SchemaDatasetImportJob);
+            setJob(message_data.data as SchemaTrainJob);
         }
     };
 
@@ -84,10 +59,6 @@ export const JobStatus = () => {
 
     if (job?.type === 'training') {
         return <TrainingJobStatus job={job} />;
-    }
-
-    if (job?.type === 'dataset_import') {
-        return <DatasetImportJobStatus job={job} />;
     }
 
     return null;

--- a/application/ui/src/features/jobs/footer/job-status.tsx
+++ b/application/ui/src/features/jobs/footer/job-status.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+
+import { Flex, ProgressCircle, Text, View } from '@geti-ui/ui';
+import useWebSocket from 'react-use-websocket';
+
+import { fetchClient } from '../../../api/client';
+import { SchemaDatasetImportJob, SchemaTrainJob } from '../../../api/openapi-spec';
+
+const DatasetImportJobStatus = ({ job }: { job: SchemaDatasetImportJob }) => {
+    if (job?.status !== 'pending' && job?.status !== 'running') {
+        return null;
+    }
+
+    return (
+        <Flex gap='size-100'>
+            <Text
+                UNSAFE_style={{
+                    color: 'var(--spectrum-global-color-gray-700)',
+                }}
+            >
+                Status:
+            </Text>
+            <Text
+                UNSAFE_style={{
+                    color: 'var(--spectrum-global-color-gray-800)',
+                }}
+            >
+                Importing dataset
+            </Text>
+        </Flex>
+    );
+};
+
+const TrainingJobStatus = ({ job }: { job: SchemaTrainJob }) => {
+    if (job?.status !== 'pending' && job?.status !== 'running') {
+        return null;
+    }
+
+    return (
+        <View width='100%' height='100%'>
+            <Flex gap='size-100' alignItems={'center'} height='100%'>
+                <ProgressCircle value={job.progress} size='S' />
+                <Text
+                    UNSAFE_style={{
+                        color: 'var(--spectrum-global-color-gray-700)',
+                    }}
+                >
+                    Status:
+                </Text>
+                <Text
+                    UNSAFE_style={{
+                        color: 'var(--spectrum-global-color-gray-800)',
+                    }}
+                >
+                    Training {job.payload.model_name}
+                </Text>
+                <Text
+                    UNSAFE_style={{
+                        color: 'var(--spectrum-global-color-gray-700)',
+                    }}
+                >
+                    {job.progress}%
+                </Text>
+            </Flex>
+        </View>
+    );
+};
+
+export const JobStatus = () => {
+    const [job, setJob] = useState<null | SchemaTrainJob | SchemaDatasetImportJob>(null);
+
+    const onMessage = ({ data }: WebSocketEventMap['message']) => {
+        const message_data = JSON.parse(data);
+
+        if (message_data.event === 'JOB_UPDATE') {
+            setJob(message_data.data as SchemaTrainJob | SchemaDatasetImportJob);
+        }
+    };
+
+    const {} = useWebSocket(fetchClient.PATH('/api/jobs/ws'), {
+        shouldReconnect: () => true,
+        onMessage: (event: WebSocketEventMap['message']) => onMessage(event),
+    });
+
+    if (job?.type === 'training') {
+        return <TrainingJobStatus job={job} />;
+    }
+
+    if (job?.type === 'dataset_import') {
+        return <DatasetImportJobStatus job={job} />;
+    }
+
+    return null;
+};

--- a/application/ui/src/features/projects/menu/projects-list-panel.component.tsx
+++ b/application/ui/src/features/projects/menu/projects-list-panel.component.tsx
@@ -1,12 +1,9 @@
-import { useState } from 'react';
-
 import {
     ActionButton,
     ActionMenu,
     ButtonGroup,
     Content,
     Dialog,
-    DialogContainer,
     DialogTrigger,
     Divider,
     Flex,
@@ -20,11 +17,10 @@ import {
     Text,
     View,
 } from '@geti-ui/ui';
-import { ChevronRightSmallLight, LogsIcon } from '@geti-ui/ui/icons';
+import { ChevronRightSmallLight } from '@geti-ui/ui/icons';
 
 import { $api } from '../../../api/client';
 import { paths } from '../../../router';
-import { LogsDialog } from '../../logs/logs-dialog';
 import { NewProjectLink } from '../list/new-project-link.component';
 import { useProjectId } from './../use-project';
 
@@ -106,90 +102,61 @@ export const ProjectsListPanel = () => {
     });
     const otherProjects = projects.filter(({ id }) => id !== project_id);
 
-    const [logsIsOpen, setLogsIsOpen] = useState(false);
-
     const selectedProjectName = project.name;
 
     return (
-        <>
-            <DialogTrigger type='popover' hideArrow>
-                <SelectedProjectButton name={selectedProjectName} />
+        <DialogTrigger type='popover' hideArrow>
+            <SelectedProjectButton name={selectedProjectName} />
 
-                {(close) => {
-                    const handleOpenLogs = () => {
-                        close();
-                        setLogsIsOpen(true);
-                    };
-                    return (
-                        <Dialog width={'size-4600'} UNSAFE_className={styles.dialog} onDismiss={close}>
-                            <Header>
-                                <Flex
-                                    direction={'column'}
-                                    justifyContent={'center'}
-                                    width={'100%'}
-                                    alignItems={'center'}
-                                >
-                                    <PhotoPlaceholder
-                                        name={selectedProjectName}
-                                        indicator={selectedProjectName}
-                                        height={'size-1000'}
-                                        width={'size-1000'}
-                                    />
-                                    <Heading level={2} marginBottom={0}>
-                                        {selectedProjectName}
-                                    </Heading>
-                                </Flex>
-                            </Header>
-                            <Content UNSAFE_className={styles.panelContent}>
-                                {otherProjects.length > 0 && (
-                                    <>
-                                        <Divider size={'S'} marginY={'size-200'} />
-                                        <ProjectsList projects={otherProjects} />
-                                    </>
-                                )}
-                                <Divider size={'S'} marginTop={'size-200'} />
+            {(close) => {
+                return (
+                    <Dialog width={'size-4600'} UNSAFE_className={styles.dialog} onDismiss={close}>
+                        <Header>
+                            <Flex direction={'column'} justifyContent={'center'} width={'100%'} alignItems={'center'}>
+                                <PhotoPlaceholder
+                                    name={selectedProjectName}
+                                    indicator={selectedProjectName}
+                                    height={'size-1000'}
+                                    width={'size-1000'}
+                                />
+                                <Heading level={2} marginBottom={0}>
+                                    {selectedProjectName}
+                                </Heading>
+                            </Flex>
+                        </Header>
+                        <Content UNSAFE_className={styles.panelContent}>
+                            {otherProjects.length > 0 && (
+                                <>
+                                    <Divider size={'S'} marginY={'size-200'} />
+                                    <ProjectsList projects={otherProjects} />
+                                </>
+                            )}
+                            <Divider size={'S'} marginTop={'size-200'} />
 
-                                <Link
-                                    href={paths.openapi({})}
-                                    UNSAFE_style={{ color: 'white', textDecoration: 'none' }}
-                                    UNSAFE_className={styles.openApiLink}
-                                >
-                                    <Flex alignItems={'center'} gap='size-100'>
+                            <Link
+                                href={paths.openapi({})}
+                                UNSAFE_style={{ color: 'white', textDecoration: 'none' }}
+                                UNSAFE_className={styles.openApiLink}
+                            >
+                                <Flex alignItems={'center'} gap='size-100'>
+                                    <Icon>
                                         <ChevronRightSmallLight fill='white' />
-                                        OpenAPI Spec
-                                    </Flex>
-                                </Link>
+                                    </Icon>
+                                    OpenAPI Spec
+                                </Flex>
+                            </Link>
 
-                                <Divider size={'S'} />
+                            <Divider size={'S'} />
 
-                                <ActionButton
-                                    isQuiet
-                                    onPress={handleOpenLogs}
-                                    UNSAFE_className={styles.openApiLink}
-                                    width='100%'
-                                    height='size-700'
-                                >
-                                    <Flex gap='size-50' marginEnd='size-100' width='100%'>
-                                        <Icon size='S'>
-                                            <LogsIcon />
-                                        </Icon>
-                                        Logs
-                                    </Flex>
-                                </ActionButton>
+                            <Divider size={'S'} marginBottom={'size-200'} />
+                        </Content>
 
-                                <Divider size={'S'} marginBottom={'size-200'} />
-                            </Content>
-
-                            <ButtonGroup UNSAFE_className={styles.panelButtons}>
-                                <NewProjectLink className={styles.addProjectButton} />
-                            </ButtonGroup>
-                        </Dialog>
-                    );
-                }}
-            </DialogTrigger>
-            <DialogContainer onDismiss={() => setLogsIsOpen(false)} type='fullscreen'>
-                {logsIsOpen && <LogsDialog close={() => setLogsIsOpen(false)} />}
-            </DialogContainer>
-        </>
+                        <ButtonGroup UNSAFE_className={styles.panelButtons}>
+                            <NewProjectLink className={styles.addProjectButton} />
+                        </ButtonGroup>
+                    </Dialog>
+                );
+            }}
+        </DialogTrigger>
     );
 };

--- a/application/ui/src/routes/projects/project.layout.tsx
+++ b/application/ui/src/routes/projects/project.layout.tsx
@@ -1,8 +1,10 @@
 import { Suspense } from 'react';
 
-import { Flex, Grid, Item, Link, Loading, TabList, Tabs, View } from '@geti-ui/ui';
+import { ActionButton, DialogTrigger, Flex, Grid, Icon, Item, Link, Loading, TabList, Tabs, View } from '@geti-ui/ui';
+import { Manifest } from '@geti-ui/ui/icons';
 import { Outlet, useLocation } from 'react-router';
 
+import { LogsDialog } from '../../features/logs/logs-dialog';
 import { ProjectsListPanel } from '../../features/projects/menu/projects-list-panel.component';
 import { useProjectId } from '../../features/projects/use-project';
 import { paths } from '../../router';
@@ -51,7 +53,7 @@ const Header = ({ project_id }: { project_id: string }) => {
                         </Flex>
                     </Item>
                 </TabList>
-                <Flex alignItems={'center'} height={'100%'} marginStart='auto'>
+                <Flex alignItems={'center'} height={'100%'} marginStart='auto' gap='size-100'>
                     <ProjectsListPanel />
                 </Flex>
             </Flex>
@@ -73,6 +75,39 @@ const getMainPageInProjectUrl = (pathname: string) => {
     }
 };
 
+const Footer = () => {
+    return (
+        <View
+            gridArea={'footer'}
+            borderTopColor={'gray-75'}
+            borderTopWidth={'thin'}
+            borderBottomColor={'gray-75'}
+            borderBottomWidth={'thin'}
+            paddingX='size-100'
+            paddingY='size-25'
+        >
+            <Flex alignItems={'center'} height='100%' gap='size-100'>
+                <View>
+                    <DialogTrigger type='fullscreen'>
+                        <ActionButton
+                            isQuiet
+                            UNSAFE_style={{
+                                paddingRight: 'var(--spectrum-global-dimension-size-100)',
+                            }}
+                        >
+                            <Icon>
+                                <Manifest />
+                            </Icon>
+                            Logs
+                        </ActionButton>
+                        {(close) => <LogsDialog close={close} />}
+                    </DialogTrigger>
+                </View>
+            </Flex>
+        </View>
+    );
+};
+
 export const ProjectLayout = () => {
     const { project_id } = useProjectId();
     const { pathname } = useLocation();
@@ -82,9 +117,10 @@ export const ProjectLayout = () => {
     return (
         <Tabs aria-label='Header navigation' selectedKey={pageName} UNSAFE_style={{ height: '100%', minHeight: 0 }}>
             <Grid
-                areas={['header', 'subheader', 'content']}
+                areas={['header', 'subheader', 'content', 'footer']}
                 UNSAFE_style={{
-                    gridTemplateRows: 'var(--spectrum-global-dimension-size-800, 4rem) min-content auto',
+                    gridTemplateRows:
+                        'var(--spectrum-global-dimension-size-800, 4rem) min-content auto var(--spectrum-global-dimension-size-400)',
                 }}
                 minHeight={0}
                 height={'100%'}
@@ -95,6 +131,7 @@ export const ProjectLayout = () => {
                         <Outlet />
                     </Suspense>
                 </View>
+                <Footer />
             </Grid>
         </Tabs>
     );

--- a/application/ui/src/routes/projects/project.layout.tsx
+++ b/application/ui/src/routes/projects/project.layout.tsx
@@ -1,9 +1,11 @@
 import { Suspense } from 'react';
 
+import { Divider } from '@adobe/react-spectrum';
 import { ActionButton, DialogTrigger, Flex, Grid, Icon, Item, Link, Loading, TabList, Tabs, View } from '@geti-ui/ui';
 import { Manifest } from '@geti-ui/ui/icons';
 import { Outlet, useLocation } from 'react-router';
 
+import { JobStatus } from '../../features/jobs/footer/job-status';
 import { LogsDialog } from '../../features/logs/logs-dialog';
 import { ProjectsListPanel } from '../../features/projects/menu/projects-list-panel.component';
 import { useProjectId } from '../../features/projects/use-project';
@@ -103,6 +105,8 @@ const Footer = () => {
                         {(close) => <LogsDialog close={close} />}
                     </DialogTrigger>
                 </View>
+                <Divider orientation='vertical' size='S' />
+                <JobStatus />
             </Flex>
         </View>
     );
@@ -120,6 +124,7 @@ export const ProjectLayout = () => {
                 areas={['header', 'subheader', 'content', 'footer']}
                 UNSAFE_style={{
                     gridTemplateRows:
+                        // eslint-disable-next-line max-len
                         'var(--spectrum-global-dimension-size-800, 4rem) min-content auto var(--spectrum-global-dimension-size-400)',
                 }}
                 minHeight={0}


### PR DESCRIPTION
This PR adds a footer to the project layout and uses it to show a button to open the application logs as well as show training status:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/81b20139-f76b-448a-8044-2b4b6a890ed2" />

Later I'd also like to add a "jobs management" panel here where users can more easily find failed, running and pending jobs as well as their associated logs.

(in the screenshot I also removed the "Models" heading, but I reverted that as it made the empty models page look too empty, will extract that in a separate PR)

## Type of Change

- [x] ♻️ `refactor` - Code refactoring
