### PR TITLE
chore: remove heading from models page

### DIFF
--- a/application/ui/src/routes/datasets/index.tsx
+++ b/application/ui/src/routes/datasets/index.tsx
@@ -20,7 +20,7 @@ const Datasets = ({ datasets }: DatasetsProps) => {
 
     if (datasets.length === 0) {
         return (
-            <Flex margin={'size-200'} direction={'column'} flex>
+            <Flex margin={'size-200'} direction={'column'} flex height='100%'>
                 <IllustratedMessage>
                     <EmptyIllustration />
                     <Content> Currently there are datasets available. </Content>

--- a/application/ui/src/routes/models/index.tsx
+++ b/application/ui/src/routes/models/index.tsx
@@ -113,10 +113,12 @@ const JobList = ({ jobs, onViewLogs }: { jobs: SchemaTrainJob[]; onViewLogs: (jo
     );
 };
 
-const useProjectJobs = (project_id: string): SchemaJob[] => {
-    const { data: allJobs } = $api.useQuery('get', '/api/jobs');
+const useProjectJobs = (project_id: string): SchemaTrainJob[] => {
+    const { data: allJobs = [] } = $api.useQuery('get', '/api/jobs');
 
-    return allJobs?.filter((j) => j.project_id === project_id) ?? [];
+    return allJobs
+        .filter((job) => job.project_id === project_id)
+        .filter((job): job is SchemaTrainJob => job.type === 'training');
 };
 
 export const Index = () => {
@@ -126,7 +128,6 @@ export const Index = () => {
     });
 
     const jobs = useProjectJobs(project_id);
-    const trainingJobs = jobs.filter((m) => m.type === 'training') as SchemaTrainJob[];
 
     const [retrainModel, setRetrainModel] = useState<SchemaModel | null>(null);
     const [logsSourceId, setLogsSourceId] = useState<string | undefined>();
@@ -173,7 +174,7 @@ export const Index = () => {
     };
 
     const hasModels = models.length > 0;
-    const hasJobs = trainingJobs.length > 0;
+    const hasJobs = jobs.length > 0;
     const showIllustratedMessage = !hasModels && !hasJobs;
 
     return (
@@ -210,7 +211,7 @@ export const Index = () => {
                             </DialogTrigger>
                         </Flex>
                         <JobList
-                            jobs={trainingJobs}
+                            jobs={jobs}
                             onViewLogs={(job) => {
                                 setLogsSourceId(job.id);
                             }}
@@ -218,7 +219,7 @@ export const Index = () => {
                         {hasModels && (
                             <ModelList
                                 models={models}
-                                jobs={trainingJobs}
+                                jobs={jobs}
                                 onRetrain={setRetrainModel}
                                 onViewLogs={handleViewLogs}
                             />

--- a/application/ui/src/routes/models/index.tsx
+++ b/application/ui/src/routes/models/index.tsx
@@ -5,13 +5,11 @@ import {
     Content,
     DialogContainer,
     DialogTrigger,
-    Divider,
     Flex,
     Heading,
     IllustratedMessage,
     Text,
     View,
-    Well,
 } from '@geti-ui/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import useWebSocket from 'react-use-websocket';
@@ -128,6 +126,8 @@ export const Index = () => {
     });
 
     const jobs = useProjectJobs(project_id);
+    const trainingJobs = jobs.filter((m) => m.type === 'training') as SchemaTrainJob[];
+
     const [retrainModel, setRetrainModel] = useState<SchemaModel | null>(null);
     const [logsSourceId, setLogsSourceId] = useState<string | undefined>();
 
@@ -173,16 +173,14 @@ export const Index = () => {
     };
 
     const hasModels = models.length > 0;
-    const hasJobs = jobs.length > 0;
+    const hasJobs = trainingJobs.length > 0;
     const showIllustratedMessage = !hasModels && !hasJobs;
 
     return (
         <Flex height='100%'>
             <Flex margin={'size-200'} direction={'column'} flex>
-                <Heading level={4}>Models</Heading>
-                <Divider size='S' marginTop='size-100' marginBottom={'size-100'} />
                 {showIllustratedMessage ? (
-                    <Well flex UNSAFE_style={{ backgroundColor: 'rgb(60,62,66)' }}>
+                    <Flex margin={'size-200'} direction={'column'} flex height='100%'>
                         <IllustratedMessage>
                             <EmptyIllustration />
                             <Content> Currently there are no trained models available. </Content>
@@ -195,7 +193,7 @@ export const Index = () => {
                                 </DialogTrigger>
                             </View>
                         </IllustratedMessage>
-                    </Well>
+                    </Flex>
                 ) : (
                     <View margin={'size-300'}>
                         <Flex justifyContent={'end'} marginBottom='size-300'>
@@ -212,7 +210,7 @@ export const Index = () => {
                             </DialogTrigger>
                         </Flex>
                         <JobList
-                            jobs={jobs.filter((m) => m.type === 'training') as SchemaTrainJob[]}
+                            jobs={trainingJobs}
                             onViewLogs={(job) => {
                                 setLogsSourceId(job.id);
                             }}
@@ -220,7 +218,7 @@ export const Index = () => {
                         {hasModels && (
                             <ModelList
                                 models={models}
-                                jobs={jobs}
+                                jobs={trainingJobs}
                                 onRetrain={setRetrainModel}
                                 onViewLogs={handleViewLogs}
                             />

--- a/application/ui/src/routes/projects/project.layout.tsx
+++ b/application/ui/src/routes/projects/project.layout.tsx
@@ -16,7 +16,7 @@ const Header = ({ project_id }: { project_id: string }) => {
             <Flex height='100%' alignItems={'center'} marginX='1rem' gap='size-200'>
                 <Link href='/' isQuiet variant='overBackground'>
                     <View marginEnd='size-200' maxWidth={'10ch'}>
-                        Physical AI Studio
+                        <span style={{ whiteSpace: 'nowrap' }}>Physical AI</span> <span>Studio</span>
                     </View>
                 </Link>
 


### PR DESCRIPTION
Adding some minor visual tweaks before recording a video of the application.

- Small visual improvements that make the empty dataset and model page feel more consistent.
- The "Models" heading when the user does have models has been removed as it didn't add much.

## Type of Change

- [x] 🔧 `chore` - Maintenance

## Screenshots

| **With models** | **Empty models** | **Empty dataset** |
|------------|-----------|-----------|
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/43ef8f0c-1e4f-455a-af28-c337e46622d1" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b344548f-7a2c-4806-a40a-ed55af1bba12" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/55cf900c-e2ec-4932-91ac-fee7d2a915fa" /> |





