### PR TITLE
chore(ci): add step-security/harden-runner and cooldown period

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,6 +56,9 @@
   ignorePresets: [":prHourlyLimit2"],
   prHourlyLimit: 10,
 
+  // Apply a default blanket cooldown of 7 days to all dependencies
+  minimumReleaseAge: "7 days",
+
   packageRules: [
     // Disable non-security upgrades for pypi, except lock file update
     {

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -23,6 +23,12 @@ jobs:
       github.event.sender.login == 'oep-renovate[bot]'
       }}
     steps:
+      - &harden-runner
+        name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Capture Commit SHA
         id: capture_sha
         run: |
@@ -48,6 +54,8 @@ jobs:
       name: auto-approve
       deployment: false
     runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    steps:
+      - *harden-runner
     steps:
       - name: Debug
         env:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,6 +20,12 @@ jobs:
     permissions:
       contents: read
     steps:
+      - &harden-runner
+        name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - &checkout
         name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,6 +50,8 @@ jobs:
     permissions:
       contents: read # to checkout code
     steps:
+      - *harden-runner
+
       - *checkout
 
       - &set-up-python
@@ -71,6 +79,8 @@ jobs:
     permissions:
       contents: read # to checkout code
     steps:
+      - *harden-runner
+
       - *checkout
 
       - *set-up-python
@@ -104,6 +114,8 @@ jobs:
       CHECKS: ${{ join(needs.*.result, ' ') }}
     if: always() && !cancelled()
     steps:
+      - *harden-runner
+
       - name: Check jobs results
         run: |
           for check in ${CHECKS}; do

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,11 @@ jobs:
           - language: javascript-typescript
             build-mode: none
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,12 @@ jobs:
     permissions:
       contents: read
     steps:
+      - &harden-runner
+        name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - &checkout
         name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -53,6 +59,8 @@ jobs:
         device: [cpu, xpu, cuda]
 
     steps:
+      - *harden-runner
+
       - *checkout
 
       - name: Log in to Container Registry

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,11 @@ jobs:
         device: [cpu, xpu, cuda]
 
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -22,6 +22,12 @@ jobs:
     permissions:
       contents: read
     steps:
+      - &harden-runner
+        name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - &checkout
         name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,6 +51,8 @@ jobs:
     permissions:
       contents: read
     steps:
+      - *harden-runner
+
       - *checkout
 
       - &set-up-python
@@ -72,6 +80,8 @@ jobs:
     permissions:
       contents: read
     steps:
+      - *harden-runner
+
       - *checkout
 
       - *set-up-python
@@ -113,6 +123,8 @@ jobs:
       CHECKS: ${{ join(needs.*.result, ' ') }}
     if: always() && !cancelled()
     steps:
+      - *harden-runner
+
       - name: Check jobs results
         run: |
           for check in ${CHECKS}; do

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -16,6 +16,11 @@ jobs:
   npm-audit-fix:
     runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,6 +12,11 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Check PR title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/publish-rc-app.yml
+++ b/.github/workflows/publish-rc-app.yml
@@ -17,6 +17,12 @@ jobs:
     outputs:
       rc_version: "${{ steps.validate.outputs.rc_version }}"
     steps:
+      - &harden-runner
+        name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -157,6 +163,8 @@ jobs:
         device: [cpu, xpu, cuda]
 
     steps:
+      - *harden-runner
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -31,6 +31,12 @@ jobs:
     permissions:
       contents: read
     steps:
+      - &harden-runner
+        name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout configuration
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -53,6 +59,8 @@ jobs:
     permissions:
       contents: read # to checkout code
     steps:
+      - *harden-runner
+
       - name: Checkout configuration
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -76,6 +84,8 @@ jobs:
       CHECKS: ${{ join(needs.*.result, ' ') }}
     if: always() && !cancelled()
     steps:
+      - *harden-runner
+
       - name: Check jobs results
         run: |
           for check in ${CHECKS}; do

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -55,6 +55,11 @@ jobs:
       contents: read
     runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,6 +22,11 @@ jobs:
       id-token: write
 
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,6 +17,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -49,6 +49,12 @@ jobs:
       contents: read
       security-events: write # Needed to upload the results to code-scanning dashboard
     steps:
+      - &harden-runner
+        name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - &checkout
         name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -69,6 +75,8 @@ jobs:
       contents: read
       security-events: write # Needed to upload the results to code-scanning dashboard
     steps:
+      - *harden-runner
+
       - *checkout
 
       - name: Run Bandit scan
@@ -87,6 +95,8 @@ jobs:
       contents: read
       security-events: write # Needed to upload the results to code-scanning dashboard
     steps:
+      - *harden-runner
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -109,6 +119,8 @@ jobs:
       contents: read
       security-events: write # Needed to upload the results to code-scanning dashboard
     steps:
+      - *harden-runner
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -131,6 +143,8 @@ jobs:
       matrix:
         ai-device: [cpu, cuda, xpu]
     steps:
+      - *harden-runner
+
       - name: Run container image scan (${{ matrix.ai-device }})
         uses: open-edge-platform/geti-ci/actions/trivy@7e686c1248b3939f8ee8e04e2612da727e379d91
         with:
@@ -153,6 +167,8 @@ jobs:
       matrix:
         ai-device: [cpu]
     steps:
+      - *harden-runner
+
       - name: Runner cleanup
         uses: open-edge-platform/geti-ci/actions/cleanup-runner@7e686c1248b3939f8ee8e04e2612da727e379d91
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Zizmor scan
-        uses: open-edge-platform/geti-ci/actions/zizmor@7e686c1248b3939f8ee8e04e2612da727e379d91
+        uses: open-edge-platform/geti-ci/actions/zizmor@0bed754fc7db24b5f9f15e7ead2eb4acdb0c7263 # zizmor/v0.1.2
         with:
           scan-scope: ${{ github.event_name == 'pull_request' && 'changed' || 'all' }}
           severity-level: ${{ github.event_name == 'pull_request' && 'MEDIUM' || 'LOW' }}

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -21,6 +21,12 @@ jobs:
     permissions:
       contents: read
     steps:
+      - &harden-runner
+        name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - &checkout
         name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,6 +51,8 @@ jobs:
     permissions:
       contents: read # to checkout code
     steps:
+      - *harden-runner
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -91,6 +99,8 @@ jobs:
     permissions:
       contents: read # to checkout code
     steps:
+      - *harden-runner
+
       - *checkout
 
       - &setup-node
@@ -137,6 +147,8 @@ jobs:
     permissions:
       contents: read # to checkout code
     steps:
+      - *harden-runner
+
       - *checkout
 
       - *setup-node
@@ -171,6 +183,8 @@ jobs:
     permissions:
       contents: read # to checkout code
     steps:
+      - *harden-runner
+
       - *checkout
 
       - *setup-node
@@ -197,6 +211,8 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-jammy@sha256:8a0360d39d1973be506dd59002904a774f6d697d4946c94063b3fd006461c8ff
     steps:
+      - *harden-runner
+
       - *checkout
 
       - *setup-node
@@ -242,6 +258,8 @@ jobs:
       CHECKS: ${{ join(needs.*.result, ' ') }}
     if: always() && !cancelled()
     steps:
+      - *harden-runner
+
       - name: Check jobs results
         run: |
           for check in ${CHECKS}; do


### PR DESCRIPTION
# Pull Request

## Description

This PR adds step-security/harden-runner action to audit outbound network connections in CI (latter it will be switched to blocking mode) and Renovate cooldown period to mitigate potential supply chain attacks.

## Type of Change

- [x] 🔧 `chore` - Maintenance