### PR TITLE
fix: Fix Inference in Studio

### DIFF
--- a/application/backend/src/control/environment_integration.py
+++ b/application/backend/src/control/environment_integration.py
@@ -132,7 +132,7 @@ class EnvironmentIntegration:
 
     def format_model_input_observation(self, raw_observation: dict, task: str | None = None) -> Observation:  # noqa: ARG002
         observation = self._remap_camera_observations(raw_observation)
-        state = np.array([[value for key, value in observation.items() if key in self.action_keys]], dtype=np.float32)
+        state = np.array([[observation[k] for k in self.action_keys]], dtype=np.float32)
         images: dict = {}
         for camera in self.environment.cameras:
             camera_name = camera.name.lower()

--- a/application/backend/src/control/sync_mixed_model_integration.py
+++ b/application/backend/src/control/sync_mixed_model_integration.py
@@ -29,6 +29,8 @@ class SyncMixedModelIntegration:
             self.queue_mixer.add(inference_result.data, offset)
             self.queue_mixer.lerp_duration = max(offset, 1)
 
+        # if self.use_synchronous we wait for the queue_mixer to empty first.
+        # else just send inference when its no longer busy.
         synchronous = self.queue_mixer.empty() if self.use_synchronous else True
 
         if synchronous and not self.inference_poller.busy:

--- a/application/backend/src/control/sync_mixed_model_integration.py
+++ b/application/backend/src/control/sync_mixed_model_integration.py
@@ -10,6 +10,7 @@ class SyncMixedModelIntegration:
     queue_mixer: QueueMixer
     inference_poller: InferencePoller
     fps: int
+    use_synchronous: bool = True
 
     def __init__(self, model_worker: ModelWorker, fps: int):
         self.model_worker = model_worker
@@ -28,7 +29,9 @@ class SyncMixedModelIntegration:
             self.queue_mixer.add(inference_result.data, offset)
             self.queue_mixer.lerp_duration = max(offset, 1)
 
-        if not self.inference_poller.busy:
+        synchronous = self.queue_mixer.empty() if self.use_synchronous else True
+
+        if synchronous and not self.inference_poller.busy:
             self.inference_poller.run_inference(observation)
 
         if not self.queue_mixer.empty():

--- a/application/backend/tests/control/test_environment_integration.py
+++ b/application/backend/tests/control/test_environment_integration.py
@@ -60,6 +60,25 @@ class TestInferenceEnvironmentIntegration:
         assert "front" in phy_ai_obs.images
         assert "grabber" in phy_ai_obs.images
 
+    def test_state_values_follow_action_keys_order_not_dict_insertion_order(
+        self, inference_environment_integration: EnvironmentIntegration
+    ):
+        action_keys = inference_environment_integration.action_keys
+        unique_values = {key: float(i) for i, key in enumerate(action_keys)}
+
+        # Build observation with joint keys in reversed insertion order — differs from action_keys order.
+        # The old code (iterating observation.items()) would have produced reversed state values.
+        observation = {
+            **{key: unique_values[key] for key in reversed(action_keys)},
+            "3ed60255-04ae-407b-8e2c-c3281847a4e0": np.zeros([480, 640, 3], dtype=np.uint8),
+            "4629e172-2aa7-4fde-86b1-e19eb1d210ff": np.zeros([480, 640, 3], dtype=np.uint8),
+        }
+
+        result = inference_environment_integration.format_model_input_observation(observation)
+
+        expected = [unique_values[k] for k in action_keys]
+        np.testing.assert_array_equal(result.state[0], expected)
+
     def test_transform_observation_to_report_to_ui(
         self, inference_environment_integration: EnvironmentIntegration, event_loop
     ):


### PR DESCRIPTION
Bug was caused by incorrect state tensor. Used observation.items to define the order, which in python is not locked in some predefined order.

Also disable async inference since we need to revisit RTC.