### PR TITLE
fix: add a workaround to get feature type from lerobot weights

### DIFF
--- a/library/src/physicalai/policies/pi05/pretrained_utils.py
+++ b/library/src/physicalai/policies/pi05/pretrained_utils.py
@@ -155,9 +155,11 @@ def parse_preprocessor_stats(
         # the normalizer actually uses at runtime.
         for feat_name, feat_stats in grouped.items():
             shape = resolve_feature_shape(feat_name, hf_config, feat_stats)
+            ftype = "VISUAL" if "observation.image" in feat_name.lower() else "UNKNOWN"
             entry: dict[str, Any] = {
                 "name": feat_name,
                 "shape": shape,
+                "type": ftype,
             }
             for stat_key in ("mean", "std", "q01", "q99", "min", "max"):
                 if stat_key in feat_stats and isinstance(feat_stats[stat_key], list):


### PR DESCRIPTION
# Pull Request

## Description

- pi05 export fails if feature type is not specified in the input `dataset_stats`
- this PR provides a workaround to enable some benchmarking scenarios

## Type of Change

- [x] 🐞 `fix` - Bug fix
