### PR TITLE
fix: set correct lightening strategy for xpu

### DIFF
--- a/application/backend/src/models/utils.py
+++ b/application/backend/src/models/utils.py
@@ -3,7 +3,6 @@
 
 from pathlib import Path
 
-import torch
 from physicalai.inference import InferenceModel
 from physicalai.policies import ACT, Pi0, Pi05, SmolVLA
 from physicalai.policies.base import Policy
@@ -27,6 +26,8 @@ def load_policy(model: Model, *, compile_model: bool = False) -> Policy:
         raise ValueError(f"Policy {model.policy} not implemented.")
 
     if compile_model:
+        import torch
+
         compile_mode = getattr(policy.config, "compile_mode", "default")
         policy.forward = torch.compile(policy.forward, mode=compile_mode)  # type: ignore[method-assign]
     return policy

--- a/application/backend/src/utils/device.py
+++ b/application/backend/src/utils/device.py
@@ -34,7 +34,11 @@ def get_lightning_strategy(device: str | None = None) -> str:
     hardware auto-detection.
     """
     if device is not None and device == "xpu":
-        import physicalai.devices.xpu  # noqa: F401
-
         return "xpu_single"
+
+    import torch
+
+    if device is None and torch.xpu.is_available():
+        return "xpu_single"
+
     return "auto"

--- a/application/ui/src/routes/models/train-model-dialog.tsx
+++ b/application/ui/src/routes/models/train-model-dialog.tsx
@@ -21,7 +21,6 @@ import {
     Picker,
     StatusLight,
     Text,
-    TextField,
     View,
 } from '@geti-ui/ui';
 
@@ -244,7 +243,7 @@ const TrainingParameters = ({
                     maxValue={256}
                     step={1}
                     width='100%'
-                    isDisabled={autoScaleBatchSize || isAutoScaleBatchDisabled}
+                    isDisabled={autoScaleBatchSize}
                     flex
                 />
                 <Flex direction='row' gap='size-100' alignItems='center'>
@@ -365,14 +364,12 @@ const TrainingParameters = ({
 export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: TrainModelDialogProps) => {
     const bestDevice = useBestTrainingDevice();
 
-    const defaultName = baseModel?.name ?? '';
     const defaultDatasetId = baseModel?.dataset_id ?? null;
     const extraPayload = baseModel ? { base_model_id: baseModel.id! } : undefined;
 
     const [selectedPolicy, setSelectedPolicy] = useState<string>(baseModel?.policy ?? 'act');
     const { datasets, id: projectId } = useProject();
 
-    const [name, setName] = useState<string>(defaultName);
     const [selectedDataset, setSelectedDataset] = useState<Key | null>(defaultDatasetId);
     const [maxSteps, setMaxSteps] = useState<number>(defaultMaxSteps);
     const [batchSize, setBatchSize] = useState<number>(8);
@@ -400,6 +397,8 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: 
         if (!dataset_id || !selectedPolicy) {
             return;
         }
+
+        const name = baseModel?.name ?? MODELS.find((policy) => policy.id === selectedPolicy)?.name ?? '';
 
         const payload: SchemaJob['payload'] = {
             dataset_id,
@@ -439,8 +438,6 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: 
                     validationBehavior='native'
                 >
                     <Flex direction='column' gap='size-200' width='100%'>
-                        <TextField label='Name' value={name} onChange={setName} width='100%' />
-
                         <Picker
                             label='Dataset'
                             selectedKey={selectedDataset}


### PR DESCRIPTION
When device is `None` we would set the strategy to auto which then triggers a `RuntimeError`,
```
Device should be xpu, got cpu instead
```

I've also included minor UI fixes due to merge conflicts from previous PR.

## Type of Change

- [x] 🐞 `fix` - Bug fix
