### PR TITLE
feat: ONNX export for SmolVLA

### DIFF
--- a/library/src/physicalai/export/backends.py
+++ b/library/src/physicalai/export/backends.py
@@ -46,11 +46,22 @@ class ExportBackend(StrEnum):
 
 @dataclass
 class ExportParameters:
-    """Parameters for exporting a model."""
+    """Parameters for exporting a model.
+
+    Attributes:
+        exporter_kwargs: Keyword arguments for the export backend.
+        preprocessors_specs: Specifications for inference preprocessors.
+        postprocessors_specs: Specifications for inference postprocessors.
+        post_export_hooks: Callables invoked in order after the model has been
+            written to disk. Each hook receives the path to the exported file
+            and may modify the file in place (e.g. to patch the graph for a
+            specific runtime). Signature: ``(export_path: str | Path) -> None``.
+    """
 
     exporter_kwargs: dict = field(default_factory=dict)
     preprocessors_specs: list = field(default_factory=list)
     postprocessors_specs: list = field(default_factory=list)
+    post_export_hooks: list[Callable[[str | Path], None]] = field(default_factory=list)
 
 
 @dataclass
@@ -59,14 +70,9 @@ class ONNXExportParameters(ExportParameters):
 
     Attributes:
         export_tokenizer: Whether to export the tokenizer alongside the model.
-        post_export_hook: Optional callable invoked after the ONNX model has been
-            written to disk. It receives the path to the exported ``.onnx`` file
-            and may modify the file in place (e.g. to patch the graph for a
-            specific runtime). Signature: ``(onnx_path: str | Path) -> None``.
     """
 
     export_tokenizer: bool = False
-    post_export_hook: Callable[[str | Path], None] | None = None
 
 
 @dataclass

--- a/library/src/physicalai/export/backends.py
+++ b/library/src/physicalai/export/backends.py
@@ -3,8 +3,10 @@
 
 """Export backends enumeration and parameters."""
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pathlib import Path
 from typing import Literal
 
 #: Supported ExecuTorch delegate backends.
@@ -53,9 +55,18 @@ class ExportParameters:
 
 @dataclass
 class ONNXExportParameters(ExportParameters):
-    """Parameters specific to ONNX export."""
+    """Parameters specific to ONNX export.
+
+    Attributes:
+        export_tokenizer: Whether to export the tokenizer alongside the model.
+        post_export_hook: Optional callable invoked after the ONNX model has been
+            written to disk. It receives the path to the exported ``.onnx`` file
+            and may modify the file in place (e.g. to patch the graph for a
+            specific runtime). Signature: ``(onnx_path: str | Path) -> None``.
+    """
 
     export_tokenizer: bool = False
+    post_export_hook: Callable[[str | Path], None] | None = None
 
 
 @dataclass

--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -291,7 +291,6 @@ class ExportablePolicyMixin:
                 hook(model_path)
 
         if extra_model_args.export_tokenizer:
-            print("Exporting tokenizer to ONNX format...")
             onnx_tokenizer = gen_processing_models(
                 self._preprocessor.tokenizer,
                 pre_kwargs={

--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -286,6 +286,9 @@ class ExportablePolicyMixin:
             **extra_export_kwargs,
         )
 
+        if extra_model_args.post_export_hook is not None:
+            extra_model_args.post_export_hook(model_path)
+
         if extra_model_args.export_tokenizer:
             onnx_tokenizer = gen_processing_models(
                 self._preprocessor.tokenizer,

--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -279,7 +279,6 @@ class ExportablePolicyMixin:
         arg_name = self._get_forward_arg_name()
 
         self.model.eval()
-        '''
         self._onnx_core_export_step(
             model_path=model_path,
             input_sample=input_sample,
@@ -290,7 +289,6 @@ class ExportablePolicyMixin:
         if extra_model_args.post_export_hooks:
             for hook in extra_model_args.post_export_hooks:
                 hook(model_path)
-        '''
 
         if extra_model_args.export_tokenizer:
             print("Exporting tokenizer to ONNX format...")

--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -279,6 +279,7 @@ class ExportablePolicyMixin:
         arg_name = self._get_forward_arg_name()
 
         self.model.eval()
+        '''
         self._onnx_core_export_step(
             model_path=model_path,
             input_sample=input_sample,
@@ -286,10 +287,13 @@ class ExportablePolicyMixin:
             **extra_export_kwargs,
         )
 
-        if extra_model_args.post_export_hook is not None:
-            extra_model_args.post_export_hook(model_path)
+        if extra_model_args.post_export_hooks:
+            for hook in extra_model_args.post_export_hooks:
+                hook(model_path)
+        '''
 
         if extra_model_args.export_tokenizer:
+            print("Exporting tokenizer to ONNX format...")
             onnx_tokenizer = gen_processing_models(
                 self._preprocessor.tokenizer,
                 pre_kwargs={
@@ -400,6 +404,11 @@ class ExportablePolicyMixin:
                 input=input_shapes,
                 **extra_export_kwargs,
             )
+
+        if extra_model_args.post_export_hooks:
+            for hook in extra_model_args.post_export_hooks:
+                hook(model_path)
+
         _postprocess_openvino_model(ov_model, extra_model_args.outputs)
 
         openvino.save_model(ov_model, str(model_path), compress_to_fp16=extra_model_args.compress_to_fp16)

--- a/library/src/physicalai/policies/smolvla/export_utils.py
+++ b/library/src/physicalai/policies/smolvla/export_utils.py
@@ -13,7 +13,7 @@ from onnx import TensorProto, helper, numpy_helper, shape_inference
 from onnx.external_data_helper import load_external_data_for_model
 
 
-def patch_onnx_for_ort(onnx_path: str | Path) -> None:
+def patch_onnx_for_ort(onnx_path: str | Path) -> None:  # noqa: PLR0912, PLR0914
     """Patch a SmolVLA ONNX export so onnxruntime (CPU EP) can load it.
 
     Three issues from the dynamo exporter are fixed:
@@ -80,8 +80,9 @@ def patch_onnx_for_ort(onnx_path: str | Path) -> None:
 
     new_nodes = []
     inserted = 0
+    num_node_inputs = 3
     for node in graph.node:
-        if node.op_type == "Where" and len(node.input) == 3:
+        if node.op_type == "Where" and len(node.input) == num_node_inputs:
             out_dt = name_to_dtype.get(node.output[0])
             for branch_idx in (1, 2):  # X, Y
                 in_name = node.input[branch_idx]

--- a/library/src/physicalai/policies/smolvla/export_utils.py
+++ b/library/src/physicalai/policies/smolvla/export_utils.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export-time utilities for the SmolVLA policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper, shape_inference
+from onnx.external_data_helper import load_external_data_for_model
+
+
+def patch_onnx_for_ort(onnx_path: str | Path) -> None:
+    """Patch a SmolVLA ONNX export so onnxruntime (CPU EP) can load it.
+
+    Three issues from the dynamo exporter are fixed:
+
+    1. ``Expand`` nodes ``node_full`` / ``node_full_1`` carry stale
+       ``value_info`` declaring ``int64`` while their inputs are actually
+       ``float32``. We drop *all* value_info and re-run shape inference so
+       downstream type inference is reliable.
+    2. The full-graph export embeds the VLM weights and many activations as
+       ``bfloat16``. ORT's CPU EP lacks kernels for most bfloat16 ops
+       (e.g. ``Mul`` produces ``NOT_IMPLEMENTED``). We rewrite every
+       bfloat16 initializer to ``float32`` and retarget every ``Cast(to=BFLOAT16)``
+       to ``Cast(to=FLOAT)``.
+    3. After re-inference, ``Where(cond, X, Y)`` nodes can have X/Y branches
+       that disagree with the Where's declared output dtype. We insert a
+       ``Cast`` on the mismatched branch.
+
+    The patched model is saved back to ``onnx_path`` with external data
+    (overwriting the original ``*.onnx.data`` sidecar) since converting
+    bfloat16 -> float32 doubles the weight size.
+
+    Args:
+        onnx_path: Path to the ``.onnx`` file produced by SmolVLA's exporter.
+    """
+
+    onnx_path = Path(onnx_path)
+    base_dir = str(Path(str(onnx_path)).parent)
+    model = onnx.load(onnx_path, load_external_data=False)
+    load_external_data_for_model(model, base_dir)
+    graph = model.graph
+
+    # 1. Drop stale value_info entirely; we re-infer from scratch.
+    del graph.value_info[:]
+
+    # 2a. Convert bfloat16 initializers to float32.
+    new_inis = []
+    for ini in graph.initializer:
+        if ini.data_type == TensorProto.BFLOAT16:
+            arr = numpy_helper.to_array(ini)
+            f32 = np.asarray(arr, dtype=np.float32)
+            new_ini = numpy_helper.from_array(f32, name=ini.name)
+            new_inis.append(new_ini)
+        else:
+            new_inis.append(ini)
+    del graph.initializer[:]
+    graph.initializer.extend(new_inis)
+
+    # 2b. Retarget Cast nodes that produce bfloat16 to produce float32.
+    for node in graph.node:
+        if node.op_type == "Cast":
+            for attr in node.attribute:
+                if attr.name == "to" and attr.i == TensorProto.BFLOAT16:
+                    attr.i = TensorProto.FLOAT
+
+    # Re-run shape inference now that the type landscape is consistent.
+    model = shape_inference.infer_shapes(model, strict_mode=False, data_prop=True)
+    graph = model.graph
+
+    # 3. Insert Casts where Where's branches disagree with its output dtype.
+    name_to_dtype: dict[str, int] = {}
+    for vi in list(graph.value_info) + list(graph.input) + list(graph.output):
+        name_to_dtype[vi.name] = vi.type.tensor_type.elem_type
+    for ini in graph.initializer:
+        name_to_dtype[ini.name] = ini.data_type
+
+    new_nodes = []
+    inserted = 0
+    for node in graph.node:
+        if node.op_type == "Where" and len(node.input) == 3:
+            out_dt = name_to_dtype.get(node.output[0])
+            for branch_idx in (1, 2):  # X, Y
+                in_name = node.input[branch_idx]
+                in_dt = name_to_dtype.get(in_name)
+                if out_dt and in_dt and in_dt != out_dt:
+                    cast_out = f"{in_name}__cast_to_{out_dt}_{inserted}"
+                    new_nodes.append(
+                        helper.make_node(
+                            "Cast",
+                            inputs=[in_name],
+                            outputs=[cast_out],
+                            name=f"patch_cast_{inserted}",
+                            to=out_dt,
+                        ),
+                    )
+                    node.input[branch_idx] = cast_out
+                    inserted += 1
+        new_nodes.append(node)
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+
+    model = shape_inference.infer_shapes(model, strict_mode=False, data_prop=True)
+
+    # Save back with external data; overwrites the existing *.onnx.data
+    # sidecar so the new (larger) float32 weights fit.
+    external_data_name = onnx_path.name + ".data"
+    external_data_path = onnx_path.parent / external_data_name
+    if external_data_path.exists():
+        external_data_path.unlink()
+    onnx.save_model(
+        model,
+        onnx_path,
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=external_data_name,
+        size_threshold=1024,
+    )

--- a/library/src/physicalai/policies/smolvla/export_utils.py
+++ b/library/src/physicalai/policies/smolvla/export_utils.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+
 import numpy as np
 import onnx
 from onnx import TensorProto, helper, numpy_helper, shape_inference
@@ -37,7 +38,6 @@ def patch_onnx_for_ort(onnx_path: str | Path) -> None:
     Args:
         onnx_path: Path to the ``.onnx`` file produced by SmolVLA's exporter.
     """
-
     onnx_path = Path(onnx_path)
     base_dir = str(Path(str(onnx_path)).parent)
     model = onnx.load(onnx_path, load_external_data=False)

--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -82,7 +82,6 @@ class SmolVLAModel(ExportableModelMixin, Model):
         min_period: float = 4e-3,
         max_period: float = 4.0,
         use_random_input_noise: bool = True,
-        tokenizer_max_length: int = 48,
         compile_model: bool = False,
     ) -> None:
         """Initialize the SmolVLA model.
@@ -114,7 +113,6 @@ class SmolVLAModel(ExportableModelMixin, Model):
             max_period: Maximum period for sine-cosine positional encoding of timesteps.
             use_random_input_noise: Whether to use random noise as the initial input for the
                 denoising process during inference. If False, zeros are used instead.
-            tokenizer_max_length: Maximum token length for the tokenizer. Default: 48.
             compile_model: Whether to apply torch.compile to the model.
         """
         super().__init__()
@@ -123,7 +121,6 @@ class SmolVLAModel(ExportableModelMixin, Model):
         self._max_action_dim = max_action_dim
         self._adapt_to_pi_aloha = adapt_to_pi_aloha
         self._vlm_model_name = vlm_model_name
-        self._tokenizer_max_length = tokenizer_max_length
         self._model = VLAFlowMatching(
             chunk_size=chunk_size,
             max_state_dim=max_state_dim,

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -501,6 +501,7 @@ class SmolVLA(ExportablePolicyMixin, Policy):
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
                 "output_names": [ACTION],
+                "opset_version": 23,
             },
             preprocessors_specs=[
                 *base_preproc_specs,
@@ -513,7 +514,7 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             ],
             postprocessors_specs=postproc_specs,
             export_tokenizer=False,
-            post_export_hook=patch_onnx_for_ort,
+            post_export_hooks=[patch_onnx_for_ort],
         )
         extra_args["openvino"] = OpenVINOExportParameters(
             outputs=[ACTION],

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -26,6 +26,7 @@ from physicalai.train.schedulers import cosine_decay_with_warmup_scheduler
 from physicalai.train.utils import reformat_dataset_to_match_policy
 
 from .config import SmolVLAConfig
+from .export_utils import patch_onnx_for_ort
 from .model import SmolVLAModel
 
 if TYPE_CHECKING:
@@ -456,7 +457,7 @@ class SmolVLA(ExportablePolicyMixin, Policy):
         Returns:
             list[str | ExportBackend]: A list of supported export backends.
         """
-        return [ExportBackend.TORCH, ExportBackend.OPENVINO]
+        return [ExportBackend.TORCH, ExportBackend.OPENVINO, ExportBackend.ONNX]
 
     @property
     def extra_export_args(self) -> dict[str, ExportParameters]:
@@ -507,6 +508,7 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             ],
             postprocessors_specs=postproc_specs,
             export_tokenizer=False,
+            post_export_hook=patch_onnx_for_ort,
         )
         extra_args["openvino"] = OpenVINOExportParameters(
             outputs=[ACTION],

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -241,7 +241,6 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             min_period=self.config.min_period,
             max_period=self.config.max_period,
             use_random_input_noise=self.config.use_random_input_noise,
-            tokenizer_max_length=self.config.tokenizer_max_length,
             compile_model=self.config.compile_model,
         )
 

--- a/library/tests/unit/export/test_mixin_export.py
+++ b/library/tests/unit/export/test_mixin_export.py
@@ -290,6 +290,30 @@ class TestToOnnx:
         onnx_model = onnx.load(str(output_path))
         onnx.checker.check_model(onnx_model)
 
+    def test_to_onnx_post_export_hooks_are_called(self, tmp_path):
+        """Test that post_export_hooks are called during ONNX export."""
+        model = ModelWithSampleInput(input_dim=10, output_dim=5)
+        wrapper = ExportWrapper(model)
+
+        # Create mock hooks
+        mock_hook1 = MagicMock()
+        mock_hook2 = MagicMock()
+
+        # Set up the extra_export_args with post_export_hooks
+        wrapper._extra_export_args = {
+            ExportBackend.ONNX: ONNXExportParameters(
+                post_export_hooks=[mock_hook1, mock_hook2],
+            ),
+        }
+
+        output_path = tmp_path / "model.onnx"
+        wrapper.to_onnx(output_path)
+
+        # Verify the hooks were called with the correct model path
+        mock_hook1.assert_called_once_with(output_path)
+        mock_hook2.assert_called_once_with(output_path)
+        assert output_path.exists()
+
 
 class TestToOpenVINO:
     """Tests for to_openvino method."""
@@ -408,6 +432,31 @@ class TestToOpenVINO:
         output_path = tmp_path / "model.xml"
         wrapper.to_openvino(output_path)
 
+        assert output_path.exists()
+        assert (tmp_path / "model.bin").exists()
+
+    def test_to_openvino_post_export_hooks_are_called(self, tmp_path):
+        """Test that post_export_hooks are called during OpenVINO export."""
+        model = ModelWithSampleInput(input_dim=10, output_dim=5)
+        wrapper = ExportWrapper(model)
+
+        # Create mock hooks
+        mock_hook1 = MagicMock()
+        mock_hook2 = MagicMock()
+
+        # Set up the extra_export_args with post_export_hooks
+        wrapper._extra_export_args = {
+            ExportBackend.OPENVINO: OpenVINOExportParameters(
+                post_export_hooks=[mock_hook1, mock_hook2],
+            ),
+        }
+
+        output_path = tmp_path / "model.xml"
+        wrapper.to_openvino(output_path)
+
+        # Verify the hooks were called with the correct model path
+        mock_hook1.assert_called_once_with(output_path)
+        mock_hook2.assert_called_once_with(output_path)
         assert output_path.exists()
         assert (tmp_path / "model.bin").exists()
 

--- a/physicalai/src/physicalai/inference/adapters/onnx.py
+++ b/physicalai/src/physicalai/inference/adapters/onnx.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+import numpy as np
+
 from physicalai.inference.adapters.base import RuntimeAdapter
 from physicalai.inference.adapters.registry import adapter_registry
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import numpy as np
     import onnxruntime
 
 
@@ -41,6 +42,7 @@ class ONNXAdapter(RuntimeAdapter):
         self.session: onnxruntime.InferenceSession | None = None
         self._input_names: list[str] = []
         self._output_names: list[str] = []
+        self._input_dtypes: dict[str, np.dtype] = {}
 
     def load(self, model_path: Path) -> None:
         """Load ONNX model from file.
@@ -71,9 +73,16 @@ class ONNXAdapter(RuntimeAdapter):
         # Cache input/output names
         self._input_names = [input_meta.name for input_meta in self.session.get_inputs()]
         self._output_names = [output_meta.name for output_meta in self.session.get_outputs()]
+        self._input_dtypes = {
+            input_meta.name: dtype
+            for input_meta in self.session.get_inputs()
+            if (dtype := _onnx_type_to_numpy_dtype(input_meta.type)) is not None
+        }
 
     def predict(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         """Run inference with ONNX Runtime.
+
+        Matches input names to session metadata, coerces dtypes as needed.
 
         Args:
             inputs: Dictionary mapping input names to numpy arrays
@@ -88,9 +97,15 @@ class ONNXAdapter(RuntimeAdapter):
             msg = "Model not loaded. Call load() first."
             raise RuntimeError(msg)
 
-        # Run inference - outputs is a list that can contain various types
-        # For typical models, these are numpy arrays
-        raw_outputs = self.session.run(self._output_names, inputs)
+        coerced: dict[str, np.ndarray] = {}
+        for name, array in inputs.items():
+            expected = self._input_dtypes.get(name)
+            if expected is not None and array.dtype != expected:
+                coerced[name] = array.astype(expected, copy=False)
+            else:
+                coerced[name] = array
+
+        raw_outputs = self.session.run(self._output_names, coerced)
         outputs = cast("list[np.ndarray]", raw_outputs)
 
         # Convert to dictionary
@@ -136,3 +151,38 @@ class ONNXAdapter(RuntimeAdapter):
             List of output names
         """
         return self._output_names
+
+
+_ONNX_TYPE_TO_NUMPY: dict[str, str] = {
+    "tensor(float)": "float32",
+    "tensor(double)": "float64",
+    "tensor(float16)": "float16",
+    "tensor(bfloat16)": "bfloat16",
+    "tensor(int64)": "int64",
+    "tensor(int32)": "int32",
+    "tensor(int16)": "int16",
+    "tensor(int8)": "int8",
+    "tensor(uint64)": "uint64",
+    "tensor(uint32)": "uint32",
+    "tensor(uint16)": "uint16",
+    "tensor(uint8)": "uint8",
+    "tensor(bool)": "bool",
+}
+
+
+def _onnx_type_to_numpy_dtype(onnx_type: str) -> np.dtype | None:
+    """Map an ONNX Runtime input type string to a numpy dtype.
+
+    Args:
+        onnx_type: Type string reported by ``InferenceSession`` metadata
+            (e.g. ``"tensor(float)"``).
+
+    Returns:
+        Matching numpy dtype, or ``None`` if the type is not recognized
+        (e.g. string/sequence inputs), in which case callers should pass
+        the array through unchanged.
+    """
+    np_name = _ONNX_TYPE_TO_NUMPY.get(onnx_type)
+    if np_name is None:
+        return None
+    return np.dtype(np_name)


### PR DESCRIPTION
# Pull Request

## Description

PR improves overall onnx export and enables it for SmolVLA:
- add after-export fixups: work for ONNX and OV, can be extended to other backends
- improve onnx input type alignment
- enable SmolVLA onnx export: verified with default onnxrt CPU execution provider

The main difficulty of ONNX execution now is nearly missing data types casting in ONNX graph: torch::aten operations are captured without implicit datatypes promotion semantics, and then onnx executors just report inconsistent types if they don't have a kernel to perform operation with exotic types. That affects VLA's a lot, because there's integer input coming from tokenizer + mixed precision. Other backends like OV insert extra data casting when processing onnx graph, so the fixup from this PR does in quite a fragile manner. We might need to update onnx fixups if any major changes in torch -> onnx conversion process.


## Type of Change

- [x] ✨ `feat` - New feature


## Examples
```python
from physicalai.data import LeRobotDataModule
from physicalai.policies import SmolVLA
from physicalai.inference import InferenceModel

l_dm = LeRobotDataModule(repo_id=data_path, train_batch_size=1, episodes=[0])
policy = SmolVLA(dataset_stats=l_dm.train_dataset.stats).eval()
policy.to_onnx("smolvla_trained_onnx")
inf_model = InferenceModel("smolvla_trained_onnx")
inf_model.select_action(next(iter(l_dm.train_dataloader())).to_numpy().to_dict())

```
