### PR TITLE
feat: add predict_action_chunk() method to InferenceModel

### DIFF
--- a/physicalai/src/physicalai/inference/adapters/__init__.py
+++ b/physicalai/src/physicalai/inference/adapters/__init__.py
@@ -31,15 +31,15 @@ from typing import Any
 __path__ = extend_path(__path__, __name__)
 
 from physicalai.inference.adapters.base import RuntimeAdapter
-from physicalai.inference.adapters.registry import (
-    RuntimeAdapterRegistry,
-    adapter_registry,
-)
+from physicalai.inference.adapters.onnx import ONNXAdapter
 
 # Eagerly import core adapters so they self-register.  Their runtime
 # dependencies (onnxruntime, openvino) are part of the `inference` extra.
 from physicalai.inference.adapters.openvino import OpenVINOAdapter
-from physicalai.inference.adapters.onnx import ONNXAdapter
+from physicalai.inference.adapters.registry import (
+    RuntimeAdapterRegistry,
+    adapter_registry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,10 +77,10 @@ _load_external_adapters()
 
 
 __all__ = [
-    "RuntimeAdapterRegistry",
     "ONNXAdapter",
     "OpenVINOAdapter",
     "RuntimeAdapter",
+    "RuntimeAdapterRegistry",
     "adapter_registry",
     "get_adapter",
 ]

--- a/physicalai/src/physicalai/inference/adapters/registry.py
+++ b/physicalai/src/physicalai/inference/adapters/registry.py
@@ -171,10 +171,7 @@ class RuntimeAdapterRegistry:
             importlib.import_module(module_path)
             if name in self._classes:
                 return self._classes[name]
-            msg = (
-                f"Module {module_path!r} was imported for backend {name!r} "
-                "but did not register an adapter."
-            )
+            msg = f"Module {module_path!r} was imported for backend {name!r} but did not register an adapter."
             raise RuntimeError(msg)
 
         available = ", ".join(self.names()) or "<none>"
@@ -232,10 +229,7 @@ class RuntimeAdapterRegistry:
 
     def __repr__(self) -> str:
         """Return a developer-friendly representation."""
-        return (
-            f"{type(self).__name__}("
-            f"eager={list(self._classes)!r}, lazy={list(self._lazy)!r})"
-        )
+        return f"{type(self).__name__}(eager={list(self._classes)!r}, lazy={list(self._lazy)!r})"
 
     @staticmethod
     def _normalize_extensions(extensions: Iterable[str]) -> tuple[str, ...]:

--- a/physicalai/src/physicalai/inference/model.py
+++ b/physicalai/src/physicalai/inference/model.py
@@ -227,11 +227,46 @@ class InferenceModel:
         Returns:
             Action array to execute.
 
+        Raises:
+            RuntimeError: If the runner does not support action chunking.
+
         Examples:
             >>> obs = env.reset()
             >>> action = policy.select_action(obs)
             >>> next_obs, reward, done = env.step(action)
         """
+        if not self.use_action_queue:
+            msg = (
+                "Action chunking is not enabled for this model. Check the runner configuration "
+                "or manifest or use predict_action_chunk() for predicting a chunk of actions."
+            )
+            raise RuntimeError(msg)
+
+        outputs = self(observation)
+        return outputs[ACTION]
+
+    def predict_action_chunk(self, observation: dict[str, np.ndarray]) -> np.ndarray:
+        """Predict a chunk of actions for the given observation.
+
+        Only applicable if the runner supports action chunking. Delegates to
+        ``__call__`` and extracts the ``"action_chunk"`` key.
+
+        Args:
+            observation: Observation dict mapping names to numpy arrays.
+
+        Returns:
+            Chunk of actions to execute.
+
+        Raises:
+            RuntimeError: If the runner does not support action chunking.
+        """
+        if self.use_action_queue:
+            msg = (
+                "Selected runner does not support action chunking. Check the runner configuration "
+                "or manifest or use select_action() for single action prediction."
+            )
+            raise RuntimeError(msg)
+
         outputs = self(observation)
         return outputs[ACTION]
 

--- a/physicalai/tests/unit/inference/test_model.py
+++ b/physicalai/tests/unit/inference/test_model.py
@@ -411,11 +411,10 @@ class TestSelectAction:
         mock_adapter.predict.return_value = {"actions": np.random.randn(1, 1, 2)}
         model.postprocessors = [ActionNormalizer()]
 
-        action = model.select_action(sample_observation)
+        with pytest.raises(RuntimeError, match="Action chunking is not enabled"):
+            model.select_action(sample_observation)
 
-        assert isinstance(action, np.ndarray)
-        assert action.shape == (1, 2)
-        mock_adapter.predict.assert_called_once()
+        mock_adapter.predict.assert_not_called()
 
     def test_select_action_with_queue(
         self,
@@ -498,7 +497,7 @@ class TestSelectAction:
         assert "action" in outputs
         assert outputs["action"].shape == (1, 2)
 
-    def test_call_and_select_action_consistent(
+    def test_call_and_prediction_consistent(
         self,
         tmp_path: Path,
         mock_adapter: MagicMock,
@@ -512,9 +511,29 @@ class TestSelectAction:
         outputs_call = model(sample_observation)
 
         mock_adapter.predict.return_value = {"actions": fixed_output.copy()}
-        action_select = model.select_action(sample_observation)
+        action_chunk = model.predict_action_chunk(sample_observation)
 
-        np.testing.assert_array_equal(outputs_call["action"], action_select)
+        np.testing.assert_array_equal(outputs_call["action"], action_chunk)
+
+    def test_select_action_raises_with_single_pass_runner(
+        self,
+        tmp_path: Path,
+        sample_observation: dict[str, np.ndarray],
+    ) -> None:
+        model = InferenceModel(_make_legacy_export_dir(tmp_path, use_action_queue=False, chunk_size=1))
+
+        with pytest.raises(RuntimeError, match="Action chunking is not enabled"):
+            model.select_action(sample_observation)
+
+    def test_predict_action_chunk_raises_with_action_chunking_runner(
+        self,
+        tmp_path: Path,
+        sample_observation: dict[str, np.ndarray],
+    ) -> None:
+        model = InferenceModel(_make_legacy_export_dir(tmp_path))
+
+        with pytest.raises(RuntimeError, match="Selected runner does not support action chunking"):
+            model.predict_action_chunk(sample_observation)
 
 
 @pytest.mark.usefixtures("_patch_adapter")


### PR DESCRIPTION
# Pull Request

## Description

`predict_action_chunk()` is added alongside with `select_action()`. `InferenceModel` can not control execution flow and therefore can not enforce the underlying runner to produce either a chunk or a single action. The correct behavior for now is to fail in case if the requested operation is not possible, which is implemented in this PR.

## Type of Change

- [x] ✨ `feat` - New feature

## Breaking Changes

`InferenceModel.select_action()` throws if the underlying runner can not produce a single action

## Examples

```python
ov_model = InferenceModel("pi05_libero_finetuned_hf_ov", device="GPU", runner=ActionChunking(SinglePass()))
ov_model.select_acton(obs)
ov_model.predict_action_chunk(obs) # throws an exception, as this method requires SinglePass runner
ov_model(obs) # produces either a chunk or single action, depending on runner 
```