### PR TITLE
feat: dataset import

### DIFF
--- a/application/backend/src/api/dataset_import.py
+++ b/application/backend/src/api/dataset_import.py
@@ -1,0 +1,165 @@
+import asyncio
+from pathlib import Path
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+
+from api.dependencies import get_dataset_import_service, get_job_service, get_project_id
+from exceptions import InvalidArchiveError, ZipBombDetectedError
+from schemas import Job
+from schemas.base_job import JobType
+from schemas.dataset_import_job import DatasetImportFinalizeInput, DatasetImportJobPayload, ImportStep
+from schemas.job import DatasetImportJob
+from services.archive_safety import SafeZipArchive, check_disk_headroom, cleanup_staged_archive
+from services.dataset_import.adapters import get_supported_dataset_import_formats
+from services.dataset_import.service import DatasetImportService
+from services.dataset_import.staging import resolve_payload_archive_path
+from services.job_service import JobService
+from settings import get_settings
+
+router = APIRouter(prefix="/api/projects/{project_id}/imports", tags=["Imports"])
+
+ProjectID = Annotated[UUID, Depends(get_project_id)]
+
+_UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024  # 8 MB
+
+
+def _write_archive_to_disk(file: UploadFile, destination: Path) -> None:
+    """Synchronous helper: write upload to *destination* in chunks."""
+    with destination.open("wb") as out:
+        while chunk := file.file.read(_UPLOAD_CHUNK_SIZE):
+            out.write(chunk)
+
+
+async def _persist_uploaded_archive(file: UploadFile, payload: DatasetImportJobPayload) -> Path:
+    """Persist an uploaded archive under the given staging id without blocking the event loop."""
+    destination = resolve_payload_archive_path(payload)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(_write_archive_to_disk, file, destination)
+    return destination
+
+
+async def get_awaiting_upload_job(
+    project_id: ProjectID,
+    job_id: UUID,
+    job_service: Annotated[JobService, Depends(get_job_service)],
+) -> DatasetImportJob:
+    """Dependency: fetch and validate a dataset import job that is awaiting archive upload."""
+    job = await job_service.get_job_by_id(job_id)
+
+    if job.project_id != project_id or job.type != JobType.DATASET_IMPORT:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dataset import job not found")
+
+    if not isinstance(job.payload, DatasetImportJobPayload):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dataset import job payload is invalid")
+
+    if job.payload.step != ImportStep.AWAITING_ARCHIVE_UPLOAD:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Archive can only be uploaded when job is in '{ImportStep.AWAITING_ARCHIVE_UPLOAD}' step",
+        )
+
+    return job
+
+
+@router.post("/datasets:prepare", status_code=status.HTTP_202_ACCEPTED)
+async def prepare_dataset_import_job(
+    project_id: ProjectID,
+    dataset_import_service: Annotated[DatasetImportService, Depends(get_dataset_import_service)],
+    format_hint: Annotated[str, Form()] = "auto",
+    dataset_name: Annotated[str, Form()] = "",
+) -> Job:
+    """Phase 1: Create a dataset import job immediately, before the archive is uploaded.
+
+    Returns a Job with step=awaiting_archive_upload. Use the returned job_id in the phase-2
+    upload endpoint to attach the archive and queue processing.
+    """
+    supported_format_hints = get_supported_dataset_import_formats()
+    if format_hint not in supported_format_hints:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid format_hint '{format_hint}'. Expected one of: {sorted(supported_format_hints)}",
+        )
+
+    if not dataset_name.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="dataset_name must be a non-empty string",
+        )
+
+    return await dataset_import_service.prepare_dataset_import_job(
+        project_id=project_id, format_hint=format_hint, dataset_name=dataset_name.strip()
+    )
+
+
+@router.put("/datasets/{job_id}:upload", status_code=status.HTTP_202_ACCEPTED)
+async def upload_dataset_import_archive(
+    project_id: ProjectID,
+    job_id: UUID,
+    archive: Annotated[UploadFile, File(description="Dataset archive ZIP")],
+    job: Annotated[DatasetImportJob, Depends(get_awaiting_upload_job)],
+    dataset_import_service: Annotated[DatasetImportService, Depends(get_dataset_import_service)],
+) -> Job:
+    """Phase 2: Upload the archive and attach it to an existing import job.
+
+    The job must be in the awaiting_archive_upload step (created via POST /datasets:prepare).
+    After this call the job transitions to step=queued_for_detection and status=pending so the
+    worker can pick it up for processing.
+    """
+    if not archive.filename:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing archive filename")
+
+    if not archive.filename.lower().endswith(".zip"):
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, detail="Only ZIP archives are supported"
+        )
+
+    # Check if there is enough space for dataset import
+    settings = get_settings()
+    cache_dir = settings.cache_dir / "imports" / "datasets"
+    upload_size_estimate = settings.data_import_max_upload_bytes
+    check_disk_headroom(cache_dir, upload_size_estimate, settings.data_import_min_free_bytes)
+
+    # Make sure we are safe against zip bomb attacks
+    uploaded_archive_path = await _persist_uploaded_archive(archive, job.payload)
+    try:
+        safe_archive = SafeZipArchive(
+            uploaded_archive_path,
+            max_uncompressed_bytes=settings.data_import_max_uncompressed_bytes,
+        )
+        await asyncio.to_thread(safe_archive.validate)
+    except (ZipBombDetectedError, InvalidArchiveError):
+        cleanup_staged_archive(uploaded_archive_path)
+        raise
+
+    return await dataset_import_service.attach_dataset_import_archive(
+        project_id=project_id,
+        job_id=job_id,
+        uploaded_archive_name=archive.filename,
+    )
+
+
+@router.post("/datasets/{job_id}:finalize", status_code=status.HTTP_202_ACCEPTED)
+async def finalize_dataset_import_job(
+    project_id: ProjectID,
+    job_id: UUID,
+    payload: DatasetImportFinalizeInput,
+    dataset_import_service: Annotated[DatasetImportService, Depends(get_dataset_import_service)],
+) -> Job:
+    """Finalize staged dataset import by providing required user inputs."""
+    return await dataset_import_service.finalize_dataset_import_job(
+        project_id=project_id,
+        job_id=job_id,
+        finalize_input=payload,
+    )
+
+
+@router.post("/datasets/{job_id}:cancel", status_code=status.HTTP_202_ACCEPTED)
+async def cancel_dataset_import_job(
+    project_id: ProjectID,
+    job_id: UUID,
+    dataset_import_service: Annotated[DatasetImportService, Depends(get_dataset_import_service)],
+) -> Job:
+    """Cancel dataset import while it is awaiting user review."""
+    return await dataset_import_service.cancel_dataset_import_job(project_id=project_id, job_id=job_id)

--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -17,6 +17,7 @@ from services import (
     ProjectService,
     RobotService,
 )
+from services.dataset_import.service import DatasetImportService
 from services.environment_service import EnvironmentService
 from services.event_processor import EventProcessor
 from services.job_service import JobService
@@ -128,6 +129,12 @@ def get_model_download_service() -> ModelDownloadService:
 def get_job_service() -> JobService:
     """Provides a JobService instance for managing jobs."""
     return JobService()
+
+
+@lru_cache
+def get_dataset_import_service() -> DatasetImportService:
+    """Provides a DatasetImportService instance for dataset import jobs."""
+    return DatasetImportService()
 
 
 def get_log_service(request: HTTPConnection) -> LogService:

--- a/application/backend/src/core/logging/log_config.py
+++ b/application/backend/src/core/logging/log_config.py
@@ -28,5 +28,6 @@ class LogConfig:
         "TrainingWorker": "training.log",
         "InferenceWorker": "inference.log",
         "TeleoperateWorker": "teleoperate.log",
+        "DatasetImportWorker": "dataset_import.log",
         None: "app.log",
     }

--- a/application/backend/src/core/scheduler.py
+++ b/application/backend/src/core/scheduler.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import psutil
 from loguru import logger
 
+from workers.dataset_import_worker import DatasetImportWorker
 from workers.training_worker import TrainingWorker
 
 if TYPE_CHECKING:
@@ -33,7 +34,15 @@ class Scheduler:
         )
         training_proc.daemon = False
         training_proc.start()
-        self.processes.extend([training_proc])
+
+        dataset_import_proc = DatasetImportWorker(
+            stop_event=self.mp_stop_event,
+            event_queue=self.event_queue,
+        )
+        dataset_import_proc.daemon = False
+        dataset_import_proc.start()
+
+        self.processes.extend([training_proc, dataset_import_proc])
 
     def shutdown(self) -> None:
         """Shutdown all processes gracefully"""

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -102,6 +102,50 @@ class UnsupportedDeviceError(BaseException):
         )
 
 
+class InvalidJobStateError(BaseException):
+    """Raised when a job action is not valid in the current state."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message=message,
+            error_code="invalid_job_state",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
+class DuplicateImportSourceError(BaseException):
+    """Raised when importing an already imported source UUID."""
+
+    def __init__(self, resource_kind: str, source_uuid: str) -> None:
+        super().__init__(
+            message=f"{resource_kind} with original source UUID `{source_uuid}` was already imported.",
+            error_code="duplicate_import_source",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
+class ZipBombDetectedError(BaseException):
+    """Raised when an uploaded archive is considered unsafe."""
+
+    def __init__(self, message: str = "Uploaded archive was rejected by zip safety validation") -> None:
+        super().__init__(
+            message=message,
+            error_code="zip_bomb_detected",
+            http_status=http.HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+        )
+
+
+class InvalidArchiveError(BaseException):
+    """Raised when an uploaded archive is invalid or unreadable."""
+
+    def __init__(self, message: str = "Uploaded archive is invalid or unreadable") -> None:
+        super().__init__(
+            message=message,
+            error_code="invalid_archive",
+            http_status=http.HTTPStatus.BAD_REQUEST,
+        )
+
+
 class UploadTooLargeError(BaseException):
     """Raised when the HTTP upload exceeds the configured maximum size."""
 
@@ -110,4 +154,15 @@ class UploadTooLargeError(BaseException):
             message=message,
             error_code="upload_too_large",
             http_status=http.HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+        )
+
+
+class InsufficientDiskSpaceError(BaseException):
+    """Raised when there is not enough free disk space to safely store the upload or extraction."""
+
+    def __init__(self, message: str = "Insufficient disk space to process the upload") -> None:
+        super().__init__(
+            message=message,
+            error_code="insufficient_disk_space",
+            http_status=http.HTTPStatus.INSUFFICIENT_STORAGE,
         )

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -12,6 +12,7 @@ from starlette.middleware.base import RequestResponseEndpoint
 
 from api.camera import router as camera_router
 from api.dataset import router as dataset_router
+from api.dataset_import import router as imports_router
 from api.dependencies import CameraRegistryDep, RobotRegistryDep
 from api.environments import router as project_environments_router
 from api.hardware import router as hardware_router
@@ -59,6 +60,7 @@ app.include_router(settings_router)
 app.include_router(models_router)
 app.include_router(policies_router)
 app.include_router(job_router)
+app.include_router(imports_router)
 app.include_router(logs_router)
 app.include_router(system_router)
 

--- a/application/backend/src/repositories/job_repo.py
+++ b/application/backend/src/repositories/job_repo.py
@@ -1,6 +1,8 @@
+import datetime
 from collections.abc import Callable
 from uuid import UUID
 
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio.session import AsyncSession
 
 from db.schema import JobDB
@@ -8,6 +10,7 @@ from repositories.base import BaseRepository
 from repositories.mappers import JobMapper
 from schemas import Job
 from schemas.base_job import JobStatus, JobType
+from schemas.dataset_import_job import ImportStep
 from schemas.job import TrainJobPayload
 
 
@@ -44,4 +47,47 @@ class JobRepository(BaseRepository):
             extra_filters={"type": job_type, "status": JobStatus.PENDING},
             order_by=self.schema.created_at,
             ascending=True,
+        )
+
+    async def claim_pending_dataset_import_job(self) -> Job | None:
+        pending_steps = [
+            ImportStep.QUEUED_FOR_DETECTION.value,
+            ImportStep.QUEUED_FOR_IMPORT.value,
+        ]
+
+        query = (
+            select(JobDB.id)
+            .where(
+                JobDB.type == JobType.DATASET_IMPORT,
+                JobDB.status == JobStatus.PENDING,
+                func.json_extract(JobDB.payload, "$.step").in_(pending_steps),
+            )
+            .order_by(JobDB.created_at.asc())
+            .limit(1)
+        )
+        result = await self.db.execute(query)
+        job_id = result.scalar_one_or_none()
+        if job_id is None:
+            return None
+
+        claim = (
+            update(JobDB)
+            .where(
+                JobDB.id == job_id,
+                JobDB.status == JobStatus.PENDING,
+                func.json_extract(JobDB.payload, "$.step").in_(pending_steps),
+            )
+            .values(
+                status=JobStatus.RUNNING,
+                start_time=datetime.datetime.now(tz=datetime.UTC),
+            )
+        )
+        await self.db.execute(claim)
+        await self.db.commit()
+
+        return await self.get_by_id(job_id)
+
+    async def get_jobs_by_type(self, project_id: UUID, job_type: JobType) -> list[Job]:
+        return await self.get_all(
+            extra_filters={"project_id": self._id_to_str(project_id), "type": job_type},
         )

--- a/application/backend/src/schemas/__init__.py
+++ b/application/backend/src/schemas/__init__.py
@@ -3,7 +3,7 @@ from .calibration import CalibrationConfig
 from .camera import Camera, CameraProfile
 from .dataset import Dataset, Episode, EpisodeInfo, EpisodeVideo, LeRobotDatasetInfo, Snapshot
 from .hardware import DeviceInfo, DeviceType
-from .job import Job, TrainJob
+from .job import DatasetImportJob, Job, TrainJob
 from .model import Model
 from .project import Project
 from .robot import LeRobotConfig, NetworkIpRobotConfig, Robot, SerialPortInfo
@@ -13,6 +13,7 @@ __all__ = [
     "Camera",
     "CameraProfile",
     "Dataset",
+    "DatasetImportJob",
     "DeviceInfo",
     "DeviceType",
     "Episode",

--- a/application/backend/src/schemas/base_job.py
+++ b/application/backend/src/schemas/base_job.py
@@ -10,6 +10,7 @@ from schemas.base import BaseIDModel
 
 class JobType(StrEnum):
     TRAINING = "training"
+    DATASET_IMPORT = "dataset_import"
 
 
 class JobStatus(StrEnum):

--- a/application/backend/src/schemas/dataset_import_job.py
+++ b/application/backend/src/schemas/dataset_import_job.py
@@ -17,7 +17,6 @@ class ManifestCameraEntry(BaseModel):
 class ManifestRobotEntry(BaseModel):
     """Recording schema entry describing a robot and its controllable joints."""
 
-    name: str
     type: str | None = None
     joints: list[str] = Field(default_factory=list)
 

--- a/application/backend/src/schemas/dataset_import_job.py
+++ b/application/backend/src/schemas/dataset_import_job.py
@@ -1,0 +1,125 @@
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_serializer
+from pydantic_core.core_schema import SerializationInfo
+
+
+class ManifestCameraEntry(BaseModel):
+    """Recording schema entry describing a single camera stream."""
+
+    name: str
+    width: int | None = None
+    height: int | None = None
+    fps: int | None = None
+
+
+class ManifestRobotEntry(BaseModel):
+    """Recording schema entry describing a robot and its controllable joints."""
+
+    name: str
+    type: str | None = None
+    joints: list[str] = Field(default_factory=list)
+
+
+class DatasetManifestRecordingSchema(BaseModel):
+    """Cameras and robots inferred from dataset format metadata."""
+
+    cameras: list[ManifestCameraEntry] = Field(default_factory=list)
+    robots: list[ManifestRobotEntry] = Field(default_factory=list)
+
+
+class ImportStep(StrEnum):
+    # User created import job and archive upload is expected next.
+    AWAITING_ARCHIVE_UPLOAD = "awaiting_archive_upload"
+    # Archive is uploaded and queued for worker-side format detection.
+    QUEUED_FOR_DETECTION = "queued_for_detection"
+    # Worker is determining dataset format adapter.
+    DETECTING_FORMAT = "detecting_format"
+    # Worker is building draft manifest and validation report.
+    BUILDING_MANIFEST_DRAFT = "building_manifest_draft"
+    # Draft is ready and UI should present finalization form.
+    AWAITING_USER_REVIEW = "awaiting_user_review"
+    # User finalized input and import is queued.
+    QUEUED_FOR_IMPORT = "queued_for_import"
+    # Worker is importing/extracting/persisting dataset.
+    IMPORTING_DATASET = "importing_dataset"
+    # Import complete
+    COMPLETED = "completed"
+
+
+class DatasetImportSource(StrEnum):
+    LEROBOT_V3 = "lerobot_v3"
+    UNKNOWN = "unknown"
+
+
+class ImportValidationSeverity(StrEnum):
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class ImportValidationMessage(BaseModel):
+    severity: ImportValidationSeverity
+    message: str
+
+
+class ImportValidationReport(BaseModel):
+    messages: list[ImportValidationMessage] = Field(default_factory=list)
+
+    def add(self, severity: ImportValidationSeverity, message: str) -> None:
+        self.messages.append(ImportValidationMessage(severity=severity, message=message))
+
+    def add_error(self, message: str) -> None:
+        self.messages.append(ImportValidationMessage(severity=ImportValidationSeverity.ERROR, message=message))
+
+    def add_warning(self, message: str) -> None:
+        self.messages.append(ImportValidationMessage(severity=ImportValidationSeverity.WARNING, message=message))
+
+    @computed_field(return_type=bool)
+    def is_valid(self) -> bool:
+        return not any(message.severity == ImportValidationSeverity.ERROR for message in self.messages)
+
+
+class DatasetManifestStatistics(BaseModel):
+    episode_count: int = Field(default=0, ge=0)
+    frame_count: int = Field(default=0, ge=0)
+
+
+class DatasetManifest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    source_type: DatasetImportSource = DatasetImportSource.UNKNOWN
+    statistics: DatasetManifestStatistics = Field(default_factory=DatasetManifestStatistics)
+    dataset_schema: DatasetManifestRecordingSchema = Field(default_factory=DatasetManifestRecordingSchema)
+
+
+class DatasetImportFinalizeInput(BaseModel):
+    environment_id: UUID
+    default_task: str = ""
+
+    @field_serializer("environment_id")
+    def serialize_environment_id(self, environment_id: UUID, _info: SerializationInfo) -> str:
+        return str(environment_id)
+
+
+class DatasetImportJobPayload(BaseModel):
+    step: ImportStep = ImportStep.AWAITING_ARCHIVE_UPLOAD
+    result_dataset_id: UUID | None = None
+
+    # Opaque staging identifier - resolve the archive path via resolve_payload_archive_path().
+    archive_staging_id: UUID
+    uploaded_archive_name: str | None = None
+    format_hint: str = "auto"
+    # User-provided dataset name, captured at prepare time.
+    dataset_name: str | None = None
+    dataset_manifest_draft: DatasetManifest | None = None
+    validation_report: ImportValidationReport | None = None
+    finalize_input: DatasetImportFinalizeInput | None = None
+
+    @field_serializer("result_dataset_id")
+    def serialize_result_dataset_id(self, result_dataset_id: UUID | None, _info: SerializationInfo) -> str | None:
+        return str(result_dataset_id) if result_dataset_id else None
+
+    @field_serializer("archive_staging_id")
+    def serialize_archive_staging_id(self, archive_staging_id: UUID, _info: SerializationInfo) -> str:
+        return str(archive_staging_id)

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -6,6 +6,7 @@ from loguru import logger
 from pydantic import BaseModel, Field, field_serializer, model_validator
 
 from schemas.base_job import BaseJob, JobType
+from schemas.dataset_import_job import DatasetImportJobPayload
 from schemas.hardware import DeviceType
 
 
@@ -103,10 +104,15 @@ class TrainJob(BaseJob):
     payload: TrainJobPayload
 
 
-JobPayload = TrainJobPayload
+class DatasetImportJob(BaseJob):
+    type: Literal[JobType.DATASET_IMPORT] = JobType.DATASET_IMPORT  # type: ignore[valid-type]
+    payload: DatasetImportJobPayload
+
+
+JobPayload = TrainJobPayload | DatasetImportJobPayload
 
 Job = Annotated[
-    TrainJob,
+    TrainJob | DatasetImportJob,
     Field(discriminator="type"),
 ]
 

--- a/application/backend/src/services/__init__.py
+++ b/application/backend/src/services/__init__.py
@@ -1,6 +1,7 @@
 from robots.robot_service import RobotService
 
 from .dataset_download_service import DatasetDownloadService
+from .dataset_import.service import DatasetImportService
 from .dataset_service import DatasetService
 from .episode_thumbnail_service import EpisodeThumbnailService
 from .model_download_service import ModelDownloadService
@@ -11,6 +12,7 @@ from .system_service import SystemService
 
 __all__ = [
     "DatasetDownloadService",
+    "DatasetImportService",
     "DatasetService",
     "EpisodeThumbnailService",
     "ModelDownloadService",

--- a/application/backend/src/services/archive_safety.py
+++ b/application/backend/src/services/archive_safety.py
@@ -1,0 +1,286 @@
+import json
+import shutil
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+from zipfile import BadZipFile, ZipFile, ZipInfo
+
+from loguru import logger
+
+from exceptions import InsufficientDiskSpaceError, InvalidArchiveError, ZipBombDetectedError
+
+DEFAULT_MAX_FILE_COUNT = 200_000
+
+
+def _collect_total_uncompressed(members: list[ZipInfo]) -> int:
+    return sum(member.file_size for member in members)
+
+
+def _normalize_zip_member_name(name: str) -> str:
+    normalized = name.replace("\\", "/").strip("/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+class SafeZipArchive:
+    """Security-aware ZIP access wrapper.
+
+    This class validates archive entries once and provides safe helper methods
+    for member lookup and extraction so callers don't have to manually invoke
+    low-level safety functions.
+    """
+
+    def __init__(
+        self,
+        archive_path: str | Path,
+        *,
+        max_uncompressed_bytes: int,
+        max_file_count: int | None = None,
+    ) -> None:
+        self.path = Path(archive_path)
+        self.max_uncompressed_bytes = max_uncompressed_bytes
+        self.max_file_count = max_file_count
+        self._validated_members: list[ZipInfo] | None = None
+
+    def validate(self) -> None:
+        """Validate ZIP entries against configured safety limits.
+
+        Triggers the one-time safety pass (file-count limit, uncompressed-size
+        limit, path traversal/symlink checks, nested ZIP policy).
+        """
+        self._get_validated_members()
+
+    def estimated_uncompressed_size(self) -> int:
+        """Return total uncompressed bytes across validated members."""
+        members = self._get_validated_members()
+        return _collect_total_uncompressed(members)
+
+    def iter_normalized_names(self) -> Iterator[str]:
+        """Iterate normalized member names.
+
+        Names are normalized to forward slashes, with leading/trailing slashes
+        removed and optional ``./`` prefixes stripped.
+        """
+        for member in self._get_validated_members():
+            yield _normalize_zip_member_name(member.filename)
+
+    def resolve_member_name(self, target_name: str) -> str | None:
+        """Resolve a logical archive path to an actual member name.
+
+        Matching is performed against normalized names and supports two forms:
+
+        1) exact match (e.g. ``meta/info.json``)
+        2) suffix match (e.g. ``dataset/meta/info.json`` ends with
+           ``/meta/info.json``)
+
+        The suffix behavior intentionally supports uploads where the dataset is
+        wrapped in a single top-level directory inside the ZIP.
+        """
+        normalized_target = _normalize_zip_member_name(target_name)
+        for member in self._get_validated_members():
+            normalized = _normalize_zip_member_name(member.filename)
+            if normalized == normalized_target or normalized.endswith(f"/{normalized_target}"):
+                return member.filename
+        return None
+
+    def read_json(self, target_name: str) -> dict | None:
+        """Read and decode a JSON member by logical path.
+
+        Uses :meth:`resolve_member_name`, so callers can request
+        ``meta/info.json`` and still resolve archives that store it as
+        ``<top-level>/meta/info.json``.
+
+        Returns ``None`` when no matching member is found.
+        """
+        raw_bytes = self._read_member(target_name)
+        if raw_bytes is None:
+            return None
+
+        try:
+            return json.loads(raw_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise InvalidArchiveError(f"Unable to read JSON '{target_name}' from archive") from error
+
+    def read_jsonl(self, target_name: str) -> Iterator[dict]:
+        raw_bytes = self._read_member(target_name)
+        if raw_bytes is None:
+            return
+
+        try:
+            for line in raw_bytes.decode("utf-8").splitlines():
+                if line := line.strip():
+                    yield json.loads(line)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise InvalidArchiveError(f"Unable to read JSONL '{target_name}' from archive") from error
+
+    def read_bytes(self, target_name: str) -> bytes | None:
+        """Read raw bytes from a member by logical path.
+
+        Uses :meth:`resolve_member_name`, so nested-root archives are supported
+        transparently (e.g. ``meta/tasks.parquet`` vs
+        ``<top-level>/meta/tasks.parquet``).
+
+        Returns ``None`` when no matching member is found.
+        """
+        return self._read_member(target_name)
+
+    def extract_to(
+        self,
+        destination_dir: str | Path,
+        *,
+        min_free_bytes: int = 0,
+    ) -> int:
+        """Extract validated members to ``destination_dir`` safely.
+
+        Each member target path is resolved and verified to remain within the
+        destination root before extraction, preventing path-escape writes.
+
+        Returns the number of non-directory entries extracted.
+        """
+        destination_root = Path(destination_dir)
+        if min_free_bytes > 0:
+            check_disk_headroom(destination_root, self.estimated_uncompressed_size(), min_free_bytes)
+
+        members = self._get_validated_members()
+        extracted_count = 0
+        resolved_destination = destination_root.resolve()
+
+        try:
+            with ZipFile(self.path, mode="r") as archive:
+                for member in members:
+                    member_name = _normalize_zip_member_name(member.filename)
+                    target_path = (resolved_destination / member_name).resolve()
+                    if resolved_destination not in target_path.parents and target_path != resolved_destination:
+                        raise ZipBombDetectedError(f"Archive contains unsafe entry path '{member.filename}'")
+
+                    archive.extract(member, resolved_destination)
+                    if not member.is_dir():
+                        extracted_count += 1
+        except BadZipFile as error:
+            raise InvalidArchiveError("Uploaded file is not a valid ZIP archive") from error
+
+        return extracted_count
+
+    def _get_validated_members(self) -> list[ZipInfo]:
+        if self._validated_members is None:
+            try:
+                with ZipFile(self.path, mode="r") as archive:
+                    members = archive.infolist()
+            except BadZipFile as error:
+                raise InvalidArchiveError("Uploaded file is not a valid ZIP archive") from error
+
+            validate_zip_entries(
+                members,
+                max_file_count=self.max_file_count,
+                max_uncompressed_bytes=self.max_uncompressed_bytes,
+            )
+            self._validated_members = members
+
+        return self._validated_members
+
+    def _read_member(self, target_name: str) -> bytes | None:
+        member_name = self.resolve_member_name(target_name)
+        if member_name is None:
+            return None
+
+        try:
+            with ZipFile(self.path, mode="r") as archive, archive.open(member_name) as file_obj:
+                return file_obj.read()
+        except (BadZipFile, OSError) as error:
+            raise InvalidArchiveError(f"Unable to read '{target_name}' from archive") from error
+
+
+def _is_symlink(member_external_attr: int) -> bool:
+    """Check if the member is a symbolic link based on its external attributes."""
+    mode = member_external_attr >> 16
+    return (mode & stat.S_IFLNK) == stat.S_IFLNK
+
+
+def validate_zip_entries(
+    members: list[ZipInfo],
+    *,
+    max_file_count: int | None,
+    max_uncompressed_bytes: int,
+) -> int:
+    """Validate ZIP entries for safety constraints and return total uncompressed bytes."""
+    if max_file_count is None:
+        max_file_count = DEFAULT_MAX_FILE_COUNT
+
+    if len(members) > max_file_count:
+        raise ZipBombDetectedError(f"Archive contains too many entries ({len(members)} > {max_file_count})")
+
+    total_uncompressed = _collect_total_uncompressed(members)
+    if total_uncompressed > max_uncompressed_bytes:
+        raise ZipBombDetectedError(
+            f"Archive uncompressed size exceeds allowed limit ({total_uncompressed} > {max_uncompressed_bytes} bytes)"
+        )
+
+    for member in members:
+        name = _normalize_zip_member_name(member.filename)
+
+        if _is_symlink(member.external_attr):
+            raise ZipBombDetectedError(f"Archive contains symlink entry '{name}', which is not allowed")
+
+        # Reject path traversal and absolute paths
+        normalized_path = Path(name)
+        if normalized_path.is_absolute() or ".." in normalized_path.parts:
+            raise ZipBombDetectedError(f"Archive contains unsafe entry path '{member.filename}'")
+
+        if Path(name).suffix.lower() == ".zip":
+            raise ZipBombDetectedError(f"Archive contains nested zip entry '{member.filename}', which is not allowed")
+
+    return total_uncompressed
+
+
+def check_disk_headroom(directory: Path, required_bytes: int, min_free_bytes: int) -> None:
+    """Ensure *directory*'s filesystem has enough headroom for the pending operation.
+
+    :param directory: Directory (or any path on the target filesystem) to
+        inspect.  The directory is created if it does not yet exist so that
+        ``shutil.disk_usage`` has a concrete path to query.
+    :param required_bytes: Bytes the caller expects to write (e.g. upload size
+        or estimated uncompressed extraction size).
+    :param min_free_bytes: Minimum headroom that must remain *after* writing
+        *required_bytes*.
+    :raises InsufficientDiskSpaceError: When free space would fall below the
+        minimum headroom.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    usage = shutil.disk_usage(directory)
+    needed = required_bytes + min_free_bytes
+    if usage.free < needed:
+        raise InsufficientDiskSpaceError(
+            f"Insufficient disk space on '{directory}': "
+            f"{usage.free} bytes free, need {needed} bytes "
+            f"({required_bytes} for data + {min_free_bytes} headroom)"
+        )
+
+
+def cleanup_staged_archive(uploaded_archive_path: str | Path | None) -> None:
+    """Best-effort staged archive cleanup used by API/service/worker paths."""
+    if uploaded_archive_path is None:
+        return
+
+    try:
+        Path(uploaded_archive_path).unlink(missing_ok=True)
+    except Exception as error:
+        logger.warning("Failed to clean staged dataset archive '{}': {}", uploaded_archive_path, error)
+
+
+def flatten_single_root_directory(destination_dir: str | Path) -> None:
+    """Flatten extracted archive when it contains exactly one root directory.
+
+    Supports archives where dataset files are nested under a single top-level
+    folder by moving that folder's contents to *destination_dir*.
+    """
+    root = Path(destination_dir)
+    entries = list(root.iterdir())
+    if len(entries) != 1 or not entries[0].is_dir():
+        return
+
+    nested_root = entries[0]
+    nested_entries = list(nested_root.iterdir())
+    for child in nested_entries:
+        shutil.move(str(child), str(root / child.name))
+    nested_root.rmdir()

--- a/application/backend/src/services/dataset_import/README.md
+++ b/application/backend/src/services/dataset_import/README.md
@@ -1,0 +1,290 @@
+# Dataset Import
+
+This folder contains the backend implementation of dataset import jobs.
+
+## What this feature does
+
+Dataset import is implemented as an **asynchronous, multi-step job flow**:
+
+1. API creates an import job (`awaiting_archive_upload`)
+2. API receives and stores uploaded ZIP, then marks job `pending` (`queued_for_detection`)
+3. Worker picks up the job, detects adapter compatibility, and builds a draft manifest
+4. Worker runs draft assessment (post-parse checks), then pauses for user review (`awaiting_user_review`)
+5. API finalizes with required input (environment), marks job `pending` (`queued_for_import`)
+6. Worker runs **pre-commit validation** and, if valid, commits import and creates the dataset
+
+Core files:
+
+- `service.py`: Job lifecycle operations for dataset import
+- `adapters/base.py`: Adapter contract
+- `adapters/lerobot_v3.py`: Current adapter implementation
+- `workers/dataset_import_worker.py` (outside this folder): worker orchestration loop
+- `api/dataset_import.py` (outside this folder): HTTP endpoints
+
+---
+
+## UI → API integration flow
+
+The UI should use this sequence for a successful import:
+
+### 1) Prepare job
+
+`POST /api/projects/{project_id}/imports/datasets:prepare`
+
+Form fields:
+
+- `format_hint`: usually `auto` (recommended), or `lerobot_v3`
+
+Response:
+
+- Returns `Job` with `payload.step = awaiting_archive_upload`
+- Save `job_id`
+
+### 2) Upload archive
+
+`PUT /api/projects/{project_id}/imports/datasets/{job_id}:upload`
+
+Multipart fields:
+
+- `archive`: ZIP file only
+
+Response:
+
+- Job is updated to `status=pending`, `payload.step=queued_for_detection`
+- Worker will pick it up
+
+### 3) Poll job state
+
+Use existing job endpoints/streams to monitor job updates.
+
+After detection+validation, worker moves the job to:
+
+- `status=pending`
+- `payload.step=awaiting_user_review`
+- `payload.validation_report`
+- `payload.dataset_manifest_draft`
+
+The `dataset_manifest_draft.dataset_schema` field is populated with a **recording schema** inferred
+from the source dataset metadata (e.g. LeRobot `meta/info.json`).  It describes:
+
+- **cameras** – one entry per video stream found under `observation.images.*`,
+  with name, width, height, and fps where available.
+- **robots** – one entry per robot with its joint names (derived from
+  `action` / `observation.state` feature `names` by stripping per-joint
+  suffixes such as `.pos`).  The robot type comes from the top-level
+  `robot_type` field.
+
+Both lists default to empty when the source metadata is absent or incomplete,
+so existing imports are unaffected.
+
+UI should then present finalization inputs.
+
+### 4) Finalize
+
+`POST /api/projects/{project_id}/imports/datasets/{job_id}:finalize`
+
+JSON body (`DatasetImportFinalizeInput`):
+
+- `environment_id` (required)
+- `default_task` (optional)
+
+Note: `dataset_name` is provided during prepare (`POST .../datasets:prepare`).
+
+Response:
+
+- Job becomes `status=pending`, `payload.step=queued_for_import`
+- Worker resumes, runs pre-commit validation, then performs commit
+
+### 5) Completion
+
+Worker eventually marks job `completed` and sets:
+
+- `payload.result_dataset_id`
+
+UI can navigate to/open the resulting dataset.
+
+### Cancel behavior
+
+`POST /api/projects/{project_id}/imports/datasets/{job_id}:cancel`
+
+Cancellation is currently allowed only while the job is in `awaiting_user_review`.
+
+---
+
+## Adapter design
+
+Dataset import uses a pluggable adapter model.
+
+Contract (`adapters/base.py`):
+
+- `detect(archive: SafeZipArchive) -> tuple[bool, ImportValidationReport]`
+- `build_draft(archive: SafeZipArchive, payload: DatasetImportJobPayload) -> tuple[DatasetManifest, ImportValidationReport]`
+- `validate_pre_commit(payload: DatasetImportJobPayload) -> ImportValidationReport`
+- `commit(payload: DatasetImportJobPayload, project_id: UUID, archive: SafeZipArchive) -> Dataset`
+
+### Stage semantics (important)
+
+`build_draft` and `validate_pre_commit` happen at different points for different purposes:
+
+| Method | When it runs | Purpose |
+|---|---|---|
+| `build_draft` | After adapter detection, before user finalization input | Parse canonical draft manifest and return user-facing assessment messages |
+| `validate_pre_commit` | Immediately before `commit(...)` | Final gate: block execution if required data is missing or invalid |
+
+### Suggested naming (conceptual)
+
+Current names are kept for code stability, but conceptually:
+
+- `build_draft` ≈ **`parse_and_assess_draft`**
+- `validate_pre_commit` ≈ **`validate_ready_to_commit`**
+
+These names better communicate intent than "pre_*" alone.
+
+### "Parse, don't validate" in current design
+
+We follow this by combining draft parsing and user-facing draft assessment into one operation:
+
+- `build_draft(...)` returns `(manifest, report)`
+- hard parse failures still raise exceptions
+- soft issues are returned as validation messages for UX
+
+`validate_pre_commit(...)` remains separate as the strict execution gate immediately before import.
+
+Worker behavior:
+
+- If `format_hint != auto`, worker tries matching adapter first
+- If `format_hint == auto`, worker scans adapters and uses first `detect(...) == True`
+- If no adapter matches, job fails
+
+Currently enabled adapters in worker:
+
+- `LeRobotV2Adapter`
+- `LeRobotV3Adapter`
+
+---
+
+## LeRobotV3 adapter compatibility criteria
+
+`LeRobotV3Adapter.detect(...)` opens the uploaded ZIP and checks that it looks like a supported **v3** dataset archive.
+
+The ZIP is considered compatible when **all** are true:
+
+1. It contains metadata info file:
+   - `meta/info.json` (directly or via normalized path)
+2. It contains v3 tasks index:
+   - `meta/tasks.parquet`
+3. It contains v3 data evidence:
+   - at least one parquet with `.../file-*.parquet` under `data/...`
+
+It is rejected as v3 when v2-only marker files are present:
+
+- `meta/tasks.jsonl`
+- `meta/episodes.jsonl`
+
+If ZIP cannot be opened (`BadZipFile`), detection returns `False`.
+
+Additional adapter behavior:
+
+- Validates finalize input presence before commit
+- Extracts ZIP safely (rejects unsafe paths like absolute paths or `..` traversal)
+- Creates a new dataset record
+
+---
+
+## Practical UI notes
+
+- Prefer `format_hint=auto` unless user explicitly chooses `lerobot_v3`
+- Show progress and status messages from job updates
+- Wait for `awaiting_user_review` before enabling final submit
+- Surface worker validation messages (`payload.validation_report.messages`) clearly to users
+  - treat `severity=error` as blocking
+  - treat `severity=warning` as non-blocking
+
+---
+
+## Operations
+
+### Environment variables
+
+All knobs are read from environment (or `.env` file) at startup via `Settings` in `settings.py`.
+
+| Variable | Default | Description |
+|---|---|---|
+| `DATA_IMPORT_MAX_UPLOAD_BYTES` | 100 GiB | Maximum raw archive size accepted by data-import upload endpoints. Checked by `upload_size_guard_middleware` before the body is read, and again by `check_disk_headroom` before file write. |
+| `DATA_IMPORT_MIN_FREE_BYTES` | 1 GiB | Minimum free headroom that must remain on the target filesystem *after* a write (applies to both cache dir staging and extraction destination). |
+| `DATA_IMPORT_MAX_UNCOMPRESSED_BYTES` | 200 GiB | Maximum total uncompressed size permitted across all ZIP entries. |
+| `STORAGE_DIR` | `~/.cache/physicalai` | Root for `datasets/` (extraction destination) and `cache/imports/datasets/` (staging area). Both must live on a filesystem with adequate free space. |
+
+### Recommended values for large imports (≥ 50 GB)
+
+```bash
+# Raise the raw upload ceiling to match your largest expected archive
+DATA_IMPORT_MAX_UPLOAD_BYTES=107374182400   # 100 GiB (default is already fine)
+
+# Raise the uncompressed cap if archives expand beyond the 200 GiB default
+DATA_IMPORT_MAX_UNCOMPRESSED_BYTES=322122547200   # 300 GiB example
+
+# Keep at least 10 GiB of headroom so the OS is not starved during extraction
+DATA_IMPORT_MIN_FREE_BYTES=10737418240
+
+# Point STORAGE_DIR at a volume with enough room for both staging and extraction
+# (the upload is cached under $STORAGE_DIR/cache/imports/datasets/ and then
+#  extracted into $STORAGE_DIR/datasets/<dataset-id>/)
+STORAGE_DIR=/mnt/large-volume/physicalai
+```
+
+Disk is touched **twice** per import: once when the raw archive lands in the cache dir, and once when it is extracted to the datasets dir. Ensure both paths are on a filesystem that can absorb the uncompressed payload plus the configured headroom.
+
+---
+
+## Security
+
+### HTTP upload size guard (`middleware/upload_size_guard.py`)
+
+`upload_size_guard_middleware` intercepts data-import upload requests. If the `Content-Length` header is present and exceeds `DATA_IMPORT_MAX_UPLOAD_BYTES`, the middleware returns a `413` response **before FastAPI reads a single byte of the body**. Requests without a `Content-Length` header pass through (disk headroom guards still apply).
+
+### ZIP safety checks (`services/archive_safety.py`)
+
+Validation runs in the upload endpoint immediately after the archive is persisted to disk via `SafeZipArchive.validate()`:
+
+| Check | Raises | Configured by |
+|---|---|---|
+| **Nested ZIP** – any entry whose extension is `.zip` (case-insensitive) | `ZipBombDetectedError` | Internal policy (not configurable) |
+| **File count** – number of ZIP entries exceeds the limit | `ZipBombDetectedError` | Internal policy (`200000`) |
+| **Uncompressed bytes** – sum of all `file_size` fields in the central directory exceeds the limit | `ZipBombDetectedError` | `DATA_IMPORT_MAX_UNCOMPRESSED_BYTES` |
+
+### Path traversal and symlink protection (`archive_safety.validate_zip_entries`)
+
+For every entry in the archive (checked at both upload time and during extraction in `SafeZipArchive.extract_to`):
+
+- **Absolute paths** are rejected.
+- **Directory traversal** (`..`) entries are rejected.
+- **Symlinks** (Unix mode `0o120000`) are rejected.
+- **Resolved-path escape** is blocked during extraction by validating target paths stay inside destination root.
+
+All violations raise `ZipBombDetectedError`, which causes the endpoint to delete the staged archive and return an error response.
+
+### Disk headroom checks (`archive_safety.check_disk_headroom`)
+
+`check_disk_headroom` is called at two points:
+
+1. **Upload endpoint** (`api/dataset_import.py`) – checks the **cache dir** (`$STORAGE_DIR/cache/imports/datasets/`) before writing the incoming archive.
+2. **Adapter commit phase** (`services/dataset_import/adapters/lerobot_v3.py`) – checks the **datasets dir** (`$STORAGE_DIR/datasets/`) before extraction.
+
+Both calls enforce `free_bytes ≥ required_bytes + DATA_IMPORT_MIN_FREE_BYTES`. Violation raises `InsufficientDiskSpaceError`.
+
+### Staged archive cleanup behavior
+
+The staged archive is removed in these scenarios:
+
+- **Upload-time validation failure** – endpoint deletes it before returning error.
+- **Successful commit** – worker deletes it after commit finalization.
+- **Cancel / worker failure** – best-effort cleanup in service/worker paths.
+
+**Caveat**: cleanup is best-effort in error paths. If the process is killed mid-import (OOM/SIGKILL/host restart), orphaned staged archives or partially extracted directories can remain and should be monitored/cleaned operationally.
+
+---
+
+## Planned: resumable uploads (TUS)
+
+Chunked/resumable upload support via TUS is planned but **not yet implemented**. Current `PUT …:upload` is single-shot multipart upload; interrupted uploads cannot be resumed.

--- a/application/backend/src/services/dataset_import/adapters/__init__.py
+++ b/application/backend/src/services/dataset_import/adapters/__init__.py
@@ -11,9 +11,7 @@ from .lerobot_v3 import LeRobotV3Adapter
 if TYPE_CHECKING:
     from services.archive_safety import SafeZipArchive
 
-REGISTERED_DATASET_IMPORT_ADAPTERS: tuple[DatasetImportAdapter, ...] = (
-    LeRobotV3Adapter(),
-)
+REGISTERED_DATASET_IMPORT_ADAPTERS: tuple[DatasetImportAdapter, ...] = (LeRobotV3Adapter(),)
 
 
 def get_registered_dataset_import_adapters() -> list[DatasetImportAdapter]:

--- a/application/backend/src/services/dataset_import/adapters/__init__.py
+++ b/application/backend/src/services/dataset_import/adapters/__init__.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from schemas.dataset_import_job import ImportValidationReport
+
+from .base import DatasetImportAdapter
+
+if TYPE_CHECKING:
+    from services.archive_safety import SafeZipArchive
+
+REGISTERED_DATASET_IMPORT_ADAPTERS: tuple[DatasetImportAdapter, ...] = (
+    # Will be added in separate PR
+)
+
+
+def get_registered_dataset_import_adapters() -> list[DatasetImportAdapter]:
+    """Return fresh adapter list for worker/runtime usage."""
+    return list(REGISTERED_DATASET_IMPORT_ADAPTERS)
+
+
+def get_supported_dataset_import_formats() -> set[str]:
+    """Single source of truth for currently supported import format hints."""
+    return {"auto", *[adapter.source.value for adapter in REGISTERED_DATASET_IMPORT_ADAPTERS]}
+
+
+@dataclass
+class DatasetAdapterSelectionResult:
+    """Structured result from :func:`select_dataset_import_adapter`.
+
+    Exactly one of *adapter* or *report* will be set:
+    - Success: ``adapter`` is the matched :class:`DatasetImportAdapter`, ``report`` is ``None``.
+    - Failure: ``adapter`` is ``None``, ``report`` carries the actionable error(s).
+    """
+
+    adapter: DatasetImportAdapter | None
+    report: ImportValidationReport | None
+
+
+def select_dataset_import_adapter(
+    adapters: list[DatasetImportAdapter],
+    format_hint: str,
+    archive: SafeZipArchive,
+) -> DatasetAdapterSelectionResult:
+    """Select the appropriate adapter given a *format_hint* and an open *archive*.
+
+    Returns a :class:`DatasetAdapterSelectionResult` — never raises for semantic
+    mismatches or unknown hints.
+    """
+    for adapter in adapters:
+        if format_hint not in ("auto", adapter.source.value):
+            continue
+
+        matched, report = adapter.detect(archive)
+        if matched:
+            return DatasetAdapterSelectionResult(adapter=adapter, report=None)
+
+        if format_hint == adapter.source.value:
+            return DatasetAdapterSelectionResult(adapter=None, report=report)
+
+    report = ImportValidationReport()
+    report.add_error(
+        "No supported dataset format was detected. "
+        "Supported formats are LeRobot v2 and LeRobot v3. "
+        "Ensure the archive contains the required metadata (meta/info.json) "
+        "and the expected data layout (data/ directory with Parquet episode files)."
+    )
+    return DatasetAdapterSelectionResult(adapter=None, report=report)
+
+
+__all__ = [
+    "DatasetAdapterSelectionResult",
+    "DatasetImportAdapter",
+    "get_registered_dataset_import_adapters",
+    "get_supported_dataset_import_formats",
+    "select_dataset_import_adapter",
+]

--- a/application/backend/src/services/dataset_import/adapters/__init__.py
+++ b/application/backend/src/services/dataset_import/adapters/__init__.py
@@ -6,12 +6,13 @@ from typing import TYPE_CHECKING
 from schemas.dataset_import_job import ImportValidationReport
 
 from .base import DatasetImportAdapter
+from .lerobot_v3 import LeRobotV3Adapter
 
 if TYPE_CHECKING:
     from services.archive_safety import SafeZipArchive
 
 REGISTERED_DATASET_IMPORT_ADAPTERS: tuple[DatasetImportAdapter, ...] = (
-    # Will be added in separate PR
+    LeRobotV3Adapter(),
 )
 
 
@@ -72,6 +73,7 @@ def select_dataset_import_adapter(
 __all__ = [
     "DatasetAdapterSelectionResult",
     "DatasetImportAdapter",
+    "LeRobotV3Adapter",
     "get_registered_dataset_import_adapters",
     "get_supported_dataset_import_formats",
     "select_dataset_import_adapter",

--- a/application/backend/src/services/dataset_import/adapters/base.py
+++ b/application/backend/src/services/dataset_import/adapters/base.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from schemas import Dataset
+from schemas.dataset_import_job import (
+    DatasetImportJobPayload,
+    DatasetImportSource,
+    DatasetManifest,
+    ImportValidationReport,
+)
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from services.archive_safety import SafeZipArchive
+
+
+class DatasetImportAdapter(ABC):
+    source: DatasetImportSource = DatasetImportSource.UNKNOWN
+
+    @abstractmethod
+    def detect(self, archive: SafeZipArchive) -> tuple[bool, ImportValidationReport]:
+        """Return (matched, report) where matched is True if this adapter can process the archive.
+
+        The report may contain error messages explaining why the archive did not match,
+        which callers may surface when the adapter was explicitly requested.
+        """
+
+    @abstractmethod
+    def build_draft(
+        self,
+        archive: SafeZipArchive,
+        payload: DatasetImportJobPayload,
+    ) -> tuple[DatasetManifest, ImportValidationReport]:
+        """Parse source archive and return draft manifest plus validation report."""
+
+    @abstractmethod
+    def validate_pre_commit(self, payload: DatasetImportJobPayload) -> ImportValidationReport:
+        """Validate the finalized payload immediately before committing.
+
+        Implementations must enforce adapter-specific requirements (for example,
+        source manifest consistency and finalize input fields). Generic shared
+        checks are handled by the import workflow before adapter validation.
+        """
+
+    @abstractmethod
+    async def commit(self, payload: DatasetImportJobPayload, project_id: UUID, archive: SafeZipArchive) -> Dataset:
+        """Execute extraction and register dataset in DB."""

--- a/application/backend/src/services/dataset_import/adapters/lerobot_v3.py
+++ b/application/backend/src/services/dataset_import/adapters/lerobot_v3.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import re
+import shutil
+from io import BytesIO
+from uuid import UUID, uuid4
+
+import pandas as pd
+from loguru import logger
+
+from exceptions import InvalidArchiveError
+from schemas import Dataset
+from schemas.dataset_import_job import (
+    DatasetImportJobPayload,
+    DatasetImportSource,
+    DatasetManifest,
+    DatasetManifestStatistics,
+    ImportValidationReport,
+)
+from services.archive_safety import SafeZipArchive, check_disk_headroom, flatten_single_root_directory
+from services.dataset_service import DatasetService
+from settings import get_settings
+
+from .base import DatasetImportAdapter
+from .recording_schema import extract_recording_schema
+
+
+class LeRobotV3Adapter(DatasetImportAdapter):
+    source = DatasetImportSource.LEROBOT_V3
+    _EPISODE_PARQUET_PATTERN = re.compile(r"(?:^|/)meta/episodes/chunk-(\d+)/file-(\d+)\.parquet$")
+
+    def _load_info(self, archive: SafeZipArchive, report: ImportValidationReport) -> dict:
+        raw_info = archive.read_json("meta/info.json")
+        if raw_info is None:
+            report.add_error("Could not read required metadata file 'meta/info.json'.")
+            return {}
+        return raw_info
+
+    def _load_episode_counts(  # noqa: C901, PLR0912, PLR0915
+        self,
+        archive: SafeZipArchive,
+        report: ImportValidationReport,
+        info: dict | None = None,
+    ) -> tuple[int, int]:
+        episode_count = 0
+        frame_count = 0
+
+        episode_shards: list[tuple[int, int, str]] = []
+        for name in archive.iter_normalized_names():
+            if match := self._EPISODE_PARQUET_PATTERN.search(name):
+                episode_shards.append((int(match.group(1)), int(match.group(2)), name))
+
+        if not episode_shards:
+            report.add_error("No episode parquet found under 'meta/episodes/chunk-*/file-*.parquet'.")
+            return episode_count, frame_count
+
+        episode_shards.sort(key=lambda item: (item[0], item[1], item[2]))
+
+        readable_shard_count = 0
+        shard_count_with_episode_index = 0
+        shard_count_without_episode_index = 0
+        shard_count_without_length = 0
+        episode_rows_total = 0
+        episode_rows_without_episode_index = 0
+        unique_episode_indices: set[int] = set()
+
+        for _chunk_index, _file_index, shard_name in episode_shards:
+            shard_bytes = archive.read_bytes(shard_name)
+            if shard_bytes is None:
+                report.add_warning(f"Could not read episode parquet '{shard_name}'.")
+                continue
+
+            try:
+                episodes_df = pd.read_parquet(BytesIO(shard_bytes))
+            except Exception as error:
+                report.add_warning(
+                    f"Could not parse episode parquet '{shard_name}' ({type(error).__name__}); skipping this shard."
+                )
+                continue
+
+            readable_shard_count += 1
+            row_count = len(episodes_df)
+            episode_rows_total += row_count
+
+            if "episode_index" in episodes_df.columns:
+                shard_count_with_episode_index += 1
+                episode_indexes = pd.to_numeric(episodes_df["episode_index"], errors="coerce").dropna()
+                unique_episode_indices.update(episode_indexes.astype("int64").tolist())
+            else:
+                shard_count_without_episode_index += 1
+                episode_rows_without_episode_index += row_count
+
+            if "length" in episodes_df.columns:
+                lengths = pd.to_numeric(episodes_df["length"], errors="coerce").fillna(0)
+                frame_count += int(lengths.sum())
+            else:
+                shard_count_without_length += 1
+
+        if readable_shard_count == 0:
+            report.add_error("No readable episode parquet found under 'meta/episodes/chunk-*/file-*.parquet'.")
+            return 0, 0
+
+        if shard_count_with_episode_index == 0:
+            episode_count = episode_rows_total
+            report.add_warning(
+                "Episode parquet shards are missing 'episode_index'; episode count is based on row count."
+            )
+        elif shard_count_without_episode_index == 0:
+            episode_count = len(unique_episode_indices)
+        else:
+            episode_count = len(unique_episode_indices) + episode_rows_without_episode_index
+            report.add_warning(
+                "Some episode parquet shards are missing 'episode_index'; episode count may be approximate."
+            )
+
+        if shard_count_without_length > 0:
+            report.add_warning(
+                f"{shard_count_without_length} episode parquet shard(s) are missing 'length';"
+                " frame count may be incomplete."
+            )
+
+        if info:
+            expected_episode_count = info.get("total_episodes")
+            if isinstance(expected_episode_count, int) and expected_episode_count != episode_count:
+                report.add_warning(
+                    "Episode count mismatch: metadata reports "
+                    f"{expected_episode_count}, parsed episode shards report {episode_count}."
+                )
+
+            expected_frame_count = info.get("total_frames")
+            if isinstance(expected_frame_count, int) and expected_frame_count != frame_count:
+                report.add_warning(
+                    "Frame count mismatch: metadata reports "
+                    f"{expected_frame_count}, parsed episode shards report {frame_count}."
+                )
+
+        return episode_count, frame_count
+
+    def detect(self, archive: SafeZipArchive) -> tuple[bool, ImportValidationReport]:
+        """Return (matched, report) for LeRobot v3 archives.
+
+        v3 markers (all required):
+          - ``meta/info.json``
+          - ``meta/tasks.parquet``         (v3 task index; v2 uses tasks.jsonl)
+          - ``data/chunk-*/file-*.parquet`` (v3 data layout; v2 uses episode_*.parquet)
+
+        Explicitly reject if v2-specific markers are found:
+          - ``meta/episodes.jsonl``  (v2 only)
+          - ``meta/tasks.jsonl``     (v2 only)
+        """
+        report = ImportValidationReport()
+        has_info = False
+        has_tasks_parquet = False
+        has_v3_data = False
+        rejected_v2_markers: list[str] = []
+
+        for name in archive.iter_normalized_names():
+            # Reject v2-only markers immediately (handle both flat and nested archives)
+            if name == "meta/episodes.jsonl" or name.endswith("/meta/episodes.jsonl"):
+                rejected_v2_markers.append("'meta/episodes.jsonl'")
+                break
+            if name == "meta/tasks.jsonl" or name.endswith("/meta/tasks.jsonl"):
+                rejected_v2_markers.append("'meta/tasks.jsonl'")
+                break
+
+            if not has_info and (name == "meta/info.json" or name.endswith("/meta/info.json")):
+                has_info = True
+            if not has_tasks_parquet and (name == "meta/tasks.parquet" or name.endswith("/meta/tasks.parquet")):
+                has_tasks_parquet = True
+            if (
+                not has_v3_data
+                and ("data/" in name or name.startswith("data/"))
+                and "/file-" in name
+                and name.endswith(".parquet")
+                and "episode_" not in name
+            ):
+                has_v3_data = True
+
+            if has_info and has_tasks_parquet and has_v3_data:
+                return True, report
+
+        if rejected_v2_markers:
+            report.add_error(
+                f"Archive contains LeRobot v2 markers ({', '.join(rejected_v2_markers)}); "
+                "use the lerobot_v2 dataset format instead."
+            )
+            return False, report
+
+        missing = []
+        if not has_info:
+            missing.append("'meta/info.json'")
+        if not has_tasks_parquet:
+            missing.append("'meta/tasks.parquet'")
+        if not has_v3_data:
+            missing.append("v3 data files ('data/chunk-*/file-*.parquet')")
+
+        if missing:
+            report.add_error(f"LeRobot v3 markers not found: {', '.join(missing)}.")
+
+        return False, report
+
+    def build_draft(
+        self,
+        archive: SafeZipArchive,
+        payload: DatasetImportJobPayload,  # noqa: ARG002
+    ) -> tuple[DatasetManifest, ImportValidationReport]:
+        report = ImportValidationReport()
+        info: dict = {}
+        episode_count = 0
+        frame_count = 0
+
+        try:
+            info = self._load_info(archive=archive, report=report)
+            episode_count, frame_count = self._load_episode_counts(archive=archive, report=report, info=info)
+
+            if archive.read_json("meta/stats.json") is None:
+                report.add_warning("No global stats metadata found in 'meta/stats.json'.")
+
+            if archive.read_bytes("meta/tasks.parquet") is None:
+                report.add_warning("No tasks index found in 'meta/tasks.parquet'.")
+
+        except (ValueError, InvalidArchiveError) as error:
+            logger.debug("Could not read LeRobot v3 info from '{}': {}", archive.path, error)
+            report.add_error(f"Unable to parse core dataset metadata from archive ('{type(error).__name__}').")
+
+        if episode_count == 0:
+            report.add_warning("Detected 0 episodes from metadata.")
+        if frame_count == 0 and episode_count > 0:
+            report.add_warning("Detected episodes but total frame count is 0.")
+
+        recording_schema = extract_recording_schema(info)
+        if not recording_schema.cameras:
+            report.add_warning("No camera streams inferred from dataset metadata.")
+        if not recording_schema.robots:
+            report.add_warning("No robot schema inferred from dataset metadata.")
+
+        logger.info(
+            "LeRobotV3Adapter manifest draft parsed: archive='{}'",
+            archive.path,
+        )
+
+        manifest = DatasetManifest(
+            source_type=DatasetImportSource.LEROBOT_V3,
+            statistics=DatasetManifestStatistics(
+                episode_count=episode_count,
+                frame_count=frame_count,
+            ),
+            dataset_schema=recording_schema,
+        )
+
+        return manifest, report
+
+    def validate_pre_commit(self, payload: DatasetImportJobPayload) -> ImportValidationReport:
+        report = ImportValidationReport()
+
+        if payload.finalize_input is None:
+            report.add_error("Finalize input is required before commit")
+
+        return report
+
+    async def commit(self, payload: DatasetImportJobPayload, project_id: UUID, archive: SafeZipArchive) -> Dataset:
+        if payload.finalize_input is None:
+            raise ValueError("Cannot commit dataset import without finalize input")
+
+        settings = get_settings()
+        settings.datasets_dir.mkdir(parents=True, exist_ok=True)
+
+        dataset_id = uuid4()
+        destination_dir = settings.datasets_dir / str(dataset_id)
+        destination_dir.mkdir(parents=True, exist_ok=False)
+        logger.info(
+            "LeRobotV3Adapter commit destination prepared: dataset_id='{}', destination_dir='{}'",
+            dataset_id,
+            destination_dir,
+        )
+
+        check_disk_headroom(
+            settings.datasets_dir,
+            required_bytes=archive.estimated_uncompressed_size(),
+            min_free_bytes=settings.data_import_min_free_bytes,
+        )
+
+        try:
+            extracted_count = archive.extract_to(
+                destination_dir,
+                min_free_bytes=settings.data_import_min_free_bytes,
+            )
+
+            # Allow users to upload a zip with the dataset either at archive root
+            # or inside a single top-level folder.
+            flatten_single_root_directory(destination_dir)
+
+            logger.info(
+                "LeRobotV3Adapter extracted archive: archive='{}', destination_dir='{}', file_count={}",
+                archive.path,
+                destination_dir,
+                extracted_count,
+            )
+
+            dataset = Dataset(
+                id=dataset_id,
+                name=payload.dataset_name or "Imported Dataset",
+                path=str(destination_dir),
+                default_task=payload.finalize_input.default_task,
+                project_id=project_id,
+                environment_id=payload.finalize_input.environment_id,
+            )
+
+            saved = await DatasetService.create_dataset(dataset)
+            logger.info(
+                "LeRobotV3Adapter dataset persisted: dataset_id='{}', project_id='{}', environment_id='{}', path='{}'",
+                saved.id,
+                saved.project_id,
+                saved.environment_id,
+                saved.path,
+            )
+
+            return saved
+        except Exception:
+            shutil.rmtree(destination_dir, ignore_errors=True)
+            raise

--- a/application/backend/src/services/dataset_import/adapters/recording_schema.py
+++ b/application/backend/src/services/dataset_import/adapters/recording_schema.py
@@ -1,0 +1,135 @@
+"""Helpers for inferring recording schema (cameras, robots) from LeRobot info.json features."""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from schemas.dataset_import_job import DatasetManifestRecordingSchema, ManifestCameraEntry, ManifestRobotEntry
+
+
+def extract_recording_schema(info: dict) -> DatasetManifestRecordingSchema:
+    """Parse LeRobot ``meta/info.json`` content and return a :class:`DatasetManifestRecordingSchema`.
+
+    Extraction is best-effort: any missing or malformed fields are silently
+    skipped so that a bad feature entry never blocks the import flow.
+
+    Camera detection
+    ----------------
+    Any feature whose key matches ``observation.images.<camera_name>`` and
+    whose ``dtype`` is ``"video"`` is treated as a camera stream.  Width,
+    height and fps are read from the nested ``info.video.*`` sub-dict when
+    present; as a fallback the spatial dimensions are taken from ``shape``
+    and fps from the top-level ``fps`` field.
+
+    Robot / joint detection
+    -----------------------
+    A single robot entry is produced when ``action`` or
+    ``observation.state`` features contain ``names`` lists.  Joint names are
+    derived by stripping everything from the first ``.`` onward
+    (e.g. ``shoulder_pan.pos`` → ``shoulder_pan``), with duplicates removed
+    while preserving insertion order.
+
+    The ``robot_type`` top-level field is used as both ``name`` and ``type``
+    when present.
+    """
+    try:
+        features: dict = {}
+        if isinstance(info.get("features"), dict):
+            features = info["features"]
+
+        dataset_fps: int | None = None
+        fps_raw = info.get("fps")
+        if fps_raw is not None:
+            dataset_fps = int(float(fps_raw))
+
+        robot_type_raw = info.get("robot_type")
+        robot_type: str | None = str(robot_type_raw).strip() if robot_type_raw else None
+
+        cameras = _extract_cameras(features, dataset_fps)
+        robots = _extract_robots(features, robot_type)
+        return DatasetManifestRecordingSchema(cameras=cameras, robots=robots)
+    except Exception as exc:
+        logger.debug("recording_schema: unexpected error during extraction, returning empty schema: {}", exc)
+        return DatasetManifestRecordingSchema()
+
+
+def _extract_cameras(features: dict, dataset_fps: int | None) -> list[ManifestCameraEntry]:
+    cameras: list[ManifestCameraEntry] = []
+    prefix = "observation.images."
+
+    for key, feature in features.items():
+        if not isinstance(key, str) or not key.startswith(prefix):
+            continue
+        if not isinstance(feature, dict):
+            continue
+        if feature.get("dtype") != "video":
+            continue
+
+        camera_name = key[len(prefix) :]
+        if not camera_name:
+            continue
+
+        width: int | None = None
+        height: int | None = None
+        fps: int | None = dataset_fps
+
+        # Prefer info.video.* for precise values
+        video_info = feature.get("info", {})
+        if isinstance(video_info, dict):
+            video_section = video_info.get("video", {})
+            if isinstance(video_section, dict):
+                width = _safe_int(video_section.get("width")) or width
+                height = _safe_int(video_section.get("height")) or height
+                fps = _safe_int(video_section.get("fps")) or fps
+
+        # Fallback: derive from shape [height, width, channels] if available
+        if width is None or height is None:
+            shape = feature.get("shape")
+            if isinstance(shape, list) and len(shape) >= 2:
+                height = height or _safe_int(shape[0])
+                width = width or _safe_int(shape[1])
+
+        cameras.append(ManifestCameraEntry(name=camera_name, width=width, height=height, fps=fps))
+
+    return cameras
+
+
+def _extract_robots(features: dict, robot_type: str | None) -> list[ManifestRobotEntry]:
+    joints: list[str] = []
+    seen: set[str] = set()
+
+    # Collect joint names from action and observation.state features
+    for key in ("action", "observation.state"):
+        feature = features.get(key)
+        if not isinstance(feature, dict):
+            continue
+        names = feature.get("names")
+        if not isinstance(names, list):
+            continue
+        for raw_name in names:
+            if not isinstance(raw_name, str):
+                continue
+            joint = raw_name.split(".")[0].strip()
+            if joint and joint not in seen:
+                seen.add(joint)
+                joints.append(joint)
+
+    if not joints and robot_type is None:
+        # Nothing to describe - return empty list rather than a placeholder robot
+        return []
+
+    robot = ManifestRobotEntry(
+        name=robot_type or "robot",
+        type=robot_type,
+        joints=joints,
+    )
+    return [robot]
+
+
+def _safe_int(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(float(value))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None

--- a/application/backend/src/services/dataset_import/adapters/recording_schema.py
+++ b/application/backend/src/services/dataset_import/adapters/recording_schema.py
@@ -29,8 +29,7 @@ def extract_recording_schema(info: dict) -> DatasetManifestRecordingSchema:
     (e.g. ``shoulder_pan.pos`` → ``shoulder_pan``), with duplicates removed
     while preserving insertion order.
 
-    The ``robot_type`` top-level field is used as both ``name`` and ``type``
-    when present.
+    The ``robot_type`` top-level field is used as ``type`` when present.
     """
     try:
         features: dict = {}
@@ -119,7 +118,6 @@ def _extract_robots(features: dict, robot_type: str | None) -> list[ManifestRobo
         return []
 
     robot = ManifestRobotEntry(
-        name=robot_type or "robot",
         type=robot_type,
         joints=joints,
     )

--- a/application/backend/src/services/dataset_import/service.py
+++ b/application/backend/src/services/dataset_import/service.py
@@ -1,0 +1,147 @@
+import datetime
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+
+from db import get_async_db_session_ctx
+from exceptions import InvalidJobStateError, ResourceNotFoundError, ResourceType
+from repositories import JobRepository
+from schemas import Job
+from schemas.base_job import JobStatus, JobType
+from schemas.dataset_import_job import DatasetImportFinalizeInput, DatasetImportJobPayload, ImportStep
+from schemas.job import DatasetImportJob
+from services.archive_safety import cleanup_staged_archive
+from services.dataset_import.staging import generate_staging_id, resolve_payload_archive_path
+
+
+class DatasetImportService:
+    @staticmethod
+    async def _load_validated_dataset_import_job(
+        repo: JobRepository,
+        *,
+        project_id: UUID,
+        job_id: UUID,
+    ) -> tuple[Job, DatasetImportJobPayload]:
+        job = await repo.get_by_id(job_id)
+        if job is None:
+            raise ResourceNotFoundError(ResourceType.JOB, str(job_id))
+        if job.project_id != project_id:
+            raise ResourceNotFoundError(ResourceType.JOB, str(job_id))
+        if job.type != JobType.DATASET_IMPORT:
+            raise InvalidJobStateError("Job is not a dataset import job")
+        if not isinstance(job.payload, DatasetImportJobPayload):
+            raise InvalidJobStateError("Dataset import job payload is invalid")
+
+        return job, job.payload
+
+    @staticmethod
+    async def prepare_dataset_import_job(
+        project_id: UUID,
+        format_hint: str = "auto",
+        dataset_name: str = "",
+    ) -> Job:
+        async with get_async_db_session_ctx() as session:
+            repo = JobRepository(session)
+            payload = DatasetImportJobPayload(
+                archive_staging_id=generate_staging_id(),
+                format_hint=format_hint,
+                dataset_name=dataset_name or None,
+                step=ImportStep.AWAITING_ARCHIVE_UPLOAD,
+            )
+            job = DatasetImportJob(
+                project_id=project_id,
+                payload=payload,
+                message="Dataset import job prepared, awaiting upload",
+            )
+            try:
+                return await repo.save(job)
+            except IntegrityError:
+                raise ResourceNotFoundError(resource_type=ResourceType.PROJECT, resource_id=project_id)
+
+    @staticmethod
+    async def attach_dataset_import_archive(
+        project_id: UUID,
+        job_id: UUID,
+        uploaded_archive_name: str,
+    ) -> Job:
+        async with get_async_db_session_ctx() as session:
+            repo = JobRepository(session)
+            job, payload = await DatasetImportService._load_validated_dataset_import_job(
+                repo,
+                project_id=project_id,
+                job_id=job_id,
+            )
+            if payload.step != ImportStep.AWAITING_ARCHIVE_UPLOAD:
+                raise InvalidJobStateError(
+                    f"Archive can only be attached when job is in '{ImportStep.AWAITING_ARCHIVE_UPLOAD}' step"
+                )
+
+            payload.uploaded_archive_name = uploaded_archive_name
+            payload.step = ImportStep.QUEUED_FOR_DETECTION
+
+            updates = {
+                "payload": payload.model_dump(mode="json"),
+                "status": JobStatus.PENDING,
+                "message": "Dataset queued for importing",
+                "progress": 5,
+            }
+            return await repo.update(job, updates)
+
+    @staticmethod
+    async def claim_pending_dataset_import_job() -> Job | None:
+        async with get_async_db_session_ctx() as session:
+            repo = JobRepository(session)
+            return await repo.claim_pending_dataset_import_job()
+
+    @staticmethod
+    async def finalize_dataset_import_job(
+        project_id: UUID,
+        job_id: UUID,
+        finalize_input: DatasetImportFinalizeInput,
+    ) -> Job:
+        async with get_async_db_session_ctx() as session:
+            repo = JobRepository(session)
+            job, payload = await DatasetImportService._load_validated_dataset_import_job(
+                repo,
+                project_id=project_id,
+                job_id=job_id,
+            )
+            if payload.step != ImportStep.AWAITING_USER_REVIEW:
+                raise InvalidJobStateError(
+                    f"Dataset import can only be finalized from '{ImportStep.AWAITING_USER_REVIEW}' step"
+                )
+
+            payload.finalize_input = finalize_input
+            payload.step = ImportStep.QUEUED_FOR_IMPORT
+
+            updates = {
+                "payload": payload.model_dump(mode="json"),
+                "status": JobStatus.PENDING,
+                "message": "Dataset import finalized and queued",
+                "progress": 45,
+            }
+
+            return await repo.update(job, updates)
+
+    @staticmethod
+    async def cancel_dataset_import_job(project_id: UUID, job_id: UUID) -> Job:
+        async with get_async_db_session_ctx() as session:
+            repo = JobRepository(session)
+            job, payload = await DatasetImportService._load_validated_dataset_import_job(
+                repo,
+                project_id=project_id,
+                job_id=job_id,
+            )
+            if payload.step != ImportStep.AWAITING_USER_REVIEW:
+                raise InvalidJobStateError(
+                    f"Dataset import can only be canceled from '{ImportStep.AWAITING_USER_REVIEW}' step"
+                )
+
+            updates = {
+                "status": JobStatus.CANCELED,
+                "message": "Dataset import canceled",
+                "end_time": datetime.datetime.now(tz=datetime.UTC),
+            }
+            updated_job = await repo.update(job, updates)
+            cleanup_staged_archive(resolve_payload_archive_path(payload))
+            return updated_job

--- a/application/backend/src/services/dataset_import/staging.py
+++ b/application/backend/src/services/dataset_import/staging.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Staging-path helpers for dataset import archives.
+
+An *opaque staging identifier* (a UUID string) is persisted in the job
+payload instead of the raw filesystem path.  The actual path is derived
+deterministically from the id at runtime so no in-memory map is needed.
+
+Layout::
+
+    <cache_dir>/imports/datasets/<staging_id>.zip
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from settings import get_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from schemas.dataset_import_job import DatasetImportJobPayload
+
+
+def generate_staging_id() -> UUID:
+    """Return a new random staging identifier (UUID v4)."""
+    return uuid4()
+
+
+def resolve_payload_archive_path(payload: DatasetImportJobPayload) -> Path:
+    """Return the archive ``Path`` for a dataset import job payload."""
+
+    settings = get_settings()
+    staging_dir = settings.cache_dir / "imports" / "datasets"
+    return staging_dir / f"{payload.archive_staging_id}.zip"

--- a/application/backend/src/services/job_service.py
+++ b/application/backend/src/services/job_service.py
@@ -15,7 +15,7 @@ from exceptions import (
 from repositories import JobRepository
 from schemas import Job
 from schemas.base_job import JobStatus, JobType
-from schemas.job import TrainJob, TrainJobPayload
+from schemas.job import JobPayload, TrainJob, TrainJobPayload
 from services.system_service import SystemService
 
 
@@ -74,6 +74,36 @@ class JobService:
         async with get_async_db_session_ctx() as session:
             repo = JobRepository(session)
             return await repo.get_pending_job_by_type(JobType.TRAINING)
+
+    @staticmethod
+    async def update_job_payload(
+        job_id: UUID,
+        payload: JobPayload,
+        *,
+        status: JobStatus | None = None,
+        message: str | None = None,
+        progress: int | None = None,
+        extra_info: dict | None = None,
+    ) -> Job:
+        async with get_async_db_session_ctx() as session:
+            repo = JobRepository(session)
+            job = await repo.get_by_id(job_id)
+            if job is None:
+                raise ResourceNotFoundError(ResourceType.JOB, resource_id=job_id)
+
+            updates: dict = {"payload": payload.model_dump(mode="json")}
+            if status is not None:
+                updates["status"] = status
+            if message is not None:
+                updates["message"] = message
+            if progress is not None:
+                updates["progress"] = progress
+            if extra_info is not None:
+                updates["extra_info"] = extra_info
+            if status in {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELED}:
+                updates["end_time"] = datetime.datetime.now(tz=datetime.UTC)
+
+            return await repo.update(job, updates)
 
     @staticmethod
     async def update_job_status(

--- a/application/backend/src/services/log_service.py
+++ b/application/backend/src/services/log_service.py
@@ -15,6 +15,7 @@ from sse_starlette import ServerSentEvent
 
 from core.logging.utils import get_job_logs_path
 from schemas.base_job import JobType
+from schemas.dataset_import_job import DatasetImportJobPayload
 from schemas.job import TrainJobPayload
 from schemas.logs import LogSource
 from services.job_service import JobService
@@ -33,6 +34,7 @@ STATIC_SOURCES: dict[str, StaticLogSource] = {
     "training": StaticLogSource(name="Training", filename="training.log", type="worker"),
     "inference": StaticLogSource(name="Inference", filename="inference.log", type="worker"),
     "teleoperate": StaticLogSource(name="Teleoperate", filename="teleoperate.log", type="worker"),
+    "dataset-import": StaticLogSource(name="Dataset Import", filename="dataset_import.log", type="worker"),
 }
 
 
@@ -92,6 +94,17 @@ class LogService:
             if job.type == JobType.TRAINING:
                 payload = TrainJobPayload.model_validate(job.payload)
                 names[str(job.id)] = f"{payload.model_name} ({payload.policy})"
+            elif job.type == JobType.DATASET_IMPORT:
+                payload = DatasetImportJobPayload.model_validate(job.payload)
+                if payload.dataset_name:
+                    display_name = payload.dataset_name
+                elif payload.uploaded_archive_name:
+                    display_name = payload.uploaded_archive_name
+                elif payload.archive_staging_id:
+                    display_name = f"{str(payload.archive_staging_id)[:8]}.zip"
+                else:
+                    display_name = f"dataset-import-{self._short_id(str(job.id))}.zip"
+                names[str(job.id)] = f"Import: {display_name}"
 
         return names
 

--- a/application/backend/src/workers/dataset_import_worker.py
+++ b/application/backend/src/workers/dataset_import_worker.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from core.logging.utils import job_logging_ctx
+from schemas.base_job import JobStatus
+from schemas.dataset_import_job import (
+    DatasetImportJobPayload,
+    ImportStep,
+    ImportValidationReport,
+    ImportValidationSeverity,
+)
+from schemas.job import DatasetImportJob
+from services.archive_safety import SafeZipArchive, cleanup_staged_archive
+from services.dataset_import.adapters import (
+    DatasetImportAdapter,
+    get_registered_dataset_import_adapters,
+    select_dataset_import_adapter,
+)
+from services.dataset_import.service import DatasetImportService
+from services.dataset_import.staging import resolve_payload_archive_path
+from services.event_processor import EventType
+from services.job_service import JobService
+from settings import get_settings
+from workers.base import BaseProcessWorker
+
+if TYPE_CHECKING:
+    import multiprocessing as mp
+    from multiprocessing.synchronize import Event as EventClass
+    from pathlib import Path
+    from uuid import UUID
+
+
+class DatasetImportWorker(BaseProcessWorker):
+    ROLE = "DatasetImportWorker"
+
+    def __init__(self, stop_event: EventClass, event_queue: mp.Queue):
+        super().__init__(stop_event=stop_event)
+        self.queue = event_queue
+        self.adapters: list[DatasetImportAdapter] = get_registered_dataset_import_adapters()
+
+    async def run_loop(self) -> None:
+        logger.info("Dataset Import Worker is running")
+        while not self.should_stop():
+            job = await DatasetImportService.claim_pending_dataset_import_job()
+            if isinstance(job, DatasetImportJob):
+                await self._process_job(job)
+
+            self.stop_aware_sleep(0.5)
+
+    async def _process_job(self, job: DatasetImportJob) -> None:
+        with job_logging_ctx(job_id=str(job.id)):
+            if not isinstance(job.payload, DatasetImportJobPayload):
+                raise ValueError(f"Invalid payload type for dataset import job: {type(job.payload)}")
+            payload = job.payload
+            archive_ref = payload.archive_staging_id
+            logger.info(
+                "Processing dataset import job: job_id='{}', step='{}', format_hint='{}', archive_ref='{}'",
+                job.id,
+                payload.step,
+                payload.format_hint,
+                archive_ref,
+            )
+
+            pre_commit_handled = False
+            try:
+                if payload.step == ImportStep.QUEUED_FOR_DETECTION:
+                    await self._run_detection(job.id, job.project_id, payload)
+                elif payload.step == ImportStep.QUEUED_FOR_IMPORT:
+                    pre_commit_handled = await self._run_commit(job.id, job.project_id, payload)
+            except Exception as e:
+                logger.exception(f"Dataset import failed: {e}")
+                if not pre_commit_handled:
+                    error_report = ImportValidationReport()
+                    error_report.add_error(f"Dataset import failed unexpectedly: {e}")
+                    await self._fail_job_with_validation_report(
+                        job_id=job.id,
+                        payload=payload,
+                        report=error_report,
+                        message=f"Dataset import failed: {e}",
+                        cleanup_archive_path=resolve_payload_archive_path(payload),
+                    )
+
+    async def _fail_job_with_validation_report(
+        self,
+        job_id: UUID,
+        payload: DatasetImportJobPayload,
+        report: ImportValidationReport,
+        message: str,
+        cleanup_archive_path: str | Path | None = None,
+    ) -> None:
+        """Persist a failed job state with a structured validation report in the payload.
+
+        Sets ``payload.validation_report`` only when the report has messages, then
+        writes FAILED status via :meth:`JobService.update_job_payload` and queues a
+        ``JOB_UPDATE`` event.  If *cleanup_archive_path* is provided, the staged
+        archive is removed after the job is persisted.
+        """
+        payload.validation_report = report if report.messages else None
+        failed_job = await JobService.update_job_payload(
+            job_id=job_id,
+            payload=payload,
+            status=JobStatus.FAILED,
+            message=message,
+        )
+        if cleanup_archive_path is not None:
+            cleanup_staged_archive(cleanup_archive_path)
+        self.queue.put((EventType.JOB_UPDATE, failed_job))
+
+    async def _run_detection(self, job_id: UUID, _project_id: UUID, payload: DatasetImportJobPayload) -> None:
+        archive_path = resolve_payload_archive_path(payload)
+
+        logger.info(
+            "Starting dataset format detection for job_id='{}' with staging_id='{}', archive='{}'",
+            job_id,
+            payload.archive_staging_id,
+            archive_path,
+        )
+        payload.step = ImportStep.DETECTING_FORMAT
+        job = await JobService.update_job_payload(
+            job_id=job_id,
+            payload=payload,
+            status=JobStatus.RUNNING,
+            message="Detecting dataset format",
+            progress=10,
+        )
+        self.queue.put((EventType.JOB_UPDATE, job))
+
+        archive = SafeZipArchive(
+            archive_path,
+            max_uncompressed_bytes=get_settings().data_import_max_uncompressed_bytes,
+        )
+        selection = select_dataset_import_adapter(
+            adapters=self.adapters,
+            format_hint=payload.format_hint,
+            archive=archive,
+        )
+        if selection.adapter is None:
+            report = selection.report
+            if report is None:
+                report = ImportValidationReport()
+                report.add_error(
+                    "Dataset format detection did not produce a validation report; "
+                    "the archive may be malformed or unreadable."
+                )
+            error_count = sum(1 for msg in report.messages)
+            logger.warning(
+                "Dataset format detection failed for archive='{}': {} message(s)",
+                archive.path,
+                error_count,
+            )
+            await self._fail_job_with_validation_report(
+                job_id=job_id,
+                payload=payload,
+                report=report,
+                message="Dataset format detection failed",
+                cleanup_archive_path=resolve_payload_archive_path(payload),
+            )
+            return
+
+        selected_adapter = selection.adapter
+
+        logger.info(
+            "Auto-detected dataset format: adapter='{}', source='{}', archive='{}'",
+            selected_adapter.__class__.__name__,
+            selected_adapter.source,
+            archive.path,
+        ) if payload.format_hint == "auto" else logger.info(
+            "Selecting adapter from format hint: hint='{}', adapter='{}'",
+            payload.format_hint,
+            selected_adapter.__class__.__name__,
+        )
+
+        payload.step = ImportStep.BUILDING_MANIFEST_DRAFT
+        job = await JobService.update_job_payload(
+            job_id=job_id,
+            payload=payload,
+            status=JobStatus.RUNNING,
+            message="Generating dataset draft",
+            progress=25,
+        )
+        self.queue.put((EventType.JOB_UPDATE, job))
+
+        payload.dataset_manifest_draft, report = selected_adapter.build_draft(archive=archive, payload=payload)
+        payload.dataset_manifest_draft.source_type = selected_adapter.source
+
+        logger.info(
+            "Dataset format selected for job_id='{}': format='{}'",
+            job_id,
+            payload.dataset_manifest_draft.source_type,
+        )
+
+        error_count = sum(1 for msg in report.messages if msg.severity == ImportValidationSeverity.ERROR)
+        warning_count = sum(1 for msg in report.messages if msg.severity == ImportValidationSeverity.WARNING)
+        logger.info(
+            "Pre-finalize validation report for job_id='{}': is_valid={}, errors={}, warnings={}",
+            job_id,
+            report.is_valid,
+            error_count,
+            warning_count,
+        )
+        # Only persist validation_report when there is actionable content; leave None when clean.
+        has_issues = bool(report.messages)
+        payload.validation_report = report if has_issues else None
+        payload.step = ImportStep.AWAITING_USER_REVIEW
+
+        job = await JobService.update_job_payload(
+            job_id=job_id,
+            payload=payload,
+            status=JobStatus.PENDING,
+            message="Waiting for user input",
+            progress=40,
+        )
+        self.queue.put((EventType.JOB_UPDATE, job))
+
+    async def _run_commit(self, job_id: UUID, project_id: UUID, payload: DatasetImportJobPayload) -> bool:
+        """Run the commit phase.  Returns True if this method handled the final job state
+        (pre-commit validation failure), so the outer error handler does not double-mark.
+        """
+        archive_path = resolve_payload_archive_path(payload)
+
+        if payload.dataset_manifest_draft is None:
+            raise ValueError("No dataset manifest draft found; cannot determine adapter for commit")
+
+        expected_source_type = payload.dataset_manifest_draft.source_type
+        adapter = next((a for a in self.adapters if a.source == expected_source_type), None)
+        if adapter is None:
+            raise ValueError(f"No adapter available for source_type='{expected_source_type}' during commit")
+
+        logger.info(
+            "Starting commit for job_id='{}' using adapter='{}', source='{}', staging_id='{}'",
+            job_id,
+            adapter.__class__.__name__,
+            expected_source_type,
+            payload.archive_staging_id,
+        )
+
+        pre_commit_report = ImportValidationReport()
+        if not payload.dataset_name:
+            pre_commit_report.add_error("dataset_name is required before commit (must be set at prepare time)")
+
+        adapter_report = adapter.validate_pre_commit(payload=payload)
+        pre_commit_report.messages.extend(adapter_report.messages)
+        if not pre_commit_report.is_valid:
+            # Persist failure state with the blocking report so it is observable in the payload
+            error_messages = "; ".join(
+                msg.message for msg in pre_commit_report.messages if msg.severity == ImportValidationSeverity.ERROR
+            )
+            payload.validation_report = pre_commit_report
+            failed_job = await JobService.update_job_payload(
+                job_id=job_id,
+                payload=payload,
+                status=JobStatus.FAILED,
+                message=f"Pre-commit validation failed: {error_messages}",
+            )
+            cleanup_staged_archive(archive_path)
+            self.queue.put((EventType.JOB_UPDATE, failed_job))
+            logger.warning(
+                "Pre-commit validation failed for job_id='{}': {}",
+                job_id,
+                error_messages,
+            )
+            return True  # handled; outer handler must not double-mark
+
+        try:
+            payload.step = ImportStep.IMPORTING_DATASET
+            job = await JobService.update_job_payload(
+                job_id=job_id,
+                payload=payload,
+                status=JobStatus.RUNNING,
+                message="Importing dataset",
+                progress=60,
+            )
+            self.queue.put((EventType.JOB_UPDATE, job))
+
+            archive = SafeZipArchive(
+                archive_path,
+                max_uncompressed_bytes=get_settings().data_import_max_uncompressed_bytes,
+            )
+            dataset = await adapter.commit(payload, project_id=project_id, archive=archive)
+            logger.info(
+                "Adapter commit completed for job_id='{}': dataset_id='{}', dataset_path='{}'",
+                job_id,
+                dataset.id,
+                dataset.path,
+            )
+
+            payload.result_dataset_id = dataset.id
+            payload.step = ImportStep.COMPLETED
+            completed = await JobService.update_job_payload(
+                job_id=job_id,
+                payload=payload,
+                status=JobStatus.COMPLETED,
+                message="Dataset import completed",
+                progress=100,
+            )
+            logger.info(
+                "Dataset import job completed: job_id='{}', result_dataset_id='{}'", job_id, payload.result_dataset_id
+            )
+            self.queue.put((EventType.JOB_UPDATE, completed))
+            return False
+        finally:
+            cleanup_staged_archive(archive_path)

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -91,7 +91,7 @@ class TrainingWorker(BaseProcessWorker):
 
                     self.interrupt_event.clear()
                     await asyncio.create_task(self._train_model(job, model, snapshot, payload, base_model))
-            await asyncio.sleep(0.5)
+            self.stop_aware_sleep(0.5)
 
     async def setup(self) -> None:
         await super().setup()

--- a/application/backend/tests/api/test_dataset_import_upload_safety.py
+++ b/application/backend/tests/api/test_dataset_import_upload_safety.py
@@ -1,0 +1,329 @@
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from api.dependencies import get_dataset_import_service, get_job_service
+from main import app
+from schemas.base_job import JobStatus, JobType
+from schemas.dataset_import_job import DatasetImportJobPayload, ImportStep
+from schemas.job import DatasetImportJob
+
+_FIXED_STAGING_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+class _StubDatasetImportService:
+    def __init__(self, project_id):
+        self.project_id = project_id
+        self.calls: list[dict] = []
+
+    async def attach_dataset_import_archive(self, project_id, job_id, uploaded_archive_name):
+        self.calls.append(
+            {
+                "project_id": project_id,
+                "job_id": job_id,
+                "uploaded_archive_name": uploaded_archive_name,
+            }
+        )
+        return DatasetImportJob(
+            id=job_id,
+            project_id=project_id,
+            status=JobStatus.PENDING,
+            progress=5,
+            message="Dataset queued for importing",
+            payload=DatasetImportJobPayload(
+                type=JobType.DATASET_IMPORT,
+                step=ImportStep.QUEUED_FOR_DETECTION,
+                archive_staging_id=_FIXED_STAGING_ID,
+                uploaded_archive_name=uploaded_archive_name,
+                format_hint="auto",
+            ),
+        )
+
+
+class _StubJobService:
+    """Minimal stub for JobService that returns a valid AWAITING_ARCHIVE_UPLOAD job."""
+
+    def __init__(self, project_id, job_id):
+        self.project_id = project_id
+        self.job_id = job_id
+        self._job = DatasetImportJob(
+            id=job_id,
+            project_id=project_id,
+            status=JobStatus.PENDING,
+            payload=DatasetImportJobPayload(
+                step=ImportStep.AWAITING_ARCHIVE_UPLOAD,
+                archive_staging_id=_FIXED_STAGING_ID,
+                format_hint="auto",
+            ),
+        )
+
+    async def get_job_by_id(self, job_id):
+        return self._job
+
+
+def _make_zip_bytes(files: dict[str, bytes], *, compression=zipfile.ZIP_DEFLATED) -> bytes:
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, mode="w", compression=compression) as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return stream.getvalue()
+
+
+def test_upload_rejects_nested_zip_and_does_not_attach_archive() -> None:
+    project_id = uuid4()
+    job_id = uuid4()
+    stub = _StubDatasetImportService(project_id)
+    job_stub = _StubJobService(project_id, job_id)
+    app.dependency_overrides[get_dataset_import_service] = lambda: stub
+    app.dependency_overrides[get_job_service] = lambda: job_stub
+
+    nested_zip_bytes = _make_zip_bytes({"payload.txt": b"hello"})
+    outer_zip_bytes = _make_zip_bytes(
+        {
+            "meta/info.json": b"{}",
+            "data/episode.parquet": b"parquet",
+            "nested/payload.zip": nested_zip_bytes,
+        }
+    )
+
+    try:
+        client = TestClient(app)
+        response = client.put(
+            f"/api/projects/{project_id}/imports/datasets/{job_id}:upload",
+            files={"archive": ("dataset.zip", outer_zip_bytes, "application/zip")},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 413
+    body = response.json()
+    assert body["error_code"] == "zip_bomb_detected"
+    assert "nested zip entry" in body["message"]
+    assert stub.calls == []
+
+
+def test_upload_rejects_archive_with_too_large_uncompressed_size_and_does_not_attach_archive() -> None:
+    project_id = uuid4()
+    job_id = uuid4()
+    stub = _StubDatasetImportService(project_id)
+    job_stub = _StubJobService(project_id, job_id)
+    app.dependency_overrides[get_dataset_import_service] = lambda: stub
+    app.dependency_overrides[get_job_service] = lambda: job_stub
+
+    large_payload = b"A" * 10_000
+    archive_bytes = _make_zip_bytes(
+        {
+            "meta/info.json": b"{}",
+            "data/episode.parquet": large_payload,
+        },
+        compression=zipfile.ZIP_STORED,
+    )
+
+    with patch("api.dataset_import.get_settings") as mock_get_settings:
+        settings = mock_get_settings.return_value
+        settings.cache_dir = Path("~/.cache/physicalai").expanduser() / "cache"
+        settings.data_import_max_upload_bytes = 100 * 1024 * 1024 * 1024
+        settings.data_import_min_free_bytes = 0
+        settings.data_import_max_uncompressed_bytes = 2_000
+
+        try:
+            client = TestClient(app)
+            response = client.put(
+                f"/api/projects/{project_id}/imports/datasets/{job_id}:upload",
+                files={"archive": ("dataset.zip", archive_bytes, "application/zip")},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    assert response.status_code == 413
+    body = response.json()
+    assert body["error_code"] == "zip_bomb_detected"
+    assert "uncompressed size exceeds allowed limit" in body["message"]
+    assert stub.calls == []
+
+
+def test_upload_accepts_valid_zip_and_attaches_archive(tmp_path: Path) -> None:
+    project_id = uuid4()
+    job_id = uuid4()
+    stub = _StubDatasetImportService(project_id)
+    job_stub = _StubJobService(project_id, job_id)
+    app.dependency_overrides[get_dataset_import_service] = lambda: stub
+    app.dependency_overrides[get_job_service] = lambda: job_stub
+
+    archive_bytes = _make_zip_bytes(
+        {
+            "meta/info.json": b"{}",
+            "data/episode.parquet": b"small-data",
+        },
+        compression=zipfile.ZIP_STORED,
+    )
+
+    def _make_settings(cache_dir: Path):
+        from unittest.mock import MagicMock
+
+        s = MagicMock()
+        s.cache_dir = cache_dir
+        s.data_import_max_upload_bytes = 100 * 1024 * 1024 * 1024
+        s.data_import_min_free_bytes = 0
+        s.data_import_max_uncompressed_bytes = 200 * 1024 * 1024 * 1024
+        return s
+
+    with (
+        patch("api.dataset_import.get_settings", return_value=_make_settings(tmp_path)),
+        patch("services.dataset_import.staging.get_settings", return_value=_make_settings(tmp_path)),
+    ):
+        try:
+            client = TestClient(app)
+            response = client.put(
+                f"/api/projects/{project_id}/imports/datasets/{job_id}:upload",
+                files={"archive": ("dataset.zip", archive_bytes, "application/zip")},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        # Resolve the staging path while patches are still active so get_settings
+        # returns the same tmp_path-based cache_dir used during the upload.
+        from services.dataset_import.staging import resolve_payload_archive_path
+
+        staged_path = resolve_payload_archive_path(job_stub._job.payload)
+
+    assert response.status_code == 202
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["uploaded_archive_name"] == "dataset.zip"
+    # The file should have been written to the staging path derived from the job's archive_staging_id.
+    assert staged_path.exists()
+    staged_path.unlink(missing_ok=True)
+
+
+def test_upload_rejects_archive_with_too_many_entries() -> None:
+    project_id = uuid4()
+    job_id = uuid4()
+    stub = _StubDatasetImportService(project_id)
+    job_stub = _StubJobService(project_id, job_id)
+    app.dependency_overrides[get_dataset_import_service] = lambda: stub
+    app.dependency_overrides[get_job_service] = lambda: job_stub
+
+    archive_bytes = _make_zip_bytes(
+        {
+            **{f"data/file_{index}.txt": b"x" for index in range(101)},
+            "meta/info.json": b"{}",
+        },
+        compression=zipfile.ZIP_STORED,
+    )
+
+    with (
+        patch("api.dataset_import.get_settings") as mock_get_settings,
+        patch("services.archive_safety.DEFAULT_MAX_FILE_COUNT", 100),
+    ):
+        settings = mock_get_settings.return_value
+        settings.cache_dir = Path("~/.cache/physicalai").expanduser() / "cache"
+        settings.data_import_max_upload_bytes = 100 * 1024 * 1024 * 1024
+        settings.data_import_min_free_bytes = 0
+        settings.data_import_max_uncompressed_bytes = 200 * 1024 * 1024 * 1024
+
+        try:
+            client = TestClient(app)
+            response = client.put(
+                f"/api/projects/{project_id}/imports/datasets/{job_id}:upload",
+                files={"archive": ("dataset.zip", archive_bytes, "application/zip")},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    assert response.status_code == 413
+    body = response.json()
+    assert body["error_code"] == "zip_bomb_detected"
+    assert "too many entries" in body["message"]
+    assert stub.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Large-upload guardrail tests
+# ---------------------------------------------------------------------------
+
+
+def test_upload_rejects_when_content_length_exceeds_max() -> None:
+    """HTTP guard: reject before reading the body when Content-Length > limit."""
+    project_id = uuid4()
+    job_id = uuid4()
+    stub = _StubDatasetImportService(project_id)
+    job_stub = _StubJobService(project_id, job_id)
+    app.dependency_overrides[get_dataset_import_service] = lambda: stub
+    app.dependency_overrides[get_job_service] = lambda: job_stub
+
+    # A tiny but valid ZIP - the rejection must happen purely on the header value.
+    archive_bytes = _make_zip_bytes(
+        {"meta/info.json": b"{}"},
+        compression=zipfile.ZIP_STORED,
+    )
+
+    # Patch settings so the threshold is lower than any real upload.
+    # We set max_upload_bytes to 1 byte so the declared Content-Length (which
+    # TestClient derives from the multipart body length) is always over the cap.
+    with patch("middleware.upload_size_guard.get_settings") as mock_get_settings:
+        settings = mock_get_settings.return_value
+        settings.data_import_max_upload_bytes = 1  # 1 byte - always exceeded
+
+        try:
+            client = TestClient(app)
+            response = client.put(
+                f"/api/projects/{project_id}/imports/datasets/{job_id}:upload",
+                files={"archive": ("dataset.zip", archive_bytes, "application/zip")},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    assert response.status_code == 413
+    body = response.json()
+    assert body["error_code"] == "upload_too_large"
+    assert "exceeds" in body["message"]
+    assert stub.calls == []
+
+
+def test_upload_rejects_when_cache_dir_has_insufficient_free_space() -> None:
+    """Disk guard: reject upload when cache dir has insufficient free space."""
+    project_id = uuid4()
+    job_id = uuid4()
+    stub = _StubDatasetImportService(project_id)
+    job_stub = _StubJobService(project_id, job_id)
+    app.dependency_overrides[get_dataset_import_service] = lambda: stub
+    app.dependency_overrides[get_job_service] = lambda: job_stub
+
+    archive_bytes = _make_zip_bytes(
+        {"meta/info.json": b"{}"},
+        compression=zipfile.ZIP_STORED,
+    )
+
+    import shutil
+
+    # Build a fake disk_usage namedtuple that always reports zero free bytes.
+    _fake_usage = shutil.disk_usage("/")._replace(free=0)
+
+    with (
+        patch("api.dataset_import.get_settings") as mock_get_settings,
+        patch("services.archive_safety.shutil.disk_usage", return_value=_fake_usage),
+    ):
+        settings = mock_get_settings.return_value
+        settings.cache_dir = Path("~/.cache/physicalai").expanduser() / "cache"
+        settings.datasets_dir = Path("~/.cache/physicalai").expanduser() / "datasets"
+        settings.data_import_max_upload_bytes = 10 * 1024 * 1024 * 1024  # huge - no header rejection
+        settings.data_import_min_free_bytes = 1  # any positive headroom will be unmet
+        settings.data_import_max_uncompressed_bytes = 5 * 1024 * 1024 * 1024
+
+        try:
+            client = TestClient(app)
+            response = client.put(
+                f"/api/projects/{project_id}/imports/datasets/{job_id}:upload",
+                files={"archive": ("dataset.zip", archive_bytes, "application/zip")},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    assert response.status_code == 507
+    body = response.json()
+    assert body["error_code"] == "insufficient_disk_space"
+    assert stub.calls == []

--- a/application/backend/tests/api/test_dataset_import_upload_safety.py
+++ b/application/backend/tests/api/test_dataset_import_upload_safety.py
@@ -90,14 +90,23 @@ def test_upload_rejects_nested_zip_and_does_not_attach_archive() -> None:
         }
     )
 
-    try:
-        client = TestClient(app)
-        response = client.put(
-            f"/api/projects/{project_id}/imports/datasets/{job_id}:upload",
-            files={"archive": ("dataset.zip", outer_zip_bytes, "application/zip")},
-        )
-    finally:
-        app.dependency_overrides.clear()
+    # Use a small max_upload_bytes so disk-headroom check only requires a few MB,
+    # making the test deterministic regardless of available disk space.
+    with patch("api.dataset_import.get_settings") as mock_get_settings:
+        settings = mock_get_settings.return_value
+        settings.cache_dir = Path("~/.cache/physicalai").expanduser() / "cache"
+        settings.data_import_max_upload_bytes = 5 * 1024 * 1024  # 5 MB
+        settings.data_import_min_free_bytes = 0
+        settings.data_import_max_uncompressed_bytes = 10 * 1024 * 1024
+
+        try:
+            client = TestClient(app)
+            response = client.put(
+                f"/api/projects/{project_id}/imports/datasets/{job_id}:upload",
+                files={"archive": ("dataset.zip", outer_zip_bytes, "application/zip")},
+            )
+        finally:
+            app.dependency_overrides.clear()
 
     assert response.status_code == 413
     body = response.json()
@@ -126,7 +135,7 @@ def test_upload_rejects_archive_with_too_large_uncompressed_size_and_does_not_at
     with patch("api.dataset_import.get_settings") as mock_get_settings:
         settings = mock_get_settings.return_value
         settings.cache_dir = Path("~/.cache/physicalai").expanduser() / "cache"
-        settings.data_import_max_upload_bytes = 100 * 1024 * 1024 * 1024
+        settings.data_import_max_upload_bytes = 5 * 1024 * 1024  # 5 MB - deterministic on CI
         settings.data_import_min_free_bytes = 0
         settings.data_import_max_uncompressed_bytes = 2_000
 
@@ -167,7 +176,7 @@ def test_upload_accepts_valid_zip_and_attaches_archive(tmp_path: Path) -> None:
 
         s = MagicMock()
         s.cache_dir = cache_dir
-        s.data_import_max_upload_bytes = 100 * 1024 * 1024 * 1024
+        s.data_import_max_upload_bytes = 5 * 1024 * 1024  # 5 MB - deterministic on CI
         s.data_import_min_free_bytes = 0
         s.data_import_max_uncompressed_bytes = 200 * 1024 * 1024 * 1024
         return s
@@ -221,7 +230,7 @@ def test_upload_rejects_archive_with_too_many_entries() -> None:
     ):
         settings = mock_get_settings.return_value
         settings.cache_dir = Path("~/.cache/physicalai").expanduser() / "cache"
-        settings.data_import_max_upload_bytes = 100 * 1024 * 1024 * 1024
+        settings.data_import_max_upload_bytes = 5 * 1024 * 1024  # 5 MB - deterministic on CI
         settings.data_import_min_free_bytes = 0
         settings.data_import_max_uncompressed_bytes = 200 * 1024 * 1024 * 1024
 

--- a/application/backend/tests/services/dataset_import/adapters/test_lerobot_v3_adapter.py
+++ b/application/backend/tests/services/dataset_import/adapters/test_lerobot_v3_adapter.py
@@ -1,0 +1,498 @@
+import json
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from schemas.dataset_import_job import ImportValidationSeverity
+from services.archive_safety import SafeZipArchive
+from services.dataset_import.adapters.lerobot_v3 import LeRobotV3Adapter
+
+
+def _write_zip(path: Path, files: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+
+
+def _episodes_parquet_bytes(
+    lengths: list[int],
+    *,
+    episode_start: int = 0,
+    include_episode_index: bool = True,
+    include_length: bool = True,
+) -> bytes:
+    data: dict[str, list[int]] = {}
+    if include_episode_index:
+        data["episode_index"] = list(range(episode_start, episode_start + len(lengths)))
+    if include_length:
+        data["length"] = lengths
+    df = pd.DataFrame(data)
+    buffer = BytesIO()
+    df.to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
+def test_lerobot_v3_detect_returns_true_for_v3_layout(tmp_path: Path) -> None:
+    """v3 archive with tasks.parquet and file-* data layout is detected."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps({"codebase_version": "v3.0"}).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    matched, _report = adapter.detect(safe_archive)
+    assert matched is True
+
+
+def test_lerobot_v3_detect_returns_true_for_nested_v3_layout(tmp_path: Path) -> None:
+    """v3 archive with dataset root inside single top-level folder is detected."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-nested.zip"
+    _write_zip(
+        archive_path,
+        {
+            "dataset/meta/info.json": json.dumps({"codebase_version": "v3.0"}).encode("utf-8"),
+            "dataset/meta/tasks.parquet": b"PAR1",
+            "dataset/data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    matched, _report = adapter.detect(safe_archive)
+    assert matched is True
+
+
+def test_lerobot_v3_detect_returns_false_for_v2_layout(tmp_path: Path) -> None:
+    """v2 archive with tasks.jsonl and episode_*.parquet is NOT detected as v3."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v2.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": b'{"codebase_version":"v2.1"}',
+            "meta/tasks.jsonl": b'{"task_index":0,"task":"pick"}\n',
+            "meta/episodes.jsonl": b'{"episode_index":0,"tasks":["pick"],"length":1}\n',
+            "data/chunk-000/episode_000000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    matched, _report = adapter.detect(safe_archive)
+    assert matched is False
+
+
+def test_lerobot_v3_detect_returns_false_without_tasks_parquet(tmp_path: Path) -> None:
+    """Archive missing meta/tasks.parquet is NOT detected as v3."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "no-tasks.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": b'{"codebase_version":"v3.0"}',
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    matched, _report = adapter.detect(safe_archive)
+    assert matched is False
+
+
+def test_lerobot_v3_detect_returns_false_without_v3_data_files(tmp_path: Path) -> None:
+    """Archive with tasks.parquet but no file-* data is NOT detected as v3."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "no-data.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": b'{"codebase_version":"v3.0"}',
+            "meta/tasks.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    matched, _report = adapter.detect(safe_archive)
+    assert matched is False
+
+
+def test_lerobot_v3_parse_manifest_reads_stats_from_nested_root_zip(tmp_path: Path) -> None:
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-nested.zip"
+    episodes_bytes = _episodes_parquet_bytes([11, 7, 5])
+    _write_zip(
+        archive_path,
+        {
+            "dataset/meta/info.json": json.dumps({"fps": 20}).encode("utf-8"),
+            "dataset/meta/episodes/chunk-000/file-000.parquet": episodes_bytes,
+            "dataset/data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    assert manifest.statistics.episode_count == 3
+    assert manifest.statistics.frame_count == 23
+
+
+def test_lerobot_v3_parse_manifest_counts_all_episode_parquet_shards(tmp_path: Path) -> None:
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-multi-episodes.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps({"codebase_version": "v3.0", "fps": 20}).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "meta/episodes/chunk-000/file-000.parquet": _episodes_parquet_bytes([11, 7], episode_start=0),
+            "meta/episodes/chunk-000/file-001.parquet": _episodes_parquet_bytes([5], episode_start=2),
+            "meta/episodes/chunk-001/file-000.parquet": _episodes_parquet_bytes([13, 9], episode_start=3),
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    assert manifest.statistics.episode_count == 5
+    assert manifest.statistics.frame_count == 45
+
+
+def test_lerobot_v3_parse_manifest_counts_episode_shards_when_file_000_is_missing(tmp_path: Path) -> None:
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-missing-first-shard.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps({"codebase_version": "v3.0", "fps": 20}).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "meta/episodes/chunk-000/file-001.parquet": _episodes_parquet_bytes([3, 4], episode_start=0),
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    assert manifest.statistics.episode_count == 2
+    assert manifest.statistics.frame_count == 7
+
+
+def test_lerobot_v3_parse_manifest_schema_empty_when_no_features(tmp_path: Path) -> None:
+    """When info.json has no features the recording schema is empty."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-no-features.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps({"fps": 10}).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    assert manifest.dataset_schema.cameras == []
+    assert manifest.dataset_schema.robots == []
+
+
+def test_lerobot_v3_parse_manifest_schema_two_cameras_six_joints(tmp_path: Path) -> None:
+    """Realistic v3 feature layout yields two cameras and six joints on one robot."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-full.zip"
+
+    info = {
+        "fps": 30,
+        "robot_type": "so100",
+        "features": {
+            "observation.images.top": {
+                "dtype": "video",
+                "shape": [480, 640, 3],
+                "info": {"video": {"fps": 30, "width": 640, "height": 480}},
+            },
+            "observation.images.wrist": {
+                "dtype": "video",
+                "shape": [480, 640, 3],
+                "info": {"video": {"fps": 30, "width": 640, "height": 480}},
+            },
+            "action": {
+                "dtype": "float32",
+                "shape": [6],
+                "names": [
+                    "shoulder_pan.pos",
+                    "shoulder_lift.pos",
+                    "elbow_flex.pos",
+                    "wrist_flex.pos",
+                    "wrist_roll.pos",
+                    "gripper.pos",
+                ],
+            },
+            "observation.state": {
+                "dtype": "float32",
+                "shape": [6],
+                "names": [
+                    "shoulder_pan.pos",
+                    "shoulder_lift.pos",
+                    "elbow_flex.pos",
+                    "wrist_flex.pos",
+                    "wrist_roll.pos",
+                    "gripper.pos",
+                ],
+            },
+        },
+    }
+
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps(info).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    schema = manifest.dataset_schema
+
+    # Two cameras
+    assert len(schema.cameras) == 2
+    camera_names = {c.name for c in schema.cameras}
+    assert camera_names == {"top", "wrist"}
+    for cam in schema.cameras:
+        assert cam.width == 640
+        assert cam.height == 480
+        assert cam.fps == 30
+
+    # One robot with six joints (set equality - ordering not contractual)
+    assert len(schema.robots) == 1
+    robot = schema.robots[0]
+    assert robot.name == "so100"
+    assert robot.type == "so100"
+    assert set(robot.joints) == {
+        "shoulder_pan",
+        "shoulder_lift",
+        "elbow_flex",
+        "wrist_flex",
+        "wrist_roll",
+        "gripper",
+    }
+    assert len(robot.joints) == 6
+
+
+def test_lerobot_v3_parse_manifest_schema_joints_deduped_across_action_and_state(tmp_path: Path) -> None:
+    """Joint names appearing in both action and observation.state are deduplicated."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-dedup.zip"
+
+    info = {
+        "fps": 10,
+        "robot_type": "myrobot",
+        "features": {
+            "action": {
+                "dtype": "float32",
+                "shape": [2],
+                "names": ["joint_a.pos", "joint_b.pos"],
+            },
+            "observation.state": {
+                "dtype": "float32",
+                "shape": [2],
+                "names": ["joint_a.pos", "joint_b.pos"],
+            },
+        },
+    }
+
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps(info).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    assert set(manifest.dataset_schema.robots[0].joints) == {"joint_a", "joint_b"}
+    assert len(manifest.dataset_schema.robots[0].joints) == 2
+
+
+def test_lerobot_v3_parse_manifest_schema_camera_falls_back_to_shape_dims(tmp_path: Path) -> None:
+    """When video.info is absent, camera dimensions come from the feature shape."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-shape-fallback.zip"
+
+    info = {
+        "fps": 15,
+        "features": {
+            "observation.images.front": {
+                "dtype": "video",
+                "shape": [240, 320, 3],
+            },
+        },
+    }
+
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps(info).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    cameras = manifest.dataset_schema.cameras
+    assert len(cameras) == 1
+    cam = cameras[0]
+    assert cam.name == "front"
+    assert cam.height == 240
+    assert cam.width == 320
+    assert cam.fps == 15  # fallback to dataset fps
+
+
+def test_lerobot_v3_parse_manifest_does_not_include_suggested_name(tmp_path: Path) -> None:
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "opaque-staging-id.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": b'{"fps":30}',
+            "meta/tasks.parquet": b"PAR1",
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    assert "suggested_name" not in manifest.model_dump()
+
+
+def test_lerobot_v3_build_draft_reports_error_when_episode_parquet_missing(tmp_path: Path) -> None:
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-no-episodes.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps({"codebase_version": "v3.0", "fps": 20}).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    _manifest, report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    assert any(msg.severity == ImportValidationSeverity.ERROR for msg in report.messages)
+    assert any("episodes" in msg.message for msg in report.messages)
+
+
+def test_lerobot_v3_build_draft_reports_warning_when_stats_missing(tmp_path: Path) -> None:
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-no-stats.zip"
+    episodes_bytes = _episodes_parquet_bytes([3])
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps({"codebase_version": "v3.0", "fps": 20}).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "meta/episodes/chunk-000/file-000.parquet": episodes_bytes,
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    _manifest, report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    warning_messages = [msg.message for msg in report.messages if msg.severity == ImportValidationSeverity.WARNING]
+    assert any("stats" in message for message in warning_messages)
+
+
+def test_lerobot_v3_build_draft_reports_warning_when_counts_mismatch_info_json(tmp_path: Path) -> None:
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-count-mismatch.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps(
+                {
+                    "codebase_version": "v3.0",
+                    "fps": 20,
+                    "total_episodes": 99,
+                    "total_frames": 999,
+                }
+            ).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "meta/episodes/chunk-000/file-000.parquet": _episodes_parquet_bytes([3, 5], episode_start=0),
+            "meta/episodes/chunk-000/file-001.parquet": _episodes_parquet_bytes([7], episode_start=2),
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    _manifest, report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    warning_messages = [msg.message for msg in report.messages if msg.severity == ImportValidationSeverity.WARNING]
+    assert any("Episode count mismatch" in message for message in warning_messages)
+    assert any("Frame count mismatch" in message for message in warning_messages)
+
+
+def test_lerobot_v3_detect_report_includes_v2_marker_error(tmp_path: Path) -> None:
+    """When detect returns False due to v2 markers, report should describe them."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v2-for-v3-check.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": b'{"codebase_version":"v2.1"}',
+            "meta/tasks.jsonl": b'{"task_index":0,"task":"pick"}\n',
+            "meta/episodes.jsonl": b'{"episode_index":0,"tasks":["pick"],"length":1}\n',
+            "data/chunk-000/episode_000000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    matched, report = adapter.detect(safe_archive)
+
+    assert matched is False
+    error_messages = [msg.message for msg in report.messages if msg.severity == ImportValidationSeverity.ERROR]
+    assert error_messages, "Expected at least one error in detect report for v2 archive"
+    combined = " ".join(error_messages)
+    assert "v2" in combined.lower() or "lerobot" in combined.lower()
+
+
+def test_lerobot_v3_detect_report_includes_missing_markers_error(tmp_path: Path) -> None:
+    """When detect returns False due to missing markers, report should name them."""
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "incomplete-v3.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": b'{"codebase_version":"v3.0"}',
+            # missing tasks.parquet and data files
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    matched, report = adapter.detect(safe_archive)
+
+    assert matched is False
+    error_messages = [msg.message for msg in report.messages if msg.severity == ImportValidationSeverity.ERROR]
+    assert error_messages
+    combined = " ".join(error_messages)
+    assert "tasks.parquet" in combined

--- a/application/backend/tests/services/dataset_import/adapters/test_lerobot_v3_adapter.py
+++ b/application/backend/tests/services/dataset_import/adapters/test_lerobot_v3_adapter.py
@@ -278,7 +278,6 @@ def test_lerobot_v3_parse_manifest_schema_two_cameras_six_joints(tmp_path: Path)
     # One robot with six joints (set equality - ordering not contractual)
     assert len(schema.robots) == 1
     robot = schema.robots[0]
-    assert robot.name == "so100"
     assert robot.type == "so100"
     assert set(robot.joints) == {
         "shoulder_pan",

--- a/application/backend/tests/services/dataset_import/adapters/test_select_dataset_import_adapter.py
+++ b/application/backend/tests/services/dataset_import/adapters/test_select_dataset_import_adapter.py
@@ -1,0 +1,256 @@
+"""Tests for select_dataset_import_adapter covering auto and explicit-hint modes."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from typing import TYPE_CHECKING
+
+from services.archive_safety import SafeZipArchive
+from services.dataset_import.adapters import (
+    DatasetAdapterSelectionResult,
+    get_registered_dataset_import_adapters,
+    select_dataset_import_adapter,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_zip(path: Path, files: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+
+
+def _open(path: Path) -> SafeZipArchive:
+    return SafeZipArchive(path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: valid v2 and v3 archives
+# ---------------------------------------------------------------------------
+
+
+def _v2_archive(tmp_path: Path) -> Path:
+    path = tmp_path / "v2.zip"
+    _write_zip(
+        path,
+        {
+            "meta/info.json": json.dumps({"codebase_version": "v2.1"}).encode(),
+            "meta/tasks.jsonl": b'{"task_index":0,"task":"pick"}\n',
+            "meta/episodes.jsonl": b'{"episode_index":0,"tasks":["pick"],"length":1}\n',
+            "data/chunk-000/episode_000000.parquet": b"PAR1",
+        },
+    )
+    return path
+
+
+def _v3_archive(tmp_path: Path) -> Path:
+    path = tmp_path / "v3.zip"
+    _write_zip(
+        path,
+        {
+            "meta/info.json": json.dumps({"codebase_version": "v3.0"}).encode(),
+            "meta/tasks.parquet": b"PAR1",
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+    return path
+
+
+def _empty_archive(tmp_path: Path) -> Path:
+    path = tmp_path / "empty.zip"
+    _write_zip(path, {"readme.txt": b"nothing useful"})
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Auto mode — successful matches
+# ---------------------------------------------------------------------------
+
+
+def test_auto_selects_v2_adapter_for_v2_archive(tmp_path: Path) -> None:
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v2_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "auto", archive)
+    assert isinstance(result, DatasetAdapterSelectionResult)
+    assert result.adapter is not None
+    assert result.adapter.source.value == "lerobot_v2"
+    assert result.report is None
+
+
+def test_auto_selects_v3_adapter_for_v3_archive(tmp_path: Path) -> None:
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v3_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "auto", archive)
+    assert isinstance(result, DatasetAdapterSelectionResult)
+    assert result.adapter is not None
+    assert result.adapter.source.value == "lerobot_v3"
+    assert result.report is None
+
+
+# ---------------------------------------------------------------------------
+# Auto mode — no match
+# ---------------------------------------------------------------------------
+
+
+def test_auto_returns_none_adapter_when_no_adapter_matches(tmp_path: Path) -> None:
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_empty_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "auto", archive)
+    assert result.adapter is None
+
+
+def test_auto_no_match_report_has_generic_error(tmp_path: Path) -> None:
+    """Auto-mode failure must surface a single generic error; no adapter-specific leakage."""
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_empty_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "auto", archive)
+    assert result.report is not None
+    assert len(result.report.messages) >= 1
+    # Generic message should mention "format" or "adapter" — not internal adapter names
+    combined = " ".join(m.message for m in result.report.messages).lower()
+    assert "format" in combined or "adapter" in combined or "unsupported" in combined
+
+
+def test_auto_no_match_does_not_raise(tmp_path: Path) -> None:
+    """Auto mode must not raise even when no adapter matches."""
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_empty_archive(tmp_path))
+    # Should not raise
+    select_dataset_import_adapter(adapters, "auto", archive)
+
+
+def test_auto_no_match_report_does_not_leak_per_adapter_details(tmp_path: Path) -> None:
+    """Auto-mode failure message must not contain per-adapter mismatch details."""
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_empty_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "auto", archive)
+    assert result.report is not None
+    combined = " ".join(m.message for m in result.report.messages)
+    # Adapter-specific markers like "episodes.jsonl" or "tasks.jsonl" must NOT appear
+    assert "episodes.jsonl" not in combined
+    assert "tasks.jsonl" not in combined
+
+
+def test_auto_no_match_report_mentions_lerobot_formats(tmp_path: Path) -> None:
+    """Generic no-match message should mention supported LeRobot versions."""
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_empty_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "auto", archive)
+    assert result.report is not None
+    combined = " ".join(m.message for m in result.report.messages).lower()
+    assert "lerobot" in combined
+
+
+def test_auto_no_match_report_mentions_metadata_or_data_layout(tmp_path: Path) -> None:
+    """Generic no-match message should hint at required archive structure."""
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_empty_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "auto", archive)
+    assert result.report is not None
+    combined = " ".join(m.message for m in result.report.messages).lower()
+    assert "meta" in combined or "data" in combined or "parquet" in combined
+
+
+# ---------------------------------------------------------------------------
+# Explicit hint mode — matching
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_hint_returns_v2_adapter_for_v2_archive(tmp_path: Path) -> None:
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v2_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "lerobot_v2", archive)
+    assert result.adapter is not None
+    assert result.adapter.source.value == "lerobot_v2"
+    assert result.report is None
+
+
+def test_explicit_hint_returns_v3_adapter_for_v3_archive(tmp_path: Path) -> None:
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v3_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "lerobot_v3", archive)
+    assert result.adapter is not None
+    assert result.adapter.source.value == "lerobot_v3"
+    assert result.report is None
+
+
+# ---------------------------------------------------------------------------
+# Explicit hint mode — mismatch: returns report, does NOT raise
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_hint_v3_mismatch_for_v2_archive_returns_no_adapter(tmp_path: Path) -> None:
+    """When v3 is hinted but archive is v2, adapter is None (no raise)."""
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v2_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "lerobot_v3", archive)
+    assert result.adapter is None
+
+
+def test_explicit_hint_v3_mismatch_report_includes_detect_details(tmp_path: Path) -> None:
+    """Mismatch report should contain detect-report messages from the adapter."""
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v2_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "lerobot_v3", archive)
+    assert result.report is not None
+    assert len(result.report.messages) >= 1
+    combined = " ".join(m.message for m in result.report.messages).lower()
+    # Adapter detect report should mention something v2-specific or lerobot-related
+    assert "v2" in combined or "lerobot" in combined or "episodes.jsonl" in combined
+
+
+def test_explicit_hint_v3_mismatch_does_not_raise(tmp_path: Path) -> None:
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v2_archive(tmp_path))
+    # Must not raise
+    select_dataset_import_adapter(adapters, "lerobot_v3", archive)
+
+
+def test_explicit_hint_v2_mismatch_for_v3_archive_returns_no_adapter(tmp_path: Path) -> None:
+    """When v2 is hinted but archive is v3, adapter is None (no raise)."""
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v3_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "lerobot_v2", archive)
+    assert result.adapter is None
+
+
+def test_explicit_hint_v2_mismatch_report_includes_detect_details(tmp_path: Path) -> None:
+    """v2 mismatch report should include names of missing v2 markers."""
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v3_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "lerobot_v2", archive)
+    assert result.report is not None
+    combined = " ".join(m.message for m in result.report.messages)
+    assert "episodes.jsonl" in combined or "tasks.jsonl" in combined
+
+
+# ---------------------------------------------------------------------------
+# Explicit hint mode — unknown hint
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_unknown_hint_returns_no_adapter(tmp_path: Path) -> None:
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v3_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "unknown_format", archive)
+    assert result.adapter is None
+
+
+def test_explicit_unknown_hint_report_contains_not_recognized_message(tmp_path: Path) -> None:
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v3_archive(tmp_path))
+    result = select_dataset_import_adapter(adapters, "unknown_format", archive)
+    assert result.report is not None
+    combined = " ".join(m.message for m in result.report.messages).lower()
+    # Generic fallback message must mention supported formats or detection failure
+    assert "supported" in combined or "format" in combined or "detected" in combined
+
+
+def test_explicit_unknown_hint_does_not_raise(tmp_path: Path) -> None:
+    adapters = get_registered_dataset_import_adapters()
+    archive = _open(_v3_archive(tmp_path))
+    # Must not raise
+    select_dataset_import_adapter(adapters, "unknown_format", archive)

--- a/application/backend/tests/services/dataset_import/adapters/test_select_dataset_import_adapter.py
+++ b/application/backend/tests/services/dataset_import/adapters/test_select_dataset_import_adapter.py
@@ -70,16 +70,6 @@ def _empty_archive(tmp_path: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def test_auto_selects_v2_adapter_for_v2_archive(tmp_path: Path) -> None:
-    adapters = get_registered_dataset_import_adapters()
-    archive = _open(_v2_archive(tmp_path))
-    result = select_dataset_import_adapter(adapters, "auto", archive)
-    assert isinstance(result, DatasetAdapterSelectionResult)
-    assert result.adapter is not None
-    assert result.adapter.source.value == "lerobot_v2"
-    assert result.report is None
-
-
 def test_auto_selects_v3_adapter_for_v3_archive(tmp_path: Path) -> None:
     adapters = get_registered_dataset_import_adapters()
     archive = _open(_v3_archive(tmp_path))
@@ -159,15 +149,6 @@ def test_auto_no_match_report_mentions_metadata_or_data_layout(tmp_path: Path) -
 # ---------------------------------------------------------------------------
 
 
-def test_explicit_hint_returns_v2_adapter_for_v2_archive(tmp_path: Path) -> None:
-    adapters = get_registered_dataset_import_adapters()
-    archive = _open(_v2_archive(tmp_path))
-    result = select_dataset_import_adapter(adapters, "lerobot_v2", archive)
-    assert result.adapter is not None
-    assert result.adapter.source.value == "lerobot_v2"
-    assert result.report is None
-
-
 def test_explicit_hint_returns_v3_adapter_for_v3_archive(tmp_path: Path) -> None:
     adapters = get_registered_dataset_import_adapters()
     archive = _open(_v3_archive(tmp_path))
@@ -217,14 +198,14 @@ def test_explicit_hint_v2_mismatch_for_v3_archive_returns_no_adapter(tmp_path: P
     assert result.adapter is None
 
 
-def test_explicit_hint_v2_mismatch_report_includes_detect_details(tmp_path: Path) -> None:
-    """v2 mismatch report should include names of missing v2 markers."""
+def test_explicit_hint_v2_unknown_hint_report_has_generic_message(tmp_path: Path) -> None:
+    """'lerobot_v2' is not a registered adapter; the generic fallback message is returned."""
     adapters = get_registered_dataset_import_adapters()
     archive = _open(_v3_archive(tmp_path))
     result = select_dataset_import_adapter(adapters, "lerobot_v2", archive)
     assert result.report is not None
-    combined = " ".join(m.message for m in result.report.messages)
-    assert "episodes.jsonl" in combined or "tasks.jsonl" in combined
+    combined = " ".join(m.message for m in result.report.messages).lower()
+    assert "supported" in combined or "format" in combined or "detected" in combined
 
 
 # ---------------------------------------------------------------------------

--- a/application/backend/tests/services/dataset_import/test_dataset_import_disk_guardrails.py
+++ b/application/backend/tests/services/dataset_import/test_dataset_import_disk_guardrails.py
@@ -1,0 +1,140 @@
+"""Service-level tests for disk-headroom guardrails in the dataset import worker.
+
+These tests exercise :func:`services.archive_safety.check_disk_headroom` and its
+integration into :class:`workers.dataset_import_worker.DatasetImportWorker._run_commit`,
+without performing any real disk I/O or network calls.
+"""
+
+import asyncio
+import io
+import shutil
+import zipfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from exceptions import InsufficientDiskSpaceError
+from services.archive_safety import check_disk_headroom
+
+# ---------------------------------------------------------------------------
+# Unit tests for the guard function itself
+# ---------------------------------------------------------------------------
+
+
+def test_check_disk_headroom_passes_when_free_space_is_sufficient(tmp_path: Path) -> None:
+    """No exception is raised when there is ample free space."""
+    _fake_usage = shutil.disk_usage("/")._replace(free=10 * 1024 * 1024 * 1024)  # 10 GiB
+
+    with patch("services.archive_safety.shutil.disk_usage", return_value=_fake_usage):
+        # Should not raise
+        check_disk_headroom(tmp_path, required_bytes=1 * 1024 * 1024, min_free_bytes=1 * 1024 * 1024)
+
+
+def test_check_disk_headroom_raises_when_free_space_is_insufficient(tmp_path: Path) -> None:
+    """InsufficientDiskSpaceError is raised when free < required + headroom."""
+    _fake_usage = shutil.disk_usage("/")._replace(free=0)
+
+    with (
+        patch("services.archive_safety.shutil.disk_usage", return_value=_fake_usage),
+        pytest.raises(InsufficientDiskSpaceError) as exc_info,
+    ):
+        check_disk_headroom(tmp_path, required_bytes=1, min_free_bytes=1)
+
+    assert "Insufficient disk space" in str(exc_info.value)
+    assert exc_info.value.error_code == "insufficient_disk_space"
+    assert exc_info.value.http_status == 507
+
+
+def test_check_disk_headroom_passes_when_free_exactly_meets_need(tmp_path: Path) -> None:
+    """Guard passes (does not raise) when free space exactly equals required + headroom."""
+    required = 500 * 1024 * 1024  # 500 MiB
+    headroom = 100 * 1024 * 1024  # 100 MiB
+    _fake_usage = shutil.disk_usage("/")._replace(free=required + headroom)
+
+    with patch("services.archive_safety.shutil.disk_usage", return_value=_fake_usage):
+        # Exactly at the limit - should not raise
+        check_disk_headroom(tmp_path, required_bytes=required, min_free_bytes=headroom)
+
+
+def test_check_disk_headroom_raises_when_free_is_one_byte_short(tmp_path: Path) -> None:
+    """Guard raises when free space is exactly one byte below the threshold."""
+    required = 500 * 1024 * 1024
+    headroom = 100 * 1024 * 1024
+    _fake_usage = shutil.disk_usage("/")._replace(free=required + headroom - 1)
+
+    with (
+        patch("services.archive_safety.shutil.disk_usage", return_value=_fake_usage),
+        pytest.raises(InsufficientDiskSpaceError),
+    ):
+        check_disk_headroom(tmp_path, required_bytes=required, min_free_bytes=headroom)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: worker _run_commit raises when datasets dir is full
+# ---------------------------------------------------------------------------
+
+
+def test_worker_run_commit_raises_when_datasets_dir_has_insufficient_space(tmp_path: Path) -> None:
+    """DatasetImportWorker._run_commit propagates InsufficientDiskSpaceError when
+    the datasets directory filesystem reports no free space."""
+    import multiprocessing as mp
+
+    from schemas.dataset_import_job import (
+        DatasetImportFinalizeInput,
+        DatasetImportJobPayload,
+        DatasetImportSource,
+        DatasetManifest,
+        ImportStep,
+    )
+    from workers.dataset_import_worker import DatasetImportWorker
+
+    # --- set up a real archive file at the staging path so stat() succeeds ---
+    staging_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    staging_dir = tmp_path / "imports" / "datasets"
+    staging_dir.mkdir(parents=True)
+    archive_path = staging_dir / f"{staging_id}.zip"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("meta/info.json", b"{}")
+    archive_path.write_bytes(buf.getvalue())
+
+    # --- build a minimal payload that has a committed manifest draft ---
+    manifest_draft = DatasetManifest(source_type=DatasetImportSource.LEROBOT_V3)
+    payload = DatasetImportJobPayload(
+        step=ImportStep.QUEUED_FOR_IMPORT,
+        archive_staging_id=staging_id,
+        dataset_name="tmp",
+        dataset_manifest_draft=manifest_draft,
+        finalize_input=DatasetImportFinalizeInput(
+            environment_id=uuid4(),
+        ),
+    )
+
+    stop_event = mp.Event()
+    event_queue: mp.Queue = mp.Queue()
+    worker = DatasetImportWorker(stop_event=stop_event, event_queue=event_queue)
+    worker.queue = MagicMock()
+
+    _fake_usage = shutil.disk_usage("/")._replace(free=0)
+
+    fake_settings = MagicMock()
+    fake_settings.cache_dir = tmp_path
+    fake_settings.datasets_dir = tmp_path / "datasets"
+    fake_settings.data_import_min_free_bytes = 1  # any positive headroom is unmet with 0 free
+
+    with (
+        patch("services.dataset_import.adapters.lerobot_v3.get_settings", return_value=fake_settings),
+        patch("services.dataset_import.staging.get_settings", return_value=fake_settings),
+        patch("services.archive_safety.shutil.disk_usage", return_value=_fake_usage),
+        patch("workers.dataset_import_worker.JobService.update_job_payload", new=AsyncMock(return_value=MagicMock())),
+        pytest.raises(InsufficientDiskSpaceError),
+    ):
+        asyncio.run(
+            worker._run_commit(
+                job_id=uuid4(),
+                project_id=uuid4(),
+                payload=payload,
+            )
+        )

--- a/application/backend/tests/services/dataset_import/test_dataset_import_service.py
+++ b/application/backend/tests/services/dataset_import/test_dataset_import_service.py
@@ -369,39 +369,6 @@ async def test_cancel_succeeds_for_awaiting_user_review_with_staging_id() -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_dataset_manifest_slim_shape_no_legacy_fields() -> None:
-    """DatasetManifest no longer carries manifest_version, resource_type, integrity,
-    warnings, or missing_fields."""
-    from schemas.dataset_import_job import DatasetImportSource, DatasetManifest, DatasetManifestStatistics
-
-    manifest = DatasetManifest(
-        source_type=DatasetImportSource.UNKNOWN,
-        statistics=DatasetManifestStatistics(episode_count=5, frame_count=150),
-    )
-    dumped = manifest.model_dump(by_alias=True)
-
-    assert "manifest_version" not in dumped
-    assert "resource_type" not in dumped
-    assert "integrity" not in dumped
-    assert "warnings" not in dumped
-    assert "missing_fields" not in dumped
-    # dataset_schema must still be present
-    assert "dataset_schema" in dumped
-
-
-def test_dataset_manifest_source_slim_shape_no_legacy_fields() -> None:
-    """DatasetManifest.source_type is a direct field; no nested DatasetManifestSource wrapper."""
-    from schemas.dataset_import_job import DatasetImportSource, DatasetManifest
-
-    manifest = DatasetManifest(source_type=DatasetImportSource.LEROBOT_V3)
-    dumped = manifest.model_dump()
-
-    assert "source_format_version" not in dumped
-    assert "source_identifier" not in dumped
-    assert "original_dataset_uuid" not in dumped
-    assert dumped["source_type"] == DatasetImportSource.LEROBOT_V3
-
-
 def test_dataset_manifest_identity_slim_shape_no_default_task() -> None:
     """DatasetManifest no longer carries identity fields such as suggested_name/default_task."""
     from schemas.dataset_import_job import DatasetManifest

--- a/application/backend/tests/services/dataset_import/test_dataset_import_service.py
+++ b/application/backend/tests/services/dataset_import/test_dataset_import_service.py
@@ -1,0 +1,548 @@
+"""Focused unit tests for DatasetImportService step/ownership validation logic.
+
+These tests cover the three public methods that enforce ownership and step
+guards without requiring a real database.  Each test patches only the minimal
+surface area needed:
+
+* ``db.get_async_db_session_ctx`` - returns a lightweight async context manager
+  that yields a sentinel session object (never used directly, because
+  ``JobRepository`` is also patched).
+* ``services.dataset_import.service.JobRepository`` - replaced by a
+  ``_StubJobRepository`` that returns pre-built ``DatasetImportJob`` fixtures.
+* ``services.archive_safety.cleanup_staged_archive`` - no-op to avoid
+  touching the filesystem.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from exceptions import InvalidJobStateError, ResourceNotFoundError
+from schemas.base_job import JobStatus
+from schemas.dataset_import_job import DatasetImportFinalizeInput, DatasetImportJobPayload, ImportStep
+from schemas.job import DatasetImportJob
+from services.dataset_import.service import DatasetImportService
+
+# ---------------------------------------------------------------------------
+# Helpers / shared infrastructure
+# ---------------------------------------------------------------------------
+
+_STAGING_ID = "a" * 8 + "-" + "b" * 4 + "-" + "c" * 4 + "-" + "d" * 4 + "-" + "e" * 12
+
+
+def _make_job(
+    *,
+    project_id=None,
+    step: ImportStep = ImportStep.AWAITING_ARCHIVE_UPLOAD,
+    archive_staging_id: str = _STAGING_ID,
+) -> DatasetImportJob:
+    """Build a minimal ``DatasetImportJob`` with the given step."""
+    return DatasetImportJob(
+        id=uuid4(),
+        project_id=project_id or uuid4(),
+        status=JobStatus.PENDING,
+        payload=DatasetImportJobPayload(
+            step=step,
+            archive_staging_id=archive_staging_id,
+        ),
+    )
+
+
+class _StubJobRepository:
+    """Minimal stub for JobRepository covering the paths exercised below."""
+
+    def __init__(self, job: DatasetImportJob | None) -> None:
+        self._job = job
+        self.updated: list[tuple] = []
+
+    async def get_by_id(self, job_id):
+        return self._job
+
+    async def update(self, job, updates):
+        self.updated.append((job, updates))
+        # Return a copy with the updates applied so callers get a valid Job
+        return job.model_copy(update=updates, deep=True)
+
+
+@contextlib.asynccontextmanager
+async def _fake_db_session_ctx():
+    """Fake async context manager that yields a sentinel session."""
+    yield MagicMock()
+
+
+def _patch_repo(stub: _StubJobRepository):
+    """Return a context manager that injects *stub* as JobRepository."""
+    return patch(
+        "services.dataset_import.service.JobRepository",
+        return_value=stub,
+    )
+
+
+def _patch_db():
+    """Return a context manager that replaces the DB session factory.
+
+    Uses ``new=_fake_db_session_ctx`` so each call to the patched symbol
+    produces a *fresh* async context manager instead of reusing a single
+    pre-created instance.
+    """
+    return patch(
+        "services.dataset_import.service.get_async_db_session_ctx",
+        new=_fake_db_session_ctx,
+    )
+
+
+def _patch_cleanup():
+    """Return a context manager that suppresses archive cleanup."""
+    return patch("services.dataset_import.service.cleanup_staged_archive")
+
+
+# ---------------------------------------------------------------------------
+# attach_dataset_import_archive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_attach_raises_resource_not_found_when_job_not_found() -> None:
+    """Ownership check: job is None -> ResourceNotFoundError."""
+    project_id = uuid4()
+    stub = _StubJobRepository(job=None)
+
+    with _patch_db(), _patch_repo(stub), pytest.raises(ResourceNotFoundError):
+        await DatasetImportService.attach_dataset_import_archive(
+            project_id=project_id,
+            job_id=uuid4(),
+            uploaded_archive_name="dataset.zip",
+        )
+
+
+@pytest.mark.anyio
+async def test_attach_raises_resource_not_found_when_project_mismatch() -> None:
+    """Ownership check: job.project_id != caller project_id -> ResourceNotFoundError."""
+    project_id = uuid4()
+    other_project_id = uuid4()
+    job = _make_job(project_id=other_project_id, step=ImportStep.AWAITING_ARCHIVE_UPLOAD)
+    stub = _StubJobRepository(job=job)
+
+    with _patch_db(), _patch_repo(stub), pytest.raises(ResourceNotFoundError):
+        await DatasetImportService.attach_dataset_import_archive(
+            project_id=project_id,
+            job_id=job.id,
+            uploaded_archive_name="dataset.zip",
+        )
+
+
+@pytest.mark.anyio
+async def test_attach_raises_invalid_job_state_when_wrong_step() -> None:
+    """Step guard: job not in AWAITING_ARCHIVE_UPLOAD -> InvalidJobStateError."""
+    project_id = uuid4()
+    job = _make_job(project_id=project_id, step=ImportStep.QUEUED_FOR_DETECTION)
+    stub = _StubJobRepository(job=job)
+
+    with _patch_db(), _patch_repo(stub), pytest.raises(InvalidJobStateError):
+        await DatasetImportService.attach_dataset_import_archive(
+            project_id=project_id,
+            job_id=job.id,
+            uploaded_archive_name="dataset.zip",
+        )
+
+
+@pytest.mark.anyio
+async def test_attach_succeeds_when_step_is_awaiting_upload() -> None:
+    """Happy path: AWAITING_ARCHIVE_UPLOAD step -> archive attached, step advances to QUEUED_FOR_DETECTION."""
+    project_id = uuid4()
+    job = _make_job(project_id=project_id, step=ImportStep.AWAITING_ARCHIVE_UPLOAD)
+    stub = _StubJobRepository(job=job)
+
+    with _patch_db(), _patch_repo(stub):
+        result = await DatasetImportService.attach_dataset_import_archive(
+            project_id=project_id,
+            job_id=job.id,
+            uploaded_archive_name="dataset.zip",
+        )
+
+    assert result is not None
+    assert len(stub.updated) == 1
+    _, updates = stub.updated[0]
+    assert updates["status"] == JobStatus.PENDING
+    # Payload in updates is a dict after model_dump
+    assert updates["payload"]["step"] == ImportStep.QUEUED_FOR_DETECTION
+    assert updates["payload"]["archive_staging_id"] == _STAGING_ID
+    assert updates["payload"]["uploaded_archive_name"] == "dataset.zip"
+
+
+# ---------------------------------------------------------------------------
+# finalize_dataset_import_job
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_finalize_raises_resource_not_found_when_job_not_found() -> None:
+    """Ownership check: job is None -> ResourceNotFoundError."""
+    project_id = uuid4()
+    stub = _StubJobRepository(job=None)
+    finalize_input = DatasetImportFinalizeInput(environment_id=uuid4())
+
+    with _patch_db(), _patch_repo(stub), pytest.raises(ResourceNotFoundError):
+        await DatasetImportService.finalize_dataset_import_job(
+            project_id=project_id,
+            job_id=uuid4(),
+            finalize_input=finalize_input,
+        )
+
+
+@pytest.mark.anyio
+async def test_finalize_raises_resource_not_found_when_project_mismatch() -> None:
+    """Ownership check: job.project_id != caller project_id -> ResourceNotFoundError."""
+    project_id = uuid4()
+    other_project_id = uuid4()
+    job = _make_job(project_id=other_project_id, step=ImportStep.AWAITING_USER_REVIEW)
+    stub = _StubJobRepository(job=job)
+    finalize_input = DatasetImportFinalizeInput(environment_id=uuid4())
+
+    with _patch_db(), _patch_repo(stub), pytest.raises(ResourceNotFoundError):
+        await DatasetImportService.finalize_dataset_import_job(
+            project_id=project_id,
+            job_id=job.id,
+            finalize_input=finalize_input,
+        )
+
+
+@pytest.mark.anyio
+async def test_finalize_raises_invalid_job_state_when_wrong_step() -> None:
+    """Step guard: step is not AWAITING_USER_REVIEW -> InvalidJobStateError."""
+    project_id = uuid4()
+    job = _make_job(project_id=project_id, step=ImportStep.AWAITING_ARCHIVE_UPLOAD)
+    stub = _StubJobRepository(job=job)
+    finalize_input = DatasetImportFinalizeInput(environment_id=uuid4())
+
+    with _patch_db(), _patch_repo(stub), pytest.raises(InvalidJobStateError):
+        await DatasetImportService.finalize_dataset_import_job(
+            project_id=project_id,
+            job_id=job.id,
+            finalize_input=finalize_input,
+        )
+
+
+@pytest.mark.parametrize(
+    "bad_step",
+    [
+        ImportStep.AWAITING_ARCHIVE_UPLOAD,
+        ImportStep.QUEUED_FOR_DETECTION,
+        ImportStep.DETECTING_FORMAT,
+        ImportStep.BUILDING_MANIFEST_DRAFT,
+        ImportStep.QUEUED_FOR_IMPORT,
+        ImportStep.IMPORTING_DATASET,
+        ImportStep.COMPLETED,
+    ],
+)
+@pytest.mark.anyio
+async def test_finalize_raises_invalid_job_state_for_every_non_waiting_step(bad_step: ImportStep) -> None:
+    """Exhaustive check: all steps except AWAITING_USER_REVIEW raise InvalidJobStateError."""
+    project_id = uuid4()
+    job = _make_job(project_id=project_id, step=bad_step)
+    stub = _StubJobRepository(job=job)
+    finalize_input = DatasetImportFinalizeInput(environment_id=uuid4())
+
+    with _patch_db(), _patch_repo(stub), pytest.raises(InvalidJobStateError):
+        await DatasetImportService.finalize_dataset_import_job(
+            project_id=project_id,
+            job_id=job.id,
+            finalize_input=finalize_input,
+        )
+
+
+@pytest.mark.anyio
+async def test_finalize_succeeds_when_step_is_waiting_for_user_input() -> None:
+    """Happy path: AWAITING_USER_REVIEW -> step advanced to QUEUED_FOR_IMPORT."""
+    project_id = uuid4()
+    environment_id = uuid4()
+    job = _make_job(project_id=project_id, step=ImportStep.AWAITING_USER_REVIEW)
+    stub = _StubJobRepository(job=job)
+    finalize_input = DatasetImportFinalizeInput(environment_id=environment_id)
+
+    with _patch_db(), _patch_repo(stub):
+        result = await DatasetImportService.finalize_dataset_import_job(
+            project_id=project_id,
+            job_id=job.id,
+            finalize_input=finalize_input,
+        )
+
+    assert result is not None
+    assert len(stub.updated) == 1
+    _, updates = stub.updated[0]
+    assert updates["status"] == JobStatus.PENDING
+    assert updates["payload"]["step"] == ImportStep.QUEUED_FOR_IMPORT
+
+
+# ---------------------------------------------------------------------------
+# cancel_dataset_import_job
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cancel_raises_resource_not_found_when_job_not_found() -> None:
+    """Ownership check: job is None -> ResourceNotFoundError."""
+    project_id = uuid4()
+    stub = _StubJobRepository(job=None)
+
+    with _patch_db(), _patch_repo(stub), _patch_cleanup(), pytest.raises(ResourceNotFoundError):
+        await DatasetImportService.cancel_dataset_import_job(
+            project_id=project_id,
+            job_id=uuid4(),
+        )
+
+
+@pytest.mark.anyio
+async def test_cancel_raises_resource_not_found_when_project_mismatch() -> None:
+    """Ownership check: job.project_id != caller project_id -> ResourceNotFoundError."""
+    project_id = uuid4()
+    other_project_id = uuid4()
+    job = _make_job(project_id=other_project_id, step=ImportStep.AWAITING_ARCHIVE_UPLOAD)
+    stub = _StubJobRepository(job=job)
+
+    with _patch_db(), _patch_repo(stub), _patch_cleanup(), pytest.raises(ResourceNotFoundError):
+        await DatasetImportService.cancel_dataset_import_job(
+            project_id=project_id,
+            job_id=job.id,
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid_step",
+    [
+        ImportStep.AWAITING_ARCHIVE_UPLOAD,
+        ImportStep.QUEUED_FOR_DETECTION,
+        ImportStep.DETECTING_FORMAT,
+        ImportStep.BUILDING_MANIFEST_DRAFT,
+        ImportStep.QUEUED_FOR_IMPORT,
+        ImportStep.IMPORTING_DATASET,
+        ImportStep.COMPLETED,
+    ],
+)
+@pytest.mark.anyio
+async def test_cancel_raises_invalid_job_state_for_steps_other_than_awaiting_user_review(
+    invalid_step: ImportStep,
+) -> None:
+    """Step guard: only AWAITING_USER_REVIEW is cancelable."""
+    project_id = uuid4()
+    job = _make_job(project_id=project_id, step=invalid_step)
+    stub = _StubJobRepository(job=job)
+
+    with _patch_db(), _patch_repo(stub), _patch_cleanup(), pytest.raises(InvalidJobStateError):
+        await DatasetImportService.cancel_dataset_import_job(
+            project_id=project_id,
+            job_id=job.id,
+        )
+
+
+@pytest.mark.anyio
+async def test_cancel_succeeds_for_awaiting_user_review_with_staging_id() -> None:
+    """Happy path: AWAITING_USER_REVIEW -> job marked CANCELED and archive cleaned up."""
+    project_id = uuid4()
+    job = _make_job(project_id=project_id, step=ImportStep.AWAITING_USER_REVIEW, archive_staging_id=_STAGING_ID)
+    stub = _StubJobRepository(job=job)
+
+    with _patch_db(), _patch_repo(stub), _patch_cleanup() as mock_cleanup:
+        result = await DatasetImportService.cancel_dataset_import_job(
+            project_id=project_id,
+            job_id=job.id,
+        )
+
+    assert result is not None
+    assert len(stub.updated) == 1
+    _, updates = stub.updated[0]
+    assert updates["status"] == JobStatus.CANCELED
+    # resolve_payload_archive_path derives path from staging id -> cleanup called with a Path
+    from pathlib import Path
+
+    called_path = mock_cleanup.call_args[0][0]
+    assert isinstance(called_path, Path)
+    assert called_path.name == f"{_STAGING_ID}.zip"
+
+
+# ---------------------------------------------------------------------------
+# Schema shape and validation_report optionality
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_manifest_slim_shape_no_legacy_fields() -> None:
+    """DatasetManifest no longer carries manifest_version, resource_type, integrity,
+    warnings, or missing_fields."""
+    from schemas.dataset_import_job import DatasetImportSource, DatasetManifest, DatasetManifestStatistics
+
+    manifest = DatasetManifest(
+        source_type=DatasetImportSource.UNKNOWN,
+        statistics=DatasetManifestStatistics(episode_count=5, frame_count=150),
+    )
+    dumped = manifest.model_dump(by_alias=True)
+
+    assert "manifest_version" not in dumped
+    assert "resource_type" not in dumped
+    assert "integrity" not in dumped
+    assert "warnings" not in dumped
+    assert "missing_fields" not in dumped
+    # dataset_schema must still be present
+    assert "dataset_schema" in dumped
+
+
+def test_dataset_manifest_source_slim_shape_no_legacy_fields() -> None:
+    """DatasetManifest.source_type is a direct field; no nested DatasetManifestSource wrapper."""
+    from schemas.dataset_import_job import DatasetImportSource, DatasetManifest
+
+    manifest = DatasetManifest(source_type=DatasetImportSource.LEROBOT_V3)
+    dumped = manifest.model_dump()
+
+    assert "source_format_version" not in dumped
+    assert "source_identifier" not in dumped
+    assert "original_dataset_uuid" not in dumped
+    assert dumped["source_type"] == DatasetImportSource.LEROBOT_V3
+
+
+def test_dataset_manifest_identity_slim_shape_no_default_task() -> None:
+    """DatasetManifest no longer carries identity fields such as suggested_name/default_task."""
+    from schemas.dataset_import_job import DatasetManifest
+
+    manifest = DatasetManifest()
+    dumped = manifest.model_dump()
+
+    assert "default_task" not in dumped
+    assert "suggested_name" not in dumped
+
+
+def test_finalize_input_slim_shape_no_user_overrides() -> None:
+    """DatasetImportFinalizeInput no longer carries dataset_name or user_overrides; default_task must be present."""
+    env_id = uuid4()
+    finalize_input = DatasetImportFinalizeInput(environment_id=env_id)
+    dumped = finalize_input.model_dump(mode="json")
+
+    assert "user_overrides" not in dumped
+    assert "dataset_name" not in dumped
+    # default_task is a first-class field and must always be serialized
+    assert "default_task" in dumped
+    assert dumped["default_task"] == ""
+
+
+def test_import_step_includes_completed() -> None:
+    """ImportStep now includes COMPLETED as a terminal enum value."""
+    from schemas.dataset_import_job import ImportStep
+
+    assert hasattr(ImportStep, "COMPLETED")
+    assert ImportStep.COMPLETED == "completed"
+
+
+# ---------------------------------------------------------------------------
+# validation_report optionality
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_import_job_payload_validation_report_defaults_to_none() -> None:
+    """A freshly created DatasetImportJobPayload has validation_report=None."""
+    payload = DatasetImportJobPayload(step=ImportStep.AWAITING_ARCHIVE_UPLOAD, archive_staging_id=_STAGING_ID)
+    assert payload.validation_report is None
+
+
+def test_dataset_import_job_payload_validation_report_is_none_when_no_issues() -> None:
+    """validation_report should be set to None when there are no issues (waiting for user input)."""
+    from schemas.dataset_import_job import ImportValidationReport
+
+    payload = DatasetImportJobPayload(step=ImportStep.AWAITING_USER_REVIEW, archive_staging_id=_STAGING_ID)
+    # Simulate the worker behaviour: clean report (no messages) -> None
+    report = ImportValidationReport()
+    has_issues = bool(report.messages)
+    payload.validation_report = report if has_issues else None
+
+    assert payload.validation_report is None
+
+
+def test_dataset_import_job_payload_validation_report_is_set_when_issues_present() -> None:
+    """validation_report is preserved when there are messages (e.g. errors)."""
+    from schemas.dataset_import_job import ImportValidationReport, ImportValidationSeverity
+
+    payload = DatasetImportJobPayload(step=ImportStep.AWAITING_USER_REVIEW, archive_staging_id=_STAGING_ID)
+    report = ImportValidationReport()
+    report.add_error("env is required")
+    has_issues = bool(report.messages)
+    payload.validation_report = report if has_issues else None
+
+    assert payload.validation_report is not None
+    assert len(payload.validation_report.messages) == 1
+    assert payload.validation_report.messages[0].severity == ImportValidationSeverity.ERROR
+
+
+# ---------------------------------------------------------------------------
+# Step consistency: completed job must have COMPLETED step
+# ---------------------------------------------------------------------------
+
+
+def test_completed_payload_step_is_completed() -> None:
+    """A completed import job payload must use ImportStep.COMPLETED, not IMPORTING_DATASET."""
+    from schemas.dataset_import_job import ImportStep
+
+    payload = DatasetImportJobPayload(step=ImportStep.COMPLETED, archive_staging_id=_STAGING_ID)
+    assert payload.step == ImportStep.COMPLETED
+    assert payload.step != ImportStep.IMPORTING_DATASET
+
+
+# ---------------------------------------------------------------------------
+# end_time consistency: pending/running updates must not set end_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_attach_archive_does_not_set_end_time_for_pending_status() -> None:
+    """Transitioning to PENDING (attach archive) must not populate end_time."""
+    project_id = uuid4()
+    job = _make_job(project_id=project_id, step=ImportStep.AWAITING_ARCHIVE_UPLOAD)
+    stub = _StubJobRepository(job=job)
+
+    with _patch_db(), _patch_repo(stub):
+        await DatasetImportService.attach_dataset_import_archive(
+            project_id=project_id,
+            job_id=job.id,
+            uploaded_archive_name="dataset.zip",
+        )
+
+    _, updates = stub.updated[0]
+    assert "end_time" not in updates
+
+
+@pytest.mark.anyio
+async def test_finalize_does_not_set_end_time_for_pending_status() -> None:
+    """Transitioning to PENDING (finalize) must not populate end_time."""
+    project_id = uuid4()
+    environment_id = uuid4()
+    job = _make_job(project_id=project_id, step=ImportStep.AWAITING_USER_REVIEW)
+    stub = _StubJobRepository(job=job)
+    finalize_input = DatasetImportFinalizeInput(environment_id=environment_id)
+
+    with _patch_db(), _patch_repo(stub):
+        await DatasetImportService.finalize_dataset_import_job(
+            project_id=project_id,
+            job_id=job.id,
+            finalize_input=finalize_input,
+        )
+
+    _, updates = stub.updated[0]
+    assert "end_time" not in updates
+
+
+@pytest.mark.anyio
+async def test_cancel_sets_end_time() -> None:
+    """Canceling from AWAITING_USER_REVIEW (terminal status CANCELED) must set end_time."""
+    project_id = uuid4()
+    job = _make_job(project_id=project_id, step=ImportStep.AWAITING_USER_REVIEW, archive_staging_id=_STAGING_ID)
+    stub = _StubJobRepository(job=job)
+
+    with _patch_db(), _patch_repo(stub), _patch_cleanup():
+        await DatasetImportService.cancel_dataset_import_job(
+            project_id=project_id,
+            job_id=job.id,
+        )
+
+    _, updates = stub.updated[0]
+    assert "end_time" in updates
+    assert updates["end_time"] is not None

--- a/application/backend/tests/services/test_archive_safety.py
+++ b/application/backend/tests/services/test_archive_safety.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from services.archive_safety import flatten_single_root_directory
+
+
+def test_flatten_single_root_directory_moves_nested_contents(tmp_path: Path) -> None:
+    (tmp_path / "dataset").mkdir(parents=True)
+    (tmp_path / "dataset" / "meta").mkdir(parents=True)
+    (tmp_path / "dataset" / "data").mkdir(parents=True)
+    (tmp_path / "dataset" / "meta" / "info.json").write_text("{}")
+
+    flatten_single_root_directory(tmp_path)
+
+    assert (tmp_path / "meta" / "info.json").exists()
+    assert (tmp_path / "data").exists()
+    assert not (tmp_path / "dataset").exists()
+
+
+def test_flatten_single_root_directory_noop_when_multiple_roots(tmp_path: Path) -> None:
+    (tmp_path / "dataset-a").mkdir(parents=True)
+    (tmp_path / "dataset-b").mkdir(parents=True)
+
+    flatten_single_root_directory(tmp_path)
+
+    assert (tmp_path / "dataset-a").exists()
+    assert (tmp_path / "dataset-b").exists()

--- a/application/backend/tests/services/test_log_service.py
+++ b/application/backend/tests/services/test_log_service.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import pytest
 
-from schemas.job import Job, JobType
+from schemas.job import Job, TrainJob
 from services.log_service import LogService
 
 
@@ -42,10 +42,9 @@ async def test_discover_job_sources_includes_training_name_and_created_at(tmp_pa
     file_path = jobs_dir / f"{job_id}.log"
     file_path.write_text("hello")
 
-    job = Job(
+    job = TrainJob(
         id=job_id,
         project_id=uuid4(),
-        type=JobType.TRAINING,
         payload={
             "project_id": str(uuid4()),
             "dataset_id": str(uuid4()),

--- a/application/backend/tests/services/test_log_service.py
+++ b/application/backend/tests/services/test_log_service.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import pytest
 
-from schemas.job import Job, TrainJob
+from schemas.job import DatasetImportJob, Job, TrainJob
 from services.log_service import LogService
 
 
@@ -46,6 +46,7 @@ async def test_discover_job_sources_includes_training_name_and_created_at(tmp_pa
         id=job_id,
         project_id=uuid4(),
         payload={
+            "type": "training",
             "project_id": str(uuid4()),
             "dataset_id": str(uuid4()),
             "policy": "pi0",
@@ -66,6 +67,85 @@ async def test_discover_job_sources_includes_training_name_and_created_at(tmp_pa
     assert job_sources[0].id == f"job-{job_id}"
     assert job_sources[0].name == "My Model (pi0)"
     assert job_sources[0].created_at is not None
+
+
+@pytest.mark.anyio
+async def test_discover_job_sources_uses_staging_id_when_no_manifest(tmp_path) -> None:
+    """New payload with archive_staging_id only -> display name derived from first 8 chars of staging id."""
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir(parents=True)
+
+    job_id = uuid4()
+    staging_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    file_path = jobs_dir / f"{job_id}.log"
+    file_path.write_text("hello import staging")
+
+    job = DatasetImportJob(
+        id=job_id,
+        project_id=uuid4(),
+        payload={
+            "type": "dataset_import",
+            "step": "queued_for_detection",
+            "archive_staging_id": staging_id,
+            "format_hint": "auto",
+            "dataset_manifest_draft": None,
+            "validation_report": None,
+            "finalize_input": None,
+            "result_dataset_id": None,
+        },
+        created_at=datetime.now(tz=UTC),
+    )
+
+    service = _build_service(tmp_path, jobs=[job])
+
+    sources = await service.get_log_sources()
+    job_sources = [source for source in sources if source.type == "job"]
+
+    assert len(job_sources) == 1
+    assert job_sources[0].id == f"job-{job_id}"
+    # First 8 chars of staging_id used as display name
+    assert job_sources[0].name == "Import: aaaaaaaa.zip"
+
+
+@pytest.mark.anyio
+async def test_discover_job_sources_prefers_dataset_name(tmp_path) -> None:
+    """Dataset name from prepare input takes priority for import job display names."""
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir(parents=True)
+
+    job_id = uuid4()
+    staging_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    file_path = jobs_dir / f"{job_id}.log"
+    file_path.write_text("hello import manifest")
+
+    job = DatasetImportJob(
+        id=job_id,
+        project_id=uuid4(),
+        payload={
+            "type": "dataset_import",
+            "step": "awaiting_user_review",
+            "archive_staging_id": staging_id,
+            "format_hint": "auto",
+            "dataset_name": "My Preferred Dataset Name",
+            "dataset_manifest_draft": {
+                "source_type": "lerobot_v3",
+                "capture": {},
+                "schema": {},
+            },
+            "validation_report": None,
+            "finalize_input": None,
+            "result_dataset_id": None,
+        },
+        created_at=datetime.now(tz=UTC),
+    )
+
+    service = _build_service(tmp_path, jobs=[job])
+
+    sources = await service.get_log_sources()
+    job_sources = [source for source in sources if source.type == "job"]
+
+    assert len(job_sources) == 1
+    assert job_sources[0].name == "Import: My Preferred Dataset Name"
 
 
 @pytest.mark.anyio

--- a/application/ui/src/features/datasets/dataset-tabs.tsx
+++ b/application/ui/src/features/datasets/dataset-tabs.tsx
@@ -1,12 +1,13 @@
 import { Suspense, useState } from 'react';
 
 import { ManagedTab, type ManagedTabAction } from '@geti-ui/blocks';
-import { ActionButton, DialogContainer, Flex, Icon, Item, TabList } from '@geti-ui/ui';
+import { ActionButton, DialogContainer, Flex, Icon, Item, Menu, MenuTrigger, TabList } from '@geti-ui/ui';
 import { Add } from '@geti-ui/ui/icons';
 import { useNavigate } from 'react-router';
 
 import { SchemaDatasetOutput } from '../../api/openapi-spec';
 import { paths } from '../../router';
+import { ImportDatasetDialog } from '../../routes/datasets/import/dataset-import-button';
 import { NewDatasetForm } from '../../routes/datasets/new-dataset.component';
 import { useProjectId } from '../projects/use-project';
 import { DeleteDatasetDialog } from './delete-dataset-dialog';
@@ -30,7 +31,7 @@ export const DatasetTabs = ({
 }) => {
     const { project_id } = useProjectId();
 
-    const [action, setAction] = useState<null | 'rename' | 'delete' | 'export' | 'add'>(null);
+    const [action, setAction] = useState<null | 'rename' | 'delete' | 'export' | 'add' | 'import'>(null);
     const selectedDataset = datasets.find((dataset) => dataset.id === selectedDatasetId);
 
     const onItemAction = (itemAction: string) => {
@@ -97,17 +98,32 @@ export const DatasetTabs = ({
                     borderBottom: 'var(--spectrum-alias-border-size-thick) solid var(--spectrum-global-color-gray-300)',
                 }}
             >
-                <ActionButton
-                    isQuiet
-                    aria-label='Add dataset'
-                    onPress={() => {
-                        setAction('add');
-                    }}
-                >
-                    <Icon>
-                        <Add />
-                    </Icon>
-                </ActionButton>
+                <MenuTrigger>
+                    <ActionButton
+                        isQuiet
+                        aria-label='Add dataset'
+                        onPress={() => {
+                            setAction('add');
+                        }}
+                    >
+                        <Icon>
+                            <Add />
+                        </Icon>
+                    </ActionButton>
+                    <Menu
+                        onAction={(key) => {
+                            if (key === 'add') {
+                                setAction('add');
+                            }
+                            if (key === 'import') {
+                                setAction('import');
+                            }
+                        }}
+                    >
+                        <Item key='add'>Add</Item>
+                        <Item key='import'>Import</Item>
+                    </Menu>
+                </MenuTrigger>
             </div>
 
             <DialogContainer
@@ -115,6 +131,7 @@ export const DatasetTabs = ({
                     setAction(null);
                 }}
             >
+                {action === 'import' && <ImportDatasetDialog onClose={() => setAction(null)} />}
                 {action === 'add' && (
                     <Suspense>
                         <NewDatasetForm project_id={project_id} onDone={onAddDataset} />

--- a/application/ui/src/routes/datasets/import/dataset-import-button.tsx
+++ b/application/ui/src/routes/datasets/import/dataset-import-button.tsx
@@ -1,0 +1,36 @@
+import { Button, DialogTrigger, Text } from '@geti-ui/ui';
+
+import { ImportDatasetDialog } from './import-dataset-dialog';
+
+interface DatasetImportButtonProps {
+    existingJobId?: string;
+    buttonLabel?: string;
+    onPendingJobDismissed?: (jobId: string) => void;
+    onImportCompleted?: (datasetId: string) => void;
+}
+
+export const DatasetImportButton = ({
+    existingJobId,
+    buttonLabel = 'Import dataset',
+    onPendingJobDismissed,
+    onImportCompleted,
+}: DatasetImportButtonProps = {}) => {
+    return (
+        <DialogTrigger>
+            <Button variant='secondary' alignSelf={'center'}>
+                <Text>{buttonLabel}</Text>
+            </Button>
+
+            {(close) => (
+                <ImportDatasetDialog
+                    initialJobId={existingJobId}
+                    onPendingJobDismissed={onPendingJobDismissed}
+                    onImportCompleted={onImportCompleted}
+                    onClose={close}
+                />
+            )}
+        </DialogTrigger>
+    );
+};
+
+export { ImportDatasetDialog } from './import-dataset-dialog';

--- a/application/ui/src/routes/datasets/import/import-dataset-dialog.tsx
+++ b/application/ui/src/routes/datasets/import/import-dataset-dialog.tsx
@@ -1,0 +1,211 @@
+import { Suspense, useEffect, useEffectEvent, useState } from 'react';
+
+import { Content, Dialog, Divider, Heading, Loading } from '@geti-ui/ui';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
+
+import { SchemaDatasetImportJob } from '../../../api/openapi-spec';
+import { useProjectId } from '../../../features/projects/use-project';
+import { paths } from '../../../router';
+import { ImportStepDetectionFailed } from './import-step-detection-failed';
+import { ImportStepInProgress } from './import-step-in-progress';
+import { ImportStepUpload } from './import-step-upload';
+import { ImportStepUserReview } from './import-step-user-review';
+import { useDatasetImportJobQuery, type FinalizeFields } from './use-dataset-import-job-state';
+
+const DETECTION_STEPS = ['queued_for_detection', 'detecting_format', 'building_manifest_draft'];
+
+const IMPORT_DIALOG_VIEW_STATE = {
+    UPLOAD: 'upload',
+    DETECTING: 'detecting',
+    DETECTION_FAILED: 'detection_failed',
+    USER_REVIEW: 'user_review',
+    IMPORTING: 'importing',
+} as const;
+
+type ImportDialogViewState = (typeof IMPORT_DIALOG_VIEW_STATE)[keyof typeof IMPORT_DIALOG_VIEW_STATE];
+
+interface InternalImportDatasetDialogProps {
+    project_id: string;
+    onClose: () => void;
+    initialJobId?: string;
+    onPendingJobDismissed?: (jobId: string) => void;
+    onImportCompleted?: (datasetId: string) => void;
+}
+
+interface ImportDatasetDialogProps {
+    onClose: () => void;
+    initialJobId?: string;
+    onPendingJobDismissed?: (jobId: string) => void;
+    onImportCompleted?: (datasetId: string) => void;
+}
+
+const DatasetImportHeading = ({
+    importJob,
+    viewState,
+}: {
+    importJob: SchemaDatasetImportJob | undefined;
+    viewState: ImportDialogViewState;
+}) => {
+    if (viewState !== IMPORT_DIALOG_VIEW_STATE.DETECTION_FAILED) {
+        return <Heading>Import dataset</Heading>;
+    }
+
+    const formatHint = importJob?.payload?.format_hint;
+    const usedAutoDetection = formatHint === 'auto' || formatHint === undefined;
+
+    return (
+        <Heading>
+            {usedAutoDetection ? 'Automatic format detection failed' : 'Selected format validation failed'}
+        </Heading>
+    );
+};
+
+const getDialogViewStatus = (importJob: SchemaDatasetImportJob | undefined): ImportDialogViewState => {
+    const importPayload = importJob?.payload;
+    const payloadStep = importPayload?.step;
+
+    if (importJob === undefined || payloadStep === 'awaiting_archive_upload') {
+        return IMPORT_DIALOG_VIEW_STATE.UPLOAD;
+    }
+
+    const isDetectionStep = payloadStep !== undefined && DETECTION_STEPS.includes(String(payloadStep));
+    if (importJob.status === 'failed' && isDetectionStep) {
+        return IMPORT_DIALOG_VIEW_STATE.DETECTION_FAILED;
+    }
+
+    if (isDetectionStep) {
+        return IMPORT_DIALOG_VIEW_STATE.DETECTING;
+    }
+
+    if (payloadStep === 'awaiting_user_review') {
+        return IMPORT_DIALOG_VIEW_STATE.USER_REVIEW;
+    }
+
+    if (payloadStep === 'queued_for_import' || payloadStep === 'importing_dataset' || payloadStep === 'completed') {
+        return IMPORT_DIALOG_VIEW_STATE.IMPORTING;
+    }
+
+    return IMPORT_DIALOG_VIEW_STATE.UPLOAD;
+};
+
+const useOnImportDone = (importJob: SchemaDatasetImportJob | undefined, onImportDone: (datasetId: string) => void) => {
+    const completedDatasetId = importJob?.status === 'completed' ? importJob.payload?.result_dataset_id : undefined;
+    const onImportDoneEvent = useEffectEvent(onImportDone);
+
+    useEffect(() => {
+        if (completedDatasetId) {
+            onImportDoneEvent(completedDatasetId);
+        }
+    }, [completedDatasetId, onImportDoneEvent]);
+};
+
+const InternalImportDatasetDialog = ({
+    project_id,
+    onClose,
+    initialJobId,
+    onPendingJobDismissed,
+    onImportCompleted,
+}: InternalImportDatasetDialogProps) => {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const [datasetName, setDatasetName] = useState('');
+    const [finalizeFields, setFinalizeFields] = useState<FinalizeFields>({
+        defaultTask: '',
+        environmentId: undefined,
+    });
+    const [importJobId, setImportJobId] = useState<string | undefined>(initialJobId);
+
+    const importJobQuery = useDatasetImportJobQuery(importJobId);
+    const importJob = importJobQuery.data as SchemaDatasetImportJob | undefined;
+
+    const status = getDialogViewStatus(importJob);
+
+    const onDialogClose = () => {
+        if (importJobId && status === IMPORT_DIALOG_VIEW_STATE.USER_REVIEW) {
+            onPendingJobDismissed?.(importJobId);
+        }
+        onClose();
+    };
+
+    useOnImportDone(importJob, (datasetId: string) => {
+        void queryClient.invalidateQueries({ queryKey: ['get', '/api/projects/{project_id}'] });
+        void queryClient.invalidateQueries({ queryKey: ['get', '/api/jobs'] });
+        onImportCompleted?.(datasetId);
+        onDialogClose();
+        navigate(paths.project.datasets.show({ project_id, dataset_id: datasetId }));
+    });
+
+    return (
+        <Dialog>
+            <DatasetImportHeading importJob={importJob} viewState={status} />
+            <Divider />
+
+            {status === IMPORT_DIALOG_VIEW_STATE.UPLOAD && (
+                <ImportStepUpload
+                    importJob={importJob}
+                    project_id={project_id}
+                    onClose={onDialogClose}
+                    datasetName={datasetName}
+                    onDatasetNameChange={setDatasetName}
+                    onUploaded={setImportJobId}
+                />
+            )}
+
+            {importJob !== undefined && status === IMPORT_DIALOG_VIEW_STATE.DETECTING && (
+                <ImportStepInProgress statusMessage='Upload accepted. Waiting for server-side dataset detection...' />
+            )}
+
+            {importJob !== undefined && status === IMPORT_DIALOG_VIEW_STATE.IMPORTING && (
+                <ImportStepInProgress statusMessage={importJob?.message ?? 'Importing dataset...'} />
+            )}
+
+            {importJob !== undefined && status === IMPORT_DIALOG_VIEW_STATE.DETECTION_FAILED && (
+                <ImportStepDetectionFailed importJob={importJob} onClose={onDialogClose} />
+            )}
+
+            {importJob !== undefined && status === IMPORT_DIALOG_VIEW_STATE.USER_REVIEW && importJobId && (
+                <ImportStepUserReview
+                    importJob={importJob}
+                    project_id={project_id}
+                    onClose={onClose}
+                    fields={finalizeFields}
+                    onFieldsChange={setFinalizeFields}
+                />
+            )}
+        </Dialog>
+    );
+};
+
+export const ImportDatasetDialog = ({
+    onClose,
+    initialJobId,
+    onPendingJobDismissed,
+    onImportCompleted,
+}: ImportDatasetDialogProps) => {
+    const { project_id } = useProjectId();
+
+    return (
+        <Suspense
+            fallback={
+                <Dialog>
+                    <Heading>Import dataset</Heading>
+                    <Divider />
+                    <Content>
+                        <Loading />
+                    </Content>
+                </Dialog>
+            }
+        >
+            <InternalImportDatasetDialog
+                project_id={project_id}
+                onClose={onClose}
+                initialJobId={initialJobId}
+                onPendingJobDismissed={onPendingJobDismissed}
+                onImportCompleted={onImportCompleted}
+            />
+        </Suspense>
+    );
+};
+
+export type { ImportDatasetDialogProps };

--- a/application/ui/src/routes/datasets/import/import-step-detection-failed.tsx
+++ b/application/ui/src/routes/datasets/import/import-step-detection-failed.tsx
@@ -1,0 +1,63 @@
+import { Button, ButtonGroup, Content, Flex, Text, View } from '@geti-ui/ui';
+
+import { SchemaDatasetImportJob } from '../../../api/openapi-spec';
+
+const getValidationErrors = (messages: { severity: string; message: string }[] | undefined) => {
+    return (messages ?? [])
+        .filter((m) => m.severity === 'error')
+        .map((m) => m.message)
+        .filter(Boolean);
+};
+
+interface ImportStepDetectionFailedProps {
+    importJob: SchemaDatasetImportJob;
+    onClose: () => void;
+}
+
+export const ImportStepDetectionFailed = ({ importJob, onClose }: ImportStepDetectionFailedProps) => {
+    const importPayload = importJob?.payload;
+    const validationErrors = getValidationErrors(importPayload?.validation_report?.messages);
+
+    const usedAutoDetection = importPayload?.format_hint === 'auto' || importPayload?.format_hint === undefined;
+
+    const errorMessage = usedAutoDetection
+        ? 'Could not automatically detect the dataset format. Please select a format manually.'
+        : 'Could not detect the selected dataset format. Please choose a different format and retry.';
+
+    const onCancel = () => {
+        onClose();
+    };
+
+    return (
+        <>
+            <Content>
+                <Flex direction='column' gap='size-100'>
+                    {validationErrors.length > 0 ? (
+                        <View backgroundColor='gray-75' borderColor='gray-200' borderWidth='thin' padding='size-150'>
+                            <Flex direction='column' gap='size-50'>
+                                <Text>
+                                    <strong>Detection details</strong>
+                                </Text>
+                                <ul>
+                                    {validationErrors.map((message, index) => (
+                                        <li key={`${message}-${index}`}>{message}</li>
+                                    ))}
+                                </ul>
+                            </Flex>
+                        </View>
+                    ) : null}
+
+                    {validationErrors.length === 0 ? <Text>{errorMessage}</Text> : null}
+
+                    <Text>Please check the application logs for more details or raise an issue on our Github.</Text>
+                </Flex>
+            </Content>
+
+            <ButtonGroup>
+                <Button variant='secondary' onPress={onCancel}>
+                    Cancel
+                </Button>
+            </ButtonGroup>
+        </>
+    );
+};

--- a/application/ui/src/routes/datasets/import/import-step-in-progress.tsx
+++ b/application/ui/src/routes/datasets/import/import-step-in-progress.tsx
@@ -1,0 +1,28 @@
+import { Content, Flex, Loading, Text, View } from '@geti-ui/ui';
+
+interface ImportStepInProgressProps {
+    statusMessage: string;
+}
+
+export const ImportStepInProgress = ({ statusMessage }: ImportStepInProgressProps) => {
+    return (
+        <>
+            <Content>
+                <View padding='size-800'>
+                    <Flex direction='column' gap='size-400'>
+                        <Loading size='M' mode='inline' />
+                        <Text
+                            UNSAFE_style={{
+                                color: 'var(--spectrum-global-color-gray-500)',
+                                fontSize: 'var(--spectrum-global-dimension-font-size-100)',
+                                textAlign: 'center',
+                            }}
+                        >
+                            {statusMessage}
+                        </Text>
+                    </Flex>
+                </View>
+            </Content>
+        </>
+    );
+};

--- a/application/ui/src/routes/datasets/import/import-step-upload.tsx
+++ b/application/ui/src/routes/datasets/import/import-step-upload.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+    Button,
+    ButtonGroup,
+    Content,
+    DropZone,
+    FileTrigger,
+    Flex,
+    Heading,
+    InlineAlert,
+    ProgressCircle,
+    Text,
+    TextField,
+    View,
+} from '@geti-ui/ui';
+import { useMutation } from '@tanstack/react-query';
+
+import { fetchClient } from '../../../api/client';
+import { SchemaDatasetImportJob } from '../../../api/openapi-spec';
+import { isAbortError } from '../../utils/download';
+
+type FormatHint = 'auto' | 'lerobot_v3';
+
+interface UseDatasetUploadResult {
+    upload: (file: File, formatHint: FormatHint, datasetName: string) => Promise<string | undefined>;
+    abort: () => void;
+    progress: number | null;
+    mutation: ReturnType<
+        typeof useMutation<{ id: string }, Error, { file: File; source: string; datasetName: string }>
+    >;
+}
+
+export const useDatasetUpload = (projectId: string): UseDatasetUploadResult => {
+    const [progress, setProgress] = useState<number | null>(null);
+    const abortRef = useRef<XMLHttpRequest | null>(null);
+
+    useEffect(() => {
+        return () => {
+            abortRef.current?.abort();
+        };
+    }, []);
+
+    const mutation = useMutation({
+        mutationFn: async ({ file, source, datasetName }: { file: File; source: string; datasetName: string }) => {
+            const { data: preparedJob, error } = await fetchClient.POST(
+                '/api/projects/{project_id}/imports/datasets:prepare',
+                {
+                    params: { path: { project_id: projectId } },
+                    body: { format_hint: source, dataset_name: datasetName },
+                    bodySerializer: (body) => {
+                        const fd = new FormData();
+                        const b = body as { format_hint: string; dataset_name: string };
+                        fd.append('format_hint', b.format_hint);
+                        fd.append('dataset_name', b.dataset_name);
+                        return fd;
+                    },
+                }
+            );
+
+            if (error || !preparedJob) {
+                throw new Error('Failed to prepare dataset import job');
+            }
+
+            const jobId = (preparedJob as { id?: string }).id;
+            if (!jobId) {
+                throw new Error('Failed to prepare import: missing job id');
+            }
+
+            const uploadPath = fetchClient.PATH('/api/projects/{project_id}/imports/datasets/{job_id}:upload', {
+                params: { path: { project_id: projectId, job_id: jobId } },
+            });
+
+            return await new Promise<{ id: string }>((resolve, reject) => {
+                const xhr = new XMLHttpRequest();
+                abortRef.current = xhr;
+                xhr.open('PUT', uploadPath);
+                xhr.responseType = 'json';
+
+                xhr.upload.onprogress = (event) => {
+                    if (event.lengthComputable && event.total > 0) {
+                        setProgress(Math.round((event.loaded / event.total) * 100));
+                    } else {
+                        setProgress(null);
+                    }
+                };
+
+                xhr.onload = () => {
+                    if (xhr.status >= 200 && xhr.status < 300) {
+                        const uploaded = xhr.response as { id?: string } | null;
+                        resolve({ id: uploaded?.id ?? jobId });
+                    } else {
+                        reject(new Error(`Failed to upload dataset archive: ${xhr.status}`));
+                    }
+                };
+
+                xhr.onerror = () => reject(new Error('Failed to upload dataset archive'));
+                xhr.onabort = () => reject(new DOMException('Upload aborted', 'AbortError'));
+
+                const fd = new FormData();
+                fd.append('archive', file);
+                xhr.send(fd);
+            });
+        },
+        onMutate: () => {
+            setProgress(null);
+        },
+        onSettled: () => {
+            abortRef.current = null;
+        },
+    });
+
+    const upload = async (file: File, formatHint: FormatHint, datasetName: string): Promise<string | undefined> => {
+        try {
+            const job = await mutation.mutateAsync({ file, source: formatHint, datasetName });
+            return job.id;
+        } catch (error) {
+            if (isAbortError(error)) {
+                return undefined;
+            }
+            return undefined;
+        }
+    };
+
+    const abort = () => {
+        abortRef.current?.abort();
+        mutation.reset();
+        setProgress(null);
+    };
+
+    return { upload, abort, progress, mutation };
+};
+
+interface ImportStepUploadProps {
+    importJob: SchemaDatasetImportJob | undefined;
+    project_id: string;
+    onClose: () => void;
+    datasetName: string;
+    onDatasetNameChange: (value: string) => void;
+    onUploaded: (jobId: string) => void;
+}
+
+export const ImportStepUpload = ({
+    importJob,
+    project_id,
+    onClose,
+    datasetName,
+    onDatasetNameChange,
+    onUploaded,
+}: ImportStepUploadProps) => {
+    const [archive, setArchive] = useState<File | null>(null);
+
+    const errorMessage =
+        importJob?.status === 'failed'
+            ? (importJob.message ?? 'Import failed during processing.')
+            : importJob?.status === 'canceled'
+              ? 'Import was canceled.'
+              : undefined;
+
+    const { upload, abort, progress, mutation } = useDatasetUpload(project_id);
+    const canUpload = archive !== null && datasetName.trim().length > 0;
+
+    const startUpload = async (file: File) => {
+        const jobId = await upload(file, 'auto', datasetName.trim());
+        if (jobId) {
+            onUploaded(jobId);
+        }
+    };
+
+    const onUpload = async () => {
+        if (archive === null || !canUpload) {
+            return;
+        }
+        await startUpload(archive);
+    };
+
+    const onFileSelected = (file: File) => {
+        setArchive(file);
+        if (datasetName.trim().length === 0) {
+            const suggestion = file.name.endsWith('.zip') ? file.name.slice(0, -4) : file.name;
+            onDatasetNameChange(suggestion);
+        }
+    };
+
+    const handleFileList = (files: FileList | null) => {
+        const file = files?.[0] ?? null;
+        if (file === null) {
+            return;
+        }
+
+        onFileSelected(file);
+    };
+
+    const onCancel = () => {
+        if (mutation.isPending) {
+            abort();
+            return;
+        }
+        onClose();
+    };
+
+    return (
+        <>
+            <Content>
+                {errorMessage ? (
+                    <InlineAlert variant='negative'>
+                        <Heading>Import setup error</Heading>
+                        <Content>{errorMessage}</Content>
+                    </InlineAlert>
+                ) : null}
+
+                <Flex direction='column' gap='size-200'>
+                    <TextField
+                        isRequired
+                        width='100%'
+                        label='Dataset name'
+                        value={datasetName}
+                        onChange={onDatasetNameChange}
+                        isDisabled={mutation.isPending}
+                    />
+
+                    <DropZone
+                        isFilled={archive !== null}
+                        onDrop={async (e) => {
+                            if (mutation.isPending) {
+                                return;
+                            }
+                            const fileItem = e.items.find((item) => item.kind === 'file');
+                            if (fileItem?.kind !== 'file') {
+                                return;
+                            }
+                            const file = await fileItem.getFile();
+                            if (file.name.endsWith('.zip')) {
+                                onFileSelected(file);
+                            }
+                        }}
+                    >
+                        {mutation.isPending ? (
+                            <Flex direction='column' alignItems='center' justifyContent='center' gap='size-100'>
+                                {progress !== null && (
+                                    <ProgressCircle
+                                        value={progress}
+                                        minValue={0}
+                                        maxValue={100}
+                                        size='M'
+                                        aria-label='Uploading dataset archive'
+                                    />
+                                )}
+                                <Text>{progress === null ? 'Uploading dataset archive...' : `${progress}%`}</Text>
+                            </Flex>
+                        ) : (
+                            <Flex direction='column' gap='size-100'>
+                                {archive !== null ? (
+                                    <Text>{archive.name}</Text>
+                                ) : (
+                                    <Text>Drop a .zip archive here or click to browse</Text>
+                                )}
+                                <View>
+                                    <FileTrigger acceptedFileTypes={['.zip']} onSelect={handleFileList}>
+                                        <Button variant='secondary'>
+                                            {archive !== null ? 'Choose a different file' : 'Browse'}
+                                        </Button>
+                                    </FileTrigger>
+                                </View>
+                            </Flex>
+                        )}
+                    </DropZone>
+                </Flex>
+
+                {mutation.isError && !isAbortError(mutation.error) ? (
+                    <InlineAlert variant='negative'>
+                        <Heading>Import error</Heading>
+                        <Content>Failed to upload dataset archive. Please try again.</Content>
+                    </InlineAlert>
+                ) : null}
+            </Content>
+            <ButtonGroup>
+                <Button variant='secondary' onPress={onCancel}>
+                    {mutation.isPending ? 'Abort upload' : 'Cancel'}
+                </Button>
+                <Button
+                    variant='accent'
+                    onPress={onUpload}
+                    isPending={mutation.isPending}
+                    isDisabled={!canUpload || mutation.isPending}
+                >
+                    Upload
+                </Button>
+            </ButtonGroup>
+        </>
+    );
+};

--- a/application/ui/src/routes/datasets/import/import-step-user-review.tsx
+++ b/application/ui/src/routes/datasets/import/import-step-user-review.tsx
@@ -1,0 +1,191 @@
+import {
+    Button,
+    ButtonGroup,
+    Content,
+    Flex,
+    Heading,
+    InlineAlert,
+    Item,
+    Picker,
+    Text,
+    TextField,
+    View,
+} from '@geti-ui/ui';
+
+import { $api } from '../../../api/client';
+import { SchemaDatasetImportJob, SchemaDatasetManifest } from '../../../api/openapi-spec';
+import type { FinalizeFields } from './use-dataset-import-job-state';
+
+const DatasetManifestSummary = ({ importJob }: { importJob: SchemaDatasetImportJob }) => {
+    const importPayload = importJob?.payload;
+    const draft = (importPayload?.dataset_manifest_draft ?? undefined) as SchemaDatasetManifest | undefined;
+
+    const detectedFormat = draft?.source_type ?? 'unknown';
+    const cameras = draft?.dataset_schema?.cameras ?? [];
+    const robots = draft?.dataset_schema?.robots ?? [];
+
+    if (draft === undefined) {
+        return null;
+    }
+
+    return (
+        <Flex direction='column' gap='size-150'>
+            <Heading level={4}>Detected dataset summary</Heading>
+
+            <Flex direction='row' wrap='wrap' gap='size-300'>
+                <Flex direction='column' gap='size-50'>
+                    <Text>
+                        <strong>Source format</strong>
+                    </Text>
+                    <Text>{detectedFormat}</Text>
+                </Flex>
+
+                <Flex direction='column' gap='size-50'>
+                    <Text>
+                        <strong>Statistics</strong>
+                    </Text>
+                    <Text>Episodes: {draft.statistics?.episode_count ?? '—'}</Text>
+                    <Text>Frames: {draft.statistics?.frame_count ?? '—'}</Text>
+                </Flex>
+
+                <Flex direction='column' gap='size-50'>
+                    <Text>
+                        <strong>Schema overview</strong>
+                    </Text>
+                    <Text>Cameras: {cameras.length}</Text>
+                    <Text>Robots: {robots.length}</Text>
+                </Flex>
+            </Flex>
+
+            {cameras.length > 0 && (
+                <Flex direction='column' gap='size-50'>
+                    <Text>
+                        <strong>Cameras</strong>
+                    </Text>
+                    {cameras.map((camera, index) => (
+                        <Text key={`${camera.name ?? 'camera'}-${index}`}>
+                            {camera.name ?? `Camera ${index + 1}`}: {camera.width ?? '—'}×{camera.height ?? '—'} @{' '}
+                            {camera.fps ?? '—'} FPS
+                        </Text>
+                    ))}
+                </Flex>
+            )}
+
+            {robots.length > 0 && (
+                <Flex direction='column' gap='size-50'>
+                    <Text>
+                        <strong>Robots</strong>
+                    </Text>
+                    {robots.map((robot, index) => (
+                        <Text key={`${robot.name ?? 'robot'}-${index}`}>
+                            {robot.name ?? `Robot ${index + 1}`} ({robot.type ?? 'unknown'}) — joints:{' '}
+                            {robot.joints?.length ?? 0}
+                        </Text>
+                    ))}
+                </Flex>
+            )}
+        </Flex>
+    );
+};
+
+interface ImportStepUserReviewProps {
+    importJob: SchemaDatasetImportJob;
+    project_id: string;
+    onClose: () => void;
+    fields: FinalizeFields;
+    onFieldsChange: (fields: FinalizeFields) => void;
+}
+
+export const ImportStepUserReview = ({
+    importJob,
+    project_id,
+    onClose,
+    fields,
+    onFieldsChange,
+}: ImportStepUserReviewProps) => {
+    const { data: environments } = $api.useSuspenseQuery('get', '/api/projects/{project_id}/environments', {
+        params: { path: { project_id } },
+    });
+
+    const finalizeMutation = $api.useMutation('post', '/api/projects/{project_id}/imports/datasets/{job_id}:finalize', {
+        meta: {
+            invalidates: [['get', '/api/jobs/{job_id}', { params: { path: { job_id: importJob.id! } } }]],
+        },
+    });
+    const canFinalize = fields.environmentId !== undefined;
+
+    const onFinalize = () => {
+        if (!canFinalize || fields.environmentId === undefined) {
+            return;
+        }
+
+        finalizeMutation.mutate({
+            params: {
+                path: {
+                    project_id,
+                    job_id: importJob.id!,
+                },
+            },
+            body: {
+                environment_id: fields.environmentId,
+                default_task: fields.defaultTask,
+            },
+        });
+    };
+
+    return (
+        <>
+            <Content>
+                <Text>
+                    Analysis complete. Review the detected metadata below, then provide environment and optional task to
+                    finalize the import.
+                </Text>
+                {finalizeMutation.isError ? (
+                    <InlineAlert variant='negative'>
+                        <Heading>Finalize import failed</Heading>
+                        <Content>Failed to finalize import. Please check job state and try again.</Content>
+                    </InlineAlert>
+                ) : null}
+
+                <View backgroundColor='gray-50' borderColor='gray-200' borderWidth='thick' padding='size-200'>
+                    <DatasetManifestSummary importJob={importJob} />
+                </View>
+
+                <Picker
+                    items={environments}
+                    selectedKey={fields.environmentId}
+                    label='Environment'
+                    onSelectionChange={(value) =>
+                        onFieldsChange({
+                            ...fields,
+                            environmentId: value === null ? undefined : value.toString(),
+                        })
+                    }
+                >
+                    {(item) => <Item key={item.id}>{item.name}</Item>}
+                </Picker>
+
+                <TextField
+                    width='100%'
+                    label='Task'
+                    value={fields.defaultTask}
+                    onChange={(value) => onFieldsChange({ ...fields, defaultTask: value })}
+                />
+            </Content>
+
+            <ButtonGroup>
+                <Button variant='secondary' onPress={onClose} isDisabled={finalizeMutation.isPending}>
+                    Cancel
+                </Button>
+                <Button
+                    variant='accent'
+                    onPress={onFinalize}
+                    isPending={finalizeMutation.isPending}
+                    isDisabled={!canFinalize}
+                >
+                    Finalize import
+                </Button>
+            </ButtonGroup>
+        </>
+    );
+};

--- a/application/ui/src/routes/datasets/import/import-step-user-review.tsx
+++ b/application/ui/src/routes/datasets/import/import-step-user-review.tsx
@@ -11,79 +11,83 @@ import {
     TextField,
     View,
 } from '@geti-ui/ui';
+import { isNumber } from 'lodash-es';
 
 import { $api } from '../../../api/client';
 import { SchemaDatasetImportJob, SchemaDatasetManifest } from '../../../api/openapi-spec';
 import type { FinalizeFields } from './use-dataset-import-job-state';
 
+const formatDuration = (seconds: number): string => {
+    const units = [
+        { unit: 'days', seconds: 86400 },
+        { unit: 'hours', seconds: 3600 },
+        { unit: 'minutes', seconds: 60 },
+        { unit: 'seconds', seconds: 1 },
+    ];
+
+    const { unit, seconds: unitSeconds } = units.find(({ seconds: s }) => seconds >= s) ?? units[units.length - 1];
+
+    const value = Math.round(seconds / unitSeconds);
+
+    return new Intl.DurationFormat('en', { style: 'long' }).format({ [unit]: value });
+};
+
 const DatasetManifestSummary = ({ importJob }: { importJob: SchemaDatasetImportJob }) => {
     const importPayload = importJob?.payload;
-    const draft = (importPayload?.dataset_manifest_draft ?? undefined) as SchemaDatasetManifest | undefined;
+    const draft = importPayload?.dataset_manifest_draft;
 
-    const detectedFormat = draft?.source_type ?? 'unknown';
-    const cameras = draft?.dataset_schema?.cameras ?? [];
-    const robots = draft?.dataset_schema?.robots ?? [];
-
-    if (draft === undefined) {
+    if (draft === undefined || draft === null) {
         return null;
     }
 
+    const detectedFormat = draft.source_type ?? 'unknown';
+    const cameras = draft.dataset_schema?.cameras ?? [];
+    const robots = draft.dataset_schema?.robots ?? [];
+
+    const fps = draft.dataset_schema?.cameras?.at(0)?.fps;
+    const episodeCount = draft.statistics?.episode_count;
+    const frameCount = draft.statistics?.frame_count;
+    const time = isNumber(fps) && fps > 0 ? Number(frameCount) / fps : null;
+
     return (
         <Flex direction='column' gap='size-150'>
-            <Heading level={4}>Detected dataset summary</Heading>
+            <Heading level={4}>Dataset import summary</Heading>
+            <Text>
+                Found <strong>{episodeCount}</strong> episodes with total length of {formatDuration(time)}.
+            </Text>
 
-            <Flex direction='row' wrap='wrap' gap='size-300'>
-                <Flex direction='column' gap='size-50'>
-                    <Text>
-                        <strong>Source format</strong>
-                    </Text>
-                    <Text>{detectedFormat}</Text>
-                </Flex>
+            <Flex direction='column' gap='size-100'>
+                {robots.length > 0 && (
+                    <Flex direction='column' gap='size-50'>
+                        <Text>
+                            <strong>Robots</strong>
+                        </Text>
+                        {robots.map((robot, index) => (
+                            <Text key={`${robot.type ?? 'robot'}-${index}`}>
+                                {robot.type ?? `Robot ${index + 1}`} with <strong>{robot.joints?.length ?? 0}</strong>{' '}
+                                joints
+                            </Text>
+                        ))}
+                    </Flex>
+                )}
 
-                <Flex direction='column' gap='size-50'>
-                    <Text>
-                        <strong>Statistics</strong>
-                    </Text>
-                    <Text>Episodes: {draft.statistics?.episode_count ?? '—'}</Text>
-                    <Text>Frames: {draft.statistics?.frame_count ?? '—'}</Text>
-                </Flex>
-
-                <Flex direction='column' gap='size-50'>
-                    <Text>
-                        <strong>Schema overview</strong>
-                    </Text>
-                    <Text>Cameras: {cameras.length}</Text>
-                    <Text>Robots: {robots.length}</Text>
-                </Flex>
+                {cameras.length > 0 && (
+                    <Flex direction='column' gap='size-50'>
+                        <Text>
+                            <strong>Cameras</strong>
+                        </Text>
+                        {cameras.map((camera, index) => (
+                            <Text key={`${camera.name ?? 'camera'}-${index}`}>
+                                {camera.name ?? `Camera ${index + 1}`}:{' '}
+                                <strong>
+                                    {camera.width ?? '—'}×{camera.height ?? '—'}
+                                </strong>{' '}
+                                @ <strong>{camera.fps ?? '-'}</strong> FPS
+                            </Text>
+                        ))}
+                    </Flex>
+                )}
             </Flex>
-
-            {cameras.length > 0 && (
-                <Flex direction='column' gap='size-50'>
-                    <Text>
-                        <strong>Cameras</strong>
-                    </Text>
-                    {cameras.map((camera, index) => (
-                        <Text key={`${camera.name ?? 'camera'}-${index}`}>
-                            {camera.name ?? `Camera ${index + 1}`}: {camera.width ?? '—'}×{camera.height ?? '—'} @{' '}
-                            {camera.fps ?? '—'} FPS
-                        </Text>
-                    ))}
-                </Flex>
-            )}
-
-            {robots.length > 0 && (
-                <Flex direction='column' gap='size-50'>
-                    <Text>
-                        <strong>Robots</strong>
-                    </Text>
-                    {robots.map((robot, index) => (
-                        <Text key={`${robot.name ?? 'robot'}-${index}`}>
-                            {robot.name ?? `Robot ${index + 1}`} ({robot.type ?? 'unknown'}) — joints:{' '}
-                            {robot.joints?.length ?? 0}
-                        </Text>
-                    ))}
-                </Flex>
-            )}
         </Flex>
     );
 };
@@ -121,10 +125,7 @@ export const ImportStepUserReview = ({
 
         finalizeMutation.mutate({
             params: {
-                path: {
-                    project_id,
-                    job_id: importJob.id!,
-                },
+                path: { project_id, job_id: importJob.id! },
             },
             body: {
                 environment_id: fields.environmentId,
@@ -136,41 +137,52 @@ export const ImportStepUserReview = ({
     return (
         <>
             <Content>
-                <Text>
-                    Analysis complete. Review the detected metadata below, then provide environment and optional task to
-                    finalize the import.
-                </Text>
-                {finalizeMutation.isError ? (
-                    <InlineAlert variant='negative'>
-                        <Heading>Finalize import failed</Heading>
-                        <Content>Failed to finalize import. Please check job state and try again.</Content>
-                    </InlineAlert>
-                ) : null}
-
-                <View backgroundColor='gray-50' borderColor='gray-200' borderWidth='thick' padding='size-200'>
+                <View
+                    backgroundColor='gray-50'
+                    borderColor='gray-200'
+                    borderWidth='thick'
+                    padding='size-200'
+                    marginBottom='size-200'
+                >
                     <DatasetManifestSummary importJob={importJob} />
                 </View>
 
-                <Picker
-                    items={environments}
-                    selectedKey={fields.environmentId}
-                    label='Environment'
-                    onSelectionChange={(value) =>
-                        onFieldsChange({
-                            ...fields,
-                            environmentId: value === null ? undefined : value.toString(),
-                        })
-                    }
-                >
-                    {(item) => <Item key={item.id}>{item.name}</Item>}
-                </Picker>
+                <View marginY='size-100'>
+                    <Text>
+                        Analysis complete. Review the metadata above, then provide environment and optional task to
+                        finalize the import.
+                    </Text>
+                    {finalizeMutation.isError ? (
+                        <InlineAlert variant='negative'>
+                            <Heading>Finalize import failed</Heading>
+                            <Content>Failed to finalize import. Please check job state and try again.</Content>
+                        </InlineAlert>
+                    ) : null}
+                </View>
 
-                <TextField
-                    width='100%'
-                    label='Task'
-                    value={fields.defaultTask}
-                    onChange={(value) => onFieldsChange({ ...fields, defaultTask: value })}
-                />
+                <Flex direction='column' gap='size-100'>
+                    <Picker
+                        label='Recording environment'
+                        width='100%'
+                        items={environments}
+                        selectedKey={fields.environmentId}
+                        onSelectionChange={(value) =>
+                            onFieldsChange({
+                                ...fields,
+                                environmentId: value === null ? undefined : value.toString(),
+                            })
+                        }
+                    >
+                        {(item) => <Item key={item.id}>{item.name}</Item>}
+                    </Picker>
+
+                    <TextField
+                        width='100%'
+                        label='Task'
+                        value={fields.defaultTask}
+                        onChange={(value) => onFieldsChange({ ...fields, defaultTask: value })}
+                    />
+                </Flex>
             </Content>
 
             <ButtonGroup>

--- a/application/ui/src/routes/datasets/import/import-step-user-review.tsx
+++ b/application/ui/src/routes/datasets/import/import-step-user-review.tsx
@@ -14,22 +14,43 @@ import {
 import { isNumber } from 'lodash-es';
 
 import { $api } from '../../../api/client';
-import { SchemaDatasetImportJob, SchemaDatasetManifest } from '../../../api/openapi-spec';
+import { SchemaDatasetImportJob, SchemaManifestCameraEntry, SchemaManifestRobotEntry } from '../../../api/openapi-spec';
+import { formatDuration } from '../../models/utils';
 import type { FinalizeFields } from './use-dataset-import-job-state';
 
-const formatDuration = (seconds: number): string => {
-    const units = [
-        { unit: 'days', seconds: 86400 },
-        { unit: 'hours', seconds: 3600 },
-        { unit: 'minutes', seconds: 60 },
-        { unit: 'seconds', seconds: 1 },
-    ];
+const RobotsSummary = ({ robots }: { robots: Array<SchemaManifestRobotEntry> }) => {
+    return (
+        <Flex direction='column' gap='size-50'>
+            <Text>
+                <strong>Robots</strong>
+            </Text>
+            {robots.map((robot, index) => (
+                <Text key={`${robot.type ?? 'robot'}-${index}`}>
+                    {robot.type ?? `Robot ${index + 1}`} with <strong>{robot.joints?.length ?? 0}</strong>
+                    joints
+                </Text>
+            ))}
+        </Flex>
+    );
+};
 
-    const { unit, seconds: unitSeconds } = units.find(({ seconds: s }) => seconds >= s) ?? units[units.length - 1];
-
-    const value = Math.round(seconds / unitSeconds);
-
-    return new Intl.DurationFormat('en', { style: 'long' }).format({ [unit]: value });
+const CamerasSummary = ({ cameras }: { cameras: Array<SchemaManifestCameraEntry> }) => {
+    return (
+        <Flex direction='column' gap='size-50'>
+            <Text>
+                <strong>Cameras</strong>
+            </Text>
+            {cameras.map((camera, index) => (
+                <Text key={`${camera.name ?? 'camera'}-${index}`}>
+                    {camera.name ?? `Camera ${index + 1}`}:{' '}
+                    <strong>
+                        {camera.width ?? '—'}×{camera.height ?? '—'}
+                    </strong>{' '}
+                    @ <strong>{camera.fps ?? '-'}</strong> FPS
+                </Text>
+            ))}
+        </Flex>
+    );
 };
 
 const DatasetManifestSummary = ({ importJob }: { importJob: SchemaDatasetImportJob }) => {
@@ -40,7 +61,6 @@ const DatasetManifestSummary = ({ importJob }: { importJob: SchemaDatasetImportJ
         return null;
     }
 
-    const detectedFormat = draft.source_type ?? 'unknown';
     const cameras = draft.dataset_schema?.cameras ?? [];
     const robots = draft.dataset_schema?.robots ?? [];
 
@@ -53,40 +73,14 @@ const DatasetManifestSummary = ({ importJob }: { importJob: SchemaDatasetImportJ
         <Flex direction='column' gap='size-150'>
             <Heading level={4}>Dataset import summary</Heading>
             <Text>
-                Found <strong>{episodeCount}</strong> episodes with total length of {formatDuration(time)}.
+                Found <strong>{episodeCount}</strong> episodes{' '}
+                {time !== null ? <>with total length of {formatDuration(1000 * time)}</> : null}.
             </Text>
 
             <Flex direction='column' gap='size-100'>
-                {robots.length > 0 && (
-                    <Flex direction='column' gap='size-50'>
-                        <Text>
-                            <strong>Robots</strong>
-                        </Text>
-                        {robots.map((robot, index) => (
-                            <Text key={`${robot.type ?? 'robot'}-${index}`}>
-                                {robot.type ?? `Robot ${index + 1}`} with <strong>{robot.joints?.length ?? 0}</strong>{' '}
-                                joints
-                            </Text>
-                        ))}
-                    </Flex>
-                )}
+                {robots.length > 0 && <RobotsSummary robots={robots} />}
 
-                {cameras.length > 0 && (
-                    <Flex direction='column' gap='size-50'>
-                        <Text>
-                            <strong>Cameras</strong>
-                        </Text>
-                        {cameras.map((camera, index) => (
-                            <Text key={`${camera.name ?? 'camera'}-${index}`}>
-                                {camera.name ?? `Camera ${index + 1}`}:{' '}
-                                <strong>
-                                    {camera.width ?? '—'}×{camera.height ?? '—'}
-                                </strong>{' '}
-                                @ <strong>{camera.fps ?? '-'}</strong> FPS
-                            </Text>
-                        ))}
-                    </Flex>
-                )}
+                {cameras.length > 0 && <CamerasSummary cameras={cameras} />}
             </Flex>
         </Flex>
     );

--- a/application/ui/src/routes/datasets/import/use-dataset-import-job-state.ts
+++ b/application/ui/src/routes/datasets/import/use-dataset-import-job-state.ts
@@ -1,0 +1,23 @@
+import { $api } from '../../../api/client';
+
+export interface FinalizeFields {
+    defaultTask: string;
+    environmentId: string | undefined;
+}
+
+export const useDatasetImportJobQuery = (importJobId: string | undefined) => {
+    return $api.useQuery(
+        'get',
+        '/api/jobs/{job_id}',
+        {
+            params: { path: { job_id: importJobId ?? '' } },
+        },
+        {
+            enabled: importJobId !== undefined,
+            refetchInterval: 1000,
+            select: (job) => {
+                return job.type === 'dataset_import' ? job : null;
+            },
+        }
+    );
+};

--- a/application/ui/src/routes/datasets/index.tsx
+++ b/application/ui/src/routes/datasets/index.tsx
@@ -1,4 +1,6 @@
-import { Content, Flex, Heading, IllustratedMessage, Item, TabPanels, Tabs, Text, View } from '@geti-ui/ui';
+import { Suspense } from 'react';
+
+import { Content, Flex, Heading, IllustratedMessage, Item, Loading, TabPanels, Tabs, Text } from '@geti-ui/ui';
 import { useParams } from 'react-router';
 
 import { SchemaDatasetOutput } from '../../api/openapi-spec';
@@ -7,6 +9,7 @@ import { useProject, useProjectId } from '../../features/projects/use-project';
 import { ReactComponent as EmptyIllustration } from './../../assets/illustration.svg';
 import { DatasetProvider } from './dataset-provider';
 import { DatasetViewer } from './dataset-viewer';
+import { DatasetImportButton } from './import/dataset-import-button';
 import { NewDatasetLink } from './new-dataset.component';
 
 interface DatasetsProps {
@@ -26,9 +29,10 @@ const Datasets = ({ datasets }: DatasetsProps) => {
                     <Content> Currently there are datasets available. </Content>
                     <Text>It&apos;s time to begin recording a dataset. </Text>
                     <Heading>No datasets yet</Heading>
-                    <View margin={'size-100'}>
+                    <Flex gap='size-100' marginTop={'size-200'}>
                         <NewDatasetLink project_id={project_id} />
-                    </View>
+                        <DatasetImportButton />
+                    </Flex>
                 </IllustratedMessage>
             </Flex>
         );
@@ -52,9 +56,11 @@ const Datasets = ({ datasets }: DatasetsProps) => {
                             {dataset_id === undefined ? (
                                 <Text>No datasets yet...</Text>
                             ) : (
-                                <DatasetProvider dataset_id={dataset_id}>
-                                    <DatasetViewer />
-                                </DatasetProvider>
+                                <Suspense fallback={<Loading />}>
+                                    <DatasetProvider dataset_id={dataset_id}>
+                                        <DatasetViewer />
+                                    </DatasetProvider>
+                                </Suspense>
                             )}
                         </Flex>
                     </Item>

--- a/application/ui/src/routes/models/index.tsx
+++ b/application/ui/src/routes/models/index.tsx
@@ -114,7 +114,7 @@ const JobList = ({ jobs, onViewLogs }: { jobs: SchemaTrainJob[]; onViewLogs: (jo
     );
 };
 
-const useProjectJobs = (project_id: string): SchemaTrainJob[] => {
+const useProjectTrainingJobs = (project_id: string): SchemaTrainJob[] => {
     const { data: allJobs = [] } = $api.useQuery('get', '/api/jobs');
 
     return allJobs
@@ -128,8 +128,7 @@ export const Index = () => {
         params: { path: { project_id } },
     });
 
-    const jobs = useProjectJobs(project_id);
-
+    const jobs = useProjectTrainingJobs(project_id);
     const [retrainModel, setRetrainModel] = useState<SchemaModel | null>(null);
     const [logsSourceId, setLogsSourceId] = useState<string | undefined>();
 

--- a/application/ui/src/routes/projects/project.layout.tsx
+++ b/application/ui/src/routes/projects/project.layout.tsx
@@ -1,7 +1,19 @@
 import { Suspense } from 'react';
 
-import { Divider } from '@adobe/react-spectrum';
-import { ActionButton, DialogTrigger, Flex, Grid, Icon, Item, Link, Loading, TabList, Tabs, View } from '@geti-ui/ui';
+import {
+    ActionButton,
+    DialogTrigger,
+    Divider,
+    Flex,
+    Grid,
+    Icon,
+    Item,
+    Link,
+    Loading,
+    TabList,
+    Tabs,
+    View,
+} from '@geti-ui/ui';
 import { Manifest } from '@geti-ui/ui/icons';
 import { Outlet, useLocation } from 'react-router';
 


### PR DESCRIPTION
This PR introduces an end-to-end dataset import jobs flow (backend + worker + UI), including:

- A new async, multi-step dataset import pipeline with explicit job steps
- New project-scoped import APIs for prepare / upload / finalize / cancel
- Worker orchestration for format detection, manifest draft generation, user-review pause, and final import
- Initial adapter support for LeRobot v3 (with adapter selection infrastructure)
- Safety guardrails for archive ingestion (ZIP validation, path traversal/symlink protection, zip-bomb checks, disk headroom checks)
- UI import dialog/flow for upload, progress, detection state, user review, finalize, and failure states
- Logging + job schema/repository updates to surface import job progress
- Broad backend test coverage for API, service, adapters, and safety behavior

Some notes:
- The initial concept for this PR was vibe-coded, but I spend quite some time on changing the overall architecture and fine tuning the backend Schemas and UI structure.
- The import worker runs in a separate process. This means crashes won't affect the server. However this also means we increase our memory usage as the way we load these hasn't been optimized.

<details>
<summary><h3>New API endpoints</summary>

All endpoints are under: `/api/projects/{project_id}/imports`

1) Prepare import job `POST /datasets:prepare`
Creates a dataset import job before upload.
Form fields
- `format_hint` (auto or lerobot_v3, we currently only use auto)
- `dataset_name` (required non-empty)
Returns
- Job (type=dataset_import) with payload.step=awaiting_archive_upload

---

2) Upload archive `PUT /datasets/{job_id}:upload`  
Uploads ZIP archive for a prepared job.
Multipart fields
- `archive` (.zip only)
Behavior
- Verifies job exists, belongs to project, and is in awaiting_archive_upload
- Performs disk headroom + archive safety checks
- Moves job to `status=pending`, `payload.step=queued_for_detection`

---

3) Finalize import `POST /datasets/{job_id}:finalize`  
Provides user inputs required to commit import after review.
JSON body
- `environment_id` (required)
- `default_task` (optional)
Returns
- Job moved to `status=pending`, `payload.step=queued_for_import`

---

4) Cancel import `POST /datasets/{job_id}:cancel`  
Cancels import while awaiting user review.

</details>

<details>
<summary><h3>Expected UI calling pattern</h3></summary>

The UI should call these endpoints in this sequence:
1. Prepare `POST .../datasets:prepare` with `dataset_name`  
   Save returned job_id.

2. Upload `PUT .../datasets/{job_id}:upload` with multipart archive (ZIP).  
   UI can show upload progress via XHR progress events.

3. Poll job state  
   Continue polling existing job endpoint: `GET /api/jobs/{job_id}`  

   Drive UI state from payload.step:
   - detection steps: queued_for_detection, detecting_format, building_manifest_draft
   - review step: awaiting_user_review (show manifest summary + validation messages)

4. Finalize  
   `POST .../datasets/{job_id}:finalize` with `environment_id` (+ optional `default_task`).

5. Wait for completion  
   Poll `GET /api/jobs/{job_id}` until `status=completed`, then navigate using:
   - `payload.result_dataset_id`

6. Optional cancel path  
   If user exits during review, call `POST .../datasets/{job_id}:cancel`.
</details>

## Type of Change

- [x] ✨ `feat` - New feature

## Screenshots

| **Create or import** | **Add or import** | **Upload** | **Uploading** | **Review** |
|----------------------|-------------------|------------|---------------|------------|
|   <img width="1920" height="1080" alt="192 168 2 118_3000_projects_1c38d43c-68df-4610-83b8-e3dcf5e6a34e_datasets(Full HD)" src="https://github.com/user-attachments/assets/ac6eb7a1-8c0d-4c04-b4d9-9e9094bc596f" />                   |    <img width="1920" height="1080" alt="192 168 2 118_3000_projects_1c38d43c-68df-4610-83b8-e3dcf5e6a34e_datasets(Full HD) (4)" src="https://github.com/user-attachments/assets/5d95acc8-30ef-45dc-9f1d-620128afcf35" />               |     <img width="1920" height="1080" alt="192 168 2 118_3000_projects_1c38d43c-68df-4610-83b8-e3dcf5e6a34e_datasets(Full HD) (1)" src="https://github.com/user-attachments/assets/0e7a4b8e-60c1-46f7-94fa-4ee94ab0c7c1" />       |     <img width="1920" height="1080" alt="192 168 2 118_3000_projects_1c38d43c-68df-4610-83b8-e3dcf5e6a34e_datasets(Full HD) (2)" src="https://github.com/user-attachments/assets/5ac7617b-c199-423d-9d46-d41d2dd5e245" />          |   <img width="1920" height="1080" alt="192 168 2 118_3000_projects_1c38d43c-68df-4610-83b8-e3dcf5e6a34e_datasets(Full HD) (3)" src="https://github.com/user-attachments/assets/0278bed1-0be7-4b17-bd08-ca4eccf181d1" />         |













