### PR TITLE
chore: remove pi0 from train model dialog

### DIFF
--- a/application/ui/src/routes/models/train-model-dialog.module.scss
+++ b/application/ui/src/routes/models/train-model-dialog.module.scss
@@ -1,6 +1,6 @@
 .policyGrid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     gap: var(--spectrum-global-dimension-size-200);
 }
 

--- a/application/ui/src/routes/models/train-model-dialog.tsx
+++ b/application/ui/src/routes/models/train-model-dialog.tsx
@@ -67,12 +67,6 @@ export const MODELS: ReadonlyArray<{
         minVRAM: 8 * GB,
     },
     {
-        id: 'pi0',
-        name: 'Pi0',
-        description: 'Vision-Language-Action model based on PaliGemma 3B',
-        minVRAM: 12 * GB,
-    },
-    {
         id: 'pi05',
         name: 'Pi0.5',
         description: 'Enhanced Pi0 with discrete state encoding and longer context',


### PR DESCRIPTION
Remove Pi0 from trainable models from the application as this has not been validated.

## Type of Change

- [x] 🔧 `chore` - Maintenance

## Screenshots

<img width="1905" height="1080" alt="image" src="https://github.com/user-attachments/assets/551ed925-1f02-491f-9c33-c4c3f571c9ae" />

