### PR TITLE
fix: refresh robot discovery when USB devices are plugged in after boot

### DIFF
--- a/application/backend/src/services/robot_calibration_service.py
+++ b/application/backend/src/services/robot_calibration_service.py
@@ -21,6 +21,12 @@ async def find_robot_port(manager: RobotConnectionManager, robot: Robot) -> str 
         if managed_robot.serial_number == robot.payload.serial_number:
             return managed_robot.connection_string
 
+    await manager.find_robots()
+
+    for managed_robot in manager.robots:
+        if managed_robot.serial_number == robot.payload.serial_number:
+            return managed_robot.connection_string
+
     return None
 
 

--- a/application/backend/src/utils/serial_robot_tools.py
+++ b/application/backend/src/utils/serial_robot_tools.py
@@ -8,8 +8,6 @@ from serial.tools.list_ports_common import ListPortInfo
 from schemas import Robot, SerialPortInfo
 from schemas.robot import RobotType
 
-available_ports = list_ports.comports()
-
 
 def from_port(port: ListPortInfo, robot_type: str) -> SerialPortInfo | None:
     """Detect if the device is a SO-100 robot."""
@@ -22,11 +20,12 @@ def from_port(port: ListPortInfo, robot_type: str) -> SerialPortInfo | None:
 
 
 class RobotConnectionManager:
-    _all_robots: list[SerialPortInfo] = []
+    _all_robots: list[SerialPortInfo]
     available_ports: list[ListPortInfo]
 
     def __init__(self):
         self.available_ports = list(list_ports.comports())
+        self._all_robots = []
 
     @property
     def robots(self) -> list[SerialPortInfo]:
@@ -38,6 +37,7 @@ class RobotConnectionManager:
 
         Use self.scan_ports() before to update self.available_ports and self.available_can_ports
         """
+        self.available_ports = list(list_ports.comports())
         self._all_robots = []
 
         # If we are only simulating, we can just use the SO100Hardware class


### PR DESCRIPTION
Before this change, RobotConnectionManager captured serial ports at startup and find_robot_port only read the cached robot list. If a SO-101 was connected over USB after the server started, the robot never entered the cache and websocket/control flows raised ResourceNotFoundError.

This updates discovery to rescan serial ports inside find_robots and makes port lookup refresh on cache miss, so late-plugged robots are detected and resolved without requiring a server restart.

## Type of Change

- [x] 🐞 `fix` - Bug fix