### PR TITLE
chore: harden ui npm resolution with min-release-age

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -109,6 +109,13 @@ jobs:
         with:
           node-version-file: application/ui/.nvmrc
 
+      # `min-release-age` in application/ui/.npmrc requires npm >= 11.5.1.
+      # Ensure a compatible npm is available regardless of the default npm
+      # bundled with the pinned Node version.
+      - &setup-compatible-npm
+        name: Ensure npm supports min-release-age
+        run: npm i -g npm@11.14.0
+
       - &install-dependencies
         name: Install dependencies
         working-directory: "application/ui"
@@ -153,6 +160,8 @@ jobs:
 
       - *setup-node
 
+      - *setup-compatible-npm
+
       - *install-dependencies
 
       - *download-openapi-spec
@@ -189,6 +198,8 @@ jobs:
 
       - *setup-node
 
+      - *setup-compatible-npm
+
       - *install-dependencies
 
       - *download-openapi-spec
@@ -216,6 +227,8 @@ jobs:
       - *checkout
 
       - *setup-node
+
+      - *setup-compatible-npm
 
       - *install-dependencies
 

--- a/application/ui/.npmrc
+++ b/application/ui/.npmrc
@@ -1,0 +1,11 @@
+# Supply-chain hardening: only consider package versions published more than
+# 7 days ago when resolving dependencies. Mitigates risk from compromised
+# package versions that are typically detected and unpublished quickly.
+#
+# Notes:
+# - Has no effect on `npm ci` (lockfile-only install).
+# - Affects `npm install`, `npm update`, and `npm audit fix --package-lock-only`.
+# - Requires npm >= 11.5.1 (reliably supported in npm 11.14.0+).
+# - To bypass for a single command (e.g. urgent CVE patch), pass
+#   `--min-release-age=0` on the CLI and document why in the PR.
+min-release-age=7

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "engines": {
         "node": "v24.2.0",
-        "npm": "11.9.0"
+        "npm": ">=11.14.0"
     },
     "scripts": {
         "build": "rsbuild build",


### PR DESCRIPTION
Add application/ui/.npmrc with min-release-age=7 to reduce supply-chain risk from newly published compromised packages. Ensure CI installs npm 11.14.0 before npm ci so the setting is supported regardless of Node-bundled npm, and align package.json engines accordingly.

## Type of Change

- [x] 🔧 `chore` - Maintenance