### PR TITLE
fix: enforce spawn multiprocessing for CUDA/XPU-safe workers

### DIFF
--- a/application/backend/src/core/lifecycle.py
+++ b/application/backend/src/core/lifecycle.py
@@ -7,6 +7,7 @@ from loguru import logger
 from core.logging import setup_logging, setup_uvicorn_logging
 from services.event_processor import EventProcessor
 from settings import get_settings
+from utils.multiprocessing import ensure_spawn_start_method
 from utils.serial_robot_tools import RobotConnectionManager
 from workers.camera_worker_registry import CameraWorkerRegistry
 from workers.model_worker_registry import ModelWorkerRegistry
@@ -35,6 +36,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     )
 
     logger.info("Starting %s application...", settings.app_name)
+    ensure_spawn_start_method()
     app_scheduler = Scheduler()
     app_scheduler.start_workers()
 

--- a/application/backend/src/core/scheduler.py
+++ b/application/backend/src/core/scheduler.py
@@ -27,6 +27,7 @@ class Scheduler:
         logger.info("Scheduler initialized")
 
     def start_workers(self) -> None:
+        # mp.set_start_method("spawn", force=True)
         training_proc = TrainingWorker(
             stop_event=self.mp_stop_event,
             interrupt_event=self.training_interrupt_event,

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import multiprocessing as mp
 import os
 from pathlib import Path
 
@@ -34,7 +33,7 @@ from core import lifespan
 from exception_handlers import register_application_exception_handlers
 from middleware.upload_size_guard import upload_size_guard_middleware
 from settings import get_settings
-from utils.device import get_torch_device
+from utils.multiprocessing import ensure_spawn_start_method
 
 settings = get_settings()
 app = FastAPI(
@@ -93,7 +92,6 @@ if (
     app.mount("/", static_files, name="webui")
 
 if __name__ == "__main__":
-    if get_torch_device() == "xpu" and mp.get_start_method(allow_none=True) != "spawn":
-        mp.set_start_method("spawn", force=True)
+    ensure_spawn_start_method()
     uvicorn_port = int(os.environ.get("HTTP_SERVER_PORT", settings.port))
     uvicorn.run(app, host=settings.host, port=uvicorn_port)

--- a/application/backend/src/utils/multiprocessing.py
+++ b/application/backend/src/utils/multiprocessing.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multiprocessing helpers."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+
+from loguru import logger
+
+
+def ensure_spawn_start_method() -> None:
+    """Ensure multiprocessing uses ``spawn`` to stay CUDA/XPU-safe.
+
+    CUDA and XPU cannot be safely re-initialized in forked subprocesses. This helper enforces
+    ``spawn`` before any worker processes/queues/events are created.
+    """
+    current = mp.get_start_method(allow_none=True)
+    if current == "spawn":
+        return
+
+    mp.set_start_method("spawn", force=True)
+    if current is None:
+        logger.info("Set multiprocessing start method to 'spawn'")
+    else:
+        logger.warning(f"Overrode multiprocessing start method from '{current}' to 'spawn'")


### PR DESCRIPTION
Add a shared `ensure_spawn_start_method()` helper and invoke it at startup before scheduler workers are created.

This prevents accelerator re-initialization errors in forked subprocesses by guaranteeing the 'spawn' start method for training and worker processes, including non-`__main__` startup paths.

## Type of Change

- [x] 🐞 `fix` - Bug fix