### PR TITLE
fix(backend): reload uncompiled policy before export

### DIFF
--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -175,7 +175,17 @@ class TrainingWorker(BaseProcessWorker):
 
             moved = shutil.move(cache_path, path.parent)
             Path(moved).rename(path)
-            await self._export_policy(policy=policy, path=path, job=job)
+
+            export_policy = policy
+            if payload.compile_model:
+                try:
+                    logger.info("Reloading non-compiled policy for export")
+                    export_policy = load_policy(model, compile_model=False)
+                except Exception as e:
+                    logger.warning("Failed to reload non-compiled policy for export; falling back to trained policy")
+                    logger.exception(e)
+
+            await self._export_policy(policy=export_policy, path=path, job=job)
 
             job = await JobService.update_job_status(
                 job_id=job.id, status=JobStatus.COMPLETED, message="Training finished"

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -177,7 +177,7 @@ class TrainingWorker(BaseProcessWorker):
             Path(moved).rename(path)
 
             export_policy = policy
-            if payload.compile_model:
+            if payload.compile_model and model.policy in ["act", "smolvla"]:
                 try:
                     logger.info("Reloading non-compiled policy for export")
                     export_policy = load_policy(model, compile_model=False)

--- a/application/backend/tests/workers/test_training_worker.py
+++ b/application/backend/tests/workers/test_training_worker.py
@@ -188,6 +188,7 @@ class TestTraining:
         job = _make_job(payload)
 
         policy = MagicMock()
+        export_policy = MagicMock()
         trainer = MagicMock()
         trainer.fit = MagicMock()  # succeeds
 
@@ -197,6 +198,7 @@ class TestTraining:
 
         with (
             patch(f"{MODULE}.setup_policy", return_value=policy) as mock_setup,
+            patch(f"{MODULE}.load_policy", return_value=export_policy) as mock_load,
             patch(f"{MODULE}.Trainer", return_value=trainer),
             patch(f"{MODULE}.JobService") as MockJobService,
             patch(f"{MODULE}.ModelService") as MockModelService,
@@ -227,6 +229,7 @@ class TestTraining:
 
             assert mock_setup.call_count == 1
             assert mock_setup.call_args_list[0].kwargs["compile_model"] is True
+            mock_load.assert_called_once_with(model, compile_model=False)
 
             trainer.fit.assert_called_once()
 


### PR DESCRIPTION
OpenVINO export failed when training used `torch.compile` because its tracing path cannot handle a dynamo-optimized forward. 
To fix this we reload the just-trained checkpoint with `compile_model=False` for export so training can stay compiled while export runs on a trace-compatible model, and cover the behavior in training worker tests.

## Type of Change

- [x] 🐞 `fix` - Bug fix