### PR TITLE
refactor: create clone of position_ids instead, stops silent alias

### DIFF
--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -1599,7 +1599,7 @@ class _SmolVLMWithExpertModel(nn.Module):
             )
             att_outputs.append(att_output)
         else:
-            expert_position_id = position_ids
+            expert_position_id = position_ids.clone()
 
         if use_cache:
             if past_key_values is None:


### PR DESCRIPTION
# Pull Request

## Description

Repeated from #589:

"The code aliases position_ids to expert_position_id without cloning, so any in-place operation on expert_position_id mutates the shared position_ids tensor. After the first attention layer all later layers receive wrong position values. This breaks RoPE attention calculations across the rest of the model and causes output mismatches despite identical inputs and weights."

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [x] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

#589 

## Breaking Changes

-

---