### PR TITLE
fix: fix start time of training jobs

### DIFF
--- a/application/backend/src/alembic/versions/d8f4b7c1a2e9_make_job_start_end_time_nullable.py
+++ b/application/backend/src/alembic/versions/d8f4b7c1a2e9_make_job_start_end_time_nullable.py
@@ -1,0 +1,43 @@
+"""Make job start_time and end_time nullable.
+
+Revision ID: d8f4b7c1a2e9
+Revises: b9f3e2a1c7d8
+Create Date: 2026-05-14 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d8f4b7c1a2e9"
+down_revision: str | Sequence[str] | None = "b9f3e2a1c7d8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.alter_column("start_time", existing_type=sa.DateTime(), nullable=True, server_default=None)
+        batch_op.alter_column("end_time", existing_type=sa.DateTime(), nullable=True, server_default=None)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.alter_column(
+            "end_time",
+            existing_type=sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+        )
+        batch_op.alter_column(
+            "start_time",
+            existing_type=sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+        )

--- a/application/backend/src/db/schema.py
+++ b/application/backend/src/db/schema.py
@@ -226,8 +226,8 @@ class JobDB(Base):
     status: Mapped[str] = mapped_column(String(64), nullable=False)
     message: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    start_time: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    end_time: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
+    start_time: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    end_time: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     payload: Mapped[str] = mapped_column(JSON, nullable=False)
     extra_info: Mapped[str] = mapped_column(JSON, nullable=True)
 

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -107,7 +108,14 @@ class TrainingWorker(BaseProcessWorker):
         self, job: Job, model: Model, snapshot: Snapshot, payload: TrainJobPayload, base_model: Model | None = None
     ):
         settings = get_settings()
-        await JobService.update_job_status(job_id=job.id, status=JobStatus.RUNNING, message="Training started")
+        await JobService.update_job(
+            job=job,
+            update={
+                "status": JobStatus.RUNNING,
+                "message": "Training started",
+                "start_time": datetime.datetime.now(tz=datetime.UTC),
+            },
+        )
         dispatcher = TrainingTrackingDispatcher(
             job_id=job.id,
             event_queue=self.queue,

--- a/application/backend/tests/workers/test_training_worker.py
+++ b/application/backend/tests/workers/test_training_worker.py
@@ -164,19 +164,16 @@ class TestTraining:
             MockDispatcher.return_value.start = MagicMock()
             MockDispatcher.return_value.is_alive = MagicMock(return_value=False)
 
-            MockJobService.update_job_status = AsyncMock(
-                side_effect=[
-                    MagicMock(),  # "Training started"
-                    failed_job,  # "Training failed"
-                ]
-            )
+            MockJobService.update_job_status = AsyncMock(return_value=failed_job)
+            MockJobService.update_job = AsyncMock(return_value=MagicMock())
 
             await worker._train_model(job, model, snapshot, payload, base_model=None)
 
             mock_setup.assert_called_once()
             trainer.fit.assert_called_once()
 
-            failed_call = MockJobService.update_job_status.call_args_list[1]
+            MockJobService.update_job.assert_called_once()
+            failed_call = MockJobService.update_job_status.call_args_list[0]
             assert failed_call.kwargs["status"] == JobStatus.FAILED
 
     @pytest.mark.anyio
@@ -215,12 +212,8 @@ class TestTraining:
             MockDispatcher.return_value.start = MagicMock()
             MockDispatcher.return_value.is_alive = MagicMock(return_value=False)
 
-            MockJobService.update_job_status = AsyncMock(
-                side_effect=[
-                    MagicMock(),  # "Training started"
-                    completed_job,  # "Training finished"
-                ]
-            )
+            MockJobService.update_job_status = AsyncMock(return_value=completed_job)
+            MockJobService.update_job = AsyncMock(return_value=MagicMock())
             MockModelService.create_model = AsyncMock(return_value=model)
 
             await worker._train_model(job, model, snapshot, payload, base_model=None)
@@ -230,7 +223,8 @@ class TestTraining:
 
             trainer.fit.assert_called_once()
 
-            assert MockJobService.update_job_status.call_args_list[1].kwargs["status"] == JobStatus.COMPLETED
+            MockJobService.update_job.assert_called_once()
+            assert MockJobService.update_job_status.call_args_list[0].kwargs["status"] == JobStatus.COMPLETED
 
     @pytest.mark.anyio
     async def test_precision_fp32_passes_32_true_to_trainer(self, worker, event_queue, tmp_path):
@@ -266,7 +260,8 @@ class TestTraining:
             MockTrainer.return_value = trainer_instance
 
             completed_job = MagicMock()
-            MockJobService.update_job_status = AsyncMock(side_effect=[MagicMock(), completed_job])
+            MockJobService.update_job = AsyncMock(return_value=MagicMock())
+            MockJobService.update_job_status = AsyncMock(return_value=completed_job)
             MockModelService.create_model = AsyncMock(return_value=model)
 
             await worker._train_model(job, model, snapshot, payload, base_model=None)
@@ -307,7 +302,8 @@ class TestTraining:
             MockTrainer.return_value = trainer_instance
 
             completed_job = MagicMock()
-            MockJobService.update_job_status = AsyncMock(side_effect=[MagicMock(), completed_job])
+            MockJobService.update_job = AsyncMock(return_value=MagicMock())
+            MockJobService.update_job_status = AsyncMock(return_value=completed_job)
             MockModelService.create_model = AsyncMock(return_value=model)
 
             await worker._train_model(job, model, snapshot, payload, base_model=None)


### PR DESCRIPTION
When a new training job is scheduled previously its `start_time` and `end_time` would default to the current time. This introduces subtle bugs like if you'd schedule multiple training jobs at once, then the training time of the last job would include the training duration of the other jobs.

This PR has two fixes:
1. Set the `start_time` of a training job to the current time when we start to train a model
2. Allow `start_time` and `end_time` to be null / None.

## Type of Change

- [x] 🐞 `fix` - Bug fix