### PR TITLE
feat: pi05 batch all camera images into single vision encoder call

### DIFF
--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -836,7 +836,7 @@ class Pi05Model(ExportableModelMixin, Model):
         Returns:
             Tuple of (embeddings, padding masks, attention masks).
         """
-        use_batched = not self.training or torch.jit.is_tracing() or torch.onnx.is_in_onnx_export()
+        use_batched = not self.training
 
         num_cameras = images.shape[0]
         bsize = images.shape[1]

--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -774,7 +774,9 @@ class Pi05Model(ExportableModelMixin, Model):
         Returns:
             4D attention mask tensor.
         """
-        att_2d_masks_4d = att_2d_masks[:, None, :, :]
+        # .bool() is needed because JIT tracing promotes bool*bool → Long
+        # in _make_att_2d_masks, but torch.where requires a boolean condition.
+        att_2d_masks_4d = att_2d_masks[:, None, :, :].bool()
         return torch.where(att_2d_masks_4d, 0.0, OPENPI_ATTENTION_MASK_VALUE)
 
     def sample_noise(self, shape: tuple, device: torch.device) -> Tensor:
@@ -821,45 +823,65 @@ class Pi05Model(ExportableModelMixin, Model):
     ) -> tuple[Tensor, Tensor, Tensor]:
         """Embed images with SigLIP and language tokens with embedding layer.
 
+        During inference or tracing (ONNX/OV export), batches all camera images
+        into a single encoder call for efficiency. During training, uses per-image
+        calls with gradient checkpointing support.
+
+        Args:
+            images: ``(num_cameras, batch, C, H, W)`` stacked image tensor.
+            img_masks: ``(num_cameras, batch)`` boolean camera masks.
+            tokens: ``(batch, seq_len)`` tokenized prompt.
+            masks: ``(batch, seq_len)`` prompt attention mask.
+
         Returns:
             Tuple of (embeddings, padding masks, attention masks).
         """
+        use_batched = not self.training or torch.jit.is_tracing() or torch.onnx.is_in_onnx_export()
+
+        num_cameras = images.shape[0]
+        bsize = images.shape[1]
+
         embs = []
         pad_masks = []
-        att_masks = []
+        att_masks: list[int] = []
 
-        for img, img_mask in zip(images, img_masks, strict=True):
+        if use_batched:
+            # Single batched encoder call: [N*B, C, H, W]
+            imgs_flat = images.reshape(num_cameras * bsize, *images.shape[2:])
+            all_img_embs = self.paligemma_with_expert.embed_image(imgs_flat)
+            num_img_embs = all_img_embs.shape[1]
+            all_img_embs = all_img_embs.reshape(num_cameras, bsize, num_img_embs, -1)
 
-            def image_embed_func(img: Tensor) -> Tensor:
-                return self.paligemma_with_expert.embed_image(img)
+        for cam_idx in range(num_cameras):
+            if use_batched:
+                img_emb = all_img_embs[cam_idx]
+            else:
+                def image_embed_func(img: Tensor) -> Tensor:
+                    return self.paligemma_with_expert.embed_image(img)
 
-            img_emb = self._apply_checkpoint(image_embed_func, img)
-            bsize, num_img_embs = img_emb.shape[:2]
+                img_emb = self._apply_checkpoint(image_embed_func, images[cam_idx])
 
+            num_img_embs = img_emb.shape[1]
             embs.append(img_emb)
-            pad_masks.append(img_mask[:, None].expand(bsize, num_img_embs))
+            pad_masks.append(img_masks[cam_idx][:, None].expand(bsize, num_img_embs))
             att_masks += [0] * num_img_embs
 
         def lang_embed_func(tokens: Tensor) -> Tensor:
             lang_emb = self.paligemma_with_expert.embed_language_tokens(tokens)
-            lang_emb_dim = lang_emb.shape[-1]
-            return lang_emb * math.sqrt(lang_emb_dim)
+            return lang_emb * math.sqrt(lang_emb.shape[-1])
 
-        lang_emb = self._apply_checkpoint(lang_embed_func, tokens)
+        lang_emb = lang_embed_func(tokens) if use_batched else self._apply_checkpoint(lang_embed_func, tokens)
+
         embs.append(lang_emb)
         pad_masks.append(masks)
+        att_masks += [0] * lang_emb.shape[1]
 
-        num_lang_embs = lang_emb.shape[1]
-        att_masks += [0] * num_lang_embs
+        embs_cat = torch.cat(embs, dim=1)
+        pad_masks_cat = torch.cat(pad_masks, dim=1)
+        att_masks_t = torch.tensor(att_masks, dtype=torch.bool, device=pad_masks_cat.device)
+        att_masks_t = att_masks_t[None, :].expand(bsize, len(att_masks))
 
-        embs = torch.cat(embs, dim=1)
-        pad_masks = torch.cat(pad_masks, dim=1)
-        att_masks = torch.tensor(att_masks, dtype=torch.bool, device=pad_masks.device)
-
-        bsize = pad_masks.shape[0]
-        att_masks = att_masks[None, :].expand(bsize, len(att_masks))
-
-        return embs, pad_masks, att_masks
+        return embs_cat, pad_masks_cat, att_masks_t
 
     def embed_suffix(
         self,

--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -854,8 +854,9 @@ class Pi05Model(ExportableModelMixin, Model):
 
         for cam_idx in range(num_cameras):
             if use_batched:
-                img_emb = all_img_embs[cam_idx]
+                img_emb = all_img_embs[cam_idx]  # pyrefly: ignore[unbound-name]
             else:
+
                 def image_embed_func(img: Tensor) -> Tensor:
                     return self.paligemma_with_expert.embed_image(img)
 

--- a/library/tests/unit/policies/test_pi05.py
+++ b/library/tests/unit/policies/test_pi05.py
@@ -1111,3 +1111,206 @@ class TestPi05ExtraExportArgs:
             assert types.index("normalize") < types.index("pi05"), (
                 f"{backend}: normalize must precede pi05, got {types}"
             )
+
+
+# ============================================================================ #
+# embed_prefix Tests                                                           #
+# ============================================================================ #
+
+
+class TestEmbedPrefix:
+    """Tests for Pi05Model.embed_prefix batched/per-camera behavior.
+
+    Uses a lightweight stub that replaces the heavy vision encoder and language
+    embedding with simple linear projections to verify control flow and shapes.
+    """
+
+    @staticmethod
+    def _make_stub_model(
+        hidden_dim: int = 32,
+        num_patches: int = 4,
+        training: bool = False,
+        gradient_checkpointing: bool = False,
+    ) -> Pi05Model:
+        """Create a minimal Pi05Model stub with mocked sub-modules."""
+        from unittest.mock import MagicMock, patch
+
+        # Bypass __init__ to avoid loading the full PaliGemma model
+        with patch.object(Pi05Model, "__init__", lambda self: None):
+            model = Pi05Model.__new__(Pi05Model)
+
+        # Set nn.Module internals manually
+        torch.nn.Module.__init__(model)
+
+        model.training = training
+        model.gradient_checkpointing_enabled = gradient_checkpointing
+
+        # Mock paligemma_with_expert with simple deterministic functions
+        mock_paligemma = MagicMock()
+
+        def _embed_image(imgs: torch.Tensor) -> torch.Tensor:
+            """Fake vision encoder: project flattened patches to hidden_dim."""
+            batch = imgs.shape[0]
+            return torch.randn(batch, num_patches, hidden_dim)
+
+        def _embed_language(tokens: torch.Tensor) -> torch.Tensor:
+            """Fake language embedding."""
+            batch, seq_len = tokens.shape
+            return torch.randn(batch, seq_len, hidden_dim)
+
+        mock_paligemma.embed_image = _embed_image
+        mock_paligemma.embed_language_tokens = _embed_language
+        model.paligemma_with_expert = mock_paligemma
+
+        return model
+
+    def test_output_shapes_eval_mode(self) -> None:
+        """Test embed_prefix returns correct shapes in eval mode (batched path)."""
+        model = self._make_stub_model(hidden_dim=32, num_patches=4, training=False)
+        num_cameras, bsize, c, h, w = 2, 3, 3, 224, 224
+        seq_len = 10
+
+        images = torch.randn(num_cameras, bsize, c, h, w)
+        img_masks = torch.ones(num_cameras, bsize, dtype=torch.bool)
+        tokens = torch.randint(0, 100, (bsize, seq_len))
+        masks = torch.ones(bsize, seq_len, dtype=torch.bool)
+
+        embs, pad_masks, att_masks = model.embed_prefix(images, img_masks, tokens, masks)
+
+        expected_seq = num_cameras * 4 + seq_len  # 4 patches per camera + lang tokens
+        assert embs.shape == (bsize, expected_seq, 32)
+        assert pad_masks.shape == (bsize, expected_seq)
+        assert att_masks.shape == (bsize, expected_seq)
+        assert att_masks.dtype == torch.bool
+
+    def test_output_shapes_train_mode(self) -> None:
+        """Test embed_prefix returns correct shapes in train mode (per-camera path)."""
+        model = self._make_stub_model(hidden_dim=32, num_patches=4, training=True)
+        num_cameras, bsize, c, h, w = 2, 3, 3, 224, 224
+        seq_len = 10
+
+        images = torch.randn(num_cameras, bsize, c, h, w)
+        img_masks = torch.ones(num_cameras, bsize, dtype=torch.bool)
+        tokens = torch.randint(0, 100, (bsize, seq_len))
+        masks = torch.ones(bsize, seq_len, dtype=torch.bool)
+
+        embs, pad_masks, att_masks = model.embed_prefix(images, img_masks, tokens, masks)
+
+        expected_seq = num_cameras * 4 + seq_len
+        assert embs.shape == (bsize, expected_seq, 32)
+        assert pad_masks.shape == (bsize, expected_seq)
+        assert att_masks.shape == (bsize, expected_seq)
+
+    def test_batched_path_calls_encoder_once(self) -> None:
+        """In eval mode, embed_image should be called once (batched) not per-camera."""
+        from unittest.mock import patch
+
+        model = self._make_stub_model(hidden_dim=32, num_patches=4, training=False)
+        num_cameras, bsize = 3, 2
+
+        images = torch.randn(num_cameras, bsize, 3, 224, 224)
+        img_masks = torch.ones(num_cameras, bsize, dtype=torch.bool)
+        tokens = torch.randint(0, 100, (bsize, 10))
+        masks = torch.ones(bsize, 10, dtype=torch.bool)
+
+        call_count = [0]
+        orig_embed = model.paligemma_with_expert.embed_image
+
+        def _counting_embed(imgs: torch.Tensor) -> torch.Tensor:
+            call_count[0] += 1
+            return orig_embed(imgs)
+
+        model.paligemma_with_expert.embed_image = _counting_embed
+
+        model.embed_prefix(images, img_masks, tokens, masks)
+
+        assert call_count[0] == 1, f"Expected 1 batched call, got {call_count[0]}"
+
+    def test_training_path_calls_encoder_per_camera(self) -> None:
+        """In train mode, embed_image should be called once per camera."""
+        model = self._make_stub_model(hidden_dim=32, num_patches=4, training=True)
+        num_cameras, bsize = 3, 2
+
+        images = torch.randn(num_cameras, bsize, 3, 224, 224)
+        img_masks = torch.ones(num_cameras, bsize, dtype=torch.bool)
+        tokens = torch.randint(0, 100, (bsize, 10))
+        masks = torch.ones(bsize, 10, dtype=torch.bool)
+
+        call_count = [0]
+        orig_embed = model.paligemma_with_expert.embed_image
+
+        def _counting_embed(imgs: torch.Tensor) -> torch.Tensor:
+            call_count[0] += 1
+            return orig_embed(imgs)
+
+        model.paligemma_with_expert.embed_image = _counting_embed
+
+        model.embed_prefix(images, img_masks, tokens, masks)
+
+        assert call_count[0] == num_cameras, f"Expected {num_cameras} calls, got {call_count[0]}"
+
+    def test_eval_and_train_produce_same_shapes(self) -> None:
+        """Both paths should produce identical output shapes for same input."""
+        num_cameras, bsize, seq_len = 2, 4, 8
+
+        images = torch.randn(num_cameras, bsize, 3, 64, 64)
+        img_masks = torch.ones(num_cameras, bsize, dtype=torch.bool)
+        tokens = torch.randint(0, 100, (bsize, seq_len))
+        masks = torch.ones(bsize, seq_len, dtype=torch.bool)
+
+        model_eval = self._make_stub_model(hidden_dim=16, num_patches=4, training=False)
+        model_train = self._make_stub_model(hidden_dim=16, num_patches=4, training=True)
+
+        embs_e, pm_e, am_e = model_eval.embed_prefix(images, img_masks, tokens, masks)
+        embs_t, pm_t, am_t = model_train.embed_prefix(images, img_masks, tokens, masks)
+
+        assert embs_e.shape == embs_t.shape
+        assert pm_e.shape == pm_t.shape
+        assert am_e.shape == am_t.shape
+
+    def test_single_camera(self) -> None:
+        """Test with a single camera produces correct sequence length."""
+        model = self._make_stub_model(hidden_dim=32, num_patches=4, training=False)
+        bsize, seq_len = 2, 5
+
+        images = torch.randn(1, bsize, 3, 224, 224)
+        img_masks = torch.ones(1, bsize, dtype=torch.bool)
+        tokens = torch.randint(0, 100, (bsize, seq_len))
+        masks = torch.ones(bsize, seq_len, dtype=torch.bool)
+
+        embs, pad_masks, att_masks = model.embed_prefix(images, img_masks, tokens, masks)
+
+        expected_seq = 4 + seq_len  # 1 camera * 4 patches + lang tokens
+        assert embs.shape == (bsize, expected_seq, 32)
+
+    def test_pad_masks_reflect_img_masks(self) -> None:
+        """Padding masks should reflect which cameras are masked out."""
+        model = self._make_stub_model(hidden_dim=16, num_patches=4, training=False)
+        num_cameras, bsize, seq_len = 2, 2, 5
+
+        images = torch.randn(num_cameras, bsize, 3, 64, 64)
+        # First camera active, second camera masked for first sample
+        img_masks = torch.ones(num_cameras, bsize, dtype=torch.bool)
+        img_masks[1, 0] = False
+        tokens = torch.randint(0, 100, (bsize, seq_len))
+        masks = torch.ones(bsize, seq_len, dtype=torch.bool)
+
+        _, pad_masks, _ = model.embed_prefix(images, img_masks, tokens, masks)
+
+        # Second camera's patches (indices 4:8) should be False for sample 0
+        assert pad_masks[0, 4:8].sum() == 0
+        # But True for sample 1
+        assert pad_masks[1, 4:8].sum() == 4
+
+    def test_att_masks_all_false(self) -> None:
+        """All attention mask values should be False (non-autoregressive prefix)."""
+        model = self._make_stub_model(hidden_dim=16, num_patches=4, training=False)
+
+        images = torch.randn(2, 3, 3, 64, 64)
+        img_masks = torch.ones(2, 3, dtype=torch.bool)
+        tokens = torch.randint(0, 100, (3, 5))
+        masks = torch.ones(3, 5, dtype=torch.bool)
+
+        _, _, att_masks = model.embed_prefix(images, img_masks, tokens, masks)
+
+        assert not att_masks.any(), "All prefix attention masks should be False"


### PR DESCRIPTION
## Description

- **Eval / tracing**: batches all camera images into one encoder call (`[N*B, C, H, W]`), avoiding redundant sequential vision encoder invocations.
- **Training**: iterates per-camera with gradient checkpointing support.

## Type of Change

- [x] ✨ `feat` - New feature
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes


## Changes Made

| File | Change |
|------|--------|
| `library/src/physicalai/policies/pi05/model.py` | Add images batching; added `.bool()` cast in `_prepare_attention_masks_4d` for JIT tracing compatibility |
| `library/tests/unit/policies/test_pi05.py` | Added `TestEmbedPrefix` class with 8 unit tests covering shapes, encoder call count, mask behavior, and train/eval parity |

## Examples

```python
def embed_prefix(self, ...):
    use_batched = not self.training or torch.jit.is_tracing() or torch.onnx.is_in_onnx_export()
    if use_batched:
        # single batched encoder call
    for cam_idx in range(num_cameras):
        if use_batched:
            img_emb = all_img_embs[cam_idx]
        else:
            img_emb = self._apply_checkpoint(image_embed_func, images[cam_idx])
    ...
```
