### PR TITLE
fix(library): fix export

### DIFF
--- a/library/src/physicalai/policies/act/policy.py
+++ b/library/src/physicalai/policies/act/policy.py
@@ -186,7 +186,7 @@ class ACT(ExportablePolicyMixin, Policy):
             features[str(stat["name"])] = Feature(
                 name=str(stat["name"]),
                 ftype=cast("FeatureType", stat["type"]),
-                shape=cast("tuple[int, ...]", stat["shape"]),
+                shape=tuple(int(s) for s in stat["shape"]),
                 normalization_data=NormalizationParameters(
                     mean=cast("list[float]", stat["mean"]),
                     std=cast("list[float]", stat["std"]),

--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -683,15 +683,15 @@ class Pi05Model(ExportableModelMixin, Model):
         for feature_id in self._dataset_stats:
             if STATE in feature_id:
                 state_feature = self._dataset_stats[feature_id]
-                sample_input[STATE] = torch.randn(1, *cast("tuple", state_feature["shape"]), device=device)
+                sample_input[STATE] = torch.randn(1, *tuple(int(s) for s in state_feature["shape"]), device=device)
             elif str(FeatureType.VISUAL) in self._dataset_stats[feature_id]["type"]:
                 image_feature = self._dataset_stats[feature_id]
                 if num_image_features == 1:
-                    sample_input[IMAGES] = torch.randn(1, *cast("tuple", image_feature["shape"]), device=device)
+                    sample_input[IMAGES] = torch.randn(1, *tuple(int(s) for s in image_feature["shape"]), device=device)
                 else:
                     sample_input[IMAGES + "." + str(image_feature["name"])] = torch.randn(
                         1,
-                        *cast("tuple", image_feature["shape"]),
+                        *tuple(int(s) for s in image_feature["shape"]),
                         device=device,
                     )
 

--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 import torch.nn.functional as F  # noqa: N812

--- a/library/src/physicalai/policies/pi05/preprocessor.py
+++ b/library/src/physicalai/policies/pi05/preprocessor.py
@@ -419,7 +419,7 @@ def make_pi05_preprocessors(
             features[mapped_name] = Feature(
                 name=mapped_name,
                 ftype=feature_type,
-                shape=cast("tuple[int, ...]", stat["shape"]),
+                shape=tuple(int(s) for s in stat["shape"]),
                 normalization_data=norm_data,
             )
 

--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -311,15 +311,15 @@ class SmolVLAModel(ExportableModelMixin, Model):
         for feature_id in self._dataset_stats:
             if STATE in feature_id:
                 state_feature = self._dataset_stats[feature_id]
-                sample_input[STATE] = torch.randn(1, *cast("tuple", state_feature["shape"]), device=device)
+                sample_input[STATE] = torch.randn(1, *tuple(int(s) for s in state_feature["shape"]), device=device)
             elif str(FeatureType.VISUAL) in self._dataset_stats[feature_id]["type"]:
                 image_feature = self._dataset_stats[feature_id]
                 if num_image_features == 1:
-                    sample_input[IMAGES] = torch.randn(1, *cast("tuple", image_feature["shape"]), device=device)
+                    sample_input[IMAGES] = torch.randn(1, *tuple(int(s) for s in image_feature["shape"]), device=device)
                 else:
                     sample_input[IMAGES + "." + str(image_feature["name"])] = torch.randn(
                         1,
-                        *cast("tuple", image_feature["shape"]),
+                        *tuple(int(s) for s in image_feature["shape"]),
                         device=device,
                     )
 

--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import copy
 import logging
 import math
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn.functional as F  # noqa: N812

--- a/library/src/physicalai/policies/smolvla/preprocessor.py
+++ b/library/src/physicalai/policies/smolvla/preprocessor.py
@@ -373,7 +373,7 @@ def make_smolvla_preprocessors(
             features[str(stat["name"])] = Feature(
                 name=str(stat["name"]),
                 ftype=feature_type,
-                shape=cast("tuple[int, ...]", stat["shape"]),
+                shape=tuple(int(s) for s in stat["shape"]),
                 normalization_data=NormalizationParameters(
                     mean=cast("list[float]", stat["mean"]),
                     std=cast("list[float]", stat["std"]),


### PR DESCRIPTION
# Pull Request

## Description

fixes following error:
```
  File "/physical-ai-studio/library/src/physicalai/policies/utils/normalization.py", line 277, in _create_stats_buffers
    q01 = torch.ones(shape, dtype=torch.float32) * torch.inf
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ones() received an invalid combination of arguments - got (tuple, dtype=torch.dtype), but expected one of:
 * (tuple of ints size, *, tuple of names names, torch.dtype dtype = None, torch.layout layout = None, torch.device device = None, bool pin_memory = False, bool requires_grad = False)
 * (tuple of ints size, *, Tensor out = None, torch.dtype dtype = None, torch.layout layout = None, torch.device device = None, bool pin_memory = False, bool requires_grad = False)
```

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
