### PR TITLE
chore: upgrade `@scalar/api-reference-react`

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -238,7 +238,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
     container:
-      image: mcr.microsoft.com/playwright:v1.59.1-jammy@sha256:8a0360d39d1973be506dd59002904a774f6d697d4946c94063b3fd006461c8ff
+      image: mcr.microsoft.com/playwright:v1.60.0-jammy@sha256:e1529a04087193966ea15d4a1617345bdaa0791690a24ab2c42b65f9ce5b2cdc
     steps:
       - *harden-runner
 

--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -14,7 +14,7 @@
                 "@geti-ui/ui": "^1.1.2",
                 "@react-three/drei": "^10.7.6",
                 "@react-three/fiber": "^9.4.0",
-                "@scalar/api-reference-react": "^0.7.48",
+                "@scalar/api-reference-react": "^0.9.38",
                 "@tanstack/react-query": "^5.80.10",
                 "@types/three": "^0.180.0",
                 "clsx": "^2.1.1",
@@ -87,7 +87,7 @@
             },
             "engines": {
                 "node": "v24.2.0",
-                "npm": "11.9.0"
+                "npm": ">=11.14.0"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -139,6 +139,69 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@ai-sdk/gateway": {
+            "version": "3.0.13",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.13.tgz",
+            "integrity": "sha512-g7nE4PFtngOZNZSy1lOPpkC+FAiHxqBJXqyRMEG7NUrEVZlz5goBdtHg1YgWRJIX776JTXAmbOI5JreAKVAsVA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "3.0.2",
+                "@ai-sdk/provider-utils": "4.0.5",
+                "@vercel/oidc": "3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/provider": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.2.tgz",
+            "integrity": "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "json-schema": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@ai-sdk/provider-utils": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.5.tgz",
+            "integrity": "sha512-Ow/X/SEkeExTTc1x+nYLB9ZHK2WUId8+9TlkamAx7Tl9vxU+cKzWx2dwjgMHeCN6twrgwkLrrtqckQeO4mxgVA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "3.0.2",
+                "@standard-schema/spec": "^1.1.0",
+                "eventsource-parser": "^3.0.6"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/vue": {
+            "version": "3.0.33",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-3.0.33.tgz",
+            "integrity": "sha512-czM9Js3a7f+Eo35gjEYEeJYUoPvMg5Dfi4bOLyDBghLqn0gaVg8yTmTaSuHCg+3K/+1xPjyXd4+2XcQIohWWiQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider-utils": "4.0.5",
+                "ai": "6.0.33",
+                "swrv": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "vue": "^3.3.4"
             }
         },
         "node_modules/@asamuzakjp/css-color": {
@@ -2361,17 +2424,6 @@
                 "crelt": "^1.0.5"
             }
         },
-        "node_modules/@codemirror/search": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
-            "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
-            "license": "MIT",
-            "dependencies": {
-                "@codemirror/state": "^6.0.0",
-                "@codemirror/view": "^6.37.0",
-                "crelt": "^1.0.5"
-            }
-        },
         "node_modules/@codemirror/state": {
             "version": "6.6.0",
             "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
@@ -2382,9 +2434,9 @@
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.42.1",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.42.1.tgz",
-            "integrity": "sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==",
+            "version": "6.43.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
+            "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.6.0",
@@ -3136,23 +3188,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/ajv": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3193,13 +3228,6 @@
             "engines": {
                 "node": ">= 4"
             }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
             "version": "3.1.5",
@@ -3277,6 +3305,12 @@
                 "@floating-ui/utils": "^0.2.11"
             }
         },
+        "node_modules/@floating-ui/core/node_modules/@floating-ui/utils": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "license": "MIT"
+        },
         "node_modules/@floating-ui/dom": {
             "version": "1.7.6",
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
@@ -3287,10 +3321,16 @@
                 "@floating-ui/utils": "^0.2.11"
             }
         },
-        "node_modules/@floating-ui/utils": {
+        "node_modules/@floating-ui/dom/node_modules/@floating-ui/utils": {
             "version": "0.2.11",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
             "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "license": "MIT"
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+            "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
             "license": "MIT"
         },
         "node_modules/@floating-ui/vue": {
@@ -3511,105 +3551,6 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
-        "node_modules/@hyperjump/browser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@hyperjump/browser/-/browser-1.3.1.tgz",
-            "integrity": "sha512-Le5XZUjnVqVjkgLYv6yyWgALat/0HpB1XaCPuCZ+GCFki9NvXloSZITIJ0H+wRW7mb9At1SxvohKBbNQbrr/cw==",
-            "license": "MIT",
-            "dependencies": {
-                "@hyperjump/json-pointer": "^1.1.0",
-                "@hyperjump/uri": "^1.2.0",
-                "content-type": "^1.0.5",
-                "just-curry-it": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/jdesrosiers"
-            }
-        },
-        "node_modules/@hyperjump/json-pointer": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@hyperjump/json-pointer/-/json-pointer-1.1.2.tgz",
-            "integrity": "sha512-zPNgu1zdhtjQHFNLGzvEsLDsLOEvhRj6u6ktIQmlz7YPESv5uF8SnAe3Dq0oL6gZ6OGWSLq2n7pphRNF6Hpg6w==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/jdesrosiers"
-            }
-        },
-        "node_modules/@hyperjump/json-schema": {
-            "version": "1.17.6",
-            "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-1.17.6.tgz",
-            "integrity": "sha512-m0QggWCn58IACqLi3fqI9cuUrFju79DVAxjkDENo+xgE26963rudPMwKwwlkZkB+JqAgu+OGvJAMfE1toevfGw==",
-            "license": "MIT",
-            "dependencies": {
-                "@hyperjump/json-pointer": "^1.1.0",
-                "@hyperjump/json-schema-formats": "^1.0.0",
-                "@hyperjump/pact": "^1.2.0",
-                "@hyperjump/uri": "^1.2.0",
-                "content-type": "^1.0.4",
-                "json-stringify-deterministic": "^1.0.12",
-                "just-curry-it": "^5.3.0",
-                "uuid": "^14.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/jdesrosiers"
-            },
-            "peerDependencies": {
-                "@hyperjump/browser": "^1.1.0"
-            }
-        },
-        "node_modules/@hyperjump/json-schema-formats": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@hyperjump/json-schema-formats/-/json-schema-formats-1.0.1.tgz",
-            "integrity": "sha512-qvcIxysnMfcPxyPSFFzzo28o2BN1CNT5b0tQXNUP0kaFpvptQNDg8SCLvlnMg2sYxuiuqna8+azGBaBthiskAw==",
-            "license": "MIT",
-            "dependencies": {
-                "@hyperjump/uri": "^1.3.2",
-                "idn-hostname": "^15.1.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/hyperjump-io"
-            }
-        },
-        "node_modules/@hyperjump/json-schema/node_modules/uuid": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist-node/bin/uuid"
-            }
-        },
-        "node_modules/@hyperjump/pact": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@hyperjump/pact/-/pact-1.4.0.tgz",
-            "integrity": "sha512-01Q7VY6BcAkp9W31Fv+ciiZycxZHGlR2N6ba9BifgyclHYHdbaZgITo0U6QMhYRlem4k8pf8J31/tApxvqAz8A==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/jdesrosiers"
-            }
-        },
-        "node_modules/@hyperjump/uri": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/@hyperjump/uri/-/uri-1.3.4.tgz",
-            "integrity": "sha512-aUVWwu2GtC/cU4DwdTM+b+5jjboM6wft6vNg1+7pUTk/nNRNaBYcYhaEnCir9eRLBbkcGPkiEO7XRUlcDkxj4Q==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/jdesrosiers"
-            }
-        },
         "node_modules/@ianvs/prettier-plugin-sort-imports": {
             "version": "4.7.1",
             "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.7.1.tgz",
@@ -3656,13 +3597,13 @@
             }
         },
         "node_modules/@inquirer/confirm": {
-            "version": "6.0.12",
-            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
-            "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
+            "version": "6.0.13",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.13.tgz",
+            "integrity": "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^11.1.9",
+                "@inquirer/core": "^11.1.10",
                 "@inquirer/type": "^4.0.5"
             },
             "engines": {
@@ -3678,9 +3619,9 @@
             }
         },
         "node_modules/@inquirer/core": {
-            "version": "11.1.9",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
-            "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+            "version": "11.1.10",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.10.tgz",
+            "integrity": "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4088,6 +4029,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/@parcel/watcher": {
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
@@ -4405,13 +4355,13 @@
             "license": "MIT"
         },
         "node_modules/@playwright/test": {
-            "version": "1.59.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-            "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.59.1"
+                "playwright": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -4856,6 +4806,13 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@redocly/config": {
             "version": "0.22.0",
             "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
@@ -4966,9 +4923,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
-            "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+            "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
             "cpu": [
                 "arm"
             ],
@@ -4980,9 +4937,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
-            "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+            "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
             "cpu": [
                 "arm64"
             ],
@@ -4994,9 +4951,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
-            "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+            "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
             "cpu": [
                 "arm64"
             ],
@@ -5008,9 +4965,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
-            "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+            "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
             "cpu": [
                 "x64"
             ],
@@ -5022,9 +4979,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
-            "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+            "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
             "cpu": [
                 "arm64"
             ],
@@ -5036,9 +4993,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
-            "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+            "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
             "cpu": [
                 "x64"
             ],
@@ -5050,9 +5007,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
-            "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+            "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
             "cpu": [
                 "arm"
             ],
@@ -5064,9 +5021,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
-            "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+            "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
             "cpu": [
                 "arm"
             ],
@@ -5078,9 +5035,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
-            "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+            "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
             "cpu": [
                 "arm64"
             ],
@@ -5092,9 +5049,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
-            "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+            "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
             "cpu": [
                 "arm64"
             ],
@@ -5106,9 +5063,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
-            "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+            "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
             "cpu": [
                 "loong64"
             ],
@@ -5120,9 +5077,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
-            "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+            "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
             "cpu": [
                 "loong64"
             ],
@@ -5134,9 +5091,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
-            "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+            "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
             "cpu": [
                 "ppc64"
             ],
@@ -5148,9 +5105,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
-            "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+            "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
             "cpu": [
                 "ppc64"
             ],
@@ -5162,9 +5119,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
-            "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+            "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
             "cpu": [
                 "riscv64"
             ],
@@ -5176,9 +5133,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
-            "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+            "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
             "cpu": [
                 "riscv64"
             ],
@@ -5190,9 +5147,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
-            "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+            "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
             "cpu": [
                 "s390x"
             ],
@@ -5204,9 +5161,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
-            "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+            "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
             "cpu": [
                 "x64"
             ],
@@ -5218,9 +5175,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
-            "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+            "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
             "cpu": [
                 "x64"
             ],
@@ -5232,9 +5189,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
-            "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+            "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
             "cpu": [
                 "x64"
             ],
@@ -5246,9 +5203,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
-            "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+            "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
             "cpu": [
                 "arm64"
             ],
@@ -5260,9 +5217,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
-            "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+            "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
             "cpu": [
                 "arm64"
             ],
@@ -5274,9 +5231,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
-            "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+            "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
             "cpu": [
                 "ia32"
             ],
@@ -5288,9 +5245,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
-            "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+            "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
             "cpu": [
                 "x64"
             ],
@@ -5302,9 +5259,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
-            "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+            "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
             "cpu": [
                 "x64"
             ],
@@ -5624,486 +5581,340 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@scalar/analytics-client": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@scalar/analytics-client/-/analytics-client-1.0.0.tgz",
-            "integrity": "sha512-pnkghhqfmSH7hhdlFpu2M3V/6EjP2R0XbKVbmP77JSli12DdInxR1c4Oiw9V5f/jgxQhVczQQTt74cFYbLzI/Q==",
+        "node_modules/@scalar/agent-chat": {
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@scalar/agent-chat/-/agent-chat-0.12.2.tgz",
+            "integrity": "sha512-8w4uZImC/9q1Gn3JZ+VZI3zhhjzawHuvqzukb0RePl8o5u5B99larOR+Bhi/RfFGZc0ZBF8WhtXON3WBKiQFyw==",
             "license": "MIT",
             "dependencies": {
-                "zod": "3.24.1"
+                "@ai-sdk/vue": "3.0.33",
+                "@scalar/api-client": "3.8.2",
+                "@scalar/components": "0.25.0",
+                "@scalar/helpers": "0.8.0",
+                "@scalar/icons": "0.7.2",
+                "@scalar/json-magic": "0.12.14",
+                "@scalar/openapi-types": "0.8.0",
+                "@scalar/schemas": "0.2.0",
+                "@scalar/themes": "0.15.5",
+                "@scalar/types": "0.11.0",
+                "@scalar/use-toasts": "0.10.2",
+                "@scalar/validation": "0.5.0",
+                "@scalar/workspace-store": "0.51.0",
+                "@vueuse/core": "13.9.0",
+                "ai": "6.0.33",
+                "js-base64": "^3.7.8",
+                "neverpanic": "0.0.7",
+                "truncate-json": "3.0.1",
+                "vue": "^3.5.30"
             },
             "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/analytics-client/node_modules/zod": {
-            "version": "3.24.1",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-            "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/api-client": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@scalar/api-client/-/api-client-2.7.0.tgz",
-            "integrity": "sha512-VE7z7HBOBcRLU2P5LuxT19m0SJy6ZsvFiaMncL94U62zSc1Noy2fPqypsINueq7fx1U/k1D5TXetnrAoeKWMCw==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@scalar/api-client/-/api-client-3.8.2.tgz",
+            "integrity": "sha512-H0kmgkNWG8PUuanZbhIDiVD3QyNpMfvrv78JrX9e03ABlIgXVQpVMGkANAk+BNuGWaDhNPgGnnteS5OnHCUFLg==",
             "license": "MIT",
             "dependencies": {
                 "@headlessui/tailwindcss": "^0.2.2",
                 "@headlessui/vue": "1.7.23",
-                "@scalar/analytics-client": "1.0.0",
-                "@scalar/components": "0.14.40",
-                "@scalar/draggable": "0.2.0",
-                "@scalar/helpers": "0.0.11",
-                "@scalar/icons": "0.4.7",
-                "@scalar/import": "0.4.29",
-                "@scalar/json-magic": "0.6.0",
-                "@scalar/oas-utils": "0.5.0",
-                "@scalar/object-utils": "1.2.7",
-                "@scalar/openapi-parser": "0.22.1",
-                "@scalar/openapi-types": "0.4.0",
-                "@scalar/postman-to-openapi": "0.3.38",
-                "@scalar/snippetz": "0.4.11",
-                "@scalar/themes": "0.13.20",
-                "@scalar/types": "0.3.0",
-                "@scalar/use-codemirror": "0.12.41",
-                "@scalar/use-hooks": "0.2.5",
-                "@scalar/use-toasts": "0.8.0",
-                "@scalar/workspace-store": "0.16.2",
-                "@types/har-format": "^1.2.15",
+                "@scalar/components": "0.25.0",
+                "@scalar/helpers": "0.8.0",
+                "@scalar/icons": "0.7.2",
+                "@scalar/json-magic": "0.12.14",
+                "@scalar/oas-utils": "0.17.0",
+                "@scalar/openapi-types": "0.8.0",
+                "@scalar/sidebar": "0.9.14",
+                "@scalar/snippetz": "0.9.8",
+                "@scalar/themes": "0.15.5",
+                "@scalar/typebox": "^0.1.3",
+                "@scalar/types": "0.11.0",
+                "@scalar/use-codemirror": "0.14.11",
+                "@scalar/use-hooks": "0.4.5",
+                "@scalar/use-toasts": "0.10.2",
+                "@scalar/workspace-store": "0.51.0",
+                "@types/har-format": "^1.2.16",
                 "@vueuse/core": "13.9.0",
                 "@vueuse/integrations": "13.9.0",
-                "focus-trap": "^7",
+                "cookie": "1.1.1",
+                "focus-trap": "^7.8.0",
                 "fuse.js": "^7.1.0",
                 "js-base64": "^3.7.8",
-                "microdiff": "^1.5.0",
-                "nanoid": "5.1.5",
-                "pretty-bytes": "^6.1.1",
-                "pretty-ms": "^8.0.0",
-                "shell-quote": "^1.8.1",
-                "type-fest": "4.41.0",
-                "vue": "^3.5.17",
-                "vue-router": "^4.3.0",
-                "whatwg-mimetype": "^4.0.0",
-                "yaml": "2.8.0",
-                "zod": "4.1.11"
+                "jsonc-parser": "3.3.1",
+                "nanoid": "^5.1.6",
+                "pretty-ms": "^9.3.0",
+                "radix-vue": "^1.9.17",
+                "set-cookie-parser": "3.1.0",
+                "vue": "^3.5.30",
+                "yaml": "^2.8.3",
+                "zod": "^4.3.5"
             },
             "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/api-client/node_modules/yaml": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/api-reference": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/@scalar/api-reference/-/api-reference-1.37.0.tgz",
-            "integrity": "sha512-Daf4ihoOA7UAai0RPnQq11r3B4N+gXTnXAtYE89z0auHn4yS3NsVHbjf/hz62Qm/rd38IEFgKn8I+HNp/1p+pQ==",
+            "version": "1.57.2",
+            "resolved": "https://registry.npmjs.org/@scalar/api-reference/-/api-reference-1.57.2.tgz",
+            "integrity": "sha512-0ZnNNvOzOtP72GE2h9ejNtXakI/rSsverhocRzC201+zPpXLxWY98NHLtrax433/IQWGGmB/RAPuE58vydI7zQ==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/vue": "1.1.9",
                 "@headlessui/vue": "1.7.23",
-                "@scalar/api-client": "2.7.0",
-                "@scalar/code-highlight": "0.2.0",
-                "@scalar/components": "0.14.40",
-                "@scalar/helpers": "0.0.11",
-                "@scalar/icons": "0.4.7",
-                "@scalar/json-magic": "0.6.0",
-                "@scalar/oas-utils": "0.5.0",
-                "@scalar/object-utils": "1.2.7",
-                "@scalar/openapi-parser": "0.22.1",
-                "@scalar/openapi-types": "0.4.0",
-                "@scalar/openapi-upgrader": "0.1.1",
-                "@scalar/snippetz": "0.4.11",
-                "@scalar/themes": "0.13.20",
-                "@scalar/types": "0.3.0",
-                "@scalar/use-hooks": "0.2.5",
-                "@scalar/use-toasts": "0.8.0",
-                "@scalar/workspace-store": "0.16.2",
-                "@unhead/vue": "^1.11.20",
+                "@scalar/agent-chat": "0.12.2",
+                "@scalar/api-client": "3.8.2",
+                "@scalar/code-highlight": "0.3.4",
+                "@scalar/components": "0.25.0",
+                "@scalar/helpers": "0.8.0",
+                "@scalar/icons": "0.7.2",
+                "@scalar/oas-utils": "0.17.0",
+                "@scalar/schemas": "0.2.0",
+                "@scalar/sidebar": "0.9.14",
+                "@scalar/snippetz": "0.9.8",
+                "@scalar/themes": "0.15.5",
+                "@scalar/types": "0.11.0",
+                "@scalar/use-hooks": "0.4.5",
+                "@scalar/use-toasts": "0.10.2",
+                "@scalar/validation": "0.5.0",
+                "@scalar/workspace-store": "0.51.0",
+                "@unhead/vue": "^2.1.4",
                 "@vueuse/core": "13.9.0",
-                "flatted": "^3.3.3",
                 "fuse.js": "^7.1.0",
-                "github-slugger": "^2.0.0",
-                "js-base64": "^3.7.8",
                 "microdiff": "^1.5.0",
-                "nanoid": "5.1.5",
-                "type-fest": "^4.41.0",
-                "vue": "^3.5.17",
-                "zod": "4.1.11"
+                "nanoid": "^5.1.6",
+                "vue": "^3.5.30",
+                "yaml": "^2.8.3"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/api-reference-react": {
-            "version": "0.7.55",
-            "resolved": "https://registry.npmjs.org/@scalar/api-reference-react/-/api-reference-react-0.7.55.tgz",
-            "integrity": "sha512-NqBDd2AHewT1mlrsoFQb7X0NkhG0VXnvozQQ/VHOyJCIj5Ahneb/BYWYFMcFSXmzmP8Xx0ng9IHYK8zrsHlz+w==",
+            "version": "0.9.38",
+            "resolved": "https://registry.npmjs.org/@scalar/api-reference-react/-/api-reference-react-0.9.38.tgz",
+            "integrity": "sha512-ELKrpUsfAZqJL65q5zx+M30fL+JWRT6+RDGn62/4miAjgcb/N2/iaFpjqdWZUgf1oA0s743X1ZmzTZgEBaDU7Q==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/api-reference": "1.37.0",
-                "@scalar/types": "0.3.0"
+                "@scalar/api-reference": "1.57.2",
+                "@scalar/types": "0.11.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@scalar/code-highlight": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@scalar/code-highlight/-/code-highlight-0.2.0.tgz",
-            "integrity": "sha512-p1Bw5J5QXDwaexREMbpqy1XYk9wm9Dda/xt6GRH5PNNJ5fEYmRL/TSqt1qdLN3S2FC9W0XceM3F2VpGnD4jNOg==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@scalar/code-highlight/-/code-highlight-0.3.4.tgz",
+            "integrity": "sha512-gGr3D8bfInwZDHsxamYIaG72Wr+kRNX8d4zcOflAfQJ0ZfvqoVbYhhkiSd6K+DLySItK9lWl/cgjJdtKWlT2ig==",
             "license": "MIT",
             "dependencies": {
                 "hast-util-to-text": "^4.0.2",
-                "highlight.js": "^11.9.0",
-                "highlightjs-curl": "^1.3.0",
-                "highlightjs-vue": "^1.0.0",
-                "lowlight": "^3.1.0",
+                "highlight.js": "^11.11.1",
+                "lowlight": "^3.3.0",
                 "rehype-external-links": "^3.0.0",
-                "rehype-format": "^5.0.0",
-                "rehype-parse": "^9.0.0",
+                "rehype-format": "^5.0.1",
+                "rehype-parse": "^9.0.1",
                 "rehype-raw": "^7.0.0",
                 "rehype-sanitize": "^6.0.0",
-                "rehype-stringify": "^10.0.0",
-                "remark-gfm": "^4.0.0",
+                "rehype-stringify": "^10.0.1",
+                "remark-gfm": "^4.0.1",
                 "remark-parse": "^11.0.0",
-                "remark-rehype": "^11.1.0",
+                "remark-rehype": "^11.1.2",
                 "remark-stringify": "^11.0.0",
-                "unified": "^11.0.4",
-                "unist-util-visit": "^5.0.0"
+                "unified": "^11.0.5",
+                "unist-util-visit": "^5.1.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/components": {
-            "version": "0.14.40",
-            "resolved": "https://registry.npmjs.org/@scalar/components/-/components-0.14.40.tgz",
-            "integrity": "sha512-CVkKl2hrC56TsxriGKE6oH6jDtM0OIOEKU/o81D4chEonlwJjGMMDNypk+gpQa6ssL2ub4POcgI4nHHIemcu/A==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@scalar/components/-/components-0.25.0.tgz",
+            "integrity": "sha512-7oCyTY0Wjkkb/17nqcbyhr+/2ESaH7uzyNsqwwt8PPgGZOeQFTvE4qRHr34a7PoVkos1GZvD3VK1kiYF/lHJnQ==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/utils": "0.2.10",
                 "@floating-ui/vue": "1.1.9",
+                "@headlessui/tailwindcss": "^0.2.2",
                 "@headlessui/vue": "1.7.23",
-                "@scalar/code-highlight": "0.2.0",
-                "@scalar/helpers": "0.0.11",
-                "@scalar/icons": "0.4.7",
-                "@scalar/oas-utils": "0.5.0",
-                "@scalar/themes": "0.13.20",
-                "@scalar/use-hooks": "0.2.5",
-                "@scalar/use-toasts": "0.8.0",
+                "@scalar/code-highlight": "0.3.4",
+                "@scalar/helpers": "0.8.0",
+                "@scalar/icons": "0.7.2",
+                "@scalar/themes": "0.15.5",
+                "@scalar/use-hooks": "0.4.5",
                 "@vueuse/core": "13.9.0",
-                "cva": "1.0.0-beta.2",
-                "nanoid": "5.1.5",
-                "pretty-bytes": "^6.1.1",
-                "radix-vue": "^1.9.3",
-                "vue": "^3.5.17",
-                "vue-component-type-helpers": "^3.0.4"
+                "cva": "1.0.0-beta.4",
+                "nanoid": "^5.1.6",
+                "radix-vue": "^1.9.17",
+                "vue": "^3.5.30",
+                "vue-component-type-helpers": "^3.2.6"
             },
             "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/components/node_modules/@floating-ui/utils": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-            "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-            "license": "MIT"
-        },
-        "node_modules/@scalar/draggable": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@scalar/draggable/-/draggable-0.2.0.tgz",
-            "integrity": "sha512-UetHRB5Bqo5egVYlS21roWBcICmyk8CKh2htsidO+bFGAjl2e7Te+rY0borhNrMclr0xezHlPuLpEs1dvgLS2g==",
-            "license": "MIT",
-            "dependencies": {
-                "vue": "^3.5.12"
-            },
-            "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/helpers": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.0.11.tgz",
-            "integrity": "sha512-EoAufzG0crQloYJxbCV8F+Y5vPyeeh1HMngGlXPT6oGSJPi6DiNA9wztqK3lvaBmSkJMh4VKIbejVqAXx1a0tg==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.0.tgz",
+            "integrity": "sha512-gmOC6VravNB9VDl6wnt/GOj4K/hn48tj5bpW4AM4MhH8Ubil6uu7g1DSoKHwltu8Ks79KEtR6JmOrROi9R7jaQ==",
             "license": "MIT",
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/icons": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/@scalar/icons/-/icons-0.4.7.tgz",
-            "integrity": "sha512-0qXPGRdZ180TMfejWCPYy7ILszBrAraq4KBhPtcM12ghc5qkncFWWpTm5yXI/vrbm10t7wvtTK08CLZ36CnXlQ==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@scalar/icons/-/icons-0.7.2.tgz",
+            "integrity": "sha512-21L2y/D6oU7wZHHa9i6FK98cZ+XH4HX9+e69uNpvlp4awRUpz6ifNHOLlxI607bq+Yz4G313gnV0uyUHwZ/pig==",
             "license": "MIT",
             "dependencies": {
                 "@phosphor-icons/core": "^2.1.1",
-                "@types/node": "^22.9.0",
-                "chalk": "^5.4.1",
-                "vue": "^3.5.17"
+                "@types/node": "^24.1.0",
+                "chalk": "^5.6.2",
+                "vue": "^3.5.30"
             },
             "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/icons/node_modules/@types/node": {
-            "version": "22.19.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
-            "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
-            }
-        },
-        "node_modules/@scalar/icons/node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "license": "MIT"
-        },
-        "node_modules/@scalar/import": {
-            "version": "0.4.29",
-            "resolved": "https://registry.npmjs.org/@scalar/import/-/import-0.4.29.tgz",
-            "integrity": "sha512-1zpYaAw2tbrULqFxCZr+nTGgeTF174QSYfBU+SOzl/Vnm4S9eUqG46VdZT2LInuZAF4+44dqx7S3DmkbK7BgeQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@scalar/helpers": "0.0.11",
-                "@scalar/openapi-parser": "0.22.1",
-                "yaml": "2.8.0"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/import/node_modules/yaml": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/json-magic": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.6.0.tgz",
-            "integrity": "sha512-sy2yL7V8ZF7oUoMl46TjFbBfqZESDmKPfPXeyWeIcwKgjFwjM/FvLdGOOPNsYQ2tPZUCzg8QCNJk9QM+BKVyRg==",
+            "version": "0.12.14",
+            "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.14.tgz",
+            "integrity": "sha512-dWrCy3ew1r7OQ1pu2r4ZjiKEVy0yVd66kXdmsl41bteOG2F2I2IBlPjmPV6p8ckjImQHxtNBIntFaQfNrdBhJg==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/helpers": "0.0.11",
-                "yaml": "2.8.0"
+                "@scalar/helpers": "0.8.0",
+                "pathe": "^2.0.3",
+                "yaml": "^2.8.3"
             },
             "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/json-magic/node_modules/yaml": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/oas-utils": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@scalar/oas-utils/-/oas-utils-0.5.0.tgz",
-            "integrity": "sha512-d6hFWEayBSzH2Lym7ivdBzmdPDvj4qcJoYPUsc/e/xnL8kpE90D1RW6DdoJvMciGsRE/aHXMA+PtpCeb8doMVA==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@scalar/oas-utils/-/oas-utils-0.17.0.tgz",
+            "integrity": "sha512-TunZsVQbBn5EHqbxsqvYHlQZbJy++tp742QxeDZtmhabPwj47h5VqEHtDTuSrVL1p1nSRCirtnZRizQkkmJauQ==",
             "license": "MIT",
             "dependencies": {
-                "@hyperjump/browser": "^1.1.0",
-                "@hyperjump/json-schema": "^1.9.6",
-                "@scalar/helpers": "0.0.11",
-                "@scalar/json-magic": "0.6.0",
-                "@scalar/object-utils": "1.2.7",
-                "@scalar/openapi-types": "0.4.0",
-                "@scalar/themes": "0.13.20",
-                "@scalar/types": "0.3.0",
-                "@scalar/workspace-store": "0.16.2",
-                "@types/har-format": "^1.2.15",
-                "flatted": "^3.3.3",
-                "js-base64": "^3.7.8",
-                "microdiff": "^1.5.0",
-                "nanoid": "5.1.5",
-                "type-fest": "4.41.0",
-                "yaml": "2.8.0",
-                "zod": "4.1.11"
+                "@scalar/helpers": "0.8.0",
+                "@scalar/themes": "0.15.5",
+                "@scalar/types": "0.11.0",
+                "@scalar/workspace-store": "0.51.0",
+                "flatted": "^3.4.0",
+                "vue": "^3.5.30",
+                "yaml": "^2.8.3"
             },
             "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/oas-utils/node_modules/yaml": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            }
-        },
-        "node_modules/@scalar/object-utils": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@scalar/object-utils/-/object-utils-1.2.7.tgz",
-            "integrity": "sha512-zD+e/NLWXWSdD3DoFQi5IjSPiX4tYN5OavotujqRgjWI/J8Uee/ED/REm0+w16k4jEzyM8Fly/vH4Osl4SMJLQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@scalar/helpers": "0.0.11",
-                "flatted": "^3.3.3",
-                "just-clone": "^6.2.0",
-                "ts-deepmerge": "^7.0.1",
-                "type-fest": "4.41.0"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/openapi-parser": {
-            "version": "0.22.1",
-            "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.22.1.tgz",
-            "integrity": "sha512-GJV7f9VLoyKbArMcWETbJ+xPqkopNBlb+oxEBSlSYYsoWc+p+sLAtuwObfJT8Ia+CStl5Y2ZRk/2DgCuy1vsaQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@scalar/json-magic": "0.6.0",
-                "@scalar/openapi-types": "0.4.0",
-                "@scalar/openapi-upgrader": "0.1.1",
-                "ajv": "^8.17.1",
-                "ajv-draft-04": "^1.0.0",
-                "ajv-formats": "^3.0.1",
-                "jsonpointer": "^5.0.1",
-                "leven": "^4.0.0",
-                "yaml": "2.8.0"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/openapi-parser/node_modules/yaml": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/openapi-types": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.4.0.tgz",
-            "integrity": "sha512-vdFLzz7vETw6kS3bxWUHCBeFtJOnr1bk/+FXKyxKkd6TbcyT6USXkoelI704IaBdoXyOgGX10FD1IVrs4FwUow==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.8.0.tgz",
+            "integrity": "sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g==",
             "license": "MIT",
-            "dependencies": {
-                "zod": "4.1.11"
-            },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/openapi-upgrader": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.1.1.tgz",
-            "integrity": "sha512-NlrQezuNGtejqS/SQshY9SjD4D66jiJcWgC2zfCS4muyfE2K85e0i6gegnKLZPSNrqoAvJyR78NPapme9z2/wg==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.2.7.tgz",
+            "integrity": "sha512-sC/uLQOivfX+Oef2QhUpgmERL7KZc1z+hiYkcwZQaUyVOHh5e6OscW0skfzbxKPyJfQ6Ocv0Iom9wMToCGaAPw==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/openapi-types": "0.4.0"
+                "@scalar/openapi-types": "0.8.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
-        "node_modules/@scalar/postman-to-openapi": {
-            "version": "0.3.38",
-            "resolved": "https://registry.npmjs.org/@scalar/postman-to-openapi/-/postman-to-openapi-0.3.38.tgz",
-            "integrity": "sha512-cxEIaorEzwGfTzxdF5eLGA8GQ8IDtJcZiu83ap+8AJfQGPKgtvrSKTuV56Nn9V/t/E7qm8M4MpG9zCdia+CmTg==",
+        "node_modules/@scalar/schemas": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.2.0.tgz",
+            "integrity": "sha512-FOpNecNoEKo8SogHEsdWlVRN4Q4PH3dzuOBWMA5tGt1xLZu5iFnPG2X/h6+Z/mOR34c7iW+hiKTqdUZoDgT9CA==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/helpers": "0.0.11",
-                "@scalar/oas-utils": "0.5.0",
-                "@scalar/openapi-types": "0.4.0"
+                "@scalar/validation": "0.5.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
+            }
+        },
+        "node_modules/@scalar/sidebar": {
+            "version": "0.9.14",
+            "resolved": "https://registry.npmjs.org/@scalar/sidebar/-/sidebar-0.9.14.tgz",
+            "integrity": "sha512-ckTvffgxmFVo4vkHp/PgrWrAXX1BBujsoUO0ZhcOKsHIZFBXgzvqAbaQrAVISSUxt3CqVn66rctQizbkI/cEWg==",
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/components": "0.25.0",
+                "@scalar/helpers": "0.8.0",
+                "@scalar/icons": "0.7.2",
+                "@scalar/themes": "0.15.5",
+                "@scalar/use-hooks": "0.4.5",
+                "@scalar/workspace-store": "0.51.0",
+                "vue": "^3.5.30"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/snippetz": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/@scalar/snippetz/-/snippetz-0.4.11.tgz",
-            "integrity": "sha512-zm53eE+wtAAJn3dvdA5wTyP4mIPkXJWTNYJNuIPDDKIrO16rYGPOdE+5zhprgOSTOhP1DaUQPv4FgJp/O5QHtw==",
+            "version": "0.9.8",
+            "resolved": "https://registry.npmjs.org/@scalar/snippetz/-/snippetz-0.9.8.tgz",
+            "integrity": "sha512-LQyZ7xJd47d0vOtww1yk9oheuSI7yEXYdtisxkfOBC/QTayjv+dIWZfQ0nmv6fYYIeCEcORq7LkFVXJtMJ3yXw==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/types": "0.3.0",
-                "stringify-object": "^5.0.0"
+                "@scalar/types": "0.11.0",
+                "js-base64": "^3.7.8",
+                "stringify-object": "^6.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/themes": {
-            "version": "0.13.20",
-            "resolved": "https://registry.npmjs.org/@scalar/themes/-/themes-0.13.20.tgz",
-            "integrity": "sha512-NOigbwPaJSz/91vuL4u0NP/aVpw9RnzZK6rJTkRb14facBnXTlKj5rKE9v7Q39zxwzH/JP1pFZXpJ0pwNBADoQ==",
+            "version": "0.15.5",
+            "resolved": "https://registry.npmjs.org/@scalar/themes/-/themes-0.15.5.tgz",
+            "integrity": "sha512-ku8MPNBEXigx/ES0Wm7Mf8Ns+QMePEcMHraDZoA5Ab/UO97yTZIrvuo/gy143QB+NftnQ83vgeDYcCRi6I95tQ==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/types": "0.3.0",
-                "nanoid": "5.1.5"
+                "nanoid": "^5.1.6"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/typebox": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@scalar/typebox/-/typebox-0.1.1.tgz",
-            "integrity": "sha512-Mhhubu4zj1PiXhtgvNbz34zniedtO6PYdD80haMkIjOJwV9aWejxXILr2elHGBMsLfdhH3s9qxux6TL6X8Q6/Q==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@scalar/typebox/-/typebox-0.1.3.tgz",
+            "integrity": "sha512-lU055AUccECZMIfGA0z/C1StYmboAYIPJLDFBzOO81yXBi35Pxdq+I4fWX6iUZ8qcoHneiLGk9jAUM1rA93iEg==",
             "license": "MIT"
         },
         "node_modules/@scalar/types": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.3.0.tgz",
-            "integrity": "sha512-RVL4waBX2jpshVBU8l1J8gsG+Ai9oRoTN1Zc1+yaO2WG/ZMXOBtq1noJWpUk2c2i16E1oxmRZC8/nPNFRbkxog==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.11.0.tgz",
+            "integrity": "sha512-TGZR8sys1jRlaWxLYfBo8y6D1W4UClYuDmkJ6Hmsb7oNuqokEAAK+AVYIzascVdBmaly0D1fqoqK7CzuGYHgyg==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/openapi-types": "0.4.0",
-                "nanoid": "5.1.5",
-                "type-fest": "4.41.0",
-                "zod": "4.1.11"
+                "@scalar/helpers": "0.8.0",
+                "nanoid": "^5.1.6",
+                "type-fest": "^5.3.1",
+                "zod": "^4.3.5"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/use-codemirror": {
-            "version": "0.12.41",
-            "resolved": "https://registry.npmjs.org/@scalar/use-codemirror/-/use-codemirror-0.12.41.tgz",
-            "integrity": "sha512-iTff9xkFvHSrN9iYpVIQeUYoFewXa3hDE8An6y5rZSMF1DdGcaGygbfs+bOVtS28vDofzcvXqYhjopJadZdbRQ==",
+            "version": "0.14.11",
+            "resolved": "https://registry.npmjs.org/@scalar/use-codemirror/-/use-codemirror-0.14.11.tgz",
+            "integrity": "sha512-5wtC4pUjzhy72j3aAueJg+fh9KflevJvXMn0YscsxiDTvqwIzeZcHe1N9VNtvzDXgLblEeBT6D0+Vs+boyExxg==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.18.3",
@@ -6120,86 +5931,71 @@
                 "@lezer/common": "^1.2.3",
                 "@lezer/highlight": "^1.2.1",
                 "@replit/codemirror-css-color-picker": "^6.3.0",
-                "@scalar/components": "0.14.40",
-                "codemirror": "^6.0.0",
-                "vue": "^3.5.17"
+                "vue": "^3.5.30"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/use-hooks": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/@scalar/use-hooks/-/use-hooks-0.2.5.tgz",
-            "integrity": "sha512-ML6o5gBNh5ZGObxmmHjCQA6mZhgi+4e8dBhYS1jcuj35tLmV+pMZe+izYJ58+k/szcyNz7aLixTWADBlgCEm0w==",
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/@scalar/use-hooks/-/use-hooks-0.4.5.tgz",
+            "integrity": "sha512-QTFC1qndQK7R4OWm1Mco/Hww7WwSp9F6we3cA4iCpoVKu1HvRBRnO+BHIMZkP1eyq1A4HeSrujTH2MIRPD+wDQ==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/use-toasts": "0.8.0",
+                "@scalar/use-toasts": "0.10.2",
+                "@scalar/validation": "0.5.0",
                 "@vueuse/core": "13.9.0",
-                "cva": "1.0.0-beta.2",
-                "tailwind-merge": "^2.5.5",
-                "vue": "^3.5.17",
-                "zod": "3.24.1"
+                "cva": "1.0.0-beta.4",
+                "tailwind-merge": "3.5.0",
+                "vue": "^3.5.30"
             },
             "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@scalar/use-hooks/node_modules/zod": {
-            "version": "3.24.1",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-            "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
+                "node": ">=22"
             }
         },
         "node_modules/@scalar/use-toasts": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@scalar/use-toasts/-/use-toasts-0.8.0.tgz",
-            "integrity": "sha512-u+o77cdTNZ5ePqHPu8ZcFw1BLlISv+cthN0bR1zJHXmqBjvanFTy2kL+Gmv3eW9HxZiHdqycKVETlYd0mWiqJQ==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@scalar/use-toasts/-/use-toasts-0.10.2.tgz",
+            "integrity": "sha512-1iHQFbDXv0YQRp13aa63S5EcTJ5K8T0ocnLxk+nziloPrLjKt6jdRt6vOHsLSv5sm9kFKcVKNQTQgialmKCOGA==",
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^5.1.5",
-                "vue": "^3.5.12",
-                "vue-sonner": "^1.0.3"
+                "vue": "^3.5.30",
+                "vue-sonner": "^1.3.2"
             },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@scalar/validation": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.5.0.tgz",
+            "integrity": "sha512-48CS1B0C7im57RQCHhS0GKt+qDLxB34IX8rO91jZj9D+Y/OosQZG3Gy57gJdHqZoD7l0sPUZtF8tVYry3BxRtw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=20"
             }
         },
         "node_modules/@scalar/workspace-store": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@scalar/workspace-store/-/workspace-store-0.16.2.tgz",
-            "integrity": "sha512-tpCX2JamjgJNtgAa9eIJGkpgXiHMfqBv8grFEsNEpbhRrfx2VSyZop8CeM3eb27A8SmUP1CdpDX3OYFz0SErag==",
+            "version": "0.51.0",
+            "resolved": "https://registry.npmjs.org/@scalar/workspace-store/-/workspace-store-0.51.0.tgz",
+            "integrity": "sha512-+eKUdPrDzUFSEmDd5gdEf1XUEPVPDH4r9iySW8T2tHF7S7ostpFwszDBhkl8qiQjxpw8DYs/aMaeSCl33/7k6w==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/code-highlight": "0.2.0",
-                "@scalar/helpers": "0.0.11",
-                "@scalar/json-magic": "0.6.0",
-                "@scalar/openapi-upgrader": "0.1.1",
-                "@scalar/snippetz": "0.4.11",
-                "@scalar/typebox": "0.1.1",
-                "@scalar/types": "0.3.0",
-                "github-slugger": "^2.0.0",
-                "type-fest": "4.41.0",
-                "vue": "^3.5.17",
-                "yaml": "2.8.0"
+                "@scalar/helpers": "0.8.0",
+                "@scalar/json-magic": "0.12.14",
+                "@scalar/openapi-upgrader": "0.2.7",
+                "@scalar/snippetz": "0.9.8",
+                "@scalar/typebox": "0.1.3",
+                "@scalar/types": "0.11.0",
+                "@scalar/validation": "0.5.0",
+                "js-base64": "^3.7.8",
+                "type-fest": "^5.3.1",
+                "vue": "^3.5.30",
+                "yaml": "^2.8.3"
             },
             "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@scalar/workspace-store/node_modules/yaml": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
+                "node": ">=22"
             }
         },
         "node_modules/@spectrum-icons/ui": {
@@ -6233,6 +6029,12 @@
                 "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "license": "MIT"
+        },
         "node_modules/@stoplight/json": {
             "version": "3.21.7",
             "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.7.tgz",
@@ -6250,6 +6052,13 @@
             "engines": {
                 "node": ">=8.3.0"
             }
+        },
+        "node_modules/@stoplight/json/node_modules/jsonc-parser": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+            "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@stoplight/ordered-object-literal": {
             "version": "1.0.5",
@@ -6542,9 +6351,9 @@
             }
         },
         "node_modules/@tanstack/eslint-plugin-query": {
-            "version": "5.100.9",
-            "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.100.9.tgz",
-            "integrity": "sha512-3jZwyxAZWSBqI7EXEdw+rktFfX1opMpqn9Lruwz52DEzQdi7kbKnqixjhR3dJ1xFfG05YxV9vsqXGxXqcLAmjA==",
+            "version": "5.100.10",
+            "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.100.10.tgz",
+            "integrity": "sha512-Ddou3agTWv5rvHSBby4yHlugUFHVh0nyo2fyoZ81qSxaTBIwNCoPgpiJhjo5QkThrH1wGC7k548BcMTszZCkBw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6565,9 +6374,9 @@
             }
         },
         "node_modules/@tanstack/query-core": {
-            "version": "5.100.9",
-            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
-            "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+            "version": "5.100.10",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.10.tgz",
+            "integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -6575,12 +6384,12 @@
             }
         },
         "node_modules/@tanstack/react-query": {
-            "version": "5.100.9",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
-            "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+            "version": "5.100.10",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.10.tgz",
+            "integrity": "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==",
             "license": "MIT",
             "dependencies": {
-                "@tanstack/query-core": "5.100.9"
+                "@tanstack/query-core": "5.100.10"
             },
             "funding": {
                 "type": "github",
@@ -6941,10 +6750,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.12.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
-            "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
-            "dev": true,
+            "version": "24.12.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+            "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.16.0"
@@ -7055,17 +6863,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-            "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+            "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.59.2",
-                "@typescript-eslint/type-utils": "8.59.2",
-                "@typescript-eslint/utils": "8.59.2",
-                "@typescript-eslint/visitor-keys": "8.59.2",
+                "@typescript-eslint/scope-manager": "8.59.3",
+                "@typescript-eslint/type-utils": "8.59.3",
+                "@typescript-eslint/utils": "8.59.3",
+                "@typescript-eslint/visitor-keys": "8.59.3",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -7078,22 +6886,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.59.2",
+                "@typescript-eslint/parser": "^8.59.3",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-            "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+            "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.59.2",
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/typescript-estree": "8.59.2",
-                "@typescript-eslint/visitor-keys": "8.59.2",
+                "@typescript-eslint/scope-manager": "8.59.3",
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/typescript-estree": "8.59.3",
+                "@typescript-eslint/visitor-keys": "8.59.3",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -7109,14 +6917,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-            "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+            "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.2",
-                "@typescript-eslint/types": "^8.59.2",
+                "@typescript-eslint/tsconfig-utils": "^8.59.3",
+                "@typescript-eslint/types": "^8.59.3",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -7131,14 +6939,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-            "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+            "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/visitor-keys": "8.59.2"
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/visitor-keys": "8.59.3"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7149,9 +6957,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-            "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+            "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7166,15 +6974,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-            "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+            "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/typescript-estree": "8.59.2",
-                "@typescript-eslint/utils": "8.59.2",
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/typescript-estree": "8.59.3",
+                "@typescript-eslint/utils": "8.59.3",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -7191,9 +6999,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-            "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+            "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7205,16 +7013,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-            "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+            "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.59.2",
-                "@typescript-eslint/tsconfig-utils": "8.59.2",
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/visitor-keys": "8.59.2",
+                "@typescript-eslint/project-service": "8.59.3",
+                "@typescript-eslint/tsconfig-utils": "8.59.3",
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/visitor-keys": "8.59.3",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -7233,16 +7041,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-            "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+            "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.59.2",
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/typescript-estree": "8.59.2"
+                "@typescript-eslint/scope-manager": "8.59.3",
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/typescript-estree": "8.59.3"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7257,13 +7065,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-            "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+            "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.2",
+                "@typescript-eslint/types": "8.59.3",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -7293,61 +7101,20 @@
             "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
             "license": "ISC"
         },
-        "node_modules/@unhead/dom": {
-            "version": "1.11.20",
-            "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.11.20.tgz",
-            "integrity": "sha512-jgfGYdOH+xHJF/j8gudjsYu3oIjFyXhCWcgKaw3vQnT616gSqyqnGQGOItL+BQtQZACKNISwIfx5PuOtztMKLA==",
-            "license": "MIT",
-            "dependencies": {
-                "@unhead/schema": "1.11.20",
-                "@unhead/shared": "1.11.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/harlan-zw"
-            }
-        },
-        "node_modules/@unhead/schema": {
-            "version": "1.11.20",
-            "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.11.20.tgz",
-            "integrity": "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA==",
-            "license": "MIT",
-            "dependencies": {
-                "hookable": "^5.5.3",
-                "zhead": "^2.2.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/harlan-zw"
-            }
-        },
-        "node_modules/@unhead/shared": {
-            "version": "1.11.20",
-            "resolved": "https://registry.npmjs.org/@unhead/shared/-/shared-1.11.20.tgz",
-            "integrity": "sha512-1MOrBkGgkUXS+sOKz/DBh4U20DNoITlJwpmvSInxEUNhghSNb56S0RnaHRq0iHkhrO/cDgz2zvfdlRpoPLGI3w==",
-            "license": "MIT",
-            "dependencies": {
-                "@unhead/schema": "1.11.20",
-                "packrup": "^0.1.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/harlan-zw"
-            }
-        },
         "node_modules/@unhead/vue": {
-            "version": "1.11.20",
-            "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.11.20.tgz",
-            "integrity": "sha512-sqQaLbwqY9TvLEGeq8Fd7+F2TIuV3nZ5ihVISHjWpAM3y7DwNWRU7NmT9+yYT+2/jw1Vjwdkv5/HvDnvCLrgmg==",
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.15.tgz",
+            "integrity": "sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==",
             "license": "MIT",
             "dependencies": {
-                "@unhead/schema": "1.11.20",
-                "@unhead/shared": "1.11.20",
-                "hookable": "^5.5.3",
-                "unhead": "1.11.20"
+                "hookable": "^6.0.1",
+                "unhead": "2.1.15"
             },
             "funding": {
                 "url": "https://github.com/sponsors/harlan-zw"
             },
             "peerDependencies": {
-                "vue": ">=2.7 || >=3"
+                "vue": ">=3.5.18"
             }
         },
         "node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -7650,6 +7417,15 @@
                 "react": ">= 16.8.0"
             }
         },
+        "node_modules/@vercel/oidc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+            "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
         "node_modules/@vitejs/plugin-react": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -7868,12 +7644,6 @@
                 "@vue/shared": "3.5.34"
             }
         },
-        "node_modules/@vue/devtools-api": {
-            "version": "6.6.4",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-            "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-            "license": "MIT"
-        },
         "node_modules/@vue/reactivity": {
             "version": "3.5.34",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
@@ -8029,9 +7799,9 @@
             }
         },
         "node_modules/@webgpu/types": {
-            "version": "0.1.69",
-            "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
-            "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+            "version": "0.1.70",
+            "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
+            "integrity": "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@yellow-ticket/seed-json-schema": {
@@ -8080,51 +7850,39 @@
                 "node": ">= 14"
             }
         },
+        "node_modules/ai": {
+            "version": "6.0.33",
+            "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.33.tgz",
+            "integrity": "sha512-bVokbmy2E2QF6Efl+5hOJx5MRWoacZ/CZY/y1E+VcewknvGlgaiCzMu8Xgddz6ArFJjiMFNUPHKxAhIePE4rmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/gateway": "3.0.13",
+                "@ai-sdk/provider": "3.0.2",
+                "@ai-sdk/provider-utils": "4.0.5",
+                "@opentelemetry/api": "1.9.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
         "node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ajv-draft-04": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "ajv": "^8.5.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ajv-formats": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
             }
         },
         "node_modules/ansi-colors": {
@@ -8582,9 +8340,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.29",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-            "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+            "version": "2.10.30",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+            "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -8788,9 +8546,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001792",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-            "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+            "version": "1.0.30001793",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
             "dev": true,
             "funding": [
                 {
@@ -8951,21 +8709,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/codemirror": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
-            "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
-            "license": "MIT",
-            "dependencies": {
-                "@codemirror/autocomplete": "^6.0.0",
-                "@codemirror/commands": "^6.0.0",
-                "@codemirror/language": "^6.0.0",
-                "@codemirror/lint": "^6.0.0",
-                "@codemirror/search": "^6.0.0",
-                "@codemirror/state": "^6.0.0",
-                "@codemirror/view": "^6.0.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -9027,13 +8770,16 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/content-type": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+        "node_modules/convert-hrtime": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+            "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/convert-source-map": {
@@ -9047,7 +8793,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
             "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -9256,9 +9001,9 @@
             "license": "MIT"
         },
         "node_modules/cva": {
-            "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/cva/-/cva-1.0.0-beta.2.tgz",
-            "integrity": "sha512-dqcOFe247I5pKxfuzqfq3seLL5iMYsTgo40Uw7+pKZAntPgFtR7Tmy59P5IVIq/XgB0NQWoIvYDt9TwHkuK8Cg==",
+            "version": "1.0.0-beta.4",
+            "resolved": "https://registry.npmjs.org/cva/-/cva-1.0.0-beta.4.tgz",
+            "integrity": "sha512-F/JS9hScapq4DBVQXcK85l9U91M6ePeXoBMSp7vypzShoefUBxjQTo3g3935PUHgQd+IW77DjbPRIxugy4/GCQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "clsx": "^2.1.1"
@@ -9267,7 +9012,7 @@
                 "url": "https://polar.sh/cva"
             },
             "peerDependencies": {
-                "typescript": ">= 4.5.5 < 6"
+                "typescript": ">= 4.5.5"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -9794,9 +9539,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.353",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
-            "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+            "version": "1.5.357",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+            "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
             "dev": true,
             "license": "ISC"
         },
@@ -10207,14 +9952,14 @@
             }
         },
         "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-            "version": "2.0.0-next.6",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-            "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+            "version": "2.0.0-next.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+            "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "is-core-module": "^2.16.1",
+                "is-core-module": "^2.16.2",
                 "node-exports-info": "^1.6.0",
                 "object-keys": "^1.1.1",
                 "path-parse": "^1.0.7",
@@ -10460,9 +10205,9 @@
             }
         },
         "node_modules/eslint-plugin-playwright": {
-            "version": "2.10.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.2.tgz",
-            "integrity": "sha512-0N+2OWc3NZbOZ0gK8mp2TK6Qu3UWcJTQ9rqU0UM2yRJXgT758pvpY0lsOLIySfbyFrLqn3TcXjixbmcK90VnuQ==",
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.3.tgz",
+            "integrity": "sha512-68WQsrFlE3NRu0KcM/J1GaiejxGVprU0EU2Er8arMALZcTZnsLub9/LsOT0XO7IDfk8iT5lgz6anIQVpfTHz2A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10610,14 +10355,14 @@
             }
         },
         "node_modules/eslint-plugin-react/node_modules/resolve": {
-            "version": "2.0.0-next.6",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-            "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+            "version": "2.0.0-next.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+            "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "is-core-module": "^2.16.1",
+                "is-core-module": "^2.16.2",
                 "node-exports-info": "^1.6.0",
                 "object-keys": "^1.1.1",
                 "path-parse": "^1.0.7",
@@ -10671,23 +10416,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint/node_modules/ajv": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/eslint/node_modules/ansi-styles": {
@@ -10763,13 +10491,6 @@
             "engines": {
                 "node": ">= 4"
             }
-        },
-        "node_modules/eslint/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/eslint/node_modules/minimatch": {
             "version": "3.1.5",
@@ -10886,6 +10607,15 @@
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "license": "MIT"
         },
+        "node_modules/eventsource-parser": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+            "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/expect-type": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -10948,22 +10678,6 @@
                 "fast-string-truncated-width": "^3.0.2"
             }
         },
-        "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause"
-        },
         "node_modules/fast-wrap-ansi": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
@@ -11017,9 +10731,9 @@
             }
         },
         "node_modules/fflate": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+            "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
             "license": "MIT"
         },
         "node_modules/file-entry-cache": {
@@ -11133,6 +10847,18 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/function-timeout": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+            "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/function.prototype.name": {
@@ -11291,12 +11017,6 @@
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
-        "node_modules/github-slugger": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-            "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-            "license": "ISC"
-        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -11367,6 +11087,15 @@
             "license": "MIT",
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+            }
+        },
+        "node_modules/guess-json-indent": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/guess-json-indent/-/guess-json-indent-3.0.1.tgz",
+            "integrity": "sha512-LWZ3Vr8BG7DHE3TzPYFqkhjNRw4vYgFSsv2nfMuHklAlOfiy54/EwiDQuQfFVLxENCVv20wpbjfTayooQHrEhQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.18.0"
             }
         },
         "node_modules/harmony-reflect": {
@@ -11792,18 +11521,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/highlightjs-curl": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/highlightjs-curl/-/highlightjs-curl-1.3.0.tgz",
-            "integrity": "sha512-50UEfZq1KR0Lfk2Tr6xb/MUIZH3h10oNC0OTy9g7WELcs5Fgy/mKN1vEhuKTkKbdo8vr5F9GXstu2eLhApfQ3A==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/highlightjs-vue": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
-            "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
-            "license": "CC0-1.0"
-        },
         "node_modules/hls.js": {
             "version": "1.6.16",
             "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
@@ -11811,9 +11528,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/hookable": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-            "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
             "license": "MIT"
         },
         "node_modules/html-encoding-sniffer": {
@@ -11890,6 +11607,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/identifier-regex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.0.1.tgz",
+            "integrity": "sha512-ZrYyM0sozNPZlvBvE7Oq9Bn44n0qKGrYu5sQ0JzMUnjIhpgWYE2JB6aBoFwEYdPjqj7jPyxXTMJiHDOxDfd8yw==",
+            "license": "MIT",
+            "dependencies": {
+                "reserved-identifiers": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/identity-obj-proxy": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
@@ -11901,15 +11633,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/idn-hostname": {
-            "version": "15.1.8",
-            "resolved": "https://registry.npmjs.org/idn-hostname/-/idn-hostname-15.1.8.tgz",
-            "integrity": "sha512-MmLwddtSVyMtzYxx+xs2IFEbfyg/facubL/mEaAoJX/XIfjt1ly5QhPByihf4yrxZYbkQfRZVEnBgISv/e2ZWw==",
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.3.1"
             }
         },
         "node_modules/ieee754": {
@@ -12272,6 +11995,22 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-identifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.0.1.tgz",
+            "integrity": "sha512-HQ5v4rEJ7REUV54bCd2l5FaD299SGDEn2UPoVXaTHAyGviLq2menVUD2udi3trQ32uvB6LdAh/0ck2EuizrtpA==",
+            "license": "MIT",
+            "dependencies": {
+                "identifier-regex": "^1.0.0",
+                "super-regex": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-map": {
@@ -12673,10 +12412,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-schema": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+            "license": "(AFL-2.1 OR BSD-3-Clause)"
+        },
         "node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
@@ -12685,15 +12431,6 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/json-stringify-deterministic": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.13.tgz",
-            "integrity": "sha512-Gm2hkhXlhD69QplkQGmY30S8Ps5noSFzruJKbgmD/nkYIXimS/Q0P1YIbJkWe2nbWDIzERmtp+hWGzC3Vk3bZg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -12709,20 +12446,10 @@
             }
         },
         "node_modules/jsonc-parser": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
-            "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
-            "dev": true,
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
             "license": "MIT"
-        },
-        "node_modules/jsonpointer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-            "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.5",
@@ -12739,18 +12466,6 @@
             "engines": {
                 "node": ">=4.0"
             }
-        },
-        "node_modules/just-clone": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
-            "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA==",
-            "license": "MIT"
-        },
-        "node_modules/just-curry-it": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-5.3.0.tgz",
-            "integrity": "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw==",
-            "license": "MIT"
         },
         "node_modules/keyv": {
             "version": "4.5.4",
@@ -12780,18 +12495,6 @@
             },
             "engines": {
                 "node": ">=0.10"
-            }
-        },
-        "node_modules/leven": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/leven/-/leven-4.1.0.tgz",
-            "integrity": "sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/levn": {
@@ -12973,6 +12676,35 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/make-asynchronous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+            "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+            "license": "MIT",
+            "dependencies": {
+                "p-event": "^6.0.0",
+                "type-fest": "^4.6.0",
+                "web-worker": "^1.5.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/make-asynchronous/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/markdown-table": {
@@ -13851,9 +13583,9 @@
             "license": "MIT"
         },
         "node_modules/msw": {
-            "version": "2.14.5",
-            "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.5.tgz",
-            "integrity": "sha512-X6G05oX4x0e+CNI55KMdhMmwHCBKf2iwazGr+iwsdoJ94JA1ED7wSXb6V+lLPdqFkmIlPiGYvayqnaNcOzobDA==",
+            "version": "2.14.6",
+            "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+            "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -13896,9 +13628,9 @@
             }
         },
         "node_modules/msw/node_modules/@mswjs/interceptors": {
-            "version": "0.41.8",
-            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.8.tgz",
-            "integrity": "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==",
+            "version": "0.41.9",
+            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+            "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13960,22 +13692,6 @@
                 "node": ">=16"
             }
         },
-        "node_modules/msw/node_modules/type-fest": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "dependencies": {
-                "tagged-tag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/mute-stream": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
@@ -13987,9 +13703,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
-            "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+            "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
             "funding": [
                 {
                     "type": "github",
@@ -14026,6 +13742,15 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/neverpanic": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/neverpanic/-/neverpanic-0.0.7.tgz",
+            "integrity": "sha512-GFRTSX2JAEATOCQYlyFkR+9FJPl0pD24toE1foqYAsL6aPLlRKn6L0UFOtJhZCxEbDv+SUsiW4AcPs9cIFwkFw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "typescript": "5"
+            }
         },
         "node_modules/no-case": {
             "version": "3.0.4",
@@ -14116,9 +13841,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.38",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-            "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+            "version": "2.0.44",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -14348,6 +14073,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/openapi-typescript/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -14391,6 +14129,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/p-event": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+            "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+            "license": "MIT",
+            "dependencies": {
+                "p-timeout": "^6.1.2"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -14423,13 +14176,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/packrup": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/packrup/-/packrup-0.1.2.tgz",
-            "integrity": "sha512-ZcKU7zrr5GlonoS9cxxrb5HVswGnyj6jQvwFBa6p5VFw7G71VAHcUKL5wyZSU/ECtPM/9gacWxy2KFQKt1gMNA==",
+        "node_modules/p-timeout": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
             "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
             "funding": {
-                "url": "https://github.com/sponsors/harlan-zw"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/parent-module": {
@@ -14465,12 +14221,12 @@
             }
         },
         "node_modules/parse-ms": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
-            "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+            "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
             "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -14547,7 +14303,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/pathval": {
@@ -14580,13 +14335,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.59.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-            "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.59.1"
+                "playwright-core": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -14599,9 +14354,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.59.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-            "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -14709,18 +14464,6 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
-        "node_modules/pretty-bytes": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
-            "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/pretty-format": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -14738,15 +14481,15 @@
             }
         },
         "node_modules/pretty-ms": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
-            "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+            "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
             "license": "MIT",
             "dependencies": {
-                "parse-ms": "^3.0.0"
+                "parse-ms": "^4.0.0"
             },
             "engines": {
-                "node": ">=14.16"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -14793,6 +14536,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -15485,6 +15229,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/reserved-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+            "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/resolve": {
             "version": "1.22.12",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -15545,9 +15301,9 @@
             "license": "MIT"
         },
         "node_modules/rollup": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
-            "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+            "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15561,31 +15317,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.60.3",
-                "@rollup/rollup-android-arm64": "4.60.3",
-                "@rollup/rollup-darwin-arm64": "4.60.3",
-                "@rollup/rollup-darwin-x64": "4.60.3",
-                "@rollup/rollup-freebsd-arm64": "4.60.3",
-                "@rollup/rollup-freebsd-x64": "4.60.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.60.3",
-                "@rollup/rollup-linux-arm64-musl": "4.60.3",
-                "@rollup/rollup-linux-loong64-gnu": "4.60.3",
-                "@rollup/rollup-linux-loong64-musl": "4.60.3",
-                "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
-                "@rollup/rollup-linux-ppc64-musl": "4.60.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
-                "@rollup/rollup-linux-riscv64-musl": "4.60.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.60.3",
-                "@rollup/rollup-linux-x64-gnu": "4.60.3",
-                "@rollup/rollup-linux-x64-musl": "4.60.3",
-                "@rollup/rollup-openbsd-x64": "4.60.3",
-                "@rollup/rollup-openharmony-arm64": "4.60.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.60.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.60.3",
-                "@rollup/rollup-win32-x64-gnu": "4.60.3",
-                "@rollup/rollup-win32-x64-msvc": "4.60.3",
+                "@rollup/rollup-android-arm-eabi": "4.60.4",
+                "@rollup/rollup-android-arm64": "4.60.4",
+                "@rollup/rollup-darwin-arm64": "4.60.4",
+                "@rollup/rollup-darwin-x64": "4.60.4",
+                "@rollup/rollup-freebsd-arm64": "4.60.4",
+                "@rollup/rollup-freebsd-x64": "4.60.4",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+                "@rollup/rollup-linux-arm64-musl": "4.60.4",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+                "@rollup/rollup-linux-loong64-musl": "4.60.4",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+                "@rollup/rollup-linux-x64-gnu": "4.60.4",
+                "@rollup/rollup-linux-x64-musl": "4.60.4",
+                "@rollup/rollup-openbsd-x64": "4.60.4",
+                "@rollup/rollup-openharmony-arm64": "4.60.4",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+                "@rollup/rollup-win32-x64-gnu": "4.60.4",
+                "@rollup/rollup-win32-x64-msvc": "4.60.4",
                 "fsevents": "~2.3.2"
             }
         },
@@ -16114,7 +15870,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
             "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/set-function-length": {
@@ -16185,18 +15940,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/side-channel": {
@@ -16429,6 +16172,24 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/string-byte-length": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/string-byte-length/-/string-byte-length-3.0.1.tgz",
+            "integrity": "sha512-yJ8vP0HMwZ54CcA8S8mKoXbkezpZHANFtmafFo8lGxZThCQcAwRHjdFabuSLgOzxj9OFJcmssmiAvmcOK4O2Hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/string-byte-slice": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/string-byte-slice/-/string-byte-slice-3.0.1.tgz",
+            "integrity": "sha512-GWv2K4lYyd2+AhmKH3BV+OVx62xDX+99rSLfKpaqFiQU7uOMaUY1tDjdrRD4gsrCr9lTyjMgjna7tZcCOw+Smg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -16579,20 +16340,21 @@
             }
         },
         "node_modules/stringify-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
-            "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-6.0.0.tgz",
+            "integrity": "sha512-6f94vIED6vmJJfh3lyVsVWxCYSfI5uM+16ntED/Ql37XIyV6kj0mRAAiTeMMc/QLYIaizC3bUprQ8pQnDDrKfA==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "get-own-enumerable-keys": "^1.0.0",
+                "is-identifier": "^1.0.1",
                 "is-obj": "^3.0.0",
                 "is-regexp": "^3.1.0"
             },
             "engines": {
-                "node": ">=14.16"
+                "node": ">=20"
             },
             "funding": {
-                "url": "https://github.com/yeoman/stringify-object?sponsor=1"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/strip-ansi": {
@@ -16670,6 +16432,23 @@
             "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
             "license": "MIT"
         },
+        "node_modules/super-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+            "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+            "license": "MIT",
+            "dependencies": {
+                "function-timeout": "^1.0.1",
+                "make-asynchronous": "^1.0.1",
+                "time-span": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/supports-color": {
             "version": "10.2.2",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -16738,6 +16517,15 @@
                 "url": "https://opencollective.com/svgo"
             }
         },
+        "node_modules/swrv": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/swrv/-/swrv-1.2.0.tgz",
+            "integrity": "sha512-lH/g4UcNyj+7lzK4eRGT4C68Q4EhQ6JtM9otPRIASfhhzfLWtbZPHcMuhuba7S9YVYuxkMUGImwMyGpfbkH07A==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "vue": ">=3.2.26 < 4"
+            }
+        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -16778,7 +16566,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
             "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -16788,9 +16575,9 @@
             }
         },
         "node_modules/tailwind-merge": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
-            "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+            "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -16841,6 +16628,21 @@
             "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
             "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
             "license": "MIT"
+        },
+        "node_modules/time-span": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+            "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+            "license": "MIT",
+            "dependencies": {
+                "convert-hrtime": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/tiny-invariant": {
             "version": "1.3.3",
@@ -17005,6 +16807,20 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/truncate-json": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/truncate-json/-/truncate-json-3.0.1.tgz",
+            "integrity": "sha512-QVsbr1WhGLq2F0oDyYbqtOXcf3gcnL8C9H5EX8bBwAr8ZWvWGJzukpPrDrWgJMrNtgDbo74BIjI4kJu3q2xQWw==",
+            "license": "MIT",
+            "dependencies": {
+                "guess-json-indent": "^3.0.1",
+                "string-byte-length": "^3.0.1",
+                "string-byte-slice": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
         "node_modules/ts-api-utils": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -17016,15 +16832,6 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.8.4"
-            }
-        },
-        "node_modules/ts-deepmerge": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.3.tgz",
-            "integrity": "sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=14.13.1"
             }
         },
         "node_modules/tsconfig-paths": {
@@ -17110,12 +16917,15 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
             "license": "(MIT OR CC0-1.0)",
+            "dependencies": {
+                "tagged-tag": "^1.0.0"
+            },
             "engines": {
-                "node": ">=16"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -17203,7 +17013,6 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -17214,16 +17023,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-            "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+            "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.59.2",
-                "@typescript-eslint/parser": "8.59.2",
-                "@typescript-eslint/typescript-estree": "8.59.2",
-                "@typescript-eslint/utils": "8.59.2"
+                "@typescript-eslint/eslint-plugin": "8.59.3",
+                "@typescript-eslint/parser": "8.59.3",
+                "@typescript-eslint/typescript-estree": "8.59.3",
+                "@typescript-eslint/utils": "8.59.3"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -17260,19 +17069,15 @@
             "version": "7.16.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
             "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/unhead": {
-            "version": "1.11.20",
-            "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.11.20.tgz",
-            "integrity": "sha512-3AsNQC0pjwlLqEYHLjtichGWankK8yqmocReITecmpB1H0aOabeESueyy+8X1gyJx4ftZVwo9hqQ4O3fPWffCA==",
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.15.tgz",
+            "integrity": "sha512-MCt5T90mCWyr3Z6pUCdM9lVRXoMoVBlL7z7U4CYVIiaDiuzad/UCfLuMqz5MeNmpZUgoBCQnrucJimU7EZR+XA==",
             "license": "MIT",
             "dependencies": {
-                "@unhead/dom": "1.11.20",
-                "@unhead/schema": "1.11.20",
-                "@unhead/shared": "1.11.20",
-                "hookable": "^5.5.3"
+                "hookable": "^6.0.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/harlan-zw"
@@ -17850,25 +17655,10 @@
             }
         },
         "node_modules/vue-component-type-helpers": {
-            "version": "3.2.8",
-            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.8.tgz",
-            "integrity": "sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==",
+            "version": "3.2.9",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.9.tgz",
+            "integrity": "sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==",
             "license": "MIT"
-        },
-        "node_modules/vue-router": {
-            "version": "4.6.4",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
-            "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/devtools-api": "^6.6.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/posva"
-            },
-            "peerDependencies": {
-                "vue": "^3.5.0"
-            }
         },
         "node_modules/vue-sonner": {
             "version": "1.3.2",
@@ -17915,6 +17705,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/web-worker": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+            "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+            "license": "Apache-2.0"
+        },
         "node_modules/webgl-constants": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
@@ -17954,6 +17750,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
             "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -18139,9 +17936,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -18195,10 +17992,9 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-            "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-            "dev": true,
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
@@ -18259,19 +18055,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/zhead": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/zhead/-/zhead-2.2.4.tgz",
-            "integrity": "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/harlan-zw"
-            }
-        },
         "node_modules/zod": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-            "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -61,7 +61,7 @@
         "@ianvs/prettier-plugin-sort-imports": "^4.4.2",
         "@msw/playwright": "^0.4.5",
         "@mswjs/source": "^0.5.0",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.60.0",
         "@rsbuild/core": "^1.3.14",
         "@rsbuild/plugin-react": "^1.3.0",
         "@rsbuild/plugin-sass": "^1.3.1",

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -32,7 +32,7 @@
         "@geti-ui/ui": "^1.1.2",
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "^9.4.0",
-        "@scalar/api-reference-react": "^0.7.48",
+        "@scalar/api-reference-react": "^0.9.38",
         "@tanstack/react-query": "^5.80.10",
         "@types/three": "^0.180.0",
         "clsx": "^2.1.1",

--- a/application/ui/src/routes/openapi.css
+++ b/application/ui/src/routes/openapi.css
@@ -1,0 +1,7 @@
+button.bg-sidebar-b-search:last-of-type {
+    display: none;
+}
+
+.scalar-mcp-layer {
+    display: none !important;
+}

--- a/application/ui/src/routes/openapi.module.scss
+++ b/application/ui/src/routes/openapi.module.scss
@@ -4,6 +4,7 @@
 
 .container {
     --scalar-background-1: var(--spectrum-global-color-gray-50);
+    --scalar-sidebar-background-1: var(--spectrum-global-color-gray-50);
     background: var(--scalar-background-1);
     overflow: hidden;
 }

--- a/application/ui/src/routes/openapi.tsx
+++ b/application/ui/src/routes/openapi.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 
 import classes from './openapi.module.scss';
 
+import './openapi.css';
 import '@scalar/api-reference-react/style.css';
 
 const Header = () => {
@@ -29,6 +30,7 @@ export const OpenApi = () => {
                         hideModels: true,
                         hideClientButton: true,
                         hideDarkModeToggle: true,
+                        showDeveloperTools: 'never',
                         metaData: {
                             title: 'Physical AI Studio | REST API specification',
                         },


### PR DESCRIPTION
Update `@scalar/api-reference-react` to close some depandabot alerts that are meant for server side rendered application (not applicable to us, but it still produces noise).
Hide tools that are likely to be confusing.

## Type of Change

- [x] 🔧 `chore` - Maintenance
