### PR TITLE
fix: do not save compile_model to lightning hyperparams

### DIFF
--- a/library/src/physicalai/policies/act/policy.py
+++ b/library/src/physicalai/policies/act/policy.py
@@ -153,7 +153,7 @@ class ACT(ExportablePolicyMixin, Policy):
         )
 
         # Save config as hyperparameters for checkpoint restoration
-        self.save_hyperparameters(ignore=["config"])  # Save individual args, not config object
+        self.save_hyperparameters(ignore=["config", "compile_model"])
         # Also save config dict for compatibility
         self.hparams["config"] = self.config.to_dict()
 

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -221,7 +221,7 @@ class Pi05(ExportablePolicyMixin, Policy):
                 scheduler_decay_lr=scheduler_decay_lr,
             )
 
-        self.save_hyperparameters(ignore=["config", "pretrained_name_or_path"])
+        self.save_hyperparameters(ignore=["config", "pretrained_name_or_path", "compile_model"])
         self.hparams["config"] = self.config.to_dict()
 
         self.model: Pi05Model | None = None

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -224,8 +224,8 @@ class SmolVLA(ExportablePolicyMixin, Policy):
 
         # Save config as hyperparameters for checkpoint restoration
         self.save_hyperparameters(
-            ignore=["config", "pretrained_name_or_path"],
-        )  # Save individual args, not config object
+            ignore=["config", "pretrained_name_or_path",  "compile_model"],
+        )
         # Also save config dict for compatibility
         self.hparams["config"] = self.config.to_dict()
 

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -224,7 +224,7 @@ class SmolVLA(ExportablePolicyMixin, Policy):
 
         # Save config as hyperparameters for checkpoint restoration
         self.save_hyperparameters(
-            ignore=["config", "pretrained_name_or_path",  "compile_model"],
+            ignore=["config", "pretrained_name_or_path", "compile_model"],
         )
         # Also save config dict for compatibility
         self.hparams["config"] = self.config.to_dict()

--- a/library/tests/unit/policies/test_act.py
+++ b/library/tests/unit/policies/test_act.py
@@ -112,6 +112,11 @@ class TestACTolicy:
         assert "state" in sample_input
         assert "images" in sample_input
 
+    def test_save_hyperparameters_ignores_compile_model(self):
+        """Test compile_model is excluded from saved hyperparameters."""
+        policy = ACT(compile_model=True)
+        assert "compile_model" not in policy.hparams
+
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     def test_dtype_change(self, policy, batch, dtype):
         """Test model behavior with different input dtypes."""

--- a/library/tests/unit/policies/test_pi05.py
+++ b/library/tests/unit/policies/test_pi05.py
@@ -936,6 +936,11 @@ class TestPi05FineTuning:
         policy = Pi05()
         assert "pretrained_name_or_path" not in policy.hparams
 
+    def test_save_hyperparameters_ignores_compile_model(self) -> None:
+        """Test compile_model is excluded from saved hyperparameters."""
+        policy = Pi05(compile_model=True)
+        assert "compile_model" not in policy.hparams
+
     def test_update_preprocessor_stats(self) -> None:
         """Test _update_preprocessor_stats rebuilds preprocessors with new stats."""
         stats = {

--- a/library/tests/unit/policies/test_smolvla.py
+++ b/library/tests/unit/policies/test_smolvla.py
@@ -109,6 +109,11 @@ class TestSmolVLAPolicy:
         assert "config" in policy.hparams
         assert policy.hparams["config"]["chunk_size"] == 100
 
+    def test_save_hyperparameters_ignores_compile_model(self) -> None:
+        """Test compile_model is excluded from saved hyperparameters."""
+        policy = SmolVLA(compile_model=True)
+        assert "compile_model" not in policy.hparams
+
     def test_config_attribute(self) -> None:
         """Test SmolVLA policy has config attribute."""
         policy = SmolVLA(chunk_size=100, optimizer_lr=2e-4)


### PR DESCRIPTION
# Pull Request

## Description

- `compile_model` should not be saved to the hyperparameters to preserve pytorch semantics: loading a checkpoint should result in getting a `nn.Module`, not `torch._dynamo.eval_frame.OptimizedModule`

## Type of Change

- [x] 🐞 `fix` - Bug fix
