### PR TITLE
chore(ci): workflows minor updates

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -96,6 +96,7 @@ jobs:
           push: "true"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          use-cache: "false" # To ensure that the application container images remain buildable
 
       - name: Resolve primary image tag for signing
         id: primary-tag

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   analysis:
     name: Scorecards analysis
-    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard
       security-events: write

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -319,15 +319,6 @@ jobs:
           fail_action: false
           artifact_name: zapapi
 
-      - name: Run ZAP Full Scan
-        uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c # v0.13.0
-        with:
-          target: "http://localhost:7860"
-          cmd_options: "-a -j"
-          allow_issue_writing: false
-          fail_action: false
-          artifact_name: zapfull
-
       - name: Run Schemathesis Scan
         uses: schemathesis/action@806cace2053cbbac93188e1281ff7da415643160 # v3
         continue-on-error: true


### PR DESCRIPTION
# Pull Request

## Description

Minor update:
- use `ubuntu-latest` in `scorecards.yml` as other runners are [not supported](https://github.com/open-edge-platform/physical-ai-studio/actions/runs/26073463958)
- do not use cache in daily container images builds to ensure that the application container images remain buildable
- temporary remove full ZAP scan (there are some [issues ](https://github.com/open-edge-platform/physical-ai-studio/actions/runs/26073941043/job/76660919604)that will be investigated)

## Type of Change

- [x] 🔧 `chore` - Maintenance