### PR TITLE
fix: chunk truncation handling in torch

### DIFF
--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -31,6 +31,7 @@ from physicalai.export.backends import (
     ExportParameters,
     ONNXExportParameters,
     OpenVINOExportParameters,
+    TorchExportParameters,
 )
 from physicalai.train import __version__
 
@@ -198,6 +199,11 @@ class ExportablePolicyMixin:
         model_path = self._prepare_export_path(checkpoint_path, ".pt")
         export_dir = model_path.parent
 
+        extra_model_args: TorchExportParameters = cast(
+            "TorchExportParameters",
+            self._get_export_extra_args(ExportBackend.TORCH),
+        )
+
         checkpoint = {}
         checkpoint["state_dict"] = self.state_dict() if hasattr(self, "state_dict") else {}
 
@@ -213,7 +219,12 @@ class ExportablePolicyMixin:
         torch.save(checkpoint, str(model_path))  # nosec B614
 
         # Create metadata files
-        self._create_metadata(export_dir, ExportBackend.TORCH)
+        self._create_metadata(
+            export_dir,
+            ExportBackend.TORCH,
+            preprocessors=extra_model_args.preprocessors_specs,
+            postprocessors=extra_model_args.postprocessors_specs,
+        )
 
     @torch.no_grad()
     def to_onnx(

--- a/library/src/physicalai/inference/adapters/pytorch.py
+++ b/library/src/physicalai/inference/adapters/pytorch.py
@@ -13,9 +13,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import torch
-import yaml
 from physicalai.inference.adapters.base import RuntimeAdapter
 from physicalai.inference.adapters.registry import adapter_registry
+from physicalai.inference.manifest import Manifest
 
 from physicalai.data.observation import Observation
 from physicalai.export.backends import TorchExportParameters
@@ -60,25 +60,18 @@ class TorchAdapter(RuntimeAdapter):
         Raises:
             FileNotFoundError: If model file doesn't exist
             RuntimeError: If model loading fails
-            KeyError: If metadata is missing required entries
+            KeyError: If manifest is missing required entries
         """
         model_path = Path(model_path)
         if not model_path.exists():
             msg = f"Model file not found: {model_path}"
             raise FileNotFoundError(msg)
 
-        metadata_path = model_path.parent / "metadata.yaml"
-        if not metadata_path.exists():
-            msg = f"Metadata file not found: {metadata_path}"
-            raise FileNotFoundError(msg)
-
-        with metadata_path.open() as f:
-            metadata = yaml.safe_load(f)
-
-            policy_class_path = metadata.get("policy_class", None)
-            if policy_class_path is None:
-                msg = "Metadata missing 'policy_class' entry."
-                raise KeyError(msg)
+        manifest = Manifest.load(model_path.parent)
+        policy_class_path = manifest.policy.source.class_path
+        if not policy_class_path:
+            msg = "Manifest missing 'policy.source.class_path' entry."
+            raise KeyError(msg)
 
         try:
             _, class_name = policy_class_path.rsplit(".", 1)

--- a/library/src/physicalai/policies/base/policy.py
+++ b/library/src/physicalai/policies/base/policy.py
@@ -171,11 +171,11 @@ class Policy(L.LightningModule, ABC):
         """
         # Handle (B, T, D) -> split along T dimension
         if actions.dim() == 3:  # noqa: PLR2004
-            # Transpose to (T, B, D), then extend queue
-            self._action_queue.extend(actions.transpose(0, 1))
+            # Transpose to (T, B, D), then truncate to _n_action_steps and extend queue
+            self._action_queue.extend(actions.transpose(0, 1)[: self._n_action_steps])
         else:
-            # Already (T, D), just extend
-            self._action_queue.extend(actions)
+            # Already (T, D), truncate to _n_action_steps and extend
+            self._action_queue.extend(actions[: self._n_action_steps])
         return self._action_queue.popleft()
 
     def _get_queued_action(self) -> torch.Tensor | None:

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -699,13 +699,14 @@ class Pi05(ExportablePolicyMixin, Policy):
                 mode=self.config.normalization_mode.lower(),
             ),
         ]
+        torch_postproc_specs = []
         if self.config.chunk_size != self.config.n_action_steps:
-            postproc_specs.append(
-                ComponentSpec(
-                    type="action_chunk_trimmer",
-                    n_action_steps=self.config.n_action_steps,
-                ),
+            chunk_trimmer = ComponentSpec(
+                type="action_chunk_trimmer",
+                n_action_steps=self.config.n_action_steps,
             )
+            postproc_specs.append(chunk_trimmer)
+            torch_postproc_specs.append(chunk_trimmer)
 
         extra_args: dict[str, ExportParameters] = {}
         extra_args["onnx"] = ONNXExportParameters(
@@ -739,6 +740,8 @@ class Pi05(ExportablePolicyMixin, Policy):
             ],
             postprocessors_specs=postproc_specs,
         )
-        extra_args["torch"] = TorchExportParameters()
+        extra_args["torch"] = TorchExportParameters(
+            postprocessors_specs=torch_postproc_specs,
+        )
 
         return extra_args

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -651,13 +651,14 @@ class SmolVLA(ExportablePolicyMixin, Policy):
                 mode="mean_std",
             ),
         ]
+        torch_postproc_specs = []
         if self.config.chunk_size != self.config.n_action_steps:
-            postproc_specs.append(
-                ComponentSpec(
-                    type="action_chunk_trimmer",
-                    n_action_steps=self.config.n_action_steps,
-                ),
+            chunk_trimmer = ComponentSpec(
+                type="action_chunk_trimmer",
+                n_action_steps=self.config.n_action_steps,
             )
+            postproc_specs.append(chunk_trimmer)
+            torch_postproc_specs.append(chunk_trimmer)
 
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
@@ -689,6 +690,8 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             ],
             postprocessors_specs=postproc_specs,
         )
-        extra_args["torch"] = TorchExportParameters()
+        extra_args["torch"] = TorchExportParameters(
+            postprocessors_specs=torch_postproc_specs,
+        )
 
         return extra_args

--- a/library/tests/unit/export/test_mixin_export.py
+++ b/library/tests/unit/export/test_mixin_export.py
@@ -11,8 +11,14 @@ import onnx
 import pytest
 import torch
 
-from physicalai.export.backends import ExportParameters, ONNXExportParameters, OpenVINOExportParameters
+from physicalai.export.backends import (
+    ExportParameters,
+    ONNXExportParameters,
+    OpenVINOExportParameters,
+    TorchExportParameters,
+)
 from physicalai.export.mixin_policy import ExportablePolicyMixin, ExportBackend
+from physicalai.inference.manifest import ComponentSpec, Manifest
 
 
 # Test configurations
@@ -553,3 +559,63 @@ class TestToExecutorch:
         with patch.object(wrapper, "to_executorch") as mock_to_executorch:
             wrapper.export(backend=ExportBackend.EXECUTORCH, output_path=tmp_path / "model.pte")
             mock_to_executorch.assert_called_once()
+
+
+class TorchExportWrapper(ExportablePolicyMixin):
+    """Policy-like wrapper that emulates chunk-aware torch export.
+
+    Mirrors how real policies build :class:`TorchExportParameters` based on
+    ``chunk_size`` vs ``n_action_steps``, appending an ``action_chunk_trimmer``
+    postprocessor when the two differ.
+    """
+
+    def __init__(self, model: torch.nn.Module, chunk_size: int, n_action_steps: int):
+        self.model = model
+        self._preprocessor = IdentityPreprocessor()
+        self.chunk_size = chunk_size
+        self.n_action_steps = n_action_steps
+
+    @property
+    def extra_export_args(self) -> dict[str, ExportParameters]:
+        postproc_specs: list[ComponentSpec] = []
+        if self.chunk_size != self.n_action_steps:
+            postproc_specs.append(
+                ComponentSpec(
+                    type="action_chunk_trimmer",
+                    n_action_steps=self.n_action_steps,
+                ),
+            )
+        return {ExportBackend.TORCH: TorchExportParameters(postprocessors_specs=postproc_specs)}
+
+    @staticmethod
+    def get_supported_export_backends() -> list[str | ExportBackend]:
+        return [ExportBackend.TORCH]
+
+
+class TestToTorch:
+    """Tests for to_torch method."""
+
+    def test_to_torch_adds_action_chunk_trimmer_when_chunk_differs(self, tmp_path):
+        """Trimmer postprocessor is recorded when chunk_size != n_action_steps."""
+        model = ModelWithSampleInput(input_dim=10, output_dim=5)
+        wrapper = TorchExportWrapper(model, chunk_size=10, n_action_steps=5)
+
+        wrapper.to_torch(tmp_path)
+
+        manifest = Manifest.load(tmp_path / "manifest.json")
+        postproc_types = [spec.type for spec in manifest.model.postprocessors]
+        assert "action_chunk_trimmer" in postproc_types
+
+        trimmer = next(spec for spec in manifest.model.postprocessors if spec.type == "action_chunk_trimmer")
+        assert trimmer.model_dump()["n_action_steps"] == 5
+
+    def test_to_torch_no_trimmer_when_chunk_matches(self, tmp_path):
+        """No trimmer is added when chunk_size equals n_action_steps."""
+        model = ModelWithSampleInput(input_dim=10, output_dim=5)
+        wrapper = TorchExportWrapper(model, chunk_size=5, n_action_steps=5)
+
+        wrapper.to_torch(tmp_path)
+
+        manifest = Manifest.load(tmp_path / "manifest.json")
+        postproc_types = [spec.type for spec in manifest.model.postprocessors]
+        assert "action_chunk_trimmer" not in postproc_types

--- a/library/tests/unit/inference/test_adapters.py
+++ b/library/tests/unit/inference/test_adapters.py
@@ -41,7 +41,7 @@ class TestTorchAdapter:
     """Test Torch inference adapter."""
 
     @staticmethod
-    def _write_policy_metadata(tmp_path: Path) -> Path:
+    def _write_policy_manifest(tmp_path: Path) -> Path:
         model_path = tmp_path / "model.pt"
         manifest_path = tmp_path / "manifest.json"
         model_path.touch()
@@ -59,7 +59,7 @@ class TestTorchAdapter:
 
     def test_lifecycle(self, tmp_path: Path) -> None:
         """Test complete adapter lifecycle: init, load, predict with numpy inputs."""
-        model_path = self._write_policy_metadata(tmp_path)
+        model_path = self._write_policy_manifest(tmp_path)
 
         mock_model = MagicMock()
         # Policy forward returns a tensor (action output)
@@ -90,7 +90,7 @@ class TestTorchAdapter:
 
     def test_predict_with_nested_images(self, tmp_path: Path) -> None:
         """Test predict with multi-camera images (dict of numpy arrays)."""
-        model_path = self._write_policy_metadata(tmp_path)
+        model_path = self._write_policy_manifest(tmp_path)
 
         mock_model = MagicMock()
         mock_model.return_value = torch.tensor([[0.1, 0.2]])
@@ -116,7 +116,7 @@ class TestTorchAdapter:
 
     def test_load_with_missing_sample_input_keeps_empty_input_names(self, tmp_path: Path) -> None:
         """Test missing sample_input still keeps empty input_names for torch adapter."""
-        model_path = self._write_policy_metadata(tmp_path)
+        model_path = self._write_policy_manifest(tmp_path)
 
         mock_model = MagicMock()
         mock_model.return_value = torch.tensor([[0.1, 0.2]])
@@ -159,7 +159,7 @@ class TestTorchAdapter:
 
     def test_load_failure(self, tmp_path: Path) -> None:
         """Test error handling when torch.load fails."""
-        model_path = self._write_policy_metadata(tmp_path)
+        model_path = self._write_policy_manifest(tmp_path)
 
         with patch("physicalai.policies.act.ACT.load_from_checkpoint", side_effect=RuntimeError("Load error")):
             adapter = TorchAdapter()

--- a/library/tests/unit/inference/test_adapters.py
+++ b/library/tests/unit/inference/test_adapters.py
@@ -10,6 +10,7 @@ Tests for the core ``onnx`` and ``openvino`` adapters live in
 ``physicalai/tests/unit/inference/test_adapters.py``.
 """
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -42,10 +43,18 @@ class TestTorchAdapter:
     @staticmethod
     def _write_policy_metadata(tmp_path: Path) -> Path:
         model_path = tmp_path / "model.pt"
-        metadata_path = tmp_path / "metadata.yaml"
+        manifest_path = tmp_path / "manifest.json"
         model_path.touch()
-        with metadata_path.open("w") as f:
-            f.write("policy_class: physicalai.policies.act.ACT\n")
+        manifest = {
+            "format": "policy_package",
+            "version": "1.0",
+            "policy": {
+                "name": "act",
+                "source": {"class_path": "physicalai.policies.act.ACT"},
+            },
+        }
+        with manifest_path.open("w") as f:
+            json.dump(manifest, f)
         return model_path
 
     def test_lifecycle(self, tmp_path: Path) -> None:

--- a/library/tests/unit/policies/test_action_queue.py
+++ b/library/tests/unit/policies/test_action_queue.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2025-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for action chunking queue behavior in base Policy.
+
+Regression test for commit 663c2f16: ``_queue_actions`` must truncate the
+predicted chunk to ``n_action_steps`` before extending the queue. Otherwise the
+bounded ``deque(maxlen=n_action_steps)`` silently drops the first items.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from physicalai.data.observation import Observation
+from physicalai.policies.base.policy import Policy
+
+
+class _ChunkPolicy(Policy):
+    """Concrete Policy returning a fixed action chunk for testing."""
+
+    def __init__(self, chunk: torch.Tensor, n_action_steps: int) -> None:
+        super().__init__(n_action_steps=n_action_steps)
+        self._chunk = chunk
+        self.predict_calls = 0
+
+    def forward(self, batch: Observation) -> torch.Tensor:  # pragma: no cover - unused
+        return self.predict_action_chunk(batch)
+
+    def predict_action_chunk(self, batch: Observation) -> torch.Tensor:
+        self.predict_calls += 1
+        return self._chunk
+
+
+def _dummy_batch() -> Observation:
+    return Observation(state=torch.zeros(1, 1))
+
+
+class TestQueueActions:
+    """Regression tests for Policy._queue_actions / select_action."""
+
+    def test_select_action_returns_first_chunk_item_unbatched(self) -> None:
+        """First select_action call must return action at index 0, not 1.
+
+        With chunk_size=8 and n_action_steps=4, before the fix the unbounded
+        ``extend`` overflowed the deque and dropped indices [0..3], so the
+        first action returned was index 4.
+        """
+        chunk = torch.arange(8, dtype=torch.float32).unsqueeze(-1)  # (T=8, D=1)
+        policy = _ChunkPolicy(chunk=chunk, n_action_steps=4)
+
+        first = policy.select_action(_dummy_batch())
+        assert torch.equal(first, chunk[0])
+
+    def test_select_action_returns_first_chunk_item_batched(self) -> None:
+        """Same regression check for (B, T, D) shaped chunks."""
+        # (B=2, T=8, D=1): values along T are 0..7 so we can identify the index.
+        t = torch.arange(8, dtype=torch.float32).unsqueeze(-1)
+        chunk = torch.stack([t, t + 100.0], dim=0)  # (2, 8, 1)
+        policy = _ChunkPolicy(chunk=chunk, n_action_steps=4)
+
+        first = policy.select_action(_dummy_batch())
+        # First call should be t=0 across the batch.
+        assert torch.equal(first, chunk[:, 0])
+
+    def test_select_action_consumes_n_steps_then_repredicts(self) -> None:
+        """Queue should yield exactly n_action_steps items before a new predict."""
+        chunk = torch.arange(8, dtype=torch.float32).unsqueeze(-1)
+        n = 4
+        policy = _ChunkPolicy(chunk=chunk, n_action_steps=n)
+
+        for i in range(n):
+            action = policy.select_action(_dummy_batch())
+            assert torch.equal(action, chunk[i]), f"step {i}"
+        assert policy.predict_calls == 1
+
+        # n+1-th call should trigger a new prediction.
+        action = policy.select_action(_dummy_batch())
+        assert policy.predict_calls == 2
+        assert torch.equal(action, chunk[0])
+
+    def test_reset_clears_queue(self) -> None:
+        chunk = torch.arange(8, dtype=torch.float32).unsqueeze(-1)
+        policy = _ChunkPolicy(chunk=chunk, n_action_steps=4)
+
+        policy.select_action(_dummy_batch())
+        assert len(policy._action_queue) == 3
+
+        policy.reset()
+        assert len(policy._action_queue) == 0


### PR DESCRIPTION
# Pull Request

## Description

The PR fixes overall behavior of `select_action` in case if chunk truncation is specified in policy configs.
- base policy doesn't drop the beginning of the chunk when it doesn't fit into action queue
- first-party policies add chunk trimmer to the manifest to allow `InferenceModel` manage trimming on it's end, as it's done for other inference backends

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] 🐞 `fix` - Bug fix


