### PR TITLE
fix: Fix log source discovery and streaming for long-running jobs

### DIFF
--- a/application/backend/src/services/log_service.py
+++ b/application/backend/src/services/log_service.py
@@ -149,6 +149,23 @@ class LogService:
 
         return sources
 
+    def _get_all_job_log_paths(self, primary_path: Path) -> list[Path]:
+        """Return all log files for a job, including rotated files, sorted chronologically.
+
+        Given a primary path like `jobs/<uuid>.log`, finds all matching files
+        (e.g. `<uuid>.2026-05-20_17-21-37_551390.log`) and returns them sorted
+        with rotated (older) files first, then the primary (active) file last.
+        """
+        jobs_dir = primary_path.parent
+        job_id = primary_path.stem
+        if not jobs_dir.is_dir():
+            return [primary_path]
+
+        # Find rotated files: <uuid>.<timestamp>.log (sorted alphabetically = chronologically)
+        rotated = sorted(jobs_dir.glob(f"{job_id}.*.log"))
+        # Primary file is the active one, append last
+        return [*rotated, primary_path]
+
     async def source_exists(self, path: Path) -> bool:
         """Check whether a source path exists on disk and is non-empty."""
         source_path = anyio.Path(path)
@@ -157,9 +174,26 @@ class LogService:
         return (await source_path.stat()).st_size > 0
 
     async def tail_log_file(self, path: Path) -> AsyncGenerator[ServerSentEvent]:
-        """Async generator that live-tails a log file and yields SSE events."""
+        """Async generator that streams log file contents and yields SSE events.
+
+        For job logs, streams all rotated files first (in chronological order),
+        then live-tails the active log file.
+        """
+        # Determine all files to stream (for jobs this includes rotated logs)
+        is_job_log = path.parent.name == "jobs"
+        paths = self._get_all_job_log_paths(path) if is_job_log else [path]
+
         try:
-            async with await anyio.open_file(path, encoding="utf-8") as f:
+            # Stream completed (rotated) files fully
+            for log_path in paths[:-1]:
+                if log_path.exists():
+                    async with await anyio.open_file(log_path, encoding="utf-8") as f:
+                        async for line in f:
+                            yield ServerSentEvent(data=line.rstrip())
+
+            # Live-tail the active file
+            active_path = paths[-1]
+            async with await anyio.open_file(active_path, encoding="utf-8") as f:
                 while True:
                     line = await f.readline()
                     if not line:

--- a/application/backend/src/services/log_service.py
+++ b/application/backend/src/services/log_service.py
@@ -118,7 +118,8 @@ class LogService:
         if not jobs_dir.is_dir():
             return sources
 
-        job_log_paths = sorted(jobs_dir.glob("*.log"))
+        # Match only <uuid>.log files (36-char UUID stem), excluding rotated <uuid>.<timestamp>.log
+        job_log_paths = sorted(p for p in jobs_dir.glob("*.log") if len(p.stem) == 36)
         job_ids = [file_path.stem for file_path in job_log_paths]
         source_name_map = await self._get_job_source_name_map(job_ids)
 

--- a/application/backend/tests/services/test_log_service.py
+++ b/application/backend/tests/services/test_log_service.py
@@ -70,6 +70,42 @@ async def test_discover_job_sources_includes_training_name_and_created_at(tmp_pa
 
 
 @pytest.mark.anyio
+async def test_discover_job_sources_ignores_rotated_job_logs(tmp_path) -> None:
+    """Rotated logs should not appear as separate sources."""
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir(parents=True)
+
+    job_id = uuid4()
+    (jobs_dir / f"{job_id}.log").write_text("latest")
+    (jobs_dir / f"{job_id}.2026-05-20_17-21-37_551390.log").write_text("rotated")
+
+    job = TrainJob(
+        id=job_id,
+        project_id=uuid4(),
+        payload={
+            "type": "training",
+            "project_id": str(uuid4()),
+            "dataset_id": str(uuid4()),
+            "policy": "pi0",
+            "model_name": "Long Job",
+            "max_steps": 100,
+            "batch_size": 8,
+            "base_model_id": None,
+        },
+        created_at=datetime.now(tz=UTC),
+    )
+
+    service = _build_service(tmp_path, jobs=[job])
+
+    sources = await service.get_log_sources()
+    job_sources = [source for source in sources if source.type == "job"]
+
+    assert len(job_sources) == 1
+    assert job_sources[0].id == f"job-{job_id}"
+    assert job_sources[0].name == "Long Job (pi0)"
+
+
+@pytest.mark.anyio
 async def test_discover_job_sources_uses_staging_id_when_no_manifest(tmp_path) -> None:
     """New payload with archive_staging_id only -> display name derived from first 8 chars of staging id."""
     jobs_dir = tmp_path / "jobs"

--- a/application/backend/tests/services/test_log_service.py
+++ b/application/backend/tests/services/test_log_service.py
@@ -105,6 +105,26 @@ async def test_discover_job_sources_ignores_rotated_job_logs(tmp_path) -> None:
     assert job_sources[0].name == "Long Job (pi0)"
 
 
+def test_get_all_job_log_paths_returns_rotated_then_active(tmp_path) -> None:
+    """Rotated logs should be returned before the active log for streaming."""
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir(parents=True)
+
+    job_id = uuid4()
+    active = jobs_dir / f"{job_id}.log"
+    rotated1 = jobs_dir / f"{job_id}.2026-05-18_10-00-00_000000.log"
+    rotated2 = jobs_dir / f"{job_id}.2026-05-19_12-00-00_000000.log"
+
+    for f in [active, rotated1, rotated2]:
+        f.write_text("content")
+
+    service = _build_service(tmp_path)
+    paths = service._get_all_job_log_paths(active)
+
+    # Rotated files first (sorted chronologically), then active
+    assert paths == [rotated1, rotated2, active]
+
+
 @pytest.mark.anyio
 async def test_discover_job_sources_uses_staging_id_when_no_manifest(tmp_path) -> None:
     """New payload with archive_staging_id only -> display name derived from first 8 chars of staging id."""


### PR DESCRIPTION
Long-running training jobs that produce large logs trigger loguru's automatic rotation, creating timestamped backup files (e.g. `<uuid>.2026-05-20_17-21-37.log`) alongside the active log file (`<uuid>.log`).
Bug: The `/api/logs/sources endpoint` would fail with a `ValueError` when rotated log files existed, because it tried to parse the full filename stem (including the timestamp suffix) as a UUID.

Fix:
1. Source discovery now filters to only `<uuid>.log` files, so each job appears once in the sources list
2. Log streaming now includes all rotated files for a job, streaming them in chronological order before live-tailing the active log file

This ensures users can view the complete log history for long-running jobs without the API crashing.

## Type of Change

- [x] 🐞 `fix` - Bug fix