### PR TITLE
fix: gh-618 make sure all required directories exist

### DIFF
--- a/application/backend/src/db/migration.py
+++ b/application/backend/src/db/migration.py
@@ -23,10 +23,14 @@ class MigrationManager:
         self.__ensure_data_directory()
 
     def __ensure_data_directory(self) -> None:
-        """Ensure the data directory exists"""
+        """Ensure all required storage directories exist"""
         self.settings.data_dir.mkdir(parents=True, exist_ok=True)
-        if hasattr(self.settings, "models_dir"):
-            self.settings.models_dir.mkdir(parents=True, exist_ok=True)
+        self.settings.models_dir.mkdir(parents=True, exist_ok=True)
+        self.settings.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.settings.snapshot_dir.mkdir(parents=True, exist_ok=True)
+        self.settings.datasets_dir.mkdir(parents=True, exist_ok=True)
+        self.settings.robots_dir.mkdir(parents=True, exist_ok=True)
+        self.settings.log_dir.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
     def check_connection() -> bool:

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -181,8 +181,8 @@ class TrainingWorker(BaseProcessWorker):
             dispatcher.start()
             trainer.fit(model=policy, datamodule=l_dm)
 
-            moved = shutil.move(cache_path, path.parent)
-            Path(moved).rename(path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(cache_path, path)
 
             export_policy = policy
             if payload.compile_model and model.policy in ["act", "smolvla"]:


### PR DESCRIPTION
Bug: When saving a trained model, the code used shutil.move() to move
the cache directory to path.parent (models/), then renamed it to the
final path. However, shutil.move() behaves differently depending on
whether the destination exists:
- If destination exists: moves source INTO destination, returns new path
- If destination doesn't exist: renames source TO destination, returns destination

On the first training run, models/ directory doesn't exist, so
shutil.move(cache_path, path.parent) would rename cache_path directly
to models/ and return 'models/'. The subsequent rename() then tried to
move models/ into models/<uuid>, which fails with 'Invalid argument'
(EINVAL) since a directory cannot be moved into itself.

Fix: Ensure the parent directory exists before moving, then move the
cache directory directly to its final destination path in one step.
This eliminates the intermediate rename and handles both first-run and
subsequent-run cases correctly.

## Type of Change

- [x] 🐞 `fix` - Bug fix
