### PR TITLE
chore: make openvino the default selected inference backend when available

### DIFF
--- a/application/backend/src/api/dataset.py
+++ b/application/backend/src/api/dataset.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from typing import Annotated
 from uuid import UUID
@@ -147,7 +148,7 @@ async def dataset_download_endpoint(
     if not dataset_path.exists() or not dataset_path.is_dir():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dataset path not found.")
 
-    archive_path = dataset_download_service.create_dataset_archive(dataset_path)
+    archive_path = await asyncio.to_thread(dataset_download_service.create_dataset_archive, dataset_path)
     filename = f"{safe_archive_name(dataset.name, fallback='dataset')}.zip"
     return FileResponse(
         archive_path,

--- a/application/backend/src/api/models.py
+++ b/application/backend/src/api/models.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from typing import Annotated
 from uuid import UUID
@@ -66,7 +67,11 @@ async def model_download_endpoint(
     if not model_path.exists() or not model_path.is_dir():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Model path not found.")
 
-    archive_path = model_download_service.create_model_archive(model_path, include_snapshot=include_snapshot)
+    archive_path = await asyncio.to_thread(
+        model_download_service.create_model_archive,
+        model_path,
+        include_snapshot=include_snapshot,
+    )
     filename = f"{safe_archive_name(model.name, fallback='model')}.zip"
     return FileResponse(
         archive_path,

--- a/application/backend/src/services/dataset_download_service.py
+++ b/application/backend/src/services/dataset_download_service.py
@@ -12,7 +12,7 @@ class DatasetDownloadService:
 
         temporary_archive_path = Path(tempfile.gettempdir()) / f"dataset-{uuid4()}.zip"
 
-        with zipfile.ZipFile(temporary_archive_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        with zipfile.ZipFile(temporary_archive_path, mode="w", compression=zipfile.ZIP_STORED) as archive:
             for path in dataset_path.rglob("*"):
                 if path.is_file():
                     archive.write(path, arcname=path.relative_to(dataset_path))

--- a/application/backend/src/services/model_download_service.py
+++ b/application/backend/src/services/model_download_service.py
@@ -30,7 +30,7 @@ class ModelDownloadService:
 
         temporary_archive_path = Path(tempfile.gettempdir()) / f"model-{uuid4()}.zip"
 
-        with zipfile.ZipFile(temporary_archive_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        with zipfile.ZipFile(temporary_archive_path, mode="w", compression=zipfile.ZIP_STORED) as archive:
             for path in model_path.rglob("*"):
                 if not path.is_file():
                     continue

--- a/application/ui/src/features/models/backend-selection.tsx
+++ b/application/ui/src/features/models/backend-selection.tsx
@@ -1,45 +1,11 @@
-import { ReactNode } from 'react';
-
 import { Divider, Flex, Heading, Radio, RadioGroup, Text, View } from '@geti-ui/ui';
 import { Label } from 'react-aria-components';
 
 import { $api } from '../../api/client';
 import { SchemaModel } from '../../api/openapi-spec';
-import { ReactComponent as ExecuTorchLogo } from './../../assets/logos/executorch-logo-small.svg';
-import { ReactComponent as ONNXLogo } from './../../assets/logos/onnx-logo-small.svg';
-import { ReactComponent as OpenVINOLogo } from './../../assets/logos/OpenVINO-small.svg';
-import { ReactComponent as TorchLogo } from './../../assets/logos/pytorch-logo-small.svg';
+import { INFERENCE_BACKENDS } from './inference-backends';
 
 export const defaultBackend = 'openvino';
-
-interface BackendConfig {
-    label: string;
-    description: string;
-    logo: ReactNode;
-}
-
-const backendConfigs: Record<string, BackendConfig> = {
-    torch: {
-        label: 'Torch',
-        description: 'Run inference using PyTorch framework.',
-        logo: <TorchLogo height={'50px'} />,
-    },
-    openvino: {
-        label: 'OpenVINO',
-        description: 'Run inference using OpenVINO.',
-        logo: <OpenVINOLogo height={'50px'} />,
-    },
-    onnx: {
-        label: 'ONNX',
-        description: 'Run inference using the ONNX Runtime.',
-        logo: <ONNXLogo height={'50px'} />,
-    },
-    executorch: {
-        label: 'ExecuTorch',
-        description: 'Run inference on edge devices using ExecuTorch.',
-        logo: <ExecuTorchLogo height={'50px'} />,
-    },
-};
 
 interface BackendProps {
     id: string;
@@ -47,7 +13,8 @@ interface BackendProps {
     isDisabled?: boolean;
 }
 const Backend = ({ id, isSelected = false, isDisabled = false }: BackendProps) => {
-    const config = backendConfigs[id];
+    const backend = INFERENCE_BACKENDS[id];
+
     return (
         <Label htmlFor={id}>
             <View
@@ -65,17 +32,19 @@ const Backend = ({ id, isSelected = false, isDisabled = false }: BackendProps) =
 
                     <Divider orientation='vertical' size='S' />
                     <Flex height='100%' alignItems='center' justifyContent={'center'} width='size-1000'>
-                        <View padding='size-100'>{config.logo}</View>
+                        <View padding='size-100'>
+                            <backend.logo height={'50px'} />
+                        </View>
                     </Flex>
                     <View>
-                        <Heading level={4}>{config.label}</Heading>
+                        <Heading level={4}>{backend.label}</Heading>
                         <Text
                             UNSAFE_style={{
                                 fontSize: '12px',
                                 color: 'var(--spectrum-global-color-gray-700)',
                             }}
                         >
-                            {config.description}
+                            {backend.description}
                         </Text>
                     </View>
                 </Flex>

--- a/application/ui/src/features/models/backend-selection.tsx
+++ b/application/ui/src/features/models/backend-selection.tsx
@@ -10,7 +10,7 @@ import { ReactComponent as ONNXLogo } from './../../assets/logos/onnx-logo-small
 import { ReactComponent as OpenVINOLogo } from './../../assets/logos/OpenVINO-small.svg';
 import { ReactComponent as TorchLogo } from './../../assets/logos/pytorch-logo-small.svg';
 
-export const defaultBackend = 'torch';
+export const defaultBackend = 'openvino';
 
 interface BackendConfig {
     label: string;

--- a/application/ui/src/features/models/inference-backends.ts
+++ b/application/ui/src/features/models/inference-backends.ts
@@ -1,0 +1,40 @@
+import { type FunctionComponent, type SVGProps } from 'react';
+
+import { ReactComponent as ExecuTorchLogo } from './../../assets/logos/executorch-logo-small.svg';
+import { ReactComponent as ONNXLogo } from './../../assets/logos/onnx-logo-small.svg';
+import { ReactComponent as OpenVINOLogo } from './../../assets/logos/OpenVINO-small.svg';
+import { ReactComponent as TorchLogo } from './../../assets/logos/pytorch-logo-small.svg';
+
+export interface InferenceBackendConfig {
+    type: string;
+    label: string;
+    description: string;
+    logo: FunctionComponent<SVGProps<SVGSVGElement>>;
+}
+
+export const INFERENCE_BACKENDS: Record<string, InferenceBackendConfig> = {
+    torch: {
+        type: 'torch',
+        label: 'PyTorch',
+        description: 'Run inference using PyTorch framework.',
+        logo: TorchLogo,
+    },
+    openvino: {
+        type: 'openvino',
+        label: 'OpenVINO',
+        description: 'Run inference using OpenVINO.',
+        logo: OpenVINOLogo,
+    },
+    onnx: {
+        type: 'onnx',
+        label: 'ONNX',
+        description: 'Run inference using the ONNX Runtime.',
+        logo: ONNXLogo,
+    },
+    executorch: {
+        type: 'executorch',
+        label: 'ExecuTorch',
+        description: 'Run inference on edge devices using ExecuTorch.',
+        logo: ExecuTorchLogo,
+    },
+};

--- a/application/ui/src/routes/models/model-row-content.component.tsx
+++ b/application/ui/src/routes/models/model-row-content.component.tsx
@@ -1,9 +1,19 @@
-import { Heading, Item, TabList, TabPanels, Tabs, View } from '@geti-ui/ui';
+import { Heading, IllustratedMessage, Item, TabList, TabPanels, Tabs, View } from '@geti-ui/ui';
 
 import { SchemaModel } from '../../api/openapi-spec';
+import { ReactComponent as EmptyIllustration } from './../../assets/illustration.svg';
 import { MetricsContent } from './metrics';
 
 import classes from './model-row-content.module.scss';
+
+const ComingSoon = () => {
+    return (
+        <IllustratedMessage marginY='size-400'>
+            <EmptyIllustration height='250px' />
+            <Heading>Coming soon</Heading>
+        </IllustratedMessage>
+    );
+};
 
 interface ModelRowContentProps {
     model: SchemaModel;
@@ -23,10 +33,10 @@ export const ModelRowContent = ({ model }: ModelRowContentProps) => {
                         <MetricsContent modelId={model.id!} />
                     </Item>
                     <Item key='datasets'>
-                        <Heading>Coming soon</Heading>
+                        <ComingSoon />
                     </Item>
                     <Item key='export'>
-                        <Heading>Coming soon</Heading>
+                        <ComingSoon />
                     </Item>
                 </TabPanels>
             </Tabs>

--- a/application/ui/src/routes/models/start-model-modal.component.tsx
+++ b/application/ui/src/routes/models/start-model-modal.component.tsx
@@ -7,13 +7,21 @@ import { SchemaModel } from '../../api/openapi-spec';
 import { BackendSelection, defaultBackend } from '../../features/models/backend-selection';
 import { paths } from '../../router';
 
+const getDefaultbackend = (model: SchemaModel) => {
+    if (model.available_backends.includes(defaultBackend)) {
+        return defaultBackend;
+    }
+
+    return model.available_backends.at(0) ?? defaultBackend;
+};
+
 interface StartInferenceDialogProps {
     close: () => void;
     model: SchemaModel;
 }
 
 export const StartInferenceDialog = ({ close, model }: StartInferenceDialogProps) => {
-    const [backend, setBackend] = useState<string>(defaultBackend);
+    const [backend, setBackend] = useState<string>(getDefaultbackend(model));
 
     const navigate = useNavigate();
     const onStart = () => {


### PR DESCRIPTION
This PR contains a few minor refactors that I made while preparing a PR for displaying model exports in the models screen.
- UI: If available make OpenVINO the default selected inference runtime, otherwise select the first available backend
- UI: Extract `backendConfigs` into a separate file (to be reused by model exports table)
- UI: Add a "Coming soon" illustration instead of empty heading placeholder
- backend: don't compress archives when downloading datasets or models (results in faster downloads, since we deal with binary data we can expect that compression won't be very effective)
- backend: offload archiving to event loop. Before when downloading a model or dataset this would make the server unresponsive until archiving was completed, this should fix that

## Type of Change

- [x] ♻️ `refactor` - Code refactoring
- [x] 🔧 `chore` - Maintenance


## Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6264310c-a1b8-4379-837f-d5e88679b2c3" />
