### PR TITLE
refactor: add custom DockView theme with Spectrum integration

### DIFF
--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -18,7 +18,7 @@
                 "@tanstack/react-query": "^5.80.10",
                 "@types/three": "^0.180.0",
                 "clsx": "^2.1.1",
-                "dockview-react": "^4.13.1",
+                "dockview-react": "^6.3.0",
                 "lodash-es": "^4.17.21",
                 "openapi-fetch": "^0.17.0",
                 "openapi-react-query": "^0.5.4",
@@ -43,7 +43,7 @@
                 "@ianvs/prettier-plugin-sort-imports": "^4.4.2",
                 "@msw/playwright": "^0.4.5",
                 "@mswjs/source": "^0.5.0",
-                "@playwright/test": "^1.57.0",
+                "@playwright/test": "^1.60.0",
                 "@rsbuild/core": "^1.3.14",
                 "@rsbuild/plugin-react": "^1.3.0",
                 "@rsbuild/plugin-sass": "^1.3.1",
@@ -9380,30 +9380,30 @@
             }
         },
         "node_modules/dockview": {
-            "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/dockview/-/dockview-4.13.1.tgz",
-            "integrity": "sha512-K8xnYt3Rvkx8MYKHaEsb8aFaPyQclKRRkXS9JcpQPZUgqxumTLnSidgdd6uIfzEps6yJsXoZGQGJ9PtcaKyDcQ==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/dockview/-/dockview-6.3.0.tgz",
+            "integrity": "sha512-8HtpQZFeFQSAs8XmSlLnmbbTyZZqpUK0QMMVrUSz/vLp6Vm19C23zZYZaVQPtCSaPhUXos0DHm36hEOKIFYtRw==",
             "license": "MIT",
             "dependencies": {
-                "dockview-core": "^4.13.1"
+                "dockview-core": "^6.3.0"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/dockview-core": {
-            "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/dockview-core/-/dockview-core-4.13.1.tgz",
-            "integrity": "sha512-+7vR0ZEoL8CNck6NqDVUMqBT22niwBu5CMMI137dZ3c8NDc7c5Si+3dGEqQgM4lNtHBLAtvypo1C4p21J2wkiQ==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/dockview-core/-/dockview-core-6.3.0.tgz",
+            "integrity": "sha512-KY4goMIcVrMh+LDtU+bwANkwK8FRxRUS6EKD/QH1OPNcj8wq0MjGKes5PojM4N0/1NxAsI4Bem/TFV4jiiOKGg==",
             "license": "MIT"
         },
         "node_modules/dockview-react": {
-            "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/dockview-react/-/dockview-react-4.13.1.tgz",
-            "integrity": "sha512-xnK0mUq+gzME/QyzM5nn+SsQO26AA2qZlCuqi1KX7wux52KIUSMraQHN5AY9Qm2qCVb/NHhCZoZNSysb/GS79A==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/dockview-react/-/dockview-react-6.3.0.tgz",
+            "integrity": "sha512-50u6Bd1WaH5ubsgArFC+Xe386WD3kY7ujSTkENGZt5AmrcK8l8pfzJrUyj0etd7iKHyNnSYsVCe0CyAISKnaGA==",
             "license": "MIT",
             "dependencies": {
-                "dockview": "^4.13.1"
+                "dockview": "^6.3.0"
             }
         },
         "node_modules/doctrine": {

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -36,7 +36,7 @@
         "@tanstack/react-query": "^5.80.10",
         "@types/three": "^0.180.0",
         "clsx": "^2.1.1",
-        "dockview-react": "^4.13.1",
+        "dockview-react": "^6.3.0",
         "lodash-es": "^4.17.21",
         "openapi-fetch": "^0.17.0",
         "openapi-react-query": "^0.5.4",

--- a/application/ui/src/features/datasets/episodes/episode-dock-view.tsx
+++ b/application/ui/src/features/datasets/episodes/episode-dock-view.tsx
@@ -15,6 +15,7 @@ import {
     SchemaEpisode,
     SchemaEpisodeVideo,
 } from '../../../api/openapi-spec';
+import { physicalAiTheme } from '../../dockview';
 import { EpisodeVideoCell } from './episode-video-cell.component';
 import { RobotCell } from './robot-cell.component';
 
@@ -121,7 +122,7 @@ export const EpisodeDockView = ({ episode, dataset, environment }: EpisodeViewer
         <View flex>
             <View backgroundColor={'gray-200'} height={'100%'} maxHeight='100vh' position={'relative'}>
                 <Suspense fallback={<CenteredLoading />}>
-                    <DockviewReact onReady={onReady} components={components} />
+                    <DockviewReact onReady={onReady} components={components} theme={physicalAiTheme} />
                 </Suspense>
             </View>
         </View>

--- a/application/ui/src/features/dockview/index.ts
+++ b/application/ui/src/features/dockview/index.ts
@@ -1,0 +1,2 @@
+export { physicalAiTheme } from './theme';
+export { default as themeStyles } from './theme.module.scss';

--- a/application/ui/src/features/dockview/theme.module.scss
+++ b/application/ui/src/features/dockview/theme.module.scss
@@ -1,0 +1,64 @@
+// Physical AI Studio - DockView Theme
+// Integrates DockView with our Spectrum-based design system
+// This theme provides a consistent, compact layout with grayscale styling
+
+.dockviewThemePhysicalAi {
+    border: 1px solid var(--spectrum-global-color-gray-300);
+
+    // === Layout & Spacing ===
+    --dv-border-radius: var(--spectrum-alias-border-radius-regular);
+    --dv-tab-margin: 0;
+    --dv-tabs-and-actions-container-height: 40px;
+    --dv-tabs-and-actions-container-font-size: 13px;
+    --dv-tab-font-size: inherit;
+
+    // === Background Colors ===
+    --dv-group-view-background-color: var(--spectrum-global-color-gray-50);
+    --dv-tabs-and-actions-container-background-color: var(--spectrum-global-color-gray-100);
+
+    // === Active Group - Visible Panel (Active Tab) ===
+    --dv-activegroup-visiblepanel-tab-background-color: var(--spectrum-global-color-gray-200);
+    --dv-activegroup-visiblepanel-tab-color: var(--spectrum-global-color-gray-900);
+
+    // === Active Group - Hidden Panel (Inactive Tabs in Active Group) ===
+    --dv-activegroup-hiddenpanel-tab-background-color: var(--spectrum-global-color-gray-100);
+    --dv-activegroup-hiddenpanel-tab-color: var(--spectrum-global-color-gray-600);
+
+    // === Inactive Group - Visible Panel (Active Tab in Inactive Group) ===
+    // Match the focused group's style so visible tabs are always prominent
+    --dv-inactivegroup-visiblepanel-tab-background-color: var(--spectrum-global-color-gray-200);
+    --dv-inactivegroup-visiblepanel-tab-color: var(--spectrum-global-color-gray-900);
+
+    // === Inactive Group - Hidden Panel (Inactive Tabs in Inactive Group) ===
+    --dv-inactivegroup-hiddenpanel-tab-background-color: var(--spectrum-global-color-gray-75);
+    --dv-inactivegroup-hiddenpanel-tab-color: var(--spectrum-global-color-gray-500);
+
+    // === Separators & Borders ===
+    --dv-tab-divider-color: var(--spectrum-global-color-gray-100);
+    --dv-separator-border: var(--spectrum-global-color-gray-300);
+    --dv-paneview-header-border-color: var(--spectrum-global-color-gray-400);
+
+    // === Sash (Resizable Splitters) ===
+    // Transparent by default, becomes visible on hover for better UX
+    --dv-sash-color: transparent;
+    --dv-active-sash-color: var(--spectrum-global-color-gray-400);
+    --dv-active-sash-transition-duration: 0.15s;
+    --dv-active-sash-transition-delay: 0.3s;
+
+    // === Drag & Drop ===
+    // Uses energy-blue tint to indicate valid drop zones
+    --dv-drag-over-background-color: rgba(0, 199, 253, 0.15);
+    --dv-drag-over-border-color: transparent;
+
+    // === Interactive Elements ===
+    --dv-icon-hover-background-color: var(--spectrum-global-color-gray-200);
+    --dv-paneview-active-outline-color: var(--energy-blue);
+
+    // === Scrollbar ===
+    --dv-scrollbar-background-color: rgba(255, 255, 255, 0.15);
+    --dv-tabs-container-scrollbar-color: var(--spectrum-global-color-gray-500);
+
+    // === Effects ===
+    --dv-floating-box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3), 0 4px 8px rgba(0, 0, 0, 0.2);
+    --dv-overlay-z-index: 999;
+}

--- a/application/ui/src/features/dockview/theme.ts
+++ b/application/ui/src/features/dockview/theme.ts
@@ -1,0 +1,48 @@
+import type { DockviewTheme } from 'dockview-react';
+
+import styles from './theme.module.scss';
+
+/**
+ * Physical AI Studio custom DockView theme
+ *
+ * This theme integrates DockView with our Spectrum-based design system,
+ * providing a consistent dark theme with compact layout and smooth interactions.
+ *
+ * Key features:
+ * - Grayscale color palette using Spectrum CSS variables
+ * - Rounded corners matching app-wide border radius
+ * - Smooth tab animations for better UX
+ * - Compact layout with no gaps between panels
+ * - Hover-visible sash/splitters for resizing
+ *
+ * To customize colors, edit theme.module.scss
+ */
+export const physicalAiTheme: DockviewTheme = {
+    name: 'physical-ai',
+    className: styles.dockviewThemePhysicalAi,
+    colorScheme: 'dark',
+
+    // Smooth tab animations when reordering
+    tabAnimation: 'smooth',
+
+    // Line-style insertion indicator (clean, modern)
+    dndTabIndicator: 'line',
+
+    // No gap between panels (compact layout)
+    gap: 0,
+
+    // Match tab container height
+    edgeGroupCollapsedSize: 40,
+
+    // Accent color border on drop zones
+    dndOverlayBorder: '2px solid var(--energy-blue)',
+
+    // Simple tab group indicator (no wrap effect)
+    tabGroupIndicator: 'none',
+
+    // Overlay mounts to root for better z-index control
+    dndOverlayMounting: 'absolute',
+
+    // Drop overlay covers entire group (simpler UX)
+    dndPanelOverlay: 'group',
+};

--- a/application/ui/src/features/robots/environment-form/preview.tsx
+++ b/application/ui/src/features/robots/environment-form/preview.tsx
@@ -4,6 +4,7 @@ import { Content, Flex, Heading, IllustratedMessage, Loading, Text, View } from 
 import { DockviewApi, IDockviewPanelProps } from 'dockview';
 import { DockviewReact, DockviewReadyEvent, IDockviewReactProps } from 'dockview-react';
 
+import { physicalAiTheme } from '../../dockview';
 import { ReactComponent as RobotIllustration } from './../../../assets/illustrations/INTEL_08_NO-TESTS.svg';
 import { CameraCell } from './cells/camera-cell';
 import { RobotCell } from './cells/robot-cell';
@@ -131,7 +132,7 @@ const ActualPreview = () => {
         buildDockviewPanels(api.current, environment);
     }, [environment]);
 
-    return <DockviewReact onReady={onReady} components={components} />;
+    return <DockviewReact onReady={onReady} components={components} theme={physicalAiTheme} />;
 };
 
 const CenteredLoading = () => {

--- a/application/ui/src/features/robots/robot-control/robot-control-view.tsx
+++ b/application/ui/src/features/robots/robot-control/robot-control-view.tsx
@@ -10,6 +10,7 @@ import {
 } from 'dockview-react';
 
 import { SchemaEnvironmentWithRelations } from '../../../api/openapi-spec';
+import { physicalAiTheme } from '../../dockview';
 import { useRobotControl } from '../robot-control-provider';
 import { CameraCell } from './camera-cell.component';
 import { RobotCell } from './robot-cell.component';
@@ -111,7 +112,7 @@ export const RobotControlView = () => {
         <View flex>
             <View backgroundColor={'gray-200'} height={'100%'} maxHeight='100vh' position={'relative'}>
                 <Suspense fallback={<CenteredLoading />}>
-                    <DockviewReact onReady={onReady} components={components} />
+                    <DockviewReact onReady={onReady} components={components} theme={physicalAiTheme} />
                 </Suspense>
             </View>
         </View>


### PR DESCRIPTION
- Map DockView CSS variables to Spectrum design tokens
- Configure compact layout with rounded corners and smooth animations
- Add energy-blue accent for drag-and-drop indicators

## Type of Change

- [x] ♻️ `refactor` - Code refactoring

## Screenshots



| **Before** | **After** |
|------------|-----------|
| <img width="1905" height="1080" alt="image" src="https://github.com/user-attachments/assets/59e0509c-45c4-46fe-9c2f-fb9df31a61d1" />           |  <img width="1905" height="1080" alt="image" src="https://github.com/user-attachments/assets/6a5211ea-f273-4d75-a74e-de6c8e6a60fd" />         |
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/07c8926e-e1ed-48e5-97fa-69fa13ed58bb" />           | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d4413e26-9535-4ba4-8280-f18b2fa53bf2" />          |
|  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ad5f283f-6151-4424-9f2e-180ebb50c501" />          |   <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b1e75aaf-2d5b-401c-b789-77ad1edd878b" />        |











