### PR TITLE
chore: remove onnx and executorch from run options

### DIFF
--- a/application/ui/src/features/models/backend-selection.tsx
+++ b/application/ui/src/features/models/backend-selection.tsx
@@ -62,7 +62,8 @@ interface BackendSelectionProps {
 export const BackendSelection = ({ model, backend, setBackend }: BackendSelectionProps) => {
     const { data: policyBackends } = $api.useSuspenseQuery('get', '/api/policies/backends');
 
-    const backends: Array<string> = policyBackends[model.policy] ?? [];
+    const backends: Array<string> =
+        policyBackends[model.policy].filter((modelBackend) => ['openvino', 'torch'].includes(modelBackend)) ?? [];
 
     return (
         <RadioGroup value={backend} onChange={(value) => setBackend(value)} isEmphasized width='100%'>


### PR DESCRIPTION
So far we've only validated that torch and OpenVINO work.
We will remove these options to avoid any surprises and bug reports that we are not ready for yet.

We will keep showing this in the "model formats" tab (#627) so that users can download them, but we don't allow running the models until we've verified that it works end-to-end.

## Type of Change

- [x] 🔧 `chore` - Maintenance