### PR TITLE
fix: lower z-index of separator so it's not placed on top of dialogs

### DIFF
--- a/application/ui/src/features/dockview/theme.module.scss
+++ b/application/ui/src/features/dockview/theme.module.scss
@@ -62,3 +62,8 @@
     --dv-floating-box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3), 0 4px 8px rgba(0, 0, 0, 0.2);
     --dv-overlay-z-index: 999;
 }
+
+// Overwrite z-index of separator so that it doesn't get placed on top of dialogs
+:global(.dv-separator-border) :global(.dv-view:not(:first-child):before) {
+    z-index: 2 !important;
+}


### PR DESCRIPTION
Fixes the separator in dockview being placed on top of spectrum dialogs by lowering its z-index.

## Type of Change

- [x] 🐞 `fix` - Bug fix

## Screenshots

| **Before** | **After** |
|------------|-----------|
|   <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c8bcc10a-1876-41d8-8d0c-45e30a086b16" />         |   <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7f2f8bcd-efcd-44e2-be83-266ed46e406b" />        |




