### PR TITLE
feat: allow user to choose inference device

### DIFF
--- a/application/backend/src/api/record.py
+++ b/application/backend/src/api/record.py
@@ -16,7 +16,7 @@ from api.dependencies import (
 )
 from core.scheduler import Scheduler
 from robots.robot_client_factory import RobotClientFactory
-from schemas import Dataset, Model
+from schemas import Dataset, InferenceDevice, Model
 from schemas.environment import EnvironmentWithRelations
 from workers.robot_control_worker import RobotControlWorker
 
@@ -46,7 +46,10 @@ async def handle_incoming(
                     locked_camera_fingerprints.update(camera.fingerprint for camera in environment.cameras)
                     process.load_environment(environment)
                 case "load_model":
-                    process.load_model(Model.model_validate(payload["model"]), payload["backend"])
+                    process.load_model(
+                        Model.model_validate(payload["model"]),
+                        InferenceDevice.model_validate(payload["inference_device"]),
+                    )
                 case "load_dataset":
                     process.load_dataset(Dataset.model_validate(payload["dataset"]))
                 case "set_follower_source":

--- a/application/backend/src/api/system.py
+++ b/application/backend/src/api/system.py
@@ -8,10 +8,18 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 
 from api.dependencies import get_system_service
-from schemas.hardware import DeviceInfo
+from schemas.hardware import DeviceInfo, InferenceDeviceInfo
 from services.system_service import SystemService
 
 system_router = APIRouter(prefix="/api/system", tags=["System"])
+
+
+@system_router.get("/devices/inference")
+async def get_inference_devices(
+    system_service: Annotated[SystemService, Depends(get_system_service)],
+) -> list[InferenceDeviceInfo]:
+    """Returns the list of available inference devices for OpenVINO and Torch."""
+    return system_service.get_inference_devices()
 
 
 @system_router.get("/devices/training")

--- a/application/backend/src/models/utils.py
+++ b/application/backend/src/models/utils.py
@@ -7,8 +7,7 @@ from physicalai.inference import InferenceModel
 from physicalai.policies import ACT, Pi0, Pi05, SmolVLA
 from physicalai.policies.base import Policy
 
-from schemas import Model
-from utils.device import get_torch_device
+from schemas import InferenceDevice, Model
 
 
 def load_policy(model: Model, *, compile_model: bool = False) -> Policy:
@@ -33,14 +32,16 @@ def load_policy(model: Model, *, compile_model: bool = False) -> Policy:
     return policy
 
 
-def load_inference_model(model: Model, backend: str) -> InferenceModel:
+def load_inference_model(model: Model, inference_device: InferenceDevice) -> InferenceModel:
     """Loads inference model."""
-    inference_device = "auto"
-    if backend == "torch":
-        inference_device = get_torch_device()
-
+    backend = inference_device.backend.value
     export_dir = Path(model.path) / "exports" / backend
-    return InferenceModel(export_dir=export_dir, policy_name=model.policy, backend=backend, device=inference_device)
+    return InferenceModel(
+        export_dir=export_dir,
+        policy_name=model.policy,
+        backend=backend,
+        device=inference_device.device,
+    )
 
 
 def setup_policy(model: Model, *, compile_model: bool = False) -> Policy:

--- a/application/backend/src/schemas/__init__.py
+++ b/application/backend/src/schemas/__init__.py
@@ -2,7 +2,7 @@ from .base_job import JobStatus, JobType
 from .calibration import CalibrationConfig
 from .camera import Camera, CameraProfile
 from .dataset import Dataset, Episode, EpisodeInfo, EpisodeVideo, LeRobotDatasetInfo, Snapshot
-from .hardware import DeviceInfo, DeviceType
+from .hardware import DeviceInfo, DeviceType, InferenceBackend, InferenceDeviceInfo
 from .job import DatasetImportJob, Job, TrainJob
 from .model import BackendExportDetail, Model, ModelDetailResponse
 from .project import Project
@@ -20,6 +20,8 @@ __all__ = [
     "Episode",
     "EpisodeInfo",
     "EpisodeVideo",
+    "InferenceBackend",
+    "InferenceDeviceInfo",
     "Job",
     "JobStatus",
     "JobType",

--- a/application/backend/src/schemas/__init__.py
+++ b/application/backend/src/schemas/__init__.py
@@ -2,7 +2,7 @@ from .base_job import JobStatus, JobType
 from .calibration import CalibrationConfig
 from .camera import Camera, CameraProfile
 from .dataset import Dataset, Episode, EpisodeInfo, EpisodeVideo, LeRobotDatasetInfo, Snapshot
-from .hardware import DeviceInfo, DeviceType, InferenceBackend, InferenceDeviceInfo
+from .hardware import DeviceInfo, DeviceType, InferenceBackend, InferenceDevice, InferenceDeviceInfo
 from .job import DatasetImportJob, Job, TrainJob
 from .model import BackendExportDetail, Model, ModelDetailResponse
 from .project import Project
@@ -21,6 +21,7 @@ __all__ = [
     "EpisodeInfo",
     "EpisodeVideo",
     "InferenceBackend",
+    "InferenceDevice",
     "InferenceDeviceInfo",
     "Job",
     "JobStatus",

--- a/application/backend/src/schemas/hardware.py
+++ b/application/backend/src/schemas/hardware.py
@@ -17,6 +17,13 @@ class DeviceType(StrEnum):
     NPU = auto()
 
 
+class InferenceBackend(StrEnum):
+    """Enumeration of supported inference backends."""
+
+    OPENVINO = auto()
+    TORCH = auto()
+
+
 class DeviceInfo(BaseModel):
     """Information about a compute device available for training."""
 
@@ -24,3 +31,10 @@ class DeviceInfo(BaseModel):
     name: str = Field(..., description="Human-readable device name")
     memory: int | None = Field(None, description="Total device memory in bytes (null for CPU)")
     index: int | None = Field(None, description="Device index among those of the same type (null for CPU)")
+
+
+class InferenceDeviceInfo(DeviceInfo):
+    """Information about a backend-specific compute device available for inference."""
+
+    backend: InferenceBackend = Field(..., description="Inference backend (openvino, torch)")
+    device: str = Field(..., description="Backend-specific device identifier")

--- a/application/backend/src/schemas/hardware.py
+++ b/application/backend/src/schemas/hardware.py
@@ -33,6 +33,13 @@ class DeviceInfo(BaseModel):
     index: int | None = Field(None, description="Device index among those of the same type (null for CPU)")
 
 
+class InferenceDevice(BaseModel):
+    """Selected backend-specific inference device."""
+
+    backend: InferenceBackend = Field(..., description="Inference backend (openvino, torch)")
+    device: str = Field(..., description="Backend-specific device identifier")
+
+
 class InferenceDeviceInfo(DeviceInfo):
     """Information about a backend-specific compute device available for inference."""
 

--- a/application/backend/src/services/system_service.py
+++ b/application/backend/src/services/system_service.py
@@ -3,6 +3,7 @@
 
 """Service for querying system hardware information."""
 
+import os
 from importlib import import_module
 from typing import Any
 
@@ -27,16 +28,17 @@ class SystemService:
         devices.extend(cls._get_openvino_inference_devices())
         return devices
 
-    @staticmethod
-    def _get_torch_inference_devices() -> list[InferenceDeviceInfo]:
+    @classmethod
+    def _get_torch_inference_devices(cls) -> list[InferenceDeviceInfo]:
         """Get compute devices available to the Torch backend for inference."""
+        system_memory = cls._get_system_memory()
         devices: list[InferenceDeviceInfo] = [
             InferenceDeviceInfo(
                 backend=InferenceBackend.TORCH,
                 device="cpu",
                 type=DeviceType.CPU,
                 name="CPU",
-                memory=None,
+                memory=system_memory,
                 index=None,
             ),
         ]
@@ -81,13 +83,14 @@ class SystemService:
             return []
 
         core = openvino.Core()
+        system_memory = cls._get_system_memory()
         devices: list[InferenceDeviceInfo] = [
             InferenceDeviceInfo(
                 backend=InferenceBackend.OPENVINO,
                 device="CPU",
                 type=DeviceType.CPU,
                 name="CPU",
-                memory=None,
+                memory=system_memory,
                 index=None,
             ),
         ]
@@ -105,7 +108,7 @@ class SystemService:
                         device=device,
                         type=DeviceType.NPU,
                         name=str(name),
-                        memory=None,
+                        memory=cls._get_openvino_device_memory(core, device) or system_memory,
                         index=cls._get_openvino_device_index(core, device),
                     ),
                 )
@@ -136,9 +139,20 @@ class SystemService:
 
     @classmethod
     def _get_openvino_device_memory(cls, core: Any, device: str) -> int | None:
-        """Return OpenVINO GPU memory in bytes when the property is available."""
+        """Return OpenVINO device memory in bytes when the property is available."""
         memory = cls._get_openvino_property(core, device, "GPU_DEVICE_TOTAL_MEM_SIZE")
         return int(memory) if memory is not None else None
+
+    @staticmethod
+    def _get_system_memory() -> int | None:
+        """Return total system memory in bytes when available."""
+        try:
+            page_size = os.sysconf("SC_PAGE_SIZE")
+            physical_pages = os.sysconf("SC_PHYS_PAGES")
+        except (ValueError, OSError, AttributeError):
+            logger.debug("Unable to read total system memory.")
+            return None
+        return int(page_size * physical_pages)
 
     @classmethod
     def _get_openvino_device_index(cls, core: Any, device: str) -> int | None:

--- a/application/backend/src/services/system_service.py
+++ b/application/backend/src/services/system_service.py
@@ -3,14 +3,160 @@
 
 """Service for querying system hardware information."""
 
+from importlib import import_module
+from typing import Any
+
 import torch
 from loguru import logger
 
-from schemas.hardware import DeviceInfo, DeviceType
+from schemas.hardware import DeviceInfo, DeviceType, InferenceBackend, InferenceDeviceInfo
 
 
 class SystemService:
     """Service to discover and report available compute hardware."""
+
+    @classmethod
+    def get_inference_devices(cls) -> list[InferenceDeviceInfo]:
+        """Get available backend-specific compute devices for inference.
+
+        Returns:
+            list[InferenceDeviceInfo]: Available inference devices with backend,
+                backend-specific device identifier, name, memory, and index.
+        """
+        devices = cls._get_torch_inference_devices()
+        devices.extend(cls._get_openvino_inference_devices())
+        return devices
+
+    @staticmethod
+    def _get_torch_inference_devices() -> list[InferenceDeviceInfo]:
+        """Get compute devices available to the Torch backend for inference."""
+        devices: list[InferenceDeviceInfo] = [
+            InferenceDeviceInfo(
+                backend=InferenceBackend.TORCH,
+                device="cpu",
+                type=DeviceType.CPU,
+                name="CPU",
+                memory=None,
+                index=None,
+            ),
+        ]
+
+        if torch.xpu.is_available():
+            for device_idx in range(torch.xpu.device_count()):
+                xpu_props = torch.xpu.get_device_properties(device_idx)
+                devices.append(
+                    InferenceDeviceInfo(
+                        backend=InferenceBackend.TORCH,
+                        device=f"xpu:{device_idx}",
+                        type=DeviceType.XPU,
+                        name=xpu_props.name,
+                        memory=xpu_props.total_memory,
+                        index=device_idx,
+                    ),
+                )
+
+        if torch.cuda.is_available():
+            for device_idx in range(torch.cuda.device_count()):
+                cuda_props = torch.cuda.get_device_properties(device_idx)
+                devices.append(
+                    InferenceDeviceInfo(
+                        backend=InferenceBackend.TORCH,
+                        device=f"cuda:{device_idx}",
+                        type=DeviceType.CUDA,
+                        name=cuda_props.name,
+                        memory=cuda_props.total_memory,
+                        index=device_idx,
+                    ),
+                )
+
+        return devices
+
+    @classmethod
+    def _get_openvino_inference_devices(cls) -> list[InferenceDeviceInfo]:
+        """Get compute devices available to the OpenVINO backend for inference."""
+        try:
+            openvino = import_module("openvino")
+        except ImportError:
+            logger.debug("OpenVINO is not installed; skipping OpenVINO inference devices.")
+            return []
+
+        core = openvino.Core()
+        devices: list[InferenceDeviceInfo] = [
+            InferenceDeviceInfo(
+                backend=InferenceBackend.OPENVINO,
+                device="CPU",
+                type=DeviceType.CPU,
+                name="CPU",
+                memory=None,
+                index=None,
+            ),
+        ]
+
+        for device in core.available_devices:
+            device_lower = device.lower()
+            if device_lower.startswith("cpu"):
+                continue
+
+            name = cls._get_openvino_property(core, device, "FULL_DEVICE_NAME") or device
+            if device_lower.startswith("npu"):
+                devices.append(
+                    InferenceDeviceInfo(
+                        backend=InferenceBackend.OPENVINO,
+                        device=device,
+                        type=DeviceType.NPU,
+                        name=str(name),
+                        memory=None,
+                        index=cls._get_openvino_device_index(core, device),
+                    ),
+                )
+            elif device_lower.startswith("gpu"):
+                devices.append(
+                    InferenceDeviceInfo(
+                        backend=InferenceBackend.OPENVINO,
+                        device=device,
+                        type=DeviceType.XPU,
+                        name=str(name),
+                        memory=cls._get_openvino_device_memory(core, device),
+                        index=cls._get_openvino_device_index(core, device),
+                    ),
+                )
+            else:
+                logger.debug("Unsupported OpenVINO inference device '{}'; skipping.", device)
+
+        return devices
+
+    @staticmethod
+    def _get_openvino_property(core: Any, device: str, property_name: str) -> Any | None:
+        """Return an OpenVINO device property if supported by the runtime."""
+        try:
+            return core.get_property(device, property_name)
+        except Exception as exc:
+            logger.debug("Unable to read OpenVINO property '{}' for '{}': {}", property_name, device, exc)
+            return None
+
+    @classmethod
+    def _get_openvino_device_memory(cls, core: Any, device: str) -> int | None:
+        """Return OpenVINO GPU memory in bytes when the property is available."""
+        memory = cls._get_openvino_property(core, device, "GPU_DEVICE_TOTAL_MEM_SIZE")
+        return int(memory) if memory is not None else None
+
+    @classmethod
+    def _get_openvino_device_index(cls, core: Any, device: str) -> int | None:
+        """Return an OpenVINO device index when available."""
+        device_id = cls._get_openvino_property(core, device, "DEVICE_ID")
+        if device_id is not None:
+            try:
+                return int(device_id)
+            except (TypeError, ValueError):
+                logger.debug("OpenVINO DEVICE_ID for '{}' is not numeric: {}", device, device_id)
+
+        _, separator, suffix = device.partition(".")
+        if separator:
+            try:
+                return int(suffix)
+            except ValueError:
+                logger.debug("OpenVINO device suffix for '{}' is not numeric.", device)
+        return None
 
     @staticmethod
     def get_training_devices() -> list[DeviceInfo]:

--- a/application/backend/src/workers/model_worker.py
+++ b/application/backend/src/workers/model_worker.py
@@ -10,7 +10,7 @@ from physicalai.inference import InferenceModel
 
 from control.inference_result import InferenceResult
 from models.utils import load_inference_model
-from schemas import Model
+from schemas import InferenceDevice, Model
 
 if TYPE_CHECKING:
     from physicalai.data import Observation
@@ -43,9 +43,9 @@ class ModelWorker(BaseProcessWorker):
     def is_loaded(self) -> bool:
         return self.model_loaded_event.is_set()
 
-    def load_model(self, model: Model, backend: str) -> None:
+    def load_model(self, model: Model, inference_device: InferenceDevice) -> None:
         """Send a load command to the worker process."""
-        self.command_queue.put(("load", model, backend))
+        self.command_queue.put(("load", model, inference_device))
 
     def unload_model(self) -> None:
         """Signal the worker to stop inference and return to idle."""
@@ -66,9 +66,14 @@ class ModelWorker(BaseProcessWorker):
             if cmd[0] != "load":
                 continue
 
-            _, model, backend = cmd
-            logger.info(f"Loading model: {model.name} ({backend})")
-            self.inference_model = load_inference_model(model, backend=backend)
+            _, model, inference_device = cmd
+            logger.info(
+                "Loading model: {} ({} on {})",
+                model.name,
+                inference_device.backend,
+                inference_device.device,
+            )
+            self.inference_model = load_inference_model(model, inference_device=inference_device)
             logger.info("Model loaded.")
             self.model_loaded_event.set()
 

--- a/application/backend/src/workers/model_worker_registry.py
+++ b/application/backend/src/workers/model_worker_registry.py
@@ -7,7 +7,7 @@ from uuid import UUID, uuid4
 
 from loguru import logger
 
-from schemas import Model
+from schemas import InferenceDevice, Model
 
 from .model_worker import ModelWorker
 
@@ -49,7 +49,7 @@ class ModelWorkerRegistry:
             self._idle.add(worker_id)
             logger.info(f"Model worker pre-spawned: {worker_id} (pid={worker.pid})")
 
-    async def acquire(self, model: Model, backend: str) -> tuple[UUID, ModelWorker]:
+    async def acquire(self, model: Model, inference_device: InferenceDevice) -> tuple[UUID, ModelWorker]:
         """
         Assign an idle worker to load the given model.
 
@@ -63,8 +63,14 @@ class ModelWorkerRegistry:
             self._busy.add(worker_id)
 
         worker = self._workers[worker_id]
-        worker.load_model(model, backend)
-        logger.info(f"Model worker {worker_id} acquired for model '{model.name}' ({backend})")
+        worker.load_model(model, inference_device)
+        logger.info(
+            "Model worker {} acquired for model '{}' ({} on {})",
+            worker_id,
+            model.name,
+            inference_device.backend,
+            inference_device.device,
+        )
         return worker_id, worker
 
     async def release(self, worker_id: UUID) -> None:

--- a/application/backend/src/workers/robot_control_worker.py
+++ b/application/backend/src/workers/robot_control_worker.py
@@ -17,7 +17,7 @@ from internal_datasets.dataset_client import DatasetClient
 from internal_datasets.lerobot.lerobot_dataset import InternalLeRobotDataset
 from internal_datasets.mutations.recording_mutation import RecordingMutation
 from robots.robot_client_factory import RobotClientFactory
-from schemas import Model
+from schemas import InferenceDevice, Model
 from schemas.dataset import Dataset, Episode
 from schemas.environment import EnvironmentWithRelations
 
@@ -80,7 +80,7 @@ class RobotControlWorker(BaseThreadWorker):
         self._model_worker_registry = model_worker_registry
         self._model_worker_id: UUID | None = None
         self._pending_model: Model | None = None
-        self._pending_backend: str | None = None
+        self._pending_inference_device: InferenceDevice | None = None
 
     def start_task(self, task: str) -> None:
         if self.state.model_loaded and self.state.environment_loaded:
@@ -118,9 +118,9 @@ class RobotControlWorker(BaseThreadWorker):
         self.state.follower_source = follower_source
         self._report_state()
 
-    def load_model(self, model: Model, backend: str) -> None:
+    def load_model(self, model: Model, inference_device: InferenceDevice) -> None:
         self._pending_model = model
-        self._pending_backend = backend
+        self._pending_inference_device = inference_device
         self.state.model_loaded = False
         self.events.new_model.set()
         self._report_state()
@@ -221,13 +221,16 @@ class RobotControlWorker(BaseThreadWorker):
         if self._pending_model is not None and self.events.new_model.is_set():
             self.events.new_model.clear()
             try:
+                if self._pending_inference_device is None:
+                    raise ValueError("Inference device must be provided before loading a model.")
+
                 # Release any previously held worker slot
                 if self._model_worker_id is not None:
                     await self._model_worker_registry.release(self._model_worker_id)
                     self._model_worker_id = None
 
                 worker_id, worker = await self._model_worker_registry.acquire(
-                    self._pending_model, self._pending_backend or "torch"
+                    self._pending_model, self._pending_inference_device
                 )
                 self._model_worker_id = worker_id
                 self.model_integration = SyncMixedModelIntegration(model_worker=worker, fps=self.fps)
@@ -239,7 +242,7 @@ class RobotControlWorker(BaseThreadWorker):
                 self._report_error(e)
             finally:
                 self._pending_model = None
-                self._pending_backend = None
+                self._pending_inference_device = None
 
     async def _handle_setup_environment(self) -> None:
         if self.environment_integration and self.events.new_environment.is_set():

--- a/application/backend/tests/api/test_record.py
+++ b/application/backend/tests/api/test_record.py
@@ -1,0 +1,39 @@
+import asyncio
+from unittest.mock import MagicMock
+
+from api.record import handle_incoming
+from schemas import InferenceBackend, InferenceDevice, Model
+
+
+class FakeWebSocket:
+    def __init__(self, messages: list[dict]) -> None:
+        self._messages = messages
+
+    async def receive_json(self, _: str) -> dict:
+        if not self._messages:
+            raise RuntimeError("No more messages")
+        return self._messages.pop(0)
+
+
+def test_handle_incoming_load_model_requires_inference_device(test_model) -> None:
+    process = MagicMock()
+    websocket = FakeWebSocket(
+        [
+            {
+                "event": "load_model",
+                "data": {
+                    "model": test_model.model_dump(mode="json"),
+                    "inference_device": {"backend": "openvino", "device": "GPU"},
+                },
+            },
+            {"event": "disconnect", "data": {}},
+        ]
+    )
+
+    asyncio.run(handle_incoming(websocket, process))
+
+    process.load_model.assert_called_once_with(
+        Model.model_validate(test_model.model_dump(mode="json")),
+        InferenceDevice(backend=InferenceBackend.OPENVINO, device="GPU"),
+    )
+    process.disconnect.assert_called_once()

--- a/application/backend/tests/api/test_record.py
+++ b/application/backend/tests/api/test_record.py
@@ -30,7 +30,7 @@ def test_handle_incoming_load_model_requires_inference_device(test_model) -> Non
         ]
     )
 
-    asyncio.run(handle_incoming(websocket, process))
+    asyncio.run(handle_incoming(websocket, process, set()))
 
     process.load_model.assert_called_once_with(
         Model.model_validate(test_model.model_dump(mode="json")),

--- a/application/backend/tests/models/test_utils.py
+++ b/application/backend/tests/models/test_utils.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from models.utils import load_inference_model
+from schemas import InferenceBackend, InferenceDevice
+
+
+def test_load_inference_model_uses_selected_torch_device(test_model) -> None:
+    inference_device = InferenceDevice(backend=InferenceBackend.TORCH, device="cuda:0")
+
+    with patch("models.utils.InferenceModel") as mock_inference_model:
+        load_inference_model(test_model, inference_device=inference_device)
+
+    mock_inference_model.assert_called_once_with(
+        export_dir=Path(test_model.path) / "exports" / "torch",
+        policy_name=test_model.policy,
+        backend="torch",
+        device="cuda:0",
+    )
+
+
+def test_load_inference_model_uses_selected_openvino_device(test_model) -> None:
+    inference_device = InferenceDevice(backend=InferenceBackend.OPENVINO, device="GPU")
+
+    with patch("models.utils.InferenceModel") as mock_inference_model:
+        load_inference_model(test_model, inference_device=inference_device)
+
+    mock_inference_model.assert_called_once_with(
+        export_dir=Path(test_model.path) / "exports" / "openvino",
+        policy_name=test_model.policy,
+        backend="openvino",
+        device="GPU",
+    )

--- a/application/backend/tests/services/test_system_service.py
+++ b/application/backend/tests/services/test_system_service.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from schemas.hardware import DeviceType, InferenceBackend
+from services.system_service import SystemService
+
+
+def _device_props(name: str, total_memory: int) -> SimpleNamespace:
+    return SimpleNamespace(name=name, total_memory=total_memory)
+
+
+def _device_summary(device):
+    return device.backend, device.device, device.type, device.name, device.memory, device.index
+
+
+def test_get_inference_devices_returns_torch_cpu_when_openvino_missing() -> None:
+    with (
+        patch("services.system_service.import_module", side_effect=ImportError),
+        patch("services.system_service.torch.xpu.is_available", return_value=False),
+        patch("services.system_service.torch.cuda.is_available", return_value=False),
+    ):
+        devices = SystemService.get_inference_devices()
+
+    assert len(devices) == 1
+    assert devices[0].backend == InferenceBackend.TORCH
+    assert devices[0].device == "cpu"
+    assert devices[0].type == DeviceType.CPU
+    assert devices[0].name == "CPU"
+    assert devices[0].memory is None
+    assert devices[0].index is None
+
+
+def test_get_inference_devices_returns_torch_accelerators() -> None:
+    with (
+        patch("services.system_service.import_module", side_effect=ImportError),
+        patch("services.system_service.torch.xpu.is_available", return_value=True),
+        patch("services.system_service.torch.xpu.device_count", return_value=1),
+        patch(
+            "services.system_service.torch.xpu.get_device_properties",
+            return_value=_device_props("Intel Arc", 8_000),
+        ),
+        patch("services.system_service.torch.cuda.is_available", return_value=True),
+        patch("services.system_service.torch.cuda.device_count", return_value=1),
+        patch(
+            "services.system_service.torch.cuda.get_device_properties",
+            return_value=_device_props("NVIDIA GPU", 16_000),
+        ),
+    ):
+        devices = SystemService.get_inference_devices()
+
+    assert [_device_summary(device) for device in devices] == [
+        (InferenceBackend.TORCH, "cpu", DeviceType.CPU, "CPU", None, None),
+        (InferenceBackend.TORCH, "xpu:0", DeviceType.XPU, "Intel Arc", 8_000, 0),
+        (InferenceBackend.TORCH, "cuda:0", DeviceType.CUDA, "NVIDIA GPU", 16_000, 0),
+    ]
+
+
+def test_get_inference_devices_returns_openvino_devices() -> None:
+    core = MagicMock()
+    core.available_devices = ["CPU", "GPU.0", "NPU.0"]
+    core.get_property.side_effect = lambda device, prop: {
+        ("GPU.0", "FULL_DEVICE_NAME"): "Intel GPU",
+        ("GPU.0", "GPU_DEVICE_TOTAL_MEM_SIZE"): "32000",
+        ("GPU.0", "DEVICE_ID"): "0",
+        ("NPU.0", "FULL_DEVICE_NAME"): "Intel NPU",
+        ("NPU.0", "DEVICE_ID"): "0",
+    }[(device, prop)]
+    openvino = SimpleNamespace(Core=MagicMock(return_value=core))
+
+    with (
+        patch("services.system_service.import_module", return_value=openvino),
+        patch("services.system_service.torch.xpu.is_available", return_value=False),
+        patch("services.system_service.torch.cuda.is_available", return_value=False),
+    ):
+        devices = SystemService.get_inference_devices()
+
+    assert [_device_summary(device) for device in devices] == [
+        (InferenceBackend.TORCH, "cpu", DeviceType.CPU, "CPU", None, None),
+        (InferenceBackend.OPENVINO, "CPU", DeviceType.CPU, "CPU", None, None),
+        (InferenceBackend.OPENVINO, "GPU.0", DeviceType.XPU, "Intel GPU", 32_000, 0),
+        (InferenceBackend.OPENVINO, "NPU.0", DeviceType.NPU, "Intel NPU", None, 0),
+    ]
+
+
+def test_get_inference_devices_uses_openvino_fallback_values() -> None:
+    core = MagicMock()
+    core.available_devices = ["GPU.1"]
+    core.get_property.side_effect = RuntimeError("unsupported property")
+    openvino = SimpleNamespace(Core=MagicMock(return_value=core))
+
+    with (
+        patch("services.system_service.import_module", return_value=openvino),
+        patch("services.system_service.torch.xpu.is_available", return_value=False),
+        patch("services.system_service.torch.cuda.is_available", return_value=False),
+    ):
+        devices = SystemService.get_inference_devices()
+
+    assert devices[-1].backend == InferenceBackend.OPENVINO
+    assert devices[-1].device == "GPU.1"
+    assert devices[-1].type == DeviceType.XPU
+    assert devices[-1].name == "GPU.1"
+    assert devices[-1].memory is None
+    assert devices[-1].index == 1

--- a/application/backend/tests/services/test_system_service.py
+++ b/application/backend/tests/services/test_system_service.py
@@ -16,6 +16,7 @@ def _device_summary(device):
 def test_get_inference_devices_returns_torch_cpu_when_openvino_missing() -> None:
     with (
         patch("services.system_service.import_module", side_effect=ImportError),
+        patch("services.system_service.SystemService._get_system_memory", return_value=64_000),
         patch("services.system_service.torch.xpu.is_available", return_value=False),
         patch("services.system_service.torch.cuda.is_available", return_value=False),
     ):
@@ -26,13 +27,14 @@ def test_get_inference_devices_returns_torch_cpu_when_openvino_missing() -> None
     assert devices[0].device == "cpu"
     assert devices[0].type == DeviceType.CPU
     assert devices[0].name == "CPU"
-    assert devices[0].memory is None
+    assert devices[0].memory == 64_000
     assert devices[0].index is None
 
 
 def test_get_inference_devices_returns_torch_accelerators() -> None:
     with (
         patch("services.system_service.import_module", side_effect=ImportError),
+        patch("services.system_service.SystemService._get_system_memory", return_value=64_000),
         patch("services.system_service.torch.xpu.is_available", return_value=True),
         patch("services.system_service.torch.xpu.device_count", return_value=1),
         patch(
@@ -49,7 +51,7 @@ def test_get_inference_devices_returns_torch_accelerators() -> None:
         devices = SystemService.get_inference_devices()
 
     assert [_device_summary(device) for device in devices] == [
-        (InferenceBackend.TORCH, "cpu", DeviceType.CPU, "CPU", None, None),
+        (InferenceBackend.TORCH, "cpu", DeviceType.CPU, "CPU", 64_000, None),
         (InferenceBackend.TORCH, "xpu:0", DeviceType.XPU, "Intel Arc", 8_000, 0),
         (InferenceBackend.TORCH, "cuda:0", DeviceType.CUDA, "NVIDIA GPU", 16_000, 0),
     ]
@@ -69,16 +71,17 @@ def test_get_inference_devices_returns_openvino_devices() -> None:
 
     with (
         patch("services.system_service.import_module", return_value=openvino),
+        patch("services.system_service.SystemService._get_system_memory", return_value=64_000),
         patch("services.system_service.torch.xpu.is_available", return_value=False),
         patch("services.system_service.torch.cuda.is_available", return_value=False),
     ):
         devices = SystemService.get_inference_devices()
 
     assert [_device_summary(device) for device in devices] == [
-        (InferenceBackend.TORCH, "cpu", DeviceType.CPU, "CPU", None, None),
-        (InferenceBackend.OPENVINO, "CPU", DeviceType.CPU, "CPU", None, None),
+        (InferenceBackend.TORCH, "cpu", DeviceType.CPU, "CPU", 64_000, None),
+        (InferenceBackend.OPENVINO, "CPU", DeviceType.CPU, "CPU", 64_000, None),
         (InferenceBackend.OPENVINO, "GPU.0", DeviceType.XPU, "Intel GPU", 32_000, 0),
-        (InferenceBackend.OPENVINO, "NPU.0", DeviceType.NPU, "Intel NPU", None, 0),
+        (InferenceBackend.OPENVINO, "NPU.0", DeviceType.NPU, "Intel NPU", 64_000, 0),
     ]
 
 
@@ -90,6 +93,7 @@ def test_get_inference_devices_uses_openvino_fallback_values() -> None:
 
     with (
         patch("services.system_service.import_module", return_value=openvino),
+        patch("services.system_service.SystemService._get_system_memory", return_value=64_000),
         patch("services.system_service.torch.xpu.is_available", return_value=False),
         patch("services.system_service.torch.cuda.is_available", return_value=False),
     ):

--- a/application/backend/tests/workers/test_model_worker.py
+++ b/application/backend/tests/workers/test_model_worker.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from schemas import InferenceBackend, InferenceDevice
 from workers.model_worker import ModelWorker
 
 
@@ -21,12 +22,13 @@ class TestModelWorker:
 
     def test_load_model_puts_command_on_queue(self, stop_event, test_model):
         worker = ModelWorker(stop_event=stop_event)
-        worker.load_model(test_model, backend="torch")
+        inference_device = InferenceDevice(backend=InferenceBackend.TORCH, device="xpu:0")
+        worker.load_model(test_model, inference_device=inference_device)
 
         cmd = worker.command_queue.get(timeout=2)
         assert cmd[0] == "load"
         assert cmd[1].name == test_model.name
-        assert cmd[2] == "torch"
+        assert cmd[2] == inference_device
 
         worker.command_queue.cancel_join_thread()
         worker.observation_queue.cancel_join_thread()
@@ -61,7 +63,10 @@ class TestModelWorker:
 
         with patch("workers.model_worker.load_inference_model", return_value=fake_inference_model):
             worker = ModelWorker(stop_event=stop_event)
-            worker.load_model(test_model, backend="torch")
+            worker.load_model(
+                test_model,
+                inference_device=InferenceDevice(backend=InferenceBackend.TORCH, device="cpu"),
+            )
 
             loop = asyncio.new_event_loop()
             t = threading.Thread(target=loop.run_until_complete, args=(worker.run_loop(),), daemon=True)

--- a/application/backend/tests/workers/test_model_worker_registry.py
+++ b/application/backend/tests/workers/test_model_worker_registry.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 import pytest
 
+from schemas import InferenceBackend, InferenceDevice
 from workers.model_worker_registry import ModelWorkerRegistry
 
 
@@ -13,6 +14,11 @@ def _make_mock_worker() -> MagicMock:
     worker = MagicMock()
     worker.model_loaded_event = mp.Event()
     return worker
+
+
+@pytest.fixture
+def inference_device():
+    return InferenceDevice(backend=InferenceBackend.TORCH, device="cpu")
 
 
 @pytest.fixture
@@ -47,48 +53,50 @@ class TestModelWorkerRegistryInit:
 
 
 class TestModelWorkerRegistryAcquire:
-    def test_acquire_returns_worker_id_and_worker(self, registry, test_model):
-        worker_id, worker = asyncio.run(registry.acquire(test_model, "torch"))
+    def test_acquire_returns_worker_id_and_worker(self, registry, test_model, inference_device):
+        worker_id, worker = asyncio.run(registry.acquire(test_model, inference_device))
         assert isinstance(worker_id, UUID)
         assert worker is registry._workers[worker_id]
 
-    def test_acquire_moves_worker_to_busy(self, registry, test_model):
-        worker_id, _ = asyncio.run(registry.acquire(test_model, "torch"))
+    def test_acquire_moves_worker_to_busy(self, registry, test_model, inference_device):
+        worker_id, _ = asyncio.run(registry.acquire(test_model, inference_device))
         assert worker_id in registry._busy
         assert worker_id not in registry._idle
 
-    def test_acquire_calls_load_model_on_worker(self, registry, test_model):
-        _, worker = asyncio.run(registry.acquire(test_model, "torch"))
-        worker.load_model.assert_called_once_with(test_model, "torch")
+    def test_acquire_calls_load_model_on_worker(self, registry, test_model, inference_device):
+        _, worker = asyncio.run(registry.acquire(test_model, inference_device))
+        worker.load_model.assert_called_once_with(test_model, inference_device)
 
-    def test_acquire_two_workers_exhausts_pool(self, registry, test_model):
-        asyncio.run(registry.acquire(test_model, "torch"))
-        asyncio.run(registry.acquire(test_model, "torch"))
+    def test_acquire_two_workers_exhausts_pool(self, registry, test_model, inference_device):
+        asyncio.run(registry.acquire(test_model, inference_device))
+        asyncio.run(registry.acquire(test_model, inference_device))
         assert len(registry._idle) == 0
         assert len(registry._busy) == 2
 
-    def test_acquire_raises_when_no_idle_workers(self, single_worker_registry, test_model):
-        asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+    def test_acquire_raises_when_no_idle_workers(self, single_worker_registry, test_model, inference_device):
+        asyncio.run(single_worker_registry.acquire(test_model, inference_device))
         with pytest.raises(ValueError, match="No idle model workers available"):
-            asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+            asyncio.run(single_worker_registry.acquire(test_model, inference_device))
 
 
 class TestModelWorkerRegistryRelease:
-    def test_release_returns_worker_to_idle(self, single_worker_registry, test_model):
-        worker_id, _ = asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+    def test_release_returns_worker_to_idle(self, single_worker_registry, test_model, inference_device):
+        worker_id, _ = asyncio.run(single_worker_registry.acquire(test_model, inference_device))
         asyncio.run(single_worker_registry.release(worker_id))
         assert worker_id in single_worker_registry._idle
         assert worker_id not in single_worker_registry._busy
 
-    def test_release_calls_unload_model(self, single_worker_registry, test_model):
-        worker_id, worker = asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+    def test_release_calls_unload_model(self, single_worker_registry, test_model, inference_device):
+        worker_id, worker = asyncio.run(single_worker_registry.acquire(test_model, inference_device))
         asyncio.run(single_worker_registry.release(worker_id))
         worker.unload_model.assert_called_once()
 
-    def test_released_worker_can_be_acquired_again(self, single_worker_registry, test_model):
-        worker_id, _ = asyncio.run(single_worker_registry.acquire(test_model, "torch"))
+    def test_released_worker_can_be_acquired_again(self, single_worker_registry, test_model, inference_device):
+        worker_id, _ = asyncio.run(single_worker_registry.acquire(test_model, inference_device))
         asyncio.run(single_worker_registry.release(worker_id))
-        new_id, _ = asyncio.run(single_worker_registry.acquire(test_model, "onnx"))
+        new_id, _ = asyncio.run(
+            single_worker_registry.acquire(test_model, InferenceDevice(backend=InferenceBackend.OPENVINO, device="GPU"))
+        )
         assert new_id == worker_id
 
     def test_release_unknown_id_is_noop(self, registry):

--- a/application/backend/tests/workers/test_robot_control_worker.py
+++ b/application/backend/tests/workers/test_robot_control_worker.py
@@ -11,6 +11,7 @@ from control.environment_integration import EnvironmentIntegration
 from control.sync_mixed_model_integration import SyncMixedModelIntegration
 from internal_datasets.lerobot.lerobot_dataset import InternalLeRobotDataset
 from internal_datasets.mutations.recording_mutation import RecordingMutation
+from schemas import InferenceBackend, InferenceDevice
 from schemas.environment import EnvironmentWithRelations
 from workers.robot_control_worker import RobotControlWorker
 
@@ -82,6 +83,11 @@ def recording_mutation():
 
 
 @pytest.fixture
+def inference_device():
+    return InferenceDevice(backend=InferenceBackend.TORCH, device="cpu")
+
+
+@pytest.fixture
 def test_dataset_impl(recording_mutation):
     mock = MagicMock(spec=InternalLeRobotDataset)
     mock.start_recording_mutation = MagicMock(return_value=recording_mutation)
@@ -112,10 +118,10 @@ def robot_control_worker(mock_robot_client_factory):
 
 @pytest.fixture
 def loaded_inference_worker(
-    robot_control_worker, environment_integration, model_integration, test_model, test_environment
+    robot_control_worker, environment_integration, model_integration, test_model, test_environment, inference_device
 ):
     with patch("workers.robot_control_worker.SyncMixedModelIntegration", return_value=model_integration):
-        robot_control_worker.load_model(test_model, "torch")
+        robot_control_worker.load_model(test_model, inference_device)
         with patch("workers.robot_control_worker.EnvironmentIntegration", return_value=environment_integration):
             robot_control_worker.load_environment(test_environment)
         model_integration.allow_setup()
@@ -192,14 +198,20 @@ class TestRobotControlWorker:
         assert observation["event"] == "observations"
         assert observation["data"] == {"foo": "bar"}
 
-    def test_load_model(self, robot_control_worker: RobotControlWorker, model_integration, test_model):
+    def test_load_model(
+        self,
+        robot_control_worker: RobotControlWorker,
+        model_integration,
+        test_model,
+        inference_device,
+    ):
         report = wait_until_message_from_queue(robot_control_worker.queue, "state")
         assert report["event"] == "state"
 
         # Keep patch active until after allow_setup(): _handle_new_model_load creates
         # SyncMixedModelIntegration asynchronously, so the patch must outlive load_model().
         with patch("workers.robot_control_worker.SyncMixedModelIntegration", return_value=model_integration):
-            robot_control_worker.load_model(test_model, "torch")
+            robot_control_worker.load_model(test_model, inference_device)
             report = wait_until_message_from_queue(robot_control_worker.queue, "state")
             assert report["event"] == "state"
             assert not report["data"]["model_loaded"]

--- a/application/ui/src/features/models/backend-selection.tsx
+++ b/application/ui/src/features/models/backend-selection.tsx
@@ -1,11 +1,48 @@
-import { Divider, Flex, Heading, Radio, RadioGroup, Text, View } from '@geti-ui/ui';
+import { useEffect } from 'react';
+
+import { Divider, Flex, Heading, Item, Picker, Radio, RadioGroup, Text, View } from '@geti-ui/ui';
 import { Label } from 'react-aria-components';
 
 import { $api } from '../../api/client';
-import { SchemaModel } from '../../api/openapi-spec';
+import { SchemaInferenceDeviceInfo, SchemaModel } from '../../api/openapi-spec';
 import { INFERENCE_BACKENDS } from './inference-backends';
 
 export const defaultBackend = 'openvino';
+
+export type InferenceDevice = Pick<SchemaInferenceDeviceInfo, 'backend' | 'device'>;
+
+const deviceTypeOrder: Record<SchemaInferenceDeviceInfo['type'], number> = {
+    xpu: 0,
+    npu: 1,
+    cuda: 2,
+    cpu: 3,
+};
+
+const getDeviceKey = ({ backend, device }: InferenceDevice) => `${backend}:${device}`;
+
+const sortInferenceDevices = (a: SchemaInferenceDeviceInfo, b: SchemaInferenceDeviceInfo) => {
+    const typeSort = deviceTypeOrder[a.type] - deviceTypeOrder[b.type];
+    if (typeSort !== 0) {
+        return typeSort;
+    }
+
+    return (a.index ?? Number.MAX_SAFE_INTEGER) - (b.index ?? Number.MAX_SAFE_INTEGER);
+};
+
+export const getSupportedInferenceDevices = (devices: SchemaInferenceDeviceInfo[], backend: string) => {
+    // We've not yet verified that running our models on NPU works,
+    // so we filter it out for now
+    return devices
+        .filter((device) => device.backend === backend && device.type !== 'npu')
+        .toSorted(sortInferenceDevices);
+};
+
+export const getDefaultInferenceDevice = (devices: SchemaInferenceDeviceInfo[], backend: string) => {
+    const supportedDevices = getSupportedInferenceDevices(devices, backend);
+
+    // Prefer hardware acceleration
+    return supportedDevices.find((device) => device.type !== 'cpu') ?? supportedDevices.at(0);
+};
 
 interface BackendProps {
     id: string;
@@ -56,25 +93,68 @@ const Backend = ({ id, isSelected = false, isDisabled = false }: BackendProps) =
 interface BackendSelectionProps {
     model: SchemaModel;
     backend: string;
+    device: string | undefined;
     setBackend: (backend: string) => void;
+    setDevice: (device: string | undefined) => void;
 }
 
-export const BackendSelection = ({ model, backend, setBackend }: BackendSelectionProps) => {
+export const BackendSelection = ({ model, backend, device, setBackend, setDevice }: BackendSelectionProps) => {
     const { data: policyBackends } = $api.useSuspenseQuery('get', '/api/policies/backends');
+    const { data: inferenceDevices } = $api.useSuspenseQuery('get', '/api/system/devices/inference');
 
     const backends: Array<string> =
         policyBackends[model.policy].filter((modelBackend) => ['openvino', 'torch'].includes(modelBackend)) ?? [];
+    const devices = getSupportedInferenceDevices(inferenceDevices, backend);
+    const selectedDevice = devices.find((inferenceDevice) => inferenceDevice.device === device);
+
+    useEffect(() => {
+        if (selectedDevice !== undefined) {
+            return;
+        }
+
+        const defaultDevice = getDefaultInferenceDevice(inferenceDevices, backend);
+        setDevice(defaultDevice?.device);
+    }, [backend, inferenceDevices, selectedDevice, setDevice]);
+
+    const onBackendChange = (value: string) => {
+        setBackend(value);
+
+        const defaultDevice = getDefaultInferenceDevice(inferenceDevices, value);
+        setDevice(defaultDevice?.device);
+    };
 
     return (
-        <RadioGroup value={backend} onChange={(value) => setBackend(value)} isEmphasized width='100%'>
-            <Flex gap='size-200' direction='column'>
-                {backends.map((backendId) => {
-                    const isSelected = backendId === backend;
-                    const isDisabled = !model.available_backends.includes(backendId);
+        <Flex gap='size-200' direction='column'>
+            <RadioGroup value={backend} onChange={onBackendChange} isEmphasized width='100%'>
+                <Flex gap='size-200' direction='column'>
+                    {backends.map((backendId) => {
+                        const isSelected = backendId === backend;
+                        const isDisabled = !model.available_backends.includes(backendId);
 
-                    return <Backend key={backendId} id={backendId} isSelected={isSelected} isDisabled={isDisabled} />;
-                })}
-            </Flex>
-        </RadioGroup>
+                        return (
+                            <Backend key={backendId} id={backendId} isSelected={isSelected} isDisabled={isDisabled} />
+                        );
+                    })}
+                </Flex>
+            </RadioGroup>
+            <Picker
+                width='100%'
+                label='Inference device'
+                selectedKey={selectedDevice === undefined ? undefined : getDeviceKey(selectedDevice)}
+                onSelectionChange={(key) => {
+                    const selected = devices.find((inferenceDevice) => getDeviceKey(inferenceDevice) === key);
+                    if (selected !== undefined) {
+                        setDevice(selected.device);
+                    }
+                }}
+                isDisabled={devices.length === 0}
+            >
+                {devices.map((inferenceDevice) => (
+                    <Item key={getDeviceKey(inferenceDevice)} textValue={inferenceDevice.name}>
+                        <Text>{inferenceDevice.name}</Text>
+                    </Item>
+                ))}
+            </Picker>
+        </Flex>
     );
 };

--- a/application/ui/src/features/models/backend-selection.tsx
+++ b/application/ui/src/features/models/backend-selection.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { Divider, Flex, Heading, Item, Picker, Radio, RadioGroup, Text, View } from '@geti-ui/ui';
 import { Label } from 'react-aria-components';
 
@@ -94,27 +92,27 @@ interface BackendSelectionProps {
     model: SchemaModel;
     backend: string;
     device: string | undefined;
+    inferenceDevices: SchemaInferenceDeviceInfo[];
     setBackend: (backend: string) => void;
     setDevice: (device: string | undefined) => void;
 }
 
-export const BackendSelection = ({ model, backend, device, setBackend, setDevice }: BackendSelectionProps) => {
-    const { data: policyBackends } = $api.useSuspenseQuery('get', '/api/policies/backends');
-    const { data: inferenceDevices } = $api.useSuspenseQuery('get', '/api/system/devices/inference');
+export const BackendSelection = ({
+    model,
+    backend,
+    device,
+    inferenceDevices,
+    setBackend,
+    setDevice,
+}: BackendSelectionProps) => {
+    const { data: policyBackends } = $api.useQuery('get', '/api/policies/backends');
 
     const backends: Array<string> =
-        policyBackends[model.policy].filter((modelBackend) => ['openvino', 'torch'].includes(modelBackend)) ?? [];
+        policyBackends?.[model.policy].filter((modelBackend) => ['openvino', 'torch'].includes(modelBackend)) ?? [];
     const devices = getSupportedInferenceDevices(inferenceDevices, backend);
-    const selectedDevice = devices.find((inferenceDevice) => inferenceDevice.device === device);
-
-    useEffect(() => {
-        if (selectedDevice !== undefined) {
-            return;
-        }
-
-        const defaultDevice = getDefaultInferenceDevice(inferenceDevices, backend);
-        setDevice(defaultDevice?.device);
-    }, [backend, inferenceDevices, selectedDevice, setDevice]);
+    const selectedDevice =
+        devices.find((inferenceDevice) => inferenceDevice.device === device) ??
+        getDefaultInferenceDevice(inferenceDevices, backend);
 
     const onBackendChange = (value: string) => {
         setBackend(value);

--- a/application/ui/src/features/models/backend-selection.tsx
+++ b/application/ui/src/features/models/backend-selection.tsx
@@ -90,35 +90,31 @@ const Backend = ({ id, isSelected = false, isDisabled = false }: BackendProps) =
 
 interface BackendSelectionProps {
     model: SchemaModel;
-    backend: string;
-    device: string | undefined;
+    inferenceDevice: InferenceDevice | undefined;
     inferenceDevices: SchemaInferenceDeviceInfo[];
-    setBackend: (backend: string) => void;
-    setDevice: (device: string | undefined) => void;
+    setInferenceDevice: (inferenceDevice: InferenceDevice | undefined) => void;
 }
 
 export const BackendSelection = ({
     model,
-    backend,
-    device,
+    inferenceDevice,
     inferenceDevices,
-    setBackend,
-    setDevice,
+    setInferenceDevice,
 }: BackendSelectionProps) => {
-    const { data: policyBackends } = $api.useQuery('get', '/api/policies/backends');
+    const { data: policyBackends } = $api.useSuspenseQuery('get', '/api/policies/backends');
+    const backend = inferenceDevice?.backend ?? defaultBackend;
+    const device = inferenceDevice?.device;
 
     const backends: Array<string> =
         policyBackends?.[model.policy].filter((modelBackend) => ['openvino', 'torch'].includes(modelBackend)) ?? [];
     const devices = getSupportedInferenceDevices(inferenceDevices, backend);
     const selectedDevice =
-        devices.find((inferenceDevice) => inferenceDevice.device === device) ??
+        devices.find((availableDevice) => availableDevice.device === device) ??
         getDefaultInferenceDevice(inferenceDevices, backend);
 
     const onBackendChange = (value: string) => {
-        setBackend(value);
-
         const defaultDevice = getDefaultInferenceDevice(inferenceDevices, value);
-        setDevice(defaultDevice?.device);
+        setInferenceDevice(defaultDevice);
     };
 
     return (
@@ -140,16 +136,16 @@ export const BackendSelection = ({
                 label='Inference device'
                 selectedKey={selectedDevice === undefined ? undefined : getDeviceKey(selectedDevice)}
                 onSelectionChange={(key) => {
-                    const selected = devices.find((inferenceDevice) => getDeviceKey(inferenceDevice) === key);
+                    const selected = devices.find((availableDevice) => getDeviceKey(availableDevice) === key);
                     if (selected !== undefined) {
-                        setDevice(selected.device);
+                        setInferenceDevice(selected);
                     }
                 }}
                 isDisabled={devices.length === 0}
             >
-                {devices.map((inferenceDevice) => (
-                    <Item key={getDeviceKey(inferenceDevice)} textValue={inferenceDevice.name}>
-                        <Text>{inferenceDevice.name}</Text>
+                {devices.map((availableDevice) => (
+                    <Item key={getDeviceKey(availableDevice)} textValue={availableDevice.name}>
+                        <Text>{availableDevice.name}</Text>
                     </Item>
                 ))}
             </Picker>

--- a/application/ui/src/features/models/backend-selection.tsx
+++ b/application/ui/src/features/models/backend-selection.tsx
@@ -28,10 +28,25 @@ const sortInferenceDevices = (a: SchemaInferenceDeviceInfo, b: SchemaInferenceDe
 };
 
 export const getSupportedInferenceDevices = (devices: SchemaInferenceDeviceInfo[], backend: string) => {
-    // We've not yet verified that running our models on NPU works,
-    // so we filter it out for now
     return devices
-        .filter((device) => device.backend === backend && device.type !== 'npu')
+        .filter((device) => {
+            if (device.backend !== backend) {
+                return false;
+            }
+
+            // We've not yet verified that running our models on NPU works,
+            // so we filter it out for now
+            if (device.type === 'npu') {
+                return false;
+            }
+
+            // Using NVIDIA GPU in OpenVINO is not supported
+            if (device.type === 'xpu' && device.name.includes('NVIDIA')) {
+                return false;
+            }
+
+            return true;
+        })
         .toSorted(sortInferenceDevices);
 };
 

--- a/application/ui/src/features/robots/robot-control-provider.tsx
+++ b/application/ui/src/features/robots/robot-control-provider.tsx
@@ -3,10 +3,17 @@ import { createContext, ReactNode, RefObject, useContext, useRef, useState } fro
 import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query';
 
 import { fetchClient } from '../../api/client';
-import { SchemaDatasetOutput, SchemaEnvironmentWithRelations, SchemaModel } from '../../api/openapi-spec';
+import {
+    SchemaDatasetOutput,
+    SchemaEnvironmentWithRelations,
+    SchemaInferenceDeviceInfo,
+    SchemaModel,
+} from '../../api/openapi-spec';
 import useWebSocketWithResponse from '../../components/websockets/use-websocket-with-response';
 
 type FollowerSource = 'teleoperation' | 'model' | null;
+
+type InferenceDevice = Pick<SchemaInferenceDeviceInfo, 'backend' | 'device'>;
 
 interface RobotControlState {
     model_loaded: boolean;
@@ -48,8 +55,13 @@ interface useRobotControlProps {
     environment: SchemaEnvironmentWithRelations;
     model?: SchemaModel;
     dataset?: SchemaDatasetOutput;
-    backend?: string;
+    inferenceDevice?: InferenceDevice;
     onError: (error: string) => void;
+}
+
+interface LoadModelPayload {
+    model: SchemaModel;
+    inference_device: InferenceDevice;
 }
 
 type MutationResult<TVariables = void> = UseMutationResult<
@@ -62,11 +74,11 @@ type RobotControlContextValue = null | {
     observation: RefObject<Observation | undefined>;
     environment: SchemaEnvironmentWithRelations;
     model: SchemaModel | undefined;
-    backend: string | undefined;
+    inferenceDevice: InferenceDevice | undefined;
     dataset: SchemaDatasetOutput | undefined;
     state: RobotControlState;
     loadEnvironment: MutationResult<SchemaEnvironmentWithRelations>;
-    loadModel: MutationResult<{ model: SchemaModel; backend: string }>;
+    loadModel: MutationResult<LoadModelPayload>;
     loadDataset: MutationResult<SchemaDatasetOutput>;
     startTask: MutationResult<string>;
     stopTask: MutationResult;
@@ -105,14 +117,14 @@ export const RobotControlProvider = (props: useRobotControlProps) => {
     const observation = useRef<Observation | undefined>(undefined);
 
     const [model, setModel] = useState<SchemaModel | undefined>(props.model);
-    const [backend, setBackend] = useState<string | undefined>(props.backend);
+    const [inferenceDevice, setInferenceDevice] = useState<InferenceDevice | undefined>(props.inferenceDevice);
     const [dataset, setDataset] = useState<SchemaDatasetOutput | undefined>(props.dataset);
     const [environment, setEnvironment] = useState<SchemaEnvironmentWithRelations>(props.environment);
 
     const onOpen = () => {
         loadEnvironment.mutate(props.environment);
-        if (model && backend) {
-            loadModel.mutate({ model, backend });
+        if (model && inferenceDevice) {
+            loadModel.mutate({ model, inference_device: inferenceDevice });
         }
         if (dataset) {
             loadDataset.mutate(dataset);
@@ -176,13 +188,13 @@ export const RobotControlProvider = (props: useRobotControlProps) => {
 
     const loadModel = useMutation({
         meta: { skipInvalidation: true },
-        mutationFn: async (properties: { model: SchemaModel; backend: string }) => {
+        mutationFn: async (properties: LoadModelPayload) => {
             const result = await sendJsonMessageAndWait<RobotControlApiJsonResponse<RobotControlState>>(
                 { event: 'load_model', data: properties },
                 ({ data }) => data['model_loaded']
             );
             setModel(properties.model);
-            setBackend(properties.backend);
+            setInferenceDevice(properties.inference_device);
             return result;
         },
     });
@@ -260,7 +272,7 @@ export const RobotControlProvider = (props: useRobotControlProps) => {
                 environment,
                 dataset,
                 model,
-                backend,
+                inferenceDevice,
                 state,
                 loadEnvironment,
                 loadModel,

--- a/application/ui/src/routes/models/inference/index.tsx
+++ b/application/ui/src/routes/models/inference/index.tsx
@@ -1,12 +1,13 @@
 import { ToastQueue } from '@geti-ui/ui';
 
 import { $api } from '../../../api/client';
+import { getDefaultInferenceDevice, getSupportedInferenceDevices } from '../../../features/models/backend-selection';
 import { RobotControlProvider } from '../../../features/robots/robot-control-provider';
 import { InferenceViewer } from './inference-viewer';
 import { useInferenceParams } from './use-inference-params';
 
 export const Index = () => {
-    const { project_id, model_id, backend } = useInferenceParams();
+    const { project_id, model_id, backend, device } = useInferenceParams();
 
     const {
         data: { model },
@@ -30,11 +31,17 @@ export const Index = () => {
         params: { path: { model_id } },
     });
 
+    const { data: inferenceDevices } = $api.useSuspenseQuery('get', '/api/system/devices/inference');
+    const selectedDevice = getSupportedInferenceDevices(inferenceDevices, backend).find(
+        (inferenceDevice) => inferenceDevice.device === device
+    );
+    const inferenceDevice = selectedDevice ?? getDefaultInferenceDevice(inferenceDevices, backend);
+
     return (
         <RobotControlProvider
             environment={initialEnvironment}
             model={model}
-            backend={backend}
+            inferenceDevice={inferenceDevice}
             onError={ToastQueue.negative}
         >
             <InferenceViewer tasks={tasks} />

--- a/application/ui/src/routes/models/inference/use-inference-params.ts
+++ b/application/ui/src/routes/models/inference/use-inference-params.ts
@@ -1,9 +1,11 @@
 import { useParams } from 'react-router';
+import { useSearchParams } from 'react-router-dom';
 
 import { defaultBackend } from '../../../features/models/backend-selection';
 
 export const useInferenceParams = () => {
     const { project_id, model_id, backend } = useParams();
+    const [searchParams] = useSearchParams();
 
     if (project_id === undefined) {
         throw new Error('Unknown project_id parameter');
@@ -13,5 +15,10 @@ export const useInferenceParams = () => {
         throw new Error('Unknown model_id parameter');
     }
 
-    return { project_id, model_id, backend: backend ?? defaultBackend };
+    return {
+        project_id,
+        model_id,
+        backend: backend ?? defaultBackend,
+        device: searchParams.get('device') ?? undefined,
+    };
 };

--- a/application/ui/src/routes/models/start-model-modal.component.tsx
+++ b/application/ui/src/routes/models/start-model-modal.component.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 
-import { Button, ButtonGroup, Content, Dialog, Divider, Heading } from '@geti-ui/ui';
+import { Button, ButtonGroup, Content, Dialog, Divider, Heading, ProgressCircle } from '@geti-ui/ui';
 import { useNavigate } from 'react-router';
 import { createSearchParams } from 'react-router-dom';
 
@@ -11,6 +11,7 @@ import {
     defaultBackend,
     getDefaultInferenceDevice,
     getSupportedInferenceDevices,
+    InferenceDevice,
 } from '../../features/models/backend-selection';
 import { paths } from '../../router';
 
@@ -28,13 +29,14 @@ interface StartInferenceDialogProps {
 }
 
 export const StartInferenceDialog = ({ close, model }: StartInferenceDialogProps) => {
-    const [backend, setBackend] = useState<string>(getDefaultbackend(model));
-    const [device, setDevice] = useState<string | undefined>();
+    const initialBackend = getDefaultbackend(model);
+    const [selectedInferenceDevice, setSelectedInferenceDevice] = useState<InferenceDevice | undefined>();
 
     const { data: inferenceDevices = [], isLoading } = $api.useQuery('get', '/api/system/devices/inference');
+    const backend = selectedInferenceDevice?.backend ?? initialBackend;
 
     const selectedDevice = getSupportedInferenceDevices(inferenceDevices, backend).find(
-        (inferenceDevice) => inferenceDevice.device === device
+        (inferenceDevice) => inferenceDevice.device === selectedInferenceDevice?.device
     );
     const inferenceDevice = selectedDevice ?? getDefaultInferenceDevice(inferenceDevices, backend);
 
@@ -60,14 +62,14 @@ export const StartInferenceDialog = ({ close, model }: StartInferenceDialogProps
             <Heading>Select your inference backend</Heading>
             <Divider />
             <Content>
-                <BackendSelection
-                    model={model}
-                    backend={backend}
-                    device={inferenceDevice?.device}
-                    inferenceDevices={inferenceDevices}
-                    setBackend={setBackend}
-                    setDevice={setDevice}
-                />
+                <Suspense fallback={<ProgressCircle aria-label='Loading backends' isIndeterminate size='S' />}>
+                    <BackendSelection
+                        model={model}
+                        inferenceDevice={inferenceDevice}
+                        inferenceDevices={inferenceDevices}
+                        setInferenceDevice={setSelectedInferenceDevice}
+                    />
+                </Suspense>
             </Content>
             <ButtonGroup>
                 <Button variant='secondary' onPress={close}>

--- a/application/ui/src/routes/models/start-model-modal.component.tsx
+++ b/application/ui/src/routes/models/start-model-modal.component.tsx
@@ -1,11 +1,17 @@
-import { Suspense, useState } from 'react';
+import { useState } from 'react';
 
-import { Button, ButtonGroup, Content, Dialog, Divider, Heading, ProgressCircle } from '@geti-ui/ui';
+import { Button, ButtonGroup, Content, Dialog, Divider, Heading } from '@geti-ui/ui';
 import { useNavigate } from 'react-router';
 import { createSearchParams } from 'react-router-dom';
 
+import { $api } from '../../api/client';
 import { SchemaModel } from '../../api/openapi-spec';
-import { BackendSelection, defaultBackend } from '../../features/models/backend-selection';
+import {
+    BackendSelection,
+    defaultBackend,
+    getDefaultInferenceDevice,
+    getSupportedInferenceDevices,
+} from '../../features/models/backend-selection';
 import { paths } from '../../router';
 
 const getDefaultbackend = (model: SchemaModel) => {
@@ -25,9 +31,16 @@ export const StartInferenceDialog = ({ close, model }: StartInferenceDialogProps
     const [backend, setBackend] = useState<string>(getDefaultbackend(model));
     const [device, setDevice] = useState<string | undefined>();
 
+    const { data: inferenceDevices = [], isLoading } = $api.useQuery('get', '/api/system/devices/inference');
+
+    const selectedDevice = getSupportedInferenceDevices(inferenceDevices, backend).find(
+        (inferenceDevice) => inferenceDevice.device === device
+    );
+    const inferenceDevice = selectedDevice ?? getDefaultInferenceDevice(inferenceDevices, backend);
+
     const navigate = useNavigate();
     const onStart = () => {
-        if (device === undefined) {
+        if (inferenceDevice === undefined) {
             return;
         }
 
@@ -38,7 +51,7 @@ export const StartInferenceDialog = ({ close, model }: StartInferenceDialogProps
                 model_id: model.id!,
                 backend,
             }),
-            search: createSearchParams({ device }).toString(),
+            search: createSearchParams({ device: inferenceDevice.device }).toString(),
         });
     };
 
@@ -47,21 +60,20 @@ export const StartInferenceDialog = ({ close, model }: StartInferenceDialogProps
             <Heading>Select your inference backend</Heading>
             <Divider />
             <Content>
-                <Suspense fallback={<ProgressCircle aria-label='Loading backends' isIndeterminate size='S' />}>
-                    <BackendSelection
-                        model={model}
-                        backend={backend}
-                        device={device}
-                        setBackend={setBackend}
-                        setDevice={setDevice}
-                    />
-                </Suspense>
+                <BackendSelection
+                    model={model}
+                    backend={backend}
+                    device={inferenceDevice?.device}
+                    inferenceDevices={inferenceDevices}
+                    setBackend={setBackend}
+                    setDevice={setDevice}
+                />
             </Content>
             <ButtonGroup>
                 <Button variant='secondary' onPress={close}>
                     Cancel
                 </Button>
-                <Button variant='accent' onPress={onStart} isDisabled={device === undefined}>
+                <Button variant='accent' onPress={onStart} isDisabled={isLoading || inferenceDevice === undefined}>
                     Start
                 </Button>
             </ButtonGroup>

--- a/application/ui/src/routes/models/start-model-modal.component.tsx
+++ b/application/ui/src/routes/models/start-model-modal.component.tsx
@@ -2,6 +2,7 @@ import { Suspense, useState } from 'react';
 
 import { Button, ButtonGroup, Content, Dialog, Divider, Heading, ProgressCircle } from '@geti-ui/ui';
 import { useNavigate } from 'react-router';
+import { createSearchParams } from 'react-router-dom';
 
 import { SchemaModel } from '../../api/openapi-spec';
 import { BackendSelection, defaultBackend } from '../../features/models/backend-selection';
@@ -22,17 +23,23 @@ interface StartInferenceDialogProps {
 
 export const StartInferenceDialog = ({ close, model }: StartInferenceDialogProps) => {
     const [backend, setBackend] = useState<string>(getDefaultbackend(model));
+    const [device, setDevice] = useState<string | undefined>();
 
     const navigate = useNavigate();
     const onStart = () => {
+        if (device === undefined) {
+            return;
+        }
+
         close();
-        navigate(
-            paths.project.models.inference({
+        navigate({
+            pathname: paths.project.models.inference({
                 project_id: model.project_id,
                 model_id: model.id!,
                 backend,
-            })
-        );
+            }),
+            search: createSearchParams({ device }).toString(),
+        });
     };
 
     return (
@@ -41,14 +48,20 @@ export const StartInferenceDialog = ({ close, model }: StartInferenceDialogProps
             <Divider />
             <Content>
                 <Suspense fallback={<ProgressCircle aria-label='Loading backends' isIndeterminate size='S' />}>
-                    <BackendSelection model={model} backend={backend} setBackend={setBackend} />
+                    <BackendSelection
+                        model={model}
+                        backend={backend}
+                        device={device}
+                        setBackend={setBackend}
+                        setDevice={setDevice}
+                    />
                 </Suspense>
             </Content>
             <ButtonGroup>
                 <Button variant='secondary' onPress={close}>
                     Cancel
                 </Button>
-                <Button variant='accent' onPress={onStart}>
+                <Button variant='accent' onPress={onStart} isDisabled={device === undefined}>
                     Start
                 </Button>
             </ButtonGroup>


### PR DESCRIPTION
This PR adds new `/api/system/devices/inference` endpoint that returns what inference devices are available for each backend that we support.
An example output is:
```
[
  {
    "type": "cpu",
    "name": "CPU",
    "memory": 66896416768,
    "index": null,
    "backend": "torch",
    "device": "cpu"
  },
  {
    "type": "xpu",
    "name": "Intel(R) Arc(TM) B390 GPU",
    "memory": 62410772480,
    "index": 0,
    "backend": "torch",
    "device": "xpu:0"
  },
  {
    "type": "cpu",
    "name": "CPU",
    "memory": 66896416768,
    "index": null,
    "backend": "openvino",
    "device": "CPU"
  },
  {
    "type": "xpu",
    "name": "Intel(R) Arc(TM) B390 GPU (iGPU)",
    "memory": 62410772480,
    "index": 0,
    "backend": "openvino",
    "device": "GPU"
  },
  {
    "type": "npu",
    "name": "Intel(R) AI Boost",
    "memory": 66896416768,
    "index": null,
    "backend": "openvino",
    "device": "NPU"
  }
]
```

We then use this info to allow the user to select the device they want to use for inference.

Notes:
- We haven't validated that our models work on NPU so for now we don't show this in the UI
- As a follow up improvement we can show a warning to the user if they choose a device that does not have sufficient (V)RAM to run the model
- We don't show NVIDIA gpus when selecting OpenVINO, in the tests I did this always failed (I believe this requires a separate OpenVINO plugin to be installed)

## Type of Change

- [x] ✨ `feat` - New feature

## Screenshots

| **Torch** | **After** |
|------------|-----------|
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/191a6fef-ec2c-457c-a4a0-e36e50de27a5" />            |  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/37242639-42ed-459a-ba41-0426203e1b7a" />         |



