### PR TITLE
fix: move persistent storage out of cache

### DIFF
--- a/application/backend/src/cli.py
+++ b/application/backend/src/cli.py
@@ -20,9 +20,9 @@ from db.schema import (
     SnapshotDB,
 )
 from settings import get_settings
+from storage_migration import StorageMigrationError, migrate_default_storage_dir
 
 settings = get_settings()
-migration_manager = MigrationManager(settings)
 
 
 @click.group()
@@ -51,6 +51,7 @@ def init_db() -> None:
     """Initialize database with migrations"""
     click.echo("Initializing database...")
 
+    migration_manager = MigrationManager(settings)
     if migration_manager.initialize_database():
         click.echo("✓ Database initialized successfully!")
         sys.exit(0)
@@ -80,6 +81,8 @@ def check_db() -> None:
     """Check database status"""
     click.echo("Checking database status...")
 
+    migration_manager = MigrationManager(settings)
+
     # Check connection
     if not migration_manager.check_connection():
         click.echo("✗ Cannot connect to database")
@@ -104,6 +107,13 @@ def migrate() -> None:
     """Run database migrations"""
     click.echo("Running database migrations...")
 
+    try:
+        migrate_default_storage_dir(settings)
+    except StorageMigrationError as e:
+        click.echo(f"✗ Storage migration failed: {e}", err=True)
+        sys.exit(1)
+
+    migration_manager = MigrationManager(settings)
     if migration_manager.run_migrations():
         click.echo("✓ Migrations completed successfully!")
         sys.exit(0)

--- a/application/backend/src/services/dataset_import/README.md
+++ b/application/backend/src/services/dataset_import/README.md
@@ -213,7 +213,7 @@ All knobs are read from environment (or `.env` file) at startup via `Settings` i
 | `DATA_IMPORT_MAX_UPLOAD_BYTES` | 100 GiB | Maximum raw archive size accepted by data-import upload endpoints. Checked by `upload_size_guard_middleware` before the body is read, and again by `check_disk_headroom` before file write. |
 | `DATA_IMPORT_MIN_FREE_BYTES` | 1 GiB | Minimum free headroom that must remain on the target filesystem *after* a write (applies to both cache dir staging and extraction destination). |
 | `DATA_IMPORT_MAX_UNCOMPRESSED_BYTES` | 200 GiB | Maximum total uncompressed size permitted across all ZIP entries. |
-| `STORAGE_DIR` | `~/.cache/physicalai` | Root for `datasets/` (extraction destination) and `cache/imports/datasets/` (staging area). Both must live on a filesystem with adequate free space. |
+| `STORAGE_DIR` | Linux: `${XDG_DATA_HOME:-~/.local/share}/physicalai`; macOS: `~/Library/Application Support/physicalai`; Docker: `/app/storage` | Root for `datasets/` (extraction destination) and `cache/imports/datasets/` (staging area). Both must live on a filesystem with adequate free space. Existing users of the old default `~/.cache/physicalai` are prompted to migrate on interactive startup; non-interactive startup fails unless `AUTO_MIGRATE_STORAGE_DIR=true` is set. |
 
 ### Recommended values for large imports (≥ 50 GB)
 

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -3,12 +3,34 @@
 
 """Application configuration management"""
 
+import os
+import sys
 from functools import lru_cache
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def get_default_storage_dir() -> Path:
+    """Return the platform-appropriate directory for persistent app data."""
+    if sys.platform == "darwin":
+        return Path("~/Library/Application Support/physicalai").expanduser()
+
+    if sys.platform == "win32":
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        if local_app_data:
+            return Path(local_app_data).expanduser() / "physicalai"
+        return Path("~/AppData/Local/physicalai").expanduser()
+
+    xdg_data_home = os.environ.get("XDG_DATA_HOME")
+    if xdg_data_home:
+        xdg_data_home_path = Path(xdg_data_home).expanduser()
+        if xdg_data_home_path.is_absolute():
+            return xdg_data_home_path / "physicalai"
+
+    return Path("~/.local/share/physicalai").expanduser()
 
 
 class Settings(BaseSettings):
@@ -28,8 +50,14 @@ class Settings(BaseSettings):
     debug: bool = Field(default=False, alias="DEBUG")
     environment: Literal["dev", "prod"] = "dev"
     data_dir: Path = Field(default=Path("data"), alias="DATA_DIR")
-    storage_dir: Path = Field(default=Path("~/.cache/physicalai").expanduser(), alias="STORAGE_DIR")
+    storage_dir: Path = Field(default_factory=get_default_storage_dir, alias="STORAGE_DIR")
     static_files_dir: str | None = Field(default=None, alias="STATIC_FILES_DIR")
+
+    @field_validator("storage_dir", mode="before")
+    @classmethod
+    def expand_storage_dir(cls, value: Path | str) -> Path:
+        """Expand user-provided storage directories like ~/.local/share."""
+        return Path(value).expanduser()
 
     # Data import/upload safety (shared for dataset/model/project imports)
     data_import_max_uncompressed_bytes: int = Field(

--- a/application/backend/src/storage_migration.py
+++ b/application/backend/src/storage_migration.py
@@ -1,0 +1,177 @@
+"""Filesystem migration for the persistent storage directory."""
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import click
+from loguru import logger
+from sqlalchemy import create_engine, update
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.pool import NullPool
+
+from db.schema import DatasetDB, ModelDB, RobotCalibrationDB, SnapshotDB
+from settings import Settings
+
+OLD_DEFAULT_STORAGE_DIR = Path("~/.cache/physicalai").expanduser()
+AUTO_MIGRATE_STORAGE_DIR_ENV = "AUTO_MIGRATE_STORAGE_DIR"
+EXPECTED_STORAGE_SUBDIRS = {"models", "cache", "snapshots", "datasets", "robots", "logs"}
+
+
+class StorageMigrationError(Exception):
+    """Raised when storage migration cannot be completed safely."""
+
+
+def migrate_default_storage_dir(settings: Settings, *, interactive: bool | None = None) -> None:
+    """Move data from the old cache-backed default storage directory when safe."""
+    old_storage_dir = OLD_DEFAULT_STORAGE_DIR
+    new_storage_dir = settings.storage_dir.expanduser()
+
+    if not old_storage_dir.exists():
+        return
+
+    if _same_path(old_storage_dir, new_storage_dir):
+        return
+
+    auto_migrate = _env_flag(AUTO_MIGRATE_STORAGE_DIR_ENV)
+    storage_dir_is_overridden = "STORAGE_DIR" in os.environ
+    if storage_dir_is_overridden and not auto_migrate:
+        logger.info("Skipping storage migration because STORAGE_DIR is set.")
+        return
+
+    if not _is_effectively_empty_storage_dir(new_storage_dir):
+        raise StorageMigrationError(_non_empty_destination_message(old_storage_dir, new_storage_dir))
+
+    if interactive is None:
+        interactive = sys.stdin.isatty()
+
+    if not auto_migrate:
+        if not interactive:
+            raise StorageMigrationError(_non_interactive_message(old_storage_dir, new_storage_dir))
+
+        click.echo("Physical AI Studio storage needs to move to a persistent application data directory.")
+        click.echo(f"  from: {old_storage_dir}")
+        click.echo(f"  to:   {new_storage_dir}")
+        if not click.confirm("Move existing storage now?", default=False):
+            raise StorageMigrationError(_declined_message(old_storage_dir, new_storage_dir))
+
+    logger.info(f"Migrating storage directory from {old_storage_dir} to {new_storage_dir}")
+    _remove_empty_storage_scaffold(new_storage_dir)
+    new_storage_dir.parent.mkdir(parents=True, exist_ok=True)
+    _move_storage_dir(old_storage_dir, new_storage_dir)
+    _rewrite_database_paths(settings, old_storage_dir, new_storage_dir)
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").lower() in {"1", "true", "yes", "on"}
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except OSError:
+        return left.expanduser().absolute() == right.expanduser().absolute()
+
+
+def _is_effectively_empty_storage_dir(path: Path) -> bool:
+    if not path.exists():
+        return True
+    if not path.is_dir():
+        return False
+
+    for child in path.iterdir():
+        if child.name not in EXPECTED_STORAGE_SUBDIRS or not child.is_dir():
+            return False
+        if any(child.iterdir()):
+            return False
+    return True
+
+
+def _remove_empty_storage_scaffold(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+
+
+def _move_storage_dir(source: Path, destination: Path) -> None:
+    try:
+        source.rename(destination)
+    except OSError:
+        shutil.move(str(source), str(destination))
+
+
+def _rewrite_database_paths(settings: Settings, old_storage_dir: Path, new_storage_dir: Path) -> None:
+    database_path = settings.data_dir / settings.database_file
+    if not database_path.exists():
+        return
+
+    engine = create_engine(
+        settings.database_url_sync,
+        connect_args={"check_same_thread": False, "timeout": 30},
+        poolclass=NullPool,
+    )
+    session_factory = sessionmaker(bind=engine)
+    with session_factory() as session:
+        try:
+            _rewrite_table_paths(session, DatasetDB, DatasetDB.path, old_storage_dir, new_storage_dir)
+            _rewrite_table_paths(session, ModelDB, ModelDB.path, old_storage_dir, new_storage_dir)
+            _rewrite_table_paths(session, SnapshotDB, SnapshotDB.path, old_storage_dir, new_storage_dir)
+            _rewrite_table_paths(
+                session, RobotCalibrationDB, RobotCalibrationDB.file_path, old_storage_dir, new_storage_dir
+            )
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+    engine.dispose()
+
+
+def _rewrite_table_paths(
+    session: Session,
+    model: type[DatasetDB] | type[ModelDB] | type[SnapshotDB] | type[RobotCalibrationDB],
+    column: InstrumentedAttribute[str],
+    old_storage_dir: Path,
+    new_storage_dir: Path,
+) -> None:
+    for row_id, path_value in session.query(model.id, column).all():
+        rewritten_path = _rewrite_path_prefix(path_value, old_storage_dir, new_storage_dir)
+        if rewritten_path != path_value:
+            session.execute(update(model).where(model.id == row_id).values({column.key: rewritten_path}))
+
+
+def _rewrite_path_prefix(path_value: str, old_storage_dir: Path, new_storage_dir: Path) -> str:
+    try:
+        relative_path = Path(path_value).relative_to(old_storage_dir)
+    except ValueError:
+        return path_value
+    return str(new_storage_dir / relative_path)
+
+
+def _non_empty_destination_message(old_storage_dir: Path, new_storage_dir: Path) -> str:
+    return (
+        "Cannot automatically migrate Physical AI Studio storage because the new storage directory already "
+        "contains files.\n\n"
+        f"Old storage: {old_storage_dir}\n"
+        f"New storage: {new_storage_dir}\n\n"
+        f"Move or merge the data manually, or set STORAGE_DIR={old_storage_dir} to keep using the old location."
+    )
+
+
+def _non_interactive_message(old_storage_dir: Path, new_storage_dir: Path) -> str:
+    return (
+        "Physical AI Studio storage needs to move, but startup is non-interactive.\n\n"
+        f"Old storage: {old_storage_dir}\n"
+        f"New storage: {new_storage_dir}\n\n"
+        f"Move the directory manually, set STORAGE_DIR={old_storage_dir} to keep using the old location, or set "
+        f"{AUTO_MIGRATE_STORAGE_DIR_ENV}=true to allow automatic migration."
+    )
+
+
+def _declined_message(old_storage_dir: Path, new_storage_dir: Path) -> str:
+    return (
+        "Storage migration was declined.\n\n"
+        f"Old storage: {old_storage_dir}\n"
+        f"New storage: {new_storage_dir}\n\n"
+        f"Move the directory manually or set STORAGE_DIR={old_storage_dir} to keep using the old location."
+    )

--- a/application/backend/tests/test_settings.py
+++ b/application/backend/tests/test_settings.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import settings as settings_module
+from settings import Settings, get_default_storage_dir
+
+
+def test_default_storage_dir_uses_xdg_data_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(settings_module.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+
+    assert get_default_storage_dir() == tmp_path / "xdg-data" / "physicalai"
+
+
+def test_default_storage_dir_ignores_relative_xdg_data_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(settings_module.sys, "platform", "linux")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", "relative/path")
+
+    assert get_default_storage_dir() == tmp_path / ".local" / "share" / "physicalai"
+
+
+def test_default_storage_dir_uses_macos_application_support(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(settings_module.sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert get_default_storage_dir() == tmp_path / "Library" / "Application Support" / "physicalai"
+
+
+def test_storage_dir_override_expands_user(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    settings = Settings(STORAGE_DIR="~/custom-storage")
+
+    assert settings.storage_dir == tmp_path / "custom-storage"

--- a/application/backend/tests/test_storage_migration.py
+++ b/application/backend/tests/test_storage_migration.py
@@ -1,0 +1,193 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+import storage_migration
+from db.schema import (
+    Base,
+    DatasetDB,
+    ModelDB,
+    ProjectDB,
+    ProjectEnvironmentDB,
+    ProjectRobotDB,
+    RobotCalibrationDB,
+    SnapshotDB,
+)
+from schemas.robot import RobotType
+from settings import Settings
+from storage_migration import StorageMigrationError, migrate_default_storage_dir
+
+
+def _settings(tmp_path: Path) -> Settings:
+    return Settings(DATA_DIR=str(tmp_path / "data"), STORAGE_DIR=str(tmp_path / "new-storage"))
+
+
+def _old_storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    old_storage = tmp_path / "old-cache" / "physicalai"
+    monkeypatch.setattr(storage_migration, "OLD_DEFAULT_STORAGE_DIR", old_storage)
+    return old_storage
+
+
+def test_migration_noops_when_old_storage_is_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(tmp_path)
+    _old_storage(tmp_path, monkeypatch)
+
+    migrate_default_storage_dir(settings, interactive=False)
+
+    assert not settings.storage_dir.exists()
+
+
+def test_migration_skips_explicit_storage_dir_without_auto_migrate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path)
+    old_storage = _old_storage(tmp_path, monkeypatch)
+    old_storage.mkdir(parents=True)
+    (old_storage / "datasets").mkdir()
+    monkeypatch.setenv("STORAGE_DIR", str(settings.storage_dir))
+    monkeypatch.delenv("AUTO_MIGRATE_STORAGE_DIR", raising=False)
+
+    migrate_default_storage_dir(settings, interactive=False)
+
+    assert old_storage.exists()
+    assert not settings.storage_dir.exists()
+
+
+def test_migration_moves_old_storage_to_missing_destination(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(tmp_path)
+    old_storage = _old_storage(tmp_path, monkeypatch)
+    (old_storage / "datasets").mkdir(parents=True)
+    (old_storage / "datasets" / "dataset.txt").write_text("data")
+    monkeypatch.setenv("AUTO_MIGRATE_STORAGE_DIR", "true")
+
+    migrate_default_storage_dir(settings, interactive=False)
+
+    assert not old_storage.exists()
+    assert (settings.storage_dir / "datasets" / "dataset.txt").read_text() == "data"
+
+
+def test_migration_replaces_empty_storage_scaffold(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(tmp_path)
+    old_storage = _old_storage(tmp_path, monkeypatch)
+    (old_storage / "models").mkdir(parents=True)
+    (old_storage / "models" / "model.txt").write_text("model")
+    for subdir in storage_migration.EXPECTED_STORAGE_SUBDIRS:
+        (settings.storage_dir / subdir).mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("AUTO_MIGRATE_STORAGE_DIR", "true")
+
+    migrate_default_storage_dir(settings, interactive=False)
+
+    assert (settings.storage_dir / "models" / "model.txt").read_text() == "model"
+
+
+def test_migration_fails_when_destination_contains_data(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(tmp_path)
+    old_storage = _old_storage(tmp_path, monkeypatch)
+    old_storage.mkdir(parents=True)
+    settings.storage_dir.mkdir(parents=True)
+    (settings.storage_dir / "existing.txt").write_text("data")
+    monkeypatch.setenv("AUTO_MIGRATE_STORAGE_DIR", "true")
+
+    with pytest.raises(StorageMigrationError, match="already contains files"):
+        migrate_default_storage_dir(settings, interactive=False)
+
+    assert old_storage.exists()
+
+
+def test_migration_fails_non_interactive_without_auto_migrate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(tmp_path)
+    old_storage = _old_storage(tmp_path, monkeypatch)
+    old_storage.mkdir(parents=True)
+    monkeypatch.delenv("AUTO_MIGRATE_STORAGE_DIR", raising=False)
+
+    with pytest.raises(StorageMigrationError, match="non-interactive"):
+        migrate_default_storage_dir(settings, interactive=False)
+
+    assert old_storage.exists()
+
+
+def test_migration_rewrites_database_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(tmp_path)
+    old_storage = _old_storage(tmp_path, monkeypatch)
+    (old_storage / "datasets" / "dataset-1").mkdir(parents=True)
+    settings.data_dir.mkdir(parents=True)
+    monkeypatch.setenv("AUTO_MIGRATE_STORAGE_DIR", "true")
+
+    engine = create_engine(settings.database_url_sync)
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+    with session_factory() as session:
+        session.add_all(
+            [
+                ProjectDB(id="project-1", name="Project"),
+                ProjectEnvironmentDB(id="environment-1", project_id="project-1", name="Environment"),
+                ProjectRobotDB(
+                    id="robot-1",
+                    project_id="project-1",
+                    name="Robot",
+                    type=RobotType.SO101_FOLLOWER,
+                    payload={},
+                ),
+            ]
+        )
+        session.commit()
+
+        session.add_all(
+            [
+                DatasetDB(
+                    id="dataset-1",
+                    name="Dataset",
+                    path=str(old_storage / "datasets" / "dataset-1"),
+                    project_id="project-1",
+                    environment_id="environment-1",
+                    default_task="",
+                ),
+                DatasetDB(
+                    id="dataset-2",
+                    name="External Dataset",
+                    path=str(tmp_path / "external" / "dataset-2"),
+                    project_id="project-1",
+                    environment_id="environment-1",
+                    default_task="",
+                ),
+                ModelDB(
+                    id="model-1",
+                    name="Model",
+                    path=str(old_storage / "models" / "model-1"),
+                    policy="act",
+                    properties={},
+                    project_id="project-1",
+                ),
+                SnapshotDB(
+                    id="snapshot-1",
+                    path=str(old_storage / "snapshots" / "snapshot-1"),
+                    dataset_id="dataset-1",
+                ),
+                RobotCalibrationDB(
+                    id="calibration-1",
+                    file_path=str(old_storage / "robots" / "robot-1" / "calibration.json"),
+                    robot_id="robot-1",
+                ),
+            ]
+        )
+        session.commit()
+
+    migrate_default_storage_dir(settings, interactive=False)
+
+    with session_factory() as session:
+        dataset_path = session.scalar(select(DatasetDB.path).where(DatasetDB.id == "dataset-1"))
+        external_dataset_path = session.scalar(select(DatasetDB.path).where(DatasetDB.id == "dataset-2"))
+        model_path = session.scalar(select(ModelDB.path).where(ModelDB.id == "model-1"))
+        snapshot_path = session.scalar(select(SnapshotDB.path).where(SnapshotDB.id == "snapshot-1"))
+        calibration_path = session.scalar(
+            select(RobotCalibrationDB.file_path).where(RobotCalibrationDB.id == "calibration-1")
+        )
+
+    assert dataset_path == str(settings.storage_dir / "datasets" / "dataset-1")
+    assert external_dataset_path == str(tmp_path / "external" / "dataset-2")
+    assert model_path == str(settings.storage_dir / "models" / "model-1")
+    assert snapshot_path == str(settings.storage_dir / "snapshots" / "snapshot-1")
+    assert calibration_path == str(settings.storage_dir / "robots" / "robot-1" / "calibration.json")
+    engine.dispose()

--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -189,6 +189,7 @@ ENV PATH="/app/application/backend/.venv/bin:$PATH" \
     STATIC_FILES_DIR="/app/application/ui/" \
     DATA_DIR="/app/data" \
     STORAGE_DIR="/app/storage" \
+    AUTO_MIGRATE_STORAGE_DIR="true" \
     PYTHONPATH="/app/application/backend"
 
 EXPOSE 8000


### PR DESCRIPTION
Physical AI Studio stores datasets, trained models, snapshots, robot calibrations, logs, and import cache under `STORAGE_DIR`. The previous default used `~/.cache/physicalai`, but cache directories are explicitly non-essential storage and may be removed by the user or system cleanup tools.
That is unsafe for data that the application expects to persist across restarts and upgrades.

This changes the default storage location to the platform app-data directory while preserving `STORAGE_DIR` as the override: `XDG_DATA_HOME/physicalai` or `~/.local/share/physicalai` on Linux, `~/Library/Application Support/physicalai` on macOS, and `LOCALAPPDATA/physicalai` on Windows when support is added.

To avoid stranding existing users, startup now runs a storage migration before Alembic.
The migration moves the old `~/.cache/physicalai` tree to the new default location and rewrites database path prefixes for datasets, models, snapshots, and robot calibration files.
It skips users who explicitly set `STORAGE_DIR` unless `AUTO_MIGRATE_STORAGE_DIR=true` is set (used in Docker).

We've tried to keep this migration safe: it fails for non-interactive startups and asks the user if it's okay to doa the migration when they start `./run.sh` manually (and only if we detect it's necessary).

Follow-up: after we have verified most early users have migrated, we can simplify this by removing the old `~/.cache/physicalai` migration path, the `AUTO_MIGRATE_STORAGE_DIR` escape hatch, and the empty-scaffold compatibility handling.

## Type of Change

- [x] 🐞 `fix` - Bug fix

## Breaking Changes

> [!CAUTION]
> Storage is no longer saved in `~/.cache/physicalai`, instead it is stored in `~/.local/share/physicalai` to emphasize that these are essential.
> The application will automatically migrate the old directory to the new and should work without issues.
