### PR TITLE
fix: prevent multi-gpu training server restart by defaulting to the first gpu device

### DIFF
--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -145,6 +145,8 @@ class TrainingWorker(BaseProcessWorker):
                 policy = setup_policy(model, compile_model=payload.compile_model)
 
             precision = str(payload.precision)
+            strategy = get_lightning_strategy(device_type)
+            devices = [device_index] if device_index is not None else 1
 
             checkpoint_callback = ModelCheckpoint(
                 dirpath=cache_path,
@@ -168,8 +170,8 @@ class TrainingWorker(BaseProcessWorker):
                         TrainingLogCallback(),
                     ],
                     accelerator=accelerator,
-                    strategy=get_lightning_strategy(device_type),
-                    devices=[device_index] if device_index is not None else "auto",
+                    strategy=strategy,
+                    devices=devices,
                     max_steps=payload.max_steps,
                     auto_scale_batch_size=payload.auto_scale_batch_size,
                     precision=precision,


### PR DESCRIPTION
When a studio was being used on a system with multiple GPUs it would crash when trying to train due to the trainer forking the process and thereby trying to start a new fastapi service using the same port as the default port. This results in an error due to the port being in use and then triggers a failure of the training job.

Ideally we should allow the user to choose the training device when they start a training job, but we need to do a bit more validation for that before we can enable this.
So instead what we do is simply default to the first GPU device.

This should be seen as a temporary fix.

Note: another user solution would be to set `CUDA_VISIBLE_DEVICES=1`.

## Type of Change

- [x] 🐞 `fix` - Bug fix
