### PR TITLE
feat: add outputs schema for exportable policies

### DIFF
--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -93,6 +93,20 @@ class ExportablePolicyMixin:
         return None
 
     @property
+    def output_schema(self) -> list[InferenceFeature] | None:
+        """Provide a description of model's expected outputs.
+
+        Override in subclasses to return a list of InferenceFeature objects describing
+        the model's expected outputs. This information can be used by export methods to
+        generate appropriate output metadata in the manifest.
+        The default implementation returns None, indicating that no output schema is provided.
+
+        Returns:
+            A list of InferenceFeature describing the model's expected outputs, or None if not provided.
+        """
+        return None
+
+    @property
     def extra_export_args(self) -> dict[str, ExportParameters]:
         """Return extra arguments for the export process.
 
@@ -271,6 +285,7 @@ class ExportablePolicyMixin:
             preprocessors=extra_model_args.preprocessors_specs,
             postprocessors=extra_model_args.postprocessors_specs,
             input_features=self._to_component_specs(self.inputs_schema or []),
+            output_features=self._to_component_specs(self.output_schema or []),
         )
 
     @torch.no_grad()
@@ -345,6 +360,7 @@ class ExportablePolicyMixin:
                 preprocessors=extra_model_args.preprocessors_specs,
                 postprocessors=extra_model_args.postprocessors_specs,
                 input_features=self._to_component_specs(self.inputs_schema or []),
+                output_features=self._to_component_specs(self.output_schema or []),
             )
 
     @torch.no_grad()
@@ -461,6 +477,7 @@ class ExportablePolicyMixin:
             preprocessors=extra_model_args.preprocessors_specs,
             postprocessors=extra_model_args.postprocessors_specs,
             input_features=self._to_component_specs(self.inputs_schema or []),
+            output_features=self._to_component_specs(self.output_schema or []),
         )
 
     @torch.no_grad()
@@ -587,6 +604,7 @@ class ExportablePolicyMixin:
             input_names=list(input_sample.keys()),  # type: ignore[arg-type, union-attr]
             output_names=extra_model_args.output_names,
             input_features=self._to_component_specs(self.inputs_schema or []),
+            output_features=self._to_component_specs(self.output_schema or []),
         )
 
         return model_path

--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -93,7 +93,7 @@ class ExportablePolicyMixin:
         return None
 
     @property
-    def output_schema(self) -> list[InferenceFeature] | None:
+    def outputs_schema(self) -> list[InferenceFeature] | None:
         """Provide a description of model's expected outputs.
 
         Override in subclasses to return a list of InferenceFeature objects describing
@@ -285,7 +285,7 @@ class ExportablePolicyMixin:
             preprocessors=extra_model_args.preprocessors_specs,
             postprocessors=extra_model_args.postprocessors_specs,
             input_features=self._to_component_specs(self.inputs_schema or []),
-            output_features=self._to_component_specs(self.output_schema or []),
+            output_features=self._to_component_specs(self.outputs_schema or []),
         )
 
     @torch.no_grad()
@@ -360,7 +360,7 @@ class ExportablePolicyMixin:
                 preprocessors=extra_model_args.preprocessors_specs,
                 postprocessors=extra_model_args.postprocessors_specs,
                 input_features=self._to_component_specs(self.inputs_schema or []),
-                output_features=self._to_component_specs(self.output_schema or []),
+                output_features=self._to_component_specs(self.outputs_schema or []),
             )
 
     @torch.no_grad()
@@ -477,7 +477,7 @@ class ExportablePolicyMixin:
             preprocessors=extra_model_args.preprocessors_specs,
             postprocessors=extra_model_args.postprocessors_specs,
             input_features=self._to_component_specs(self.inputs_schema or []),
-            output_features=self._to_component_specs(self.output_schema or []),
+            output_features=self._to_component_specs(self.outputs_schema or []),
         )
 
     @torch.no_grad()
@@ -604,7 +604,7 @@ class ExportablePolicyMixin:
             input_names=list(input_sample.keys()),  # type: ignore[arg-type, union-attr]
             output_names=extra_model_args.output_names,
             input_features=self._to_component_specs(self.inputs_schema or []),
-            output_features=self._to_component_specs(self.output_schema or []),
+            output_features=self._to_component_specs(self.outputs_schema or []),
         )
 
         return model_path

--- a/library/src/physicalai/policies/act/policy.py
+++ b/library/src/physicalai/policies/act/policy.py
@@ -559,14 +559,15 @@ class ACT(ExportablePolicyMixin, Policy):
             )
 
         extra_args: dict[str, ExportParameters] = {}
+        output_names = [feature.name for feature in (self.output_schema or [])]
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
-                "output_names": ["action"],
+                "output_names": output_names,
             },
             postprocessors_specs=postproc_specs,
         )
         extra_args["openvino"] = OpenVINOExportParameters(
-            outputs=["action"],
+            outputs=output_names,
             export_tokenizer=False,
             compress_to_fp16=False,
             exporter_kwargs={},

--- a/library/src/physicalai/policies/act/policy.py
+++ b/library/src/physicalai/policies/act/policy.py
@@ -514,7 +514,7 @@ class ACT(ExportablePolicyMixin, Policy):
         return schema
 
     @property
-    def output_schema(self) -> list[InferenceFeature] | None:
+    def outputs_schema(self) -> list[InferenceFeature] | None:
         """Describe the policy's model output for export.
 
         Returns:
@@ -559,7 +559,7 @@ class ACT(ExportablePolicyMixin, Policy):
             )
 
         extra_args: dict[str, ExportParameters] = {}
-        output_names = [feature.name for feature in (self.output_schema or [])]
+        output_names = [feature.name for feature in (self.outputs_schema or [])]
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
                 "output_names": output_names,

--- a/library/src/physicalai/policies/act/policy.py
+++ b/library/src/physicalai/policies/act/policy.py
@@ -10,7 +10,7 @@ from physicalai.inference.data import InferenceFeature, InferenceFeatureDtype, I
 from physicalai.inference.manifest import ComponentSpec
 
 from physicalai.data import Dataset, Feature, FeatureType, NormalizationParameters, Observation
-from physicalai.data.observation import IMAGES, STATE
+from physicalai.data.observation import ACTION, IMAGES, STATE
 from physicalai.export.backends import (
     ExecuTorchExportParameters,
     ExportParameters,
@@ -512,6 +512,35 @@ class ACT(ExportablePolicyMixin, Policy):
                 )
 
         return schema
+
+    @property
+    def output_schema(self) -> list[InferenceFeature] | None:
+        """Describe the policy's model output for export.
+
+        Returns:
+            A list with a single ``action`` feature of shape
+            ``(chunk_size, *action_feature.shape)``. Returns ``None`` if the
+            underlying model has not been initialized yet.
+
+        Raises:
+            RuntimeError: If the action feature shape is not defined.
+        """
+        if self.model is None:
+            return None
+
+        action_feature = self.model._config.action_feature  # noqa: SLF001
+        if action_feature is None or action_feature.shape is None:
+            msg = "Action feature is not defined in the model configuration."
+            raise RuntimeError(msg)
+
+        return [
+            InferenceFeature(
+                ftype=InferenceFeatureType.ACTION,
+                shape=(self.config.chunk_size, *tuple(action_feature.shape)),
+                name=ACTION,
+                dtype=InferenceFeatureDtype.FLOAT32,
+            ),
+        ]
 
     @property
     def extra_export_args(self) -> dict[str, ExportParameters]:

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -747,7 +747,7 @@ class Pi05(ExportablePolicyMixin, Policy):
         return schema
 
     @property
-    def output_schema(self) -> list[InferenceFeature] | None:
+    def outputs_schema(self) -> list[InferenceFeature] | None:
         """Describe the policy's model output for export.
 
         Returns:
@@ -816,7 +816,7 @@ class Pi05(ExportablePolicyMixin, Policy):
             torch_postproc_specs.append(chunk_trimmer)
 
         extra_args: dict[str, ExportParameters] = {}
-        output_names = [feature.name for feature in (self.output_schema or [])]
+        output_names = [feature.name for feature in (self.outputs_schema or [])]
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
                 "output_names": output_names,

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -816,9 +816,10 @@ class Pi05(ExportablePolicyMixin, Policy):
             torch_postproc_specs.append(chunk_trimmer)
 
         extra_args: dict[str, ExportParameters] = {}
+        output_names = [feature.name for feature in (self.output_schema or [])]
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
-                "output_names": [ACTION],
+                "output_names": output_names,
             },
             export_tokenizer=False,
             preprocessors_specs=[
@@ -833,7 +834,7 @@ class Pi05(ExportablePolicyMixin, Policy):
             postprocessors_specs=postproc_specs,
         )
         extra_args["openvino"] = OpenVINOExportParameters(
-            outputs=[ACTION],
+            outputs=output_names,
             compress_to_fp16=True,
             via_onnx=True,
             export_tokenizer=True,

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -747,6 +747,30 @@ class Pi05(ExportablePolicyMixin, Policy):
         return schema
 
     @property
+    def output_schema(self) -> list[InferenceFeature] | None:
+        """Describe the policy's model output for export.
+
+        Returns:
+            A list with a single ``action`` feature of shape
+            ``(chunk_size, *action_dim)``, where ``action_dim`` is the actual
+            action dimension taken from the dataset stats. Returns ``None`` if the
+            underlying model or dataset stats have not been initialized yet.
+        """
+        if self.model is None or self._dataset_stats is None:
+            return None
+
+        action_shape = cast("tuple", self._dataset_stats[ACTION]["shape"])
+
+        return [
+            InferenceFeature(
+                ftype=InferenceFeatureType.ACTION,
+                shape=(self.config.chunk_size, *action_shape),
+                name=ACTION,
+                dtype=InferenceFeatureDtype.FLOAT32,
+            ),
+        ]
+
+    @property
     def extra_export_args(self) -> dict[str, ExportParameters]:
         """Additional export arguments for model conversion.
 

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -670,7 +670,7 @@ class SmolVLA(ExportablePolicyMixin, Policy):
         return schema
 
     @property
-    def output_schema(self) -> list[InferenceFeature] | None:
+    def outputs_schema(self) -> list[InferenceFeature] | None:
         """Describe the policy's model output for export.
 
         Returns:
@@ -736,7 +736,7 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             postproc_specs.append(chunk_trimmer)
             torch_postproc_specs.append(chunk_trimmer)
 
-        output_names = [feature.name for feature in (self.output_schema or [])]
+        output_names = [feature.name for feature in (self.outputs_schema or [])]
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
                 "output_names": output_names,

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -670,6 +670,30 @@ class SmolVLA(ExportablePolicyMixin, Policy):
         return schema
 
     @property
+    def output_schema(self) -> list[InferenceFeature] | None:
+        """Describe the policy's model output for export.
+
+        Returns:
+            A list with a single ``action`` feature of shape
+            ``(chunk_size, *action_dim)``, where ``action_dim`` is the actual
+            action dimension taken from the dataset stats. Returns ``None`` if the
+            underlying model or dataset stats have not been initialized yet.
+        """
+        if self.model is None or self._dataset_stats is None:
+            return None
+
+        action_shape = cast("tuple", self._dataset_stats[ACTION]["shape"])
+
+        return [
+            InferenceFeature(
+                ftype=InferenceFeatureType.ACTION,
+                shape=(self.config.chunk_size, *action_shape),
+                name=ACTION,
+                dtype=InferenceFeatureDtype.FLOAT32,
+            ),
+        ]
+
+    @property
     def extra_export_args(self) -> dict[str, ExportParameters]:
         """Additional export arguments for model conversion.
 

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -736,9 +736,10 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             postproc_specs.append(chunk_trimmer)
             torch_postproc_specs.append(chunk_trimmer)
 
+        output_names = [feature.name for feature in (self.output_schema or [])]
         extra_args["onnx"] = ONNXExportParameters(
             exporter_kwargs={
-                "output_names": [ACTION],
+                "output_names": output_names,
             },
             preprocessors_specs=[
                 *base_preproc_specs,
@@ -753,7 +754,7 @@ class SmolVLA(ExportablePolicyMixin, Policy):
             export_tokenizer=False,
         )
         extra_args["openvino"] = OpenVINOExportParameters(
-            outputs=[ACTION],
+            outputs=output_names,
             compress_to_fp16=False,
             export_tokenizer=True,
             exporter_kwargs={},


### PR DESCRIPTION
# Pull Request

## Description

- outputs schema provides a description of model's expected outputs (mirrors `inputs_schema` for inputs)
- outputs information is embedded into exported model's manifest
- outputs information is utilized on export to name the output nodes of the resulting model

## Type of Change

- [x] ✨ `feat` - New feature

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

The exported models are compatible with the old runtime: extra data in manifest is ignored.
Old models are also compatible with new inference runtime: i/o specs are empty in the manifest, but it doesn't affect inference so far, only benchmark won't work.

## Examples

```
policy = SmolVLA(dataset_stats=l_dm.train_dataset.stats, n_action_steps=40).eval()
policy.outputs_schema
>> [InferenceFeature(ftype=<InferenceFeatureType.ACTION: 'ACTION'>, shape=(50, 7), name='action', dtype=<InferenceFeatureDtype.FLOAT32: 'float32'>)]
```
In manifest:
```json
{
  "policy": {
    "name": "smolvla",
    "source": {
      "class_path": "physicalai.policies.smolvla.policy.SmolVLA"
    }
  },
  "model": {
    "runner": {
      "class_path": "physicalai.inference.runners.single_pass.SinglePass"
    },
    "artifacts": {
      "openvino": "smolvla.xml"
    },
...
    "output_features": [
      {
        "class_path": "physicalai.inference.data.features.InferenceFeature",
        "init_args": {
          "ftype": "ACTION",
          "shape": [
            50,
            7
          ],
          "name": "action",
          "dtype": "float32"
        }
      }
    ]
  },
  "format": "policy_package",
  "version": "1.0"
}

```
