### PR TITLE
fix: dont return empty model export folders

### DIFF
--- a/application/backend/src/schemas/model.py
+++ b/application/backend/src/schemas/model.py
@@ -27,7 +27,19 @@ class Model(BaseIDModel):
         exports_dir = Path(self.path) / "exports"
         if not exports_dir.is_dir():
             return []
-        return sorted(d.name for d in exports_dir.iterdir() if d.is_dir())
+
+        backends: list[str] = []
+        for backend_dir in exports_dir.iterdir():
+            if not backend_dir.is_dir():
+                continue
+
+            # Backend exports folder may be empty if export failed
+            if not any(backend_dir.iterdir()):
+                continue
+
+            backends.append(backend_dir.name)
+
+        return sorted(backends)
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/application/backend/src/services/model_service.py
+++ b/application/backend/src/services/model_service.py
@@ -71,6 +71,11 @@ class ModelService:
             if not backend_dir.is_dir():
                 continue
             files = [f for f in backend_dir.rglob("*") if f.is_file()]
+
+            # Backend exports folder may be empty if export failed
+            if len(files) == 0:
+                continue
+
             total_size = sum(f.stat().st_size for f in files)
             exported_at = datetime.fromtimestamp(backend_dir.stat().st_mtime)
             details.append(


### PR DESCRIPTION
The training worker can produce empty folders if export fails. As a quick fix we now filter out any empty folders when returning the available backends and/or export details.

## Type of Change

- [x] 🐞 `fix` - Bug fix