### PR TITLE
fix(ci): add endpoints to enable Renovate and secret scanner verification

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -66,6 +66,7 @@ jobs:
             auth.docker.io:443
             centralus.data.mcr.microsoft.com:443
             eastus.data.mcr.microsoft.com:443
+            endoflife.date:443
             ghcr.io:443
             github.com:443
             hub.docker.com:443
@@ -74,6 +75,8 @@ jobs:
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
+            download-r2.pytorch.org:443
+            download.pytorch.org:443
             files.pythonhosted.org:443
             pypi.org:443
             registry.npmjs.org:443

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,10 +24,16 @@ jobs:
           disable-telemetry: true
           egress-policy: block
           allowed-endpoints: >
+            api.sonarcloud.io:443
+            app.eraser.io:443
             ghcr.io:443
             github.com:443
             pkg-containers.githubusercontent.com:443
-
+            sonarcloud.io:443
+            api.github.com:443
+            auth.docker.io:443
+            registry.npmjs.org:443
+            upload.pypi.org:443
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
This PR adds allowed endpoints to enable Renovate job run.

## Type of Change

- [x] 🐞 `fix` - Bug fix
