### PR TITLE
fix(logs): route robot control worker logs

### DIFF
--- a/application/backend/src/core/logging/log_config.py
+++ b/application/backend/src/core/logging/log_config.py
@@ -26,8 +26,8 @@ class LogConfig:
     # None key is used for application-level logs that don't belong to any specific worker.
     worker_log_info: ClassVar[dict[str | None, str]] = {
         "TrainingWorker": "training.log",
-        "InferenceWorker": "inference.log",
-        "TeleoperateWorker": "teleoperate.log",
+        "ModelWorker": "inference.log",
+        "RobotControlWorker": "robot_control.log",
         "DatasetImportWorker": "dataset_import.log",
         None: "app.log",
     }

--- a/application/backend/src/services/log_service.py
+++ b/application/backend/src/services/log_service.py
@@ -33,7 +33,7 @@ STATIC_SOURCES: dict[str, StaticLogSource] = {
     "application": StaticLogSource(name="Application", filename="app.log", type="application"),
     "training": StaticLogSource(name="Training", filename="training.log", type="worker"),
     "inference": StaticLogSource(name="Inference", filename="inference.log", type="worker"),
-    "teleoperate": StaticLogSource(name="Teleoperate", filename="teleoperate.log", type="worker"),
+    "robot-control": StaticLogSource(name="Robot Control", filename="robot_control.log", type="worker"),
     "dataset-import": StaticLogSource(name="Dataset Import", filename="dataset_import.log", type="worker"),
 }
 

--- a/application/backend/tests/core/logging/test_log_config.py
+++ b/application/backend/tests/core/logging/test_log_config.py
@@ -1,0 +1,21 @@
+from importlib import import_module
+
+from core.logging.log_config import LogConfig
+
+
+def test_worker_log_info_references_existing_worker_classes() -> None:
+    worker_modules = {
+        "TrainingWorker": "workers.training_worker",
+        "ModelWorker": "workers.model_worker",
+        "RobotControlWorker": "workers.robot_control_worker",
+        "DatasetImportWorker": "workers.dataset_import_worker",
+    }
+
+    for worker_name in LogConfig.worker_log_info:
+        if worker_name is None:
+            continue
+
+        module = import_module(worker_modules[worker_name])
+        worker_class = getattr(module, worker_name)
+
+        assert worker_name == worker_class.ROLE

--- a/application/backend/tests/services/test_log_service.py
+++ b/application/backend/tests/services/test_log_service.py
@@ -26,11 +26,28 @@ def test_resolve_source_path_for_static_and_job(tmp_path) -> None:
     job_id = str(uuid4())
 
     assert service.resolve_source_path("application") == tmp_path / "app.log"
+    assert service.resolve_source_path("inference") == tmp_path / "inference.log"
+    assert service.resolve_source_path("robot-control") == tmp_path / "robot_control.log"
     job_log_path = service.resolve_source_path(f"job-{job_id}")
     assert job_log_path is not None
     assert job_log_path.name == f"{job_id}.log"
     assert job_log_path.parent.name == "jobs"
     assert service.resolve_source_path("does-not-exist") is None
+
+
+@pytest.mark.anyio
+async def test_get_log_sources_includes_current_static_workers(tmp_path) -> None:
+    service = _build_service(tmp_path)
+
+    sources = await service.get_log_sources()
+
+    assert [(source.id, source.name, source.type) for source in sources] == [
+        ("application", "Application", "application"),
+        ("training", "Training", "worker"),
+        ("inference", "Inference", "worker"),
+        ("robot-control", "Robot Control", "worker"),
+        ("dataset-import", "Dataset Import", "worker"),
+    ]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Our `log_config.py` was not updated when we refactored the teleoperate worker.
This PR updates that log config and adds an extra test that makes sure that the workers referenced in the config exists and have the expected role.

With this the user will be able to see the robot control logs (anything related to robot setup, camera setup etc) when selecting "Robot Control" from the sources picker.
Inference logs can be found by selecting "Inference".

## Type of Change

- [x] 🐞 `fix` - Bug fix