### PR TITLE
fix: always store a final checkpoint after training

### DIFF
--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -183,6 +183,9 @@ class TrainingWorker(BaseProcessWorker):
             dispatcher.start()
             trainer.fit(model=policy, datamodule=l_dm)
 
+            final_checkpoint = cache_path / "model.ckpt"
+            trainer.save_checkpoint(final_checkpoint)
+
             path.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(cache_path, path)
 

--- a/application/backend/tests/workers/test_training_worker.py
+++ b/application/backend/tests/workers/test_training_worker.py
@@ -188,6 +188,7 @@ class TestTraining:
         export_policy = MagicMock()
         trainer = MagicMock()
         trainer.fit = MagicMock()  # succeeds
+        trainer.save_checkpoint = MagicMock()
 
         completed_job = MagicMock()
         completed_job.id = job.id
@@ -225,6 +226,7 @@ class TestTraining:
             mock_load.assert_called_once_with(model, compile_model=False)
 
             trainer.fit.assert_called_once()
+            trainer.save_checkpoint.assert_called_once_with(tmp_path / "cache" / str(job.id) / "model.ckpt")
 
             MockJobService.update_job.assert_called_once()
             assert MockJobService.update_job_status.call_args_list[0].kwargs["status"] == JobStatus.COMPLETED


### PR DESCRIPTION
Before we'd only store a checkpoint when model training finishes training on 1 epoch.
This results in some ambiguities: if you use a step size that's very small (like 100 for testing) then training won't produce a checkpoint. Another problem is that if you'd choose say 100_000 steps then that might not coincide exactly to a multiple of an epoch, so `policy` would be newer than the previously stored checkpoint.
Since we export our models based on the current `policy` this might result in the exported models not being the same as the saved checkpoints.

## Type of Change

- [x] 🐞 `fix` - Bug fix