### PR TITLE
fix: move samples inputs to the same device that holds policy

### DIFF
--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -41,10 +41,18 @@ DATASET_STATS_KEY = "dataset_stats"
 
 
 class ExportablePolicyMixin:
-    """Mixin class for exporting torch model checkpoints."""
+    """Mixin class for exporting torch model checkpoints.
+
+    Attributes:
+        model: Internal torch module to be exported.
+        _preprocessor: The torch module applied to raw inputs before they reach
+            the model during export tracing.
+        device: The torch device on which the model and sample inputs live.
+    """
 
     model: torch.nn.Module
     _preprocessor: torch.nn.Module
+    device: torch.device
 
     @property
     def sample_input(self) -> dict[str, torch.Tensor | str] | None:
@@ -689,6 +697,7 @@ class ExportablePolicyMixin:
         sample = self.sample_input
         if sample is None:
             return None
+        sample = {k: v.to(self.device) if isinstance(v, torch.Tensor) else v for k, v in sample.items()}
         processed_sample = self._preprocessor(sample)
         return {k: v for k, v in processed_sample.items() if isinstance(v, torch.Tensor)}
 

--- a/library/tests/unit/export/test_executorch_integration.py
+++ b/library/tests/unit/export/test_executorch_integration.py
@@ -44,6 +44,7 @@ class _ExportWrapper(ExportablePolicyMixin):
         self.model = model
         # Identity preprocessor: returns the sample dict unchanged.
         self._preprocessor = torch.nn.Identity()
+        self.device = torch.device("cpu")
 
     @property
     def sample_input(self) -> dict[str, torch.Tensor] | None:

--- a/library/tests/unit/export/test_mixin_export.py
+++ b/library/tests/unit/export/test_mixin_export.py
@@ -149,6 +149,7 @@ class ExportWrapper(ExportablePolicyMixin):
     def __init__(self, model: torch.nn.Module):
         self.model = model
         self._preprocessor = IdentityPreprocessor()
+        self.device = torch.device("cpu")
         self._extra_export_args = {
             ExportBackend.ONNX: ONNXExportParameters(),
             ExportBackend.OPENVINO: OpenVINOExportParameters(),
@@ -566,6 +567,7 @@ class TorchExportWrapper(ExportablePolicyMixin):
     def __init__(self, model: torch.nn.Module, chunk_size: int, n_action_steps: int):
         self.model = model
         self._preprocessor = IdentityPreprocessor()
+        self.device = torch.device("cpu")
         self.chunk_size = chunk_size
         self.n_action_steps = n_action_steps
 
@@ -669,3 +671,26 @@ class TestSampleInputFromSchema:
         assert sample["step"].dtype == torch.int64
 
         assert sample["task"] == "Example prompt string"
+
+
+class TestDefaultExportInputSample:
+    """Tests for ``_get_default_export_input_sample``."""
+
+    def test_tensors_moved_to_policy_device(self):
+        """Processed sample tensors are moved to the policy's ``device``."""
+        model = ModelWithSampleInput(input_dim=10, output_dim=5)
+        wrapper = ExportWrapper(model)
+        # ``meta`` device works without GPU hardware and is easy to assert on.
+        wrapper.device = torch.device("meta")
+
+        sample = wrapper._get_default_export_input_sample()
+
+        assert sample is not None
+        assert all(tensor.device.type == "meta" for tensor in sample.values())
+
+    def test_returns_none_without_sample_input(self):
+        """``None`` is returned when the policy provides no ``sample_input``."""
+        model = SimpleModel(SimpleConfig())
+        wrapper = ExportWrapper(model)
+
+        assert wrapper._get_default_export_input_sample() is None


### PR DESCRIPTION
# Pull Request

## Description

- Explicitly move model inputs to the policy device during export
- Overall, that's experimental changes: might not work with all the devices, policies and export backends we have

## Type of Change

- [x] 🐞 `fix` - Bug fix
