### PR TITLE
feat(ui): Show model training details

### DIFF
--- a/application/ui/src/features/models/details/model-details.tsx
+++ b/application/ui/src/features/models/details/model-details.tsx
@@ -1,0 +1,259 @@
+import { Suspense, useState } from 'react';
+
+import { Divider, Flex, Grid, Heading, Loading, Switch, Text, View } from '@geti-ui/ui';
+
+import { $api } from '../../../api/client';
+import type { components, SchemaModel, SchemaModelDetailResponse } from '../../../api/openapi-spec';
+import { Box } from '../../../routes/models/box.component';
+
+interface ModelDetailsProps {
+    model: SchemaModel;
+}
+
+type ExportDetail = components['schemas']['BackendExportDetail'];
+type IOFeature = components['schemas']['IOFeature'];
+
+const SKIP_HPARAMS_KEYS = new Set(['dataset_stats']);
+
+const isPrimitive = (v: unknown): v is string | number | boolean | null => {
+    return v === null || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean';
+};
+
+const DetailRow = ({ name, value }: { name: string; value: unknown }) => {
+    const display = isPrimitive(value) ? String(value) : JSON.stringify(value);
+    return (
+        <>
+            <Divider orientation='horizontal' size='S' />
+            <View paddingY='size-50'>
+                <Flex gap='size-200'>
+                    <Text UNSAFE_style={{ flexShrink: 0, fontWeight: 'bold' }} width={'size-3000'}>
+                        {name}
+                    </Text>
+                    <Text>{display}</Text>
+                </Flex>
+            </View>
+        </>
+    );
+};
+
+const formatShape = (shape: IOFeature['shape']) => {
+    if (shape === null || shape === undefined) {
+        return '-';
+    }
+
+    return shape.length === 0 ? 'scalar' : `[${shape.join(', ')}]`;
+};
+
+const getHeadingColor = (feature: IOFeature) => {
+    if (feature.ftype === 'STATE') {
+        return 'var(--coral)';
+    }
+
+    if (feature.ftype === 'VISUAL') {
+        return 'var(--moss-tint-1)';
+    }
+
+    if (feature.ftype === 'LANGUAGE') {
+        return 'var(--brand-daisy)';
+    }
+
+    if (feature.ftype === 'ACTION') {
+        return 'var(--energy-blue)';
+    }
+
+    return undefined;
+};
+
+const FeatureRow = ({ feature }: { feature: IOFeature }) => {
+    const color = getHeadingColor(feature);
+
+    return (
+        <View
+            backgroundColor={'gray-100'}
+            padding='size-100'
+            borderRadius={'regular'}
+            borderWidth={'thin'}
+            borderColor='gray-300'
+        >
+            <Flex direction='column' gap='size-10'>
+                <Text UNSAFE_style={{ fontWeight: 'bold', color }}>{feature.ftype}</Text>
+                <Text UNSAFE_style={{ fontWeight: 'bold' }}>{feature.name}</Text>
+                <Divider orientation='horizontal' size='S' marginY='size-50' />
+                <View marginTop='size-50' UNSAFE_style={{ fontFamily: 'monospace' }}>
+                    <Text marginEnd='size-100'>{feature.dtype}</Text>
+                    <Text>{formatShape(feature.shape)}</Text>
+                </View>
+            </Flex>
+        </View>
+    );
+};
+
+const ModelInputInterface = ({ inputFeatures }: { inputFeatures: IOFeature[] }) => {
+    return (
+        <Flex direction='column' gap='size-100' width='size-3600'>
+            <Text UNSAFE_style={{ fontWeight: 600 }}>Inputs ({inputFeatures.length})</Text>
+            <Flex direction={'column'} gap='size-200'>
+                {inputFeatures.map((feature) => {
+                    return <FeatureRow key={feature.name} feature={feature} />;
+                })}
+            </Flex>
+        </Flex>
+    );
+};
+
+const ModelOutputInterface = ({ outputFeatures }: { outputFeatures: IOFeature[] }) => {
+    return (
+        <Flex direction='column' gap='size-100' width='size-3600'>
+            <Text UNSAFE_style={{ fontWeight: 600 }}>Inputs ({outputFeatures.length})</Text>
+            <Flex direction={'column'} gap='size-200'>
+                {outputFeatures.map((feature) => {
+                    return <FeatureRow key={feature.name} feature={feature} />;
+                })}
+            </Flex>
+        </Flex>
+    );
+};
+
+const ModelInterface = ({ exports }: { exports: ExportDetail[] }) => {
+    const exportsWithIoSpec = exports.filter(({ io_spec }) => io_spec !== null && io_spec !== undefined);
+
+    const mainFormat =
+        exportsWithIoSpec.find((e) => {
+            return e.type === 'torch';
+        }) ?? exportsWithIoSpec.at(0);
+
+    if (exportsWithIoSpec.length === 0 || mainFormat === undefined) {
+        return null;
+    }
+
+    const inputFeatures = mainFormat.io_spec?.input_features ?? [];
+    const outputFeatures = mainFormat.io_spec?.output_features ?? [];
+
+    return (
+        <View gridArea='model-interface'>
+            <Box
+                title='Model interface'
+                content={
+                    <Flex direction='row' gap='size-400'>
+                        <ModelInputInterface inputFeatures={inputFeatures} />
+
+                        <Divider size='S' orientation='vertical' />
+
+                        <ModelOutputInterface outputFeatures={outputFeatures} />
+                    </Flex>
+                }
+            />
+        </View>
+    );
+};
+
+const TrainingParameters = ({ summary }: { summary: SchemaModelDetailResponse['training_summary'] }) => {
+    if (summary === undefined || summary === null) {
+        return null;
+    }
+
+    return (
+        <View>
+            <Heading>Training parameters</Heading>
+            <Flex direction='column' gap='size-75'>
+                <DetailRow name='Max steps' value={summary.max_steps} />
+                <DetailRow name='Batch size' value={summary.auto_scale_batch_size ? 'Auto' : summary.batch_size} />
+                <DetailRow name='Workers' value={summary.num_workers ?? '—'} />
+                {summary.precision && <DetailRow name='Precision' value={summary.precision} />}
+                {summary.compile_model !== null && summary.compile_model !== undefined && (
+                    <DetailRow name='Compiled' value={summary.compile_model ? 'Yes' : 'No'} />
+                )}
+                {summary.val_split !== null && summary.val_split !== undefined && summary.val_split > 0 && (
+                    <DetailRow name='Validation split' value={summary.val_split} />
+                )}
+                {summary.device_type && <DetailRow name='Device' value={summary.device_type} />}
+            </Flex>
+        </View>
+    );
+};
+
+const HyperParameters = ({ hparams }: { hparams: SchemaModelDetailResponse['training_summary'] }) => {
+    const [showJSON, setShowJSON] = useState(false);
+
+    if (hparams === null) {
+        return null;
+    }
+
+    return (
+        <View>
+            <View marginBottom={'size-100'}>
+                <Flex direction='row' justifyContent={'space-between'}>
+                    <Heading marginTop='size-200'>Hyper parameters</Heading>
+                    <Switch isSelected={showJSON} onChange={setShowJSON}>
+                        Show JSON
+                    </Switch>
+                </Flex>
+            </View>
+            <View maxHeight='60vh' overflow='auto'>
+                {showJSON ? (
+                    <View backgroundColor={'gray-100'} borderWidth='thin' borderColor='gray-200' paddingX='size-100'>
+                        <pre>{JSON.stringify(hparams, null, 4)}</pre>
+                    </View>
+                ) : (
+                    <Flex direction='column' gap='size-75'>
+                        {hparams &&
+                            Object.entries(hparams)
+                                .filter(([key]) => !SKIP_HPARAMS_KEYS.has(key))
+                                .map(([key, value]) => <DetailRow key={key} name={key} value={value} />)}
+                    </Flex>
+                )}
+            </View>
+        </View>
+    );
+};
+
+const TrainingConfiguration = ({
+    summary,
+    hparams,
+}: {
+    summary: SchemaModelDetailResponse['training_summary'];
+    hparams: SchemaModelDetailResponse['training_summary'];
+}) => {
+    return (
+        <View gridArea='training'>
+            <Box
+                title='Training configuration'
+                content={
+                    <Flex direction='column' gap='size-50'>
+                        <TrainingParameters summary={summary} />
+
+                        <HyperParameters hparams={hparams} />
+                    </Flex>
+                }
+            />
+        </View>
+    );
+};
+
+const ModelDetailsContent = ({ model }: { model: SchemaModel }) => {
+    const { data: modelDetail } = $api.useSuspenseQuery('get', '/api/models/{model_id}', {
+        params: { path: { model_id: model.id! } },
+    });
+
+    return (
+        <Grid
+            areas={{
+                L: ['model-interface training', 'model-interface training'],
+                M: ['model-interface', 'training'],
+            }}
+            gap='size-200'
+            columns={['auto 1fr']}
+        >
+            <ModelInterface exports={modelDetail.exports} />
+            <TrainingConfiguration summary={modelDetail.training_summary} hparams={modelDetail.hparams} />
+        </Grid>
+    );
+};
+
+export const ModelDetails = ({ model }: ModelDetailsProps) => {
+    return (
+        <Suspense fallback={<Loading mode='inline' size='M' marginY='size-400' />}>
+            <ModelDetailsContent model={model} />
+        </Suspense>
+    );
+};

--- a/application/ui/src/routes/models/model-row-content.component.tsx
+++ b/application/ui/src/routes/models/model-row-content.component.tsx
@@ -1,6 +1,7 @@
 import { Heading, IllustratedMessage, Item, TabList, TabPanels, Tabs, View } from '@geti-ui/ui';
 
 import { SchemaModel } from '../../api/openapi-spec';
+import { ModelDetails } from '../../features/models/details/model-details';
 import { ModelFormats } from '../../features/models/formats/model-formats';
 import { ReactComponent as EmptyIllustration } from './../../assets/illustration.svg';
 import { MetricsContent } from './metrics';
@@ -41,7 +42,7 @@ export const ModelRowContent = ({ model }: ModelRowContentProps) => {
                         <ComingSoon />
                     </Item>
                     <Item key='training_details'>
-                        <ComingSoon />
+                        <ModelDetails model={model} />
                     </Item>
                 </TabPanels>
             </Tabs>


### PR DESCRIPTION
This PR implements an initial design for the training details tab.
This tab shows:
- Input and output spec of a model (via #635 and #647) 
- Training job summary (batch size, compiled model configuration etc)
- Hyper parameters from `hparams.yaml`

The design is a bit basic and should be improved once we get some feedback. One thing I'd like to do is categorize the hyper parameters. For instance for Act we can group `use_vae`, `latent_dim`, `n_vae_encoder_layers` and `kl_weights` into a "VAE" group.
In addition it would be nice if we can add a description to each of the parameters. Ideally this should come from the training library so that we only need to maintain this in 1 place.

## Type of Change

- [x] ✨ `feat` - New feature

## Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/118a5f7f-b9a7-4ded-8331-cf56cec7a03d" />