### PR TITLE
chore: allow setting alembic configuration via env vars

### DIFF
--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "physical-ai-studio"
-version = "1.0.0"
+version = "0.1.0"
 description = "Physical AI Studio server"
+readme = "README.md"
 requires-python = ">=3.12,<3.14"
 
 dependencies = [

--- a/application/backend/src/core/__init__.py
+++ b/application/backend/src/core/__init__.py
@@ -1,5 +1,0 @@
-from core.lifecycle import lifespan
-
-# from core.scheduler import Scheduler
-
-__all__ = ["lifespan"]

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -29,7 +29,7 @@ from api.robots import router as project_robots_router
 from api.settings import router as settings_router
 from api.system import system_router
 from api.webui import SPAStaticFiles
-from core import lifespan
+from core.lifecycle import lifespan
 from exception_handlers import register_application_exception_handlers
 from middleware.upload_size_guard import upload_size_guard_middleware
 from settings import get_settings

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -116,8 +116,8 @@ class Settings(BaseSettings):
     db_echo: bool = Field(default=False, alias="DB_ECHO")
 
     # Alembic
-    alembic_config_path: str = "src/alembic.ini"
-    alembic_script_location: str = "src/alembic"
+    alembic_config_path: str = Field(default="src/alembic.ini", alias="ALEMBIC_CONFIG_PATH")
+    alembic_script_location: str = Field(default="src/alembic", alias="ALEMBIC_SCRIPT_LOCATION")
 
     # Proxy settings
     no_proxy: str = Field(default="localhost,127.0.0.1,::1", alias="no_proxy")

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "physical-ai-studio"
-version = "1.0.0"
+version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR makes some minor adjustments that will make it easier for us to deploy the backend + frontend as a python wheel.
- Fix a possible circular import issue by avoiding `__init__.py`
- Let user override alembic file location
- Update `pyproject.toml` with version and `README.md`

## Type of Change

- [x] 🔧 `chore` - Maintenance

