### PR TITLE
docs: add troubleshooting for network errors during training

### DIFF
--- a/application/docker/.env.example
+++ b/application/docker/.env.example
@@ -1,4 +1,8 @@
 # Corporate proxies
+# If your network requires a proxy, set these before building or starting the
+# container. Verify propagation with:
+#   docker compose config | grep -i proxy
+#   docker exec physical-ai-studio-<profile> env | grep -i proxy
 HTTP_PROXY=
 HTTPS_PROXY=
 NO_PROXY=

--- a/application/docker/README.md
+++ b/application/docker/README.md
@@ -6,12 +6,24 @@ Docker container with support for CPU, Intel XPU, and NVIDIA CUDA hardware.
 
 ## Prerequisites
 
-- [**Docker Engine**](https://docs.docker.com/engine/install/ubuntu/) 24+ with **Docker Compose** v2
+- [**Docker Engine**](https://docs.docker.com/engine/install/ubuntu/) 24.0+ with **Docker Compose** v2.24.0+
 - A supported hardware backend:
   - **CPU** — any x86_64 system (default)
   - **Intel XPU** — Intel discrete/integrated GPU with Level Zero drivers on the host
   - **NVIDIA CUDA** — NVIDIA GPU with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed
 - Robot hardware (optional): USB serial ports (`/dev/ttyACM*`), USB cameras (`/dev/video*`), or Intel RealSense cameras
+
+Check your installed versions with:
+
+```bash
+docker version
+docker compose version
+```
+
+Docker Compose v2.24.0+ is required because `docker-compose.yaml` uses long-form
+`env_file` entries with `required: false`. Older Compose versions may not pass
+`.env` values into the running container, which can break proxy-dependent model
+training even when `.env` looks correct on the host.
 
 ## Quick Start
 
@@ -269,3 +281,33 @@ NO_PROXY=localhost,127.0.0.1
 ```
 
 These are passed to both the Docker build process and the running container.
+
+If training fails with a network error such as `urlopen error [Errno 99] Cannot assign requested address`, first verify that the proxy settings are visible to Docker Compose and to the running container:
+
+```bash
+# Run from application/docker/
+grep -i proxy .env
+docker compose --profile cuda config | grep -i proxy
+docker exec physical-ai-studio-cuda env | grep -i proxy
+```
+
+Use the matching service name for your profile: `physical-ai-studio-cpu`, `physical-ai-studio-xpu`, or `physical-ai-studio-cuda`.
+
+If the values appear in `.env` but not in `docker compose ... config`, check your Docker Compose version and upgrade to v2.24.0+.
+
+If the values appear in `docker compose ... config` but not inside the running container, recreate the container after upgrading Docker Compose:
+
+```bash
+docker compose --profile cuda up -d --force-recreate
+```
+
+For corporate proxies, configure both uppercase and lowercase variables when required by your environment:
+
+```bash
+HTTP_PROXY=http://proxy.example.com:8080
+HTTPS_PROXY=http://proxy.example.com:8080
+NO_PROXY=localhost,127.0.0.1,::1
+http_proxy=http://proxy.example.com:8080
+https_proxy=http://proxy.example.com:8080
+no_proxy=localhost,127.0.0.1,::1
+```

--- a/application/docs/01-installation.md
+++ b/application/docs/01-installation.md
@@ -13,8 +13,15 @@ Use our native setup if you are planning to contribute to the project and want t
 
 ## Install with Docker (recommended)
 
-Install [Docker Engine](https://docs.docker.com/engine/install/ubuntu/) 24+ with Docker Compose v2.
+Install [Docker Engine](https://docs.docker.com/engine/install/ubuntu/) 24.0+ with Docker Compose v2.24.0+.
 For hardware-specific setup, see the [Docker README](../docker/README.md).
+
+Check your installed versions with:
+
+```bash
+docker version
+docker compose version
+```
 
 Then from `application/docker/`:
 

--- a/application/docs/06-training-policies.md
+++ b/application/docs/06-training-policies.md
@@ -19,9 +19,56 @@ First, choose the model policy. We currently support:
 - SmolVLA
 - Pi0.5
 
+Some policies download assets from Hugging Face Hub during setup or training. Configure `HF_TOKEN` before training Hub-backed policies such as SmolVLA or Pi0.5, especially on shared networks or when using gated/private models.
+
 Depending on the amount of VRAM available on your GPU, you may need to adjust the advanced settings.
 These settings include _batch size_, _training steps_, _amount of data workers_, _precision_, and an option to _compile model_ before training.
 You may need to tune these settings to get an optimal result.
+
+## Hugging Face Hub access
+
+If `HF_TOKEN` is not set, the backend uses unauthenticated Hugging Face Hub access and may log a warning. Downloads can fail without a token because of anonymous rate limits or access restrictions on gated/private repositories.
+
+Use a token with read-only model access:
+
+- Required: `Read` permission for model repositories.
+- Not required: `Write` or admin permissions.
+- For gated/private models, use a Hugging Face account that has access to those repositories.
+- For fine-grained tokens, grant read access to the specific model repositories you plan to use.
+
+To create a token:
+
+1. Sign in to [huggingface.co](https://huggingface.co/).
+2. Open **Settings** -> **Access Tokens**.
+3. Create a new token.
+4. Set permissions to read-only model access.
+5. Copy the token value.
+
+For Docker deployments, add the token to `application/docker/.env`:
+
+```env
+HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Then recreate or start the Docker stack from `application/docker/`:
+
+```bash
+docker compose up -d --force-recreate
+```
+
+For native backend deployments, add the token to `application/backend/.env`:
+
+```env
+HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Then start the backend from `application/backend/`:
+
+```bash
+./run.sh
+```
+
+Never commit real tokens to source control. Store them only in local `.env` files or your secret manager, and rotate the token immediately if it is exposed.
 
 ## Monitor training progress
 

--- a/application/docs/06-training-policies.md
+++ b/application/docs/06-training-policies.md
@@ -45,6 +45,26 @@ If a training job takes too long, you can interrupt it. This stores a checkpoint
 When training finishes we export the model to all its supported backends: [PyTorch](https://github.com/pytorch/pytorch), [OpenVINO](https://github.com/openvinotoolkit/openvino), [ONNX](https://github.com/onnx/onnx) and [ExecuTorch](https://github.com/pytorch/executorch).
 Download the model and then use [OpenVINO PhysicalAI](https://github.com/openvinotoolkit/physicalai) to deploy it on your hardware.
 
+## Troubleshooting training network errors
+
+If training fails with a network error such as `urlopen error [Errno 99] Cannot assign requested address`, verify that the running container has the expected proxy configuration. Some training paths and model policies may contact external services such as Hugging Face Hub.
+
+From `application/docker/`, check the host `.env`, the rendered Compose configuration, and the running container environment:
+
+```bash
+grep -i proxy .env
+docker compose --profile cuda config | grep -i proxy
+docker exec physical-ai-studio-cuda env | grep -i proxy
+```
+
+Use the profile and container name that match your setup: `cpu`, `xpu`, or `cuda`.
+
+If proxy values are present in `.env` but missing from `docker compose ... config` or from the running container, upgrade to Docker Compose v2.24.0+ and recreate the container:
+
+```bash
+docker compose up -d --force-recreate
+```
+
 ## Next
 
 - Run/deploy in UI: [Deploying Model Policies](./07-deploying-model-policies.md).

--- a/application/docs/06-training-policies.md
+++ b/application/docs/06-training-policies.md
@@ -100,11 +100,8 @@ From `application/docker/`, check the host `.env`, the rendered Compose configur
 
 ```bash
 grep -i proxy .env
-docker compose --profile cuda config | grep -i proxy
-docker exec physical-ai-studio-cuda env | grep -i proxy
+docker compose config | grep -i proxy
 ```
-
-Use the profile and container name that match your setup: `cpu`, `xpu`, or `cuda`.
 
 If proxy values are present in `.env` but missing from `docker compose ... config` or from the running container, upgrade to Docker Compose v2.24.0+ and recreate the container:
 


### PR DESCRIPTION
Add more specific docker (and compose) version requirements given that we use `env_file` to setup our environment variables.
I've also added more troubleshooting information regarding network errors while training when using a corporate proxy/vpn setup.

The training docs now also mention requiring a `HF_TOKEN` to speed up downloads as well as access gated (for Pi05) models.

## Type of Change

- [x] 📚 `docs` - Documentation
