### PR TITLE
refactor: Update and streamline Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,29 +1,3 @@
-# GitHub Copilot Instructions for Physical AI Studio
-
-> **Note**: This file is synchronized with `.cursorrules`. Both Cursor and VS Code (GitHub Copilot) use these same standards.
-
-## Table of Contents
-
-- [GitHub Copilot Instructions for Physical AI Studio](#github-copilot-instructions-for-physical-ai-studio)
-  - [Table of Contents](#table-of-contents)
-  - [Project Overview](#project-overview)
-  - [Coding Standards](#coding-standards)
-    - [Python Environment Management](#python-environment-management)
-    - [Python Code](#python-code)
-    - [TypeScript/React Code](#typescriptreact-code)
-    - [General Principles](#general-principles)
-  - [Writing Style](#writing-style)
-  - [Documentation Standards](#documentation-standards)
-  - [Testing Guidelines](#testing-guidelines)
-  - [File Organization](#file-organization)
-  - [Git Commit Messages](#git-commit-messages)
-  - [Pull Request Guidelines](#pull-request-guidelines)
-  - [Performance Considerations](#performance-considerations)
-  - [Security Best Practices](#security-best-practices)
-  - [AI/ML Specific Guidelines](#aiml-specific-guidelines)
-  - [Questions to Consider Before Coding](#questions-to-consider-before-coding)
-  - [When Suggesting Code Changes](#when-suggesting-code-changes)
-
 ## Project Overview
 
 Full-stack application with:
@@ -41,7 +15,6 @@ Full-stack application with:
 - Install with `uv pip install` or `uv sync`
 - Create environments with `uv venv`
 - Never use `pip` directly
-- Ensure `.venv` is in `.gitignore`
 
 ### Python Code
 
@@ -50,38 +23,7 @@ Full-stack application with:
 - Prefer `pathlib.Path` over string paths
 - Use `ruff` for linting and formatting
 - Address all ruff warnings
-
-**Docstrings** - Google style format:
-
-```python
-def function_name(param1: str, param2: int) -> bool:
-    """Brief description of function.
-
-    Args:
-        param1: Description of param1
-        param2: Description of param2
-
-    Returns:
-        Description of return value
-
-    Raises:
-        ValueError: Description of when this is raised
-
-    Examples:
-        >>> result = function_name("test", 42)
-        >>> print(result)
-        True
-
-        Multi-line example without prompt:
-
-        from module import function_name
-
-        result = function_name("test", 42)
-        if result:
-            print("Success")
-    """
-```
-
+- Use Google style docstrings
 - Use `logging` instead of `print()`
 - Prefer dataclasses or Pydantic models
 - Use context managers for resource management
@@ -98,58 +40,19 @@ def function_name(param1: str, param2: int) -> bool:
 
 ### General Principles
 
-- **DRY**: Extract common logic
-- **Single Responsibility**: One clear purpose per function/class
-- **Error Handling**: Handle errors with informative messages
-- **Testing**: Write tests for new functionality
-- **Security**: Use environment variables for secrets
-- **Performance**: Consider implications, especially for ML operations
+DRY, single responsibility, informative error messages, and tests for new functionality. Store secrets in environment variables. Mind performance of ML operations.
 
 ## Writing Style
 
 Apply to code comments, documentation, commit messages, and PR descriptions:
 
-**Be Concise**
+- **Be concise**: cut unnecessary words, avoid repetition, prefer short sentences.
+- **Be direct**: state the point first, use active voice, drop hedging ("may", "might", "could potentially").
+- **Use simple language**: plain words over complex ones, explain domain-specific terms.
+- **Sound natural**: write as if explaining to a colleague. Avoid formulaic transitions ("Furthermore", "Moreover") and filler ("It is important to note that", "It is worth noting"). Vary sentence length.
+- **Clarity over impressive vocabulary.**
 
-- Remove unnecessary words
-- Avoid repeating ideas
-- Use 10 words instead of 20
-- Prefer short sentences
-
-**Be Direct**
-
-- State the point immediately
-- Use active voice
-- Remove hedging language ("may", "might", "could potentially")
-
-**Use Simple Language**
-
-- Choose simple words over complex ones
-- Avoid jargon unless necessary
-- Break complex sentences into shorter ones
-
-**Sound Natural**
-
-- Write as if explaining to a colleague
-- Avoid formulaic transitions ("Furthermore", "Moreover", "Additionally")
-- Don't use numbered lists when a paragraph works
-- Avoid: "It is important to note that", "It should be mentioned", "It is worth noting"
-- Vary sentence length naturally
-
-**Academic But Accessible**
-
-- Use technical terms when needed, explain domain-specific ones
-- Prefer clarity over impressive vocabulary
-
-**Examples:**
-
-❌ "It is important to note that the workshop aims to establish a comprehensive platform that serves to bring together researchers from diverse backgrounds in order to facilitate meaningful collaboration."
-
-✅ "The workshop brings together researchers from diverse backgrounds to facilitate collaboration."
-
-❌ "The methodology demonstrates significant improvements in terms of performance metrics."
-
-✅ "The method improves performance."
+Example — ❌ "The methodology demonstrates significant improvements in terms of performance metrics." ✅ "The method improves performance."
 
 ## Documentation Standards
 
@@ -204,12 +107,18 @@ Apply to code comments, documentation, commit messages, and PR descriptions:
 ```
 application/backend/src/
 ├── api/          # API routes and endpoints
+├── control/      # Robot control logic
 ├── core/         # Core business logic
 ├── db/           # Database models and migrations
+├── internal_datasets/ # Built-in datasets
+├── middleware/   # Request/response middleware
+├── models/       # Domain models
 ├── repositories/ # Data access layer
+├── robots/       # Robot integrations
 ├── schemas/      # Pydantic schemas
 ├── services/     # Business logic services
-└── utils/        # Utility functions
+├── utils/        # Utility functions
+└── workers/      # Background workers
 ```
 
 **Frontend**
@@ -223,15 +132,22 @@ application/ui/src/
 └── assets/       # Static assets
 ```
 
-**Library**
+**Library** (`physicalai-train` distribution, `physicalai` import package)
 
 ```
 library/src/physicalai/
-├── configs/      # Configuration management
+├── benchmark/    # Benchmarking
+├── cli/          # Studio CLI subcommands
+├── config/       # Configuration management
 ├── data/         # Data loading and processing
+├── devices/      # Device handling
+├── eval/         # Evaluation
+├── export/       # Artifact export
+├── gyms/         # Environments
 ├── inference/    # Inference engine
-├── policy/       # Policy implementations
-└── trainer/      # Training logic
+├── policies/     # Policy implementations
+├── train/        # Training logic
+└── transforms/   # Data transforms
 ```
 
 ## Git Commit Messages
@@ -258,39 +174,18 @@ Write clear, concise messages. Reference issue numbers.
 ## Performance Considerations
 
 - Lazy load heavy dependencies
-- Use async/await for I/O
-- Implement caching
-- Optimize database queries (indexes, avoid N+1)
-- Profile before optimizing
-- Consider memory usage for ML models
+- Consider memory usage, inference latency, and throughput for ML models
 
 ## Security Best Practices
 
-- Validate and sanitize inputs
-- Use parameterized queries
-- Implement authentication and authorization
-- Store secrets in environment variables
-- Keep dependencies updated
-- Follow OWASP guidelines
+- For `library/` code, follow `.github/instructions/lib.security.instructions.md`
+- Validate inputs; use parameterized queries
 
 ## AI/ML Specific Guidelines
 
-- Document model architectures and hyperparameters
-- Version control training configurations
-- Log training metrics and artifacts
-- Handle model inference errors
-- Consider inference latency and throughput
-- Document model limitations and assumptions
+- Version-control training configurations; log training metrics and artifacts
+- Document model architectures, hyperparameters, limitations, and assumptions
 
-## Questions to Consider Before Coding
-
-1. Does this align with project architecture?
-2. Can I reuse existing utilities/components?
-3. How will this be tested?
-4. What error cases need handling?
-5. Are there performance implications?
-6. Does this need documentation?
-7. Security considerations?
 
 ## When Suggesting Code Changes
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,197 +1,46 @@
 ## Project Overview
 
-Full-stack application with:
-
+Full-stack application:
 - **Backend**: Python FastAPI (`application/backend/`)
 - **Frontend**: React/TypeScript (`application/ui/`)
-- **Library**: Vision-language-action policies (`library/`)
+- **Library**: Vision-language-action policies (`library/`, `physicalai-train` package, `physicalai` import)
 
-## Coding Standards
+## Python
 
-### Python Environment Management
+- **Always use `uv`** — never `pip` directly. Commands: `uv pip install`, `uv sync`, `uv run pytest`.
+- Type hints on all functions. `pathlib.Path` over string paths.
+- `ruff` for linting and formatting — address all warnings.
+- Google-style docstrings. `logging` over `print()`.
+- Prefer dataclasses or Pydantic models.
 
-- **Always use `uv`** for package management and virtual environments
-- Use `uv` generated virtual environments (`.venv`)
-- Install with `uv pip install` or `uv sync`
-- Create environments with `uv venv`
-- Never use `pip` directly
+## TypeScript/React
 
-### Python Code
-
-- Follow PEP 8
-- Use type hints for all functions
-- Prefer `pathlib.Path` over string paths
-- Use `ruff` for linting and formatting
-- Address all ruff warnings
-- Use Google style docstrings
-- Use `logging` instead of `print()`
-- Prefer dataclasses or Pydantic models
-- Use context managers for resource management
-
-### TypeScript/React Code
-
-- Use functional components with hooks
-- Prefer named exports over default exports
-- Use TypeScript strict mode with explicit types
-- Follow component structure in `application/ui/src/`
-- Use proper prop types and interfaces
-- Implement error boundaries
-- Use React Query for data fetching
-
-### General Principles
-
-DRY, single responsibility, informative error messages, and tests for new functionality. Store secrets in environment variables. Mind performance of ML operations.
+- Functional components, named exports, TypeScript strict mode.
+- React Query for data fetching. Error boundaries on route-level components.
 
 ## Writing Style
 
-Apply to code comments, documentation, commit messages, and PR descriptions:
+Applies to comments, docstrings, commit messages, and PR descriptions.
 
-- **Be concise**: cut unnecessary words, avoid repetition, prefer short sentences.
-- **Be direct**: state the point first, use active voice, drop hedging ("may", "might", "could potentially").
-- **Use simple language**: plain words over complex ones, explain domain-specific terms.
-- **Sound natural**: write as if explaining to a colleague. Avoid formulaic transitions ("Furthermore", "Moreover") and filler ("It is important to note that", "It is worth noting"). Vary sentence length.
-- **Clarity over impressive vocabulary.**
+- State the point first. Active voice. No hedging ("may", "might", "could potentially").
+- Cut filler: no "It is important to note that", "Furthermore", "Moreover".
+- Comments explain *why*, not *what*.
+- Commit messages and PR titles: conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`).
 
-Example — ❌ "The methodology demonstrates significant improvements in terms of performance metrics." ✅ "The method improves performance."
+❌ "The methodology demonstrates significant improvements in terms of performance metrics."
+✅ "The method improves performance."
 
-## Documentation Standards
+## Testing
 
-**Code Comments**
+- Python: `pytest` via `uv run pytest`. Tests in `tests/unit/` and `tests/integration/`. Mock external dependencies.
+- TypeScript: Vitest for unit tests, Playwright for E2E.
 
-- Write self-documenting code
-- Add comments only for the "why", not the "what"
-- Update comments when code changes
+## Security
 
-**README Files**
+- For all `library/` code, follow `.github/instructions/lib.security.instructions.md` — read it before making changes.
+- Validate all inputs. Store secrets in environment variables, never in source files.
 
-- Each major component needs a README.md
-- Include: purpose, installation, usage examples, configuration, troubleshooting
+## AI/ML
 
-**API Documentation**
-
-- Document endpoints with OpenAPI/Swagger
-- Include request/response examples
-- Document error responses and status codes
-
-**Inline Documentation**
-
-- Use JSDoc for TypeScript/JavaScript
-- Use docstrings for Python
-- Document parameters, return values, exceptions
-- Include usage examples for complex functions
-
-## Testing Guidelines
-
-**Python Tests**
-
-- Use `pytest` with `uv` (e.g., `uv run pytest`)
-- Place in `tests/unit/` and `tests/integration/`
-- Name files: `test_<module_name>.py`
-- Name functions: `test_<feature>_<scenario>`
-- Use fixtures from `conftest.py`
-- Aim for >80% coverage
-- Mock external dependencies
-
-**TypeScript Tests**
-
-- Use Vitest for unit tests
-- Use Playwright for E2E tests
-- Name files: `<component>.test.ts(x)`
-- Use descriptive `describe` and `it` blocks
-- Mock API calls and dependencies
-
-## File Organization
-
-**Backend**
-
-```
-application/backend/src/
-├── api/          # API routes and endpoints
-├── control/      # Robot control logic
-├── core/         # Core business logic
-├── db/           # Database models and migrations
-├── internal_datasets/ # Built-in datasets
-├── middleware/   # Request/response middleware
-├── models/       # Domain models
-├── repositories/ # Data access layer
-├── robots/       # Robot integrations
-├── schemas/      # Pydantic schemas
-├── services/     # Business logic services
-├── utils/        # Utility functions
-└── workers/      # Background workers
-```
-
-**Frontend**
-
-```
-application/ui/src/
-├── api/          # API client and hooks
-├── components/   # Reusable UI components
-├── features/     # Feature-specific code
-├── routes/       # Page components
-└── assets/       # Static assets
-```
-
-**Library** (`physicalai-train` distribution, `physicalai` import package)
-
-```
-library/src/physicalai/
-├── benchmark/    # Benchmarking
-├── cli/          # Studio CLI subcommands
-├── config/       # Configuration management
-├── data/         # Data loading and processing
-├── devices/      # Device handling
-├── eval/         # Evaluation
-├── export/       # Artifact export
-├── gyms/         # Environments
-├── inference/    # Inference engine
-├── policies/     # Policy implementations
-├── train/        # Training logic
-└── transforms/   # Data transforms
-```
-
-## Git Commit Messages
-
-Use conventional commits:
-
-- `feat:` - new features
-- `fix:` - bug fixes
-- `docs:` - documentation changes
-- `refactor:` - code refactoring
-- `test:` - adding tests
-- `chore:` - maintenance tasks
-
-Write clear, concise messages. Reference issue numbers.
-
-## Pull Request Guidelines
-
-- Use the PR template (`.github/pull_request_template.md`)
-- Fill out: Description, Type of Change, Related Issues, Changes Made, Examples, Breaking Changes
-- Provide usage examples and before/after comparisons
-- Follow conventional commit format for PR title
-- **Tip**: Draft PRs in `tmp_PR_TEMPLATE_<branch-name>.md` for preview
-
-## Performance Considerations
-
-- Lazy load heavy dependencies
-- Consider memory usage, inference latency, and throughput for ML models
-
-## Security Best Practices
-
-- For `library/` code, follow `.github/instructions/lib.security.instructions.md`
-- Validate inputs; use parameterized queries
-
-## AI/ML Specific Guidelines
-
-- Version-control training configurations; log training metrics and artifacts
-- Document model architectures, hyperparameters, limitations, and assumptions
-
-
-## When Suggesting Code Changes
-
-- Explain reasoning
-- Consider backward compatibility
-- Highlight breaking changes
-- Suggest related test updates
-- Note configuration changes
-- Consider impact on existing functionality
+- Version-control training configs. Log metrics and artifacts.
+- Lazy-load heavy dependencies. Mind inference latency and memory usage.

--- a/.github/instructions/lib.security.instructions.md
+++ b/.github/instructions/lib.security.instructions.md
@@ -37,12 +37,6 @@ description: Security constraints for `library/` (`physicalai-train` package). A
 
 12. Never log `HF_TOKEN`, checkpoint paths, or exception chains that dump env vars.
 
-13. No `yaml.load()`, `yaml.full_load()`, or `yaml.unsafe_load()`. Use `yaml.safe_load()` exclusively.
+13. Prefer `.safetensors` over `.ckpt`/`.pt` for weights.
 
-14. No `os.system`, no `subprocess` with `shell=True`, no command strings built by concatenating variables - all enable shell injection. Use `subprocess.run(["cmd", arg1, arg2], ...)` with a list argument. Flag as a security finding: any `os.system()` call; any `subprocess.run/Popen/call` with `shell=True`; any `subprocess` call where the first argument is a string instead of a list.
-
-15. Prefer `.safetensors` over `.ckpt`/`.pt` for weights.
-
-16. Use `logging` not `print()`.
-
-17. Strip notebook outputs before committing — `jupyter nbconvert --clear-output --inplace <notebook.ipynb>`.
+14. Strip notebook outputs before committing — `jupyter nbconvert --clear-output --inplace <notebook.ipynb>`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,15 +4,6 @@
 
 <!-- What does this PR do? Why is it needed? -->
 
-## Type of Change
-
-- [ ] ✨ `feat` - New feature
-- [ ] 🐞 `fix` - Bug fix
-- [ ] 📚 `docs` - Documentation
-- [ ] ♻️ `refactor` - Code refactoring
-- [ ] 🧪 `test` - Tests
-- [ ] 🔧 `chore` - Maintenance
-
 ## Related Issues
 
 <!-- Link issues: Fixes #123, Relates to #456 -->

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,6 +2,11 @@ name: PR Title
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
 
 permissions: {} # No permissions by default on workflow level
 


### PR DESCRIPTION
## Description

**Removed (stale, generic, or inferable from the workspace):**
- Table of contents and the `.cursorrules` sync note (no `.cursorrules` file exists in the repo).
- File-organization trees. Copilot reads the workspace directly, and the embedded Library tree was already stale.
- Standalone Git, PR, Documentation, and "Questions to Consider" sections.  Generic best practice or duplicated by the PR template.
- Verbose docstring example block and meta "When Suggesting Code Changes" list.

Trimmed a small redundant section from `lib.security.instructions.md`. Either already covered by general copilot instructions or by a ruff/bandit rule. 

Fixes the PR title workflow to rerun if the PR title changes 

Removes the type of change section from PR template. This is already covered by the PR title. 

resolves https://github.com/open-edge-platform/physical-ai-studio/issues/693