### PR TITLE
chore: migrate `data/physicalai.db` to storage dir

### DIFF
--- a/application/backend/README.md
+++ b/application/backend/README.md
@@ -105,12 +105,9 @@ Once the server is running:
 
 Configuration via environment variables (see `src/settings.py`):
 
-| Variable       | Description              | Default                               |
-| -------------- | ------------------------ | ------------------------------------- |
-| `DATABASE_URL` | SQLite database path     | `sqlite+aiosqlite:///./physicalai.db` |
-| `CORS_ORIGINS` | Allowed CORS origins     | `["http://localhost:3000"]`           |
-| `LOG_LEVEL`    | Logging level            | `INFO`                                |
-| `SEED_DB`      | Seed database on startup | `false`                               |
+| Variable      | Description                                                                                                  | Default                                                                                                 |
+|---------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `STORAGE_DIR` | Root directory for persistent artifacts (`datasets/`, `models/`, `snapshots/`, `robots/`, `cache/`, `logs/`) | Linux: `${XDG_DATA_HOME:-~/.local/share}/physicalai`; macOS: `~/Library/Application Support/physicalai` |
 
 Create `.env` file in backend directory for local overrides.
 
@@ -150,25 +147,20 @@ uv run pyrefly check -c pyproject.toml
 
 ## Troubleshooting
 
-### Database Locked Error
+### Data/Storage Migration Behavior
 
-SQLite doesn't handle high concurrency well. For production, use PostgreSQL:
+On startup (`./run.sh`), the backend runs migration checks before Alembic:
 
-```bash
-export DATABASE_URL="postgresql+asyncpg://user:pass@localhost/physicalai"
-```
+- Storage migration: old `~/.cache/physicalai` -> `STORAGE_DIR`
+- Database migration: old `data/physicalai.db`, Docker legacy `/app/data/physicalai.db`, or a legacy `$DATA_DIR/physicalai.db` -> `$STORAGE_DIR/data/physicalai.db`
+
+In interactive terminals, users are prompted for confirmation when a migration is needed.
 
 ### Camera Not Detected
 
 - **RealSense**: Install [librealsense](https://github.com/IntelRealSense/librealsense)
 - **GenICam**: Install vendor-specific SDKs
 - **USB**: Check permissions (`sudo usermod -a -G video $USER`)
-
-### WebRTC Connection Issues
-
-- Ensure firewall allows UDP traffic
-- Check browser console for ICE candidate errors
-- Verify STUN/TURN server configuration
 
 ## See Also
 

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -49,7 +49,6 @@ class Settings(BaseSettings):
     openapi_url: str = "/api/openapi.json"
     debug: bool = Field(default=False, alias="DEBUG")
     environment: Literal["dev", "prod"] = "dev"
-    data_dir: Path = Field(default=Path("data"), alias="DATA_DIR")
     storage_dir: Path = Field(default_factory=get_default_storage_dir, alias="STORAGE_DIR")
     static_files_dir: str | None = Field(default=None, alias="STATIC_FILES_DIR")
 
@@ -81,6 +80,11 @@ class Settings(BaseSettings):
     def datasets_dir(self) -> Path:
         """Storage directory for datasets."""
         return self.storage_dir / "datasets"
+
+    @property
+    def data_dir(self) -> Path:
+        """Storage directory for application data."""
+        return self.storage_dir / "data"
 
     @property
     def snapshot_dir(self) -> Path:

--- a/application/backend/src/storage_migration.py
+++ b/application/backend/src/storage_migration.py
@@ -16,6 +16,7 @@ from db.schema import DatasetDB, ModelDB, RobotCalibrationDB, SnapshotDB
 from settings import Settings
 
 OLD_DEFAULT_STORAGE_DIR = Path("~/.cache/physicalai").expanduser()
+OLD_DEFAULT_DATA_DIR_CANDIDATES = (Path("data"), Path("/app/data"))
 AUTO_MIGRATE_STORAGE_DIR_ENV = "AUTO_MIGRATE_STORAGE_DIR"
 EXPECTED_STORAGE_SUBDIRS = {"models", "cache", "snapshots", "datasets", "robots", "logs"}
 
@@ -25,6 +26,15 @@ class StorageMigrationError(Exception):
 
 
 def migrate_default_storage_dir(settings: Settings, *, interactive: bool | None = None) -> None:
+    """Move legacy storage and database files into the current storage directory."""
+    if interactive is None:
+        interactive = sys.stdin.isatty()
+
+    _migrate_default_storage_dir(settings, interactive=interactive)
+    _migrate_default_database_file(settings, interactive=interactive)
+
+
+def _migrate_default_storage_dir(settings: Settings, *, interactive: bool) -> None:
     """Move data from the old cache-backed default storage directory when safe."""
     old_storage_dir = OLD_DEFAULT_STORAGE_DIR
     new_storage_dir = settings.storage_dir.expanduser()
@@ -44,9 +54,6 @@ def migrate_default_storage_dir(settings: Settings, *, interactive: bool | None 
     if not _is_effectively_empty_storage_dir(new_storage_dir):
         raise StorageMigrationError(_non_empty_destination_message(old_storage_dir, new_storage_dir))
 
-    if interactive is None:
-        interactive = sys.stdin.isatty()
-
     if not auto_migrate:
         if not interactive:
             raise StorageMigrationError(_non_interactive_message(old_storage_dir, new_storage_dir))
@@ -62,6 +69,39 @@ def migrate_default_storage_dir(settings: Settings, *, interactive: bool | None 
     new_storage_dir.parent.mkdir(parents=True, exist_ok=True)
     _move_storage_dir(old_storage_dir, new_storage_dir)
     _rewrite_database_paths(settings, old_storage_dir, new_storage_dir)
+
+
+def _migrate_default_database_file(settings: Settings, *, interactive: bool) -> None:
+    """Move the SQLite database file into the storage-backed data directory."""
+    source_database_path = _resolve_source_database_path(settings)
+    if source_database_path is None:
+        return
+
+    destination_database_path = settings.data_dir / settings.database_file
+    if _same_path(source_database_path, destination_database_path):
+        return
+
+    if destination_database_path.exists():
+        raise StorageMigrationError(
+            _database_destination_exists_message(source_database_path, destination_database_path)
+        )
+
+    auto_migrate = _env_flag(AUTO_MIGRATE_STORAGE_DIR_ENV)
+    if not auto_migrate:
+        if not interactive:
+            raise StorageMigrationError(
+                _database_non_interactive_message(source_database_path, destination_database_path)
+            )
+
+        click.echo("Physical AI Studio database needs to move into the storage directory.")
+        click.echo(f"  from: {source_database_path}")
+        click.echo(f"  to:   {destination_database_path}")
+        if not click.confirm("Move existing database now?", default=False):
+            raise StorageMigrationError(_database_declined_message(source_database_path, destination_database_path))
+
+    logger.info(f"Migrating database from {source_database_path} to {destination_database_path}")
+    destination_database_path.parent.mkdir(parents=True, exist_ok=True)
+    _move_file(source_database_path, destination_database_path)
 
 
 def _env_flag(name: str) -> bool:
@@ -101,13 +141,20 @@ def _move_storage_dir(source: Path, destination: Path) -> None:
         shutil.move(str(source), str(destination))
 
 
+def _move_file(source: Path, destination: Path) -> None:
+    try:
+        source.rename(destination)
+    except OSError:
+        shutil.move(str(source), str(destination))
+
+
 def _rewrite_database_paths(settings: Settings, old_storage_dir: Path, new_storage_dir: Path) -> None:
-    database_path = settings.data_dir / settings.database_file
+    database_path = _resolve_database_path(settings)
     if not database_path.exists():
         return
 
     engine = create_engine(
-        settings.database_url_sync,
+        f"sqlite:///{database_path}",
         connect_args={"check_same_thread": False, "timeout": 30},
         poolclass=NullPool,
     )
@@ -125,6 +172,32 @@ def _rewrite_database_paths(settings: Settings, old_storage_dir: Path, new_stora
             session.rollback()
             raise
     engine.dispose()
+
+
+def _resolve_database_path(settings: Settings) -> Path:
+    configured_database_path = settings.data_dir / settings.database_file
+    if configured_database_path.exists():
+        return configured_database_path
+
+    legacy_database_path = _resolve_source_database_path(settings)
+    if legacy_database_path is not None:
+        return legacy_database_path
+
+    return configured_database_path
+
+
+def _resolve_source_database_path(settings: Settings) -> Path | None:
+    data_dir_env = os.environ.get("DATA_DIR")
+    if data_dir_env:
+        database_path = Path(data_dir_env).expanduser() / settings.database_file
+        if database_path.exists():
+            return database_path
+
+    for data_dir in OLD_DEFAULT_DATA_DIR_CANDIDATES:
+        database_path = data_dir.expanduser() / settings.database_file
+        if database_path.exists():
+            return database_path
+    return None
 
 
 def _rewrite_table_paths(
@@ -174,4 +247,31 @@ def _declined_message(old_storage_dir: Path, new_storage_dir: Path) -> str:
         f"Old storage: {old_storage_dir}\n"
         f"New storage: {new_storage_dir}\n\n"
         f"Move the directory manually or set STORAGE_DIR={old_storage_dir} to keep using the old location."
+    )
+
+
+def _database_destination_exists_message(source_database_path: Path, destination_database_path: Path) -> str:
+    return (
+        "Cannot automatically migrate Physical AI Studio database because the new database file already exists.\n\n"
+        f"Old database: {source_database_path}\n"
+        f"New database: {destination_database_path}\n\n"
+        "Move or merge the database manually."
+    )
+
+
+def _database_non_interactive_message(source_database_path: Path, destination_database_path: Path) -> str:
+    return (
+        "Physical AI Studio database needs to move, but startup is non-interactive.\n\n"
+        f"Old database: {source_database_path}\n"
+        f"New database: {destination_database_path}\n\n"
+        f"Move the file manually or set {AUTO_MIGRATE_STORAGE_DIR_ENV}=true to allow automatic migration."
+    )
+
+
+def _database_declined_message(source_database_path: Path, destination_database_path: Path) -> str:
+    return (
+        "Database migration was declined.\n\n"
+        f"Old database: {source_database_path}\n"
+        f"New database: {destination_database_path}\n\n"
+        "Move the file manually into the new data directory."
     )

--- a/application/backend/tests/test_settings.py
+++ b/application/backend/tests/test_settings.py
@@ -32,3 +32,13 @@ def test_storage_dir_override_expands_user(monkeypatch, tmp_path: Path) -> None:
     settings = Settings(STORAGE_DIR="~/custom-storage")
 
     assert settings.storage_dir == tmp_path / "custom-storage"
+
+
+def test_data_dir_is_storage_backed_even_with_data_dir_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    custom_data_dir = tmp_path / "custom-data"
+    monkeypatch.setenv("DATA_DIR", str(custom_data_dir))
+
+    settings = Settings(STORAGE_DIR="~/custom-storage")
+
+    assert settings.data_dir == tmp_path / "custom-storage" / "data"

--- a/application/backend/tests/test_storage_migration.py
+++ b/application/backend/tests/test_storage_migration.py
@@ -20,14 +20,28 @@ from settings import Settings
 from storage_migration import StorageMigrationError, migrate_default_storage_dir
 
 
+@pytest.fixture(autouse=True)
+def isolate_migration_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTO_MIGRATE_STORAGE_DIR", raising=False)
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    monkeypatch.delenv("STORAGE_DIR", raising=False)
+    monkeypatch.setattr(storage_migration, "OLD_DEFAULT_DATA_DIR_CANDIDATES", (tmp_path / "missing-data",))
+
+
 def _settings(tmp_path: Path) -> Settings:
-    return Settings(DATA_DIR=str(tmp_path / "data"), STORAGE_DIR=str(tmp_path / "new-storage"))
+    return Settings(STORAGE_DIR=str(tmp_path / "new-storage"))
 
 
 def _old_storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     old_storage = tmp_path / "old-cache" / "physicalai"
     monkeypatch.setattr(storage_migration, "OLD_DEFAULT_STORAGE_DIR", old_storage)
     return old_storage
+
+
+def _old_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    old_data_dir = tmp_path / "old-data"
+    monkeypatch.setattr(storage_migration, "OLD_DEFAULT_DATA_DIR_CANDIDATES", (old_data_dir,))
+    return old_data_dir
 
 
 def test_migration_noops_when_old_storage_is_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -112,10 +126,13 @@ def test_migration_rewrites_database_paths(tmp_path: Path, monkeypatch: pytest.M
     settings = _settings(tmp_path)
     old_storage = _old_storage(tmp_path, monkeypatch)
     (old_storage / "datasets" / "dataset-1").mkdir(parents=True)
-    settings.data_dir.mkdir(parents=True)
+    legacy_data_dir = tmp_path / "data"
+    legacy_data_dir.mkdir(parents=True)
+    monkeypatch.setattr(storage_migration, "OLD_DEFAULT_DATA_DIR_CANDIDATES", (legacy_data_dir,))
+    monkeypatch.setenv("DATA_DIR", str(legacy_data_dir))
     monkeypatch.setenv("AUTO_MIGRATE_STORAGE_DIR", "true")
 
-    engine = create_engine(settings.database_url_sync)
+    engine = create_engine(f"sqlite:///{legacy_data_dir / settings.database_file}")
     Base.metadata.create_all(engine)
     session_factory = sessionmaker(bind=engine)
     with session_factory() as session:
@@ -191,3 +208,91 @@ def test_migration_rewrites_database_paths(tmp_path: Path, monkeypatch: pytest.M
     assert snapshot_path == str(settings.storage_dir / "snapshots" / "snapshot-1")
     assert calibration_path == str(settings.storage_dir / "robots" / "robot-1" / "calibration.json")
     engine.dispose()
+
+
+def test_migration_uses_data_dir_env_as_legacy_database_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(tmp_path)
+    _old_storage(tmp_path, monkeypatch)
+    old_data_dir = tmp_path / "custom-data"
+    old_data_dir.mkdir(parents=True)
+    (old_data_dir / settings.database_file).write_text("db")
+    monkeypatch.setenv("DATA_DIR", str(old_data_dir))
+    monkeypatch.setenv("AUTO_MIGRATE_STORAGE_DIR", "true")
+
+    migrate_default_storage_dir(settings, interactive=False)
+
+    assert not (old_data_dir / settings.database_file).exists()
+    assert (settings.data_dir / settings.database_file).read_text() == "db"
+
+
+def test_migration_moves_database_file_without_moving_legacy_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path)
+    _old_storage(tmp_path, monkeypatch)
+    old_data_dir = _old_data_dir(tmp_path, monkeypatch)
+    old_data_dir.mkdir(parents=True)
+    (old_data_dir / settings.database_file).write_text("db")
+    (old_data_dir / "runtime.txt").write_text("runtime")
+    monkeypatch.setenv("AUTO_MIGRATE_STORAGE_DIR", "true")
+
+    migrate_default_storage_dir(settings, interactive=False)
+
+    assert old_data_dir.exists()
+    assert not (old_data_dir / settings.database_file).exists()
+    assert (old_data_dir / "runtime.txt").read_text() == "runtime"
+    assert (settings.data_dir / settings.database_file).read_text() == "db"
+
+
+def test_migration_fails_when_destination_database_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(tmp_path)
+    _old_storage(tmp_path, monkeypatch)
+    old_data_dir = _old_data_dir(tmp_path, monkeypatch)
+    old_data_dir.mkdir(parents=True)
+    (old_data_dir / settings.database_file).write_text("old db")
+    settings.data_dir.mkdir(parents=True)
+    (settings.data_dir / settings.database_file).write_text("new db")
+    monkeypatch.setenv("AUTO_MIGRATE_STORAGE_DIR", "true")
+
+    with pytest.raises(StorageMigrationError, match="already exists"):
+        migrate_default_storage_dir(settings, interactive=False)
+
+    assert (old_data_dir / settings.database_file).read_text() == "old db"
+    assert (settings.data_dir / settings.database_file).read_text() == "new db"
+
+
+def test_database_migration_fails_non_interactive_without_auto_migrate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path)
+    _old_storage(tmp_path, monkeypatch)
+    old_data_dir = _old_data_dir(tmp_path, monkeypatch)
+    old_data_dir.mkdir(parents=True)
+    (old_data_dir / settings.database_file).write_text("db")
+    monkeypatch.delenv("AUTO_MIGRATE_STORAGE_DIR", raising=False)
+
+    with pytest.raises(StorageMigrationError, match="non-interactive"):
+        migrate_default_storage_dir(settings, interactive=False)
+
+    assert (old_data_dir / settings.database_file).exists()
+    assert not (settings.data_dir / settings.database_file).exists()
+
+
+def test_migration_moves_storage_before_database_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(tmp_path)
+    old_storage = _old_storage(tmp_path, monkeypatch)
+    (old_storage / "datasets").mkdir(parents=True)
+    (old_storage / "datasets" / "dataset.txt").write_text("data")
+    old_data_dir = _old_data_dir(tmp_path, monkeypatch)
+    old_data_dir.mkdir(parents=True)
+    engine = create_engine(f"sqlite:///{old_data_dir / settings.database_file}")
+    Base.metadata.create_all(engine)
+    engine.dispose()
+    monkeypatch.setenv("AUTO_MIGRATE_STORAGE_DIR", "true")
+
+    migrate_default_storage_dir(settings, interactive=False)
+
+    assert not old_storage.exists()
+    assert (settings.storage_dir / "datasets" / "dataset.txt").read_text() == "data"
+    assert not (old_data_dir / settings.database_file).exists()
+    assert (settings.data_dir / settings.database_file).is_file()

--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -234,7 +234,6 @@ ENV PATH="/app/application/backend/.venv/bin:$PATH" \
     CXX=/usr/bin/g++ \
     UV_NO_SYNC=1 \
     STATIC_FILES_DIR="/app/application/ui/" \
-    DATA_DIR="/app/data" \
     STORAGE_DIR="/app/storage" \
     AUTO_MIGRATE_STORAGE_DIR="true" \
     PYTHONPATH="/app/application/backend"

--- a/application/docker/README.md
+++ b/application/docker/README.md
@@ -171,11 +171,16 @@ sudo usermod -aG render $USER   # Intel XPU only
 
 The compose file defines two named volumes and one bind mount:
 
-| Volume                       | Container path                                         | Purpose                                       |
-|------------------------------|--------------------------------------------------------|-----------------------------------------------|
-| `physical-ai-studio-data`    | `/app/data`                                            | Application database and runtime data         |
-| `physical-ai-studio-storage` | `/app/storage`                                         | Trained models, datasets, and other artifacts |
-| *(bind mount)*               | `~/.cache/huggingface/lerobot/calibration` (read-only) | Shared robot calibration data from the host   |
+| Volume                       | Container path                                         | Purpose                                              |
+|------------------------------|--------------------------------------------------------|------------------------------------------------------|
+| `physical-ai-studio-data`    | `/app/data`                                            | Legacy data-dir mount kept for one-time migration    |
+| `physical-ai-studio-storage` | `/app/storage`                                         | Persistent storage, including app data and artifacts |
+| *(bind mount)*               | `~/.cache/huggingface/lerobot/calibration` (read-only) | Shared robot calibration data from the host          |
+
+Runtime defaults use `STORAGE_DIR=/app/storage`; the application database is stored under `$STORAGE_DIR/data`.
+`/app/data` stays mounted as a legacy database source so existing users can be migrated
+automatically. The container enables non-interactive migration with
+`AUTO_MIGRATE_STORAGE_DIR=true`.
 
 To inspect volume contents:
 


### PR DESCRIPTION
Follow up of #642. Move the database from `data/physicalai.db` (relative to `application/backend`) into our STORAGE_DIR.

This makes it so that all the persisted storage used by the application is in 1 place. This is necessary if we'd like to allow installing the app globally as a python wheel (or via `uvx physicalai-studio`)

## Type of Change

- [x] 🔧 `chore` - Maintenance

> [!CAUTION]
> Like #642 this PR adds a breaking change as we move the database file to a different location. 
