### PR TITLE
fix: Address several UX issues 

### DIFF
--- a/application/ui/src/features/robots/controller/robot-viewer.tsx
+++ b/application/ui/src/features/robots/controller/robot-viewer.tsx
@@ -157,7 +157,7 @@ export const RobotViewer = ({ robot = { type: 'SO101_Follower' }, featureValues,
                     <directionalLight position={[-5, 5, -5]} intensity={0.3} />
                     <directionalLight position={[0, -3, 5]} intensity={0.2} />
                     <PerspectiveCamera makeDefault position={[2.0, 1, 1]} />
-                    <OrbitControls />
+                    <OrbitControls enableDamping={false} />
                     <Grid infiniteGrid cellSize={0.25} sectionColor={'rgb(0, 199, 253)'} fadeDistance={10} />
                     {model && (
                         <group key={model.uuid} position={[0, 0, 0]} rotation={[0, angle, 0]}>

--- a/application/ui/src/features/robots/environment-form/form.tsx
+++ b/application/ui/src/features/robots/environment-form/form.tsx
@@ -43,9 +43,10 @@ export const EnvironmentForm = ({ heading = 'Add new environment', submitButton 
                         </Text>
                     </View>
                     <TextField
+                        // eslint-disable-next-line jsx-a11y/no-autofocus
+                        autoFocus
                         isRequired
-                        necessityIndicator='label'
-                        label='name'
+                        label='Name'
                         width='100%'
                         onChange={(name) => {
                             setEnvironmentForm((oldForm) => {

--- a/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
+++ b/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
@@ -19,7 +19,7 @@ export const SubmitNewEnvironmentButton = () => {
 
     const environment_id = uuidv4();
     const body = useEnvironmentFormBody(environment_id);
-    const isDisabled = false; // body.name.length === 0 || body.robots.length === 0 || body.cameras.length === 0;
+    const isDisabled = body.name.length === 0;
 
     return (
         <Button

--- a/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
+++ b/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
@@ -19,7 +19,7 @@ export const SubmitNewEnvironmentButton = () => {
 
     const environment_id = uuidv4();
     const body = useEnvironmentFormBody(environment_id);
-    const isDisabled = body.name.length === 0;
+    const isDisabled = body.name.trim().length === 0 || body.robots.length === 0 || body.cameras.length === 0;
 
     return (
         <Button

--- a/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
+++ b/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
@@ -19,7 +19,7 @@ export const SubmitNewEnvironmentButton = () => {
 
     const environment_id = uuidv4();
     const body = useEnvironmentFormBody(environment_id);
-    const isDisabled = body.name.trim().length === 0 || body.robots.length === 0 || body.cameras.length === 0;
+    const isDisabled = body.name.trim().length === 0;
 
     return (
         <Button

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -13,6 +13,7 @@ import {
     View,
 } from '@geti-ui/ui';
 import { ChevronLeft, Refresh } from '@geti-ui/ui/icons';
+import { type FormEvent, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { $api } from '../../../api/client';
@@ -278,6 +279,14 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
     const robotForm = useRobotForm();
     const setRobotForm = useSetRobotForm();
 
+    const submitContainerRef = useRef<HTMLDivElement>(null);
+
+    // Make Enter behave like clicking the submit button. A disabled button ignores the click, so validation still applies.
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        submitContainerRef.current?.querySelector('button')?.click();
+    };
+
     return (
         <Flex direction='column' gap='size-200'>
             <Flex alignItems={'center'} gap='size-200'>
@@ -294,7 +303,9 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
                 <Heading>{heading}</Heading>
             </Flex>
             <Divider orientation='horizontal' size='S' />
-            <Form>
+            {/* Prevent native form submission, which reloads the page and discards form state.
+                Advancing to the next step is handled by the submit button's onPress. */}
+            <Form onSubmit={handleSubmit}>
                 <Flex direction='column' gap='size-200'>
                     <Flex direction='column' gap='size-200' width='100%'>
                         <TextField
@@ -314,7 +325,7 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
                         <FormFields robotType={robotForm.type} />
                     </Flex>
                     <Divider orientation='horizontal' size='S' />
-                    <View>{submitButton}</View>
+                    <div ref={submitContainerRef}>{submitButton}</div>
                 </Flex>
             </Form>
         </Flex>

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -1,3 +1,5 @@
+import { useRef, type FormEvent } from 'react';
+
 import {
     ActionButton,
     Button,
@@ -13,7 +15,6 @@ import {
     View,
 } from '@geti-ui/ui';
 import { ChevronLeft, Refresh } from '@geti-ui/ui/icons';
-import { type FormEvent, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { $api } from '../../../api/client';

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -282,7 +282,8 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
 
     const submitContainerRef = useRef<HTMLDivElement>(null);
 
-    // Make Enter behave like clicking the submit button. A disabled button ignores the click, so validation still applies.
+    // Make Enter behave like clicking the submit button. A disabled button ignores
+    // the click, so validation still applies.
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         submitContainerRef.current?.querySelector('button')?.click();

--- a/application/ui/src/features/robots/setup-wizard/shared/setup-robot-viewer.tsx
+++ b/application/ui/src/features/robots/setup-wizard/shared/setup-robot-viewer.tsx
@@ -183,7 +183,7 @@ export const SetupRobotViewer = ({ robotType, highlights = [] }: SetupRobotViewe
                         shadow-mapSize-height={1024}
                     />
                     <PerspectiveCamera makeDefault position={[2.0, 1, 1]} />
-                    <OrbitControls ref={controlsRef} />
+                    <OrbitControls ref={controlsRef} enableDamping={false} />
                     <CameraController controlsRef={controlsRef} model={model} highlights={highlights} />
                     <Grid infiniteGrid cellSize={0.25} sectionColor={'rgb(0, 199, 253)'} fadeDistance={10} />
                     {model && (

--- a/application/ui/src/routes/datasets/index.tsx
+++ b/application/ui/src/routes/datasets/index.tsx
@@ -26,7 +26,7 @@ const Datasets = ({ datasets }: DatasetsProps) => {
             <Flex margin={'size-200'} direction={'column'} flex height='100%'>
                 <IllustratedMessage>
                     <EmptyIllustration />
-                    <Content> Currently there are datasets available. </Content>
+                    <Content> Currently there are no datasets available. </Content>
                     <Text>It&apos;s time to begin recording a dataset. </Text>
                     <Heading>No datasets yet</Heading>
                     <Flex gap='size-100' marginTop={'size-200'}>

--- a/application/ui/src/routes/datasets/new-dataset.component.tsx
+++ b/application/ui/src/routes/datasets/new-dataset.component.tsx
@@ -70,6 +70,7 @@ export const NewDatasetForm = ({ project_id, onDone }: NewDatasetFormProps) => {
                 <Divider />
                 <Content>
                     <Picker
+                        isRequired
                         items={environments}
                         selectedKey={environmentId}
                         label='Environment'
@@ -89,20 +90,18 @@ export const NewDatasetForm = ({ project_id, onDone }: NewDatasetFormProps) => {
                         onChange={setName}
                     />
 
-                    <TextField
-                        // eslint-disable-next-line jsx-a11y/no-autofocus
-                        autoFocus
-                        width='100%'
-                        label='Task'
-                        value={defaultTask}
-                        onChange={setDefaultTask}
-                    />
+                    <TextField width='100%' label='Task' value={defaultTask} onChange={setDefaultTask} />
                 </Content>
                 <ButtonGroup>
                     <Button variant='secondary' onPress={() => onDone(undefined)}>
                         Cancel
                     </Button>
-                    <Button variant='accent' type='submit' isDisabled={name === ''} isPending={saveMutation.isPending}>
+                    <Button
+                        variant='accent'
+                        type='submit'
+                        isDisabled={name === '' || environmentId === undefined}
+                        isPending={saveMutation.isPending}
+                    >
                         Save
                     </Button>
                 </ButtonGroup>

--- a/application/ui/src/routes/datasets/new-dataset.component.tsx
+++ b/application/ui/src/routes/datasets/new-dataset.component.tsx
@@ -99,7 +99,7 @@ export const NewDatasetForm = ({ project_id, onDone }: NewDatasetFormProps) => {
                     <Button
                         variant='accent'
                         type='submit'
-                        isDisabled={name === '' || environmentId === undefined}
+                        isDisabled={name.trim() === '' || environmentId === undefined}
                         isPending={saveMutation.isPending}
                     >
                         Save

--- a/application/ui/src/routes/models/job-table.component.tsx
+++ b/application/ui/src/routes/models/job-table.component.tsx
@@ -142,13 +142,16 @@ export const TrainingRow = ({
                                     <Button variant='secondary'>Interrupt</Button>
                                     <AlertDialog
                                         onPrimaryAction={onInterrupt}
-                                        title='Interrupt training'
+                                        title='Stop training?'
                                         variant='warning'
-                                        primaryActionLabel='Interrupt'
+                                        primaryActionLabel='Stop'
                                         cancelLabel='Cancel'
                                     >
-                                        Are you sure you want to interrupt training for {trainJob.payload.model_name}?
-                                        This stops the run and cannot be undone.
+                                        Stop training for {trainJob.payload.model_name}?
+                                        <br />
+                                        <br />
+                                        Your model checkpoint will be saved at the current step. You cannot resume
+                                        this run.
                                     </AlertDialog>
                                 </DialogTrigger>
                             )}

--- a/application/ui/src/routes/models/job-table.component.tsx
+++ b/application/ui/src/routes/models/job-table.component.tsx
@@ -147,8 +147,8 @@ export const TrainingRow = ({
                                         primaryActionLabel='Interrupt'
                                         cancelLabel='Cancel'
                                     >
-                                        Are you sure you want to interrupt training for{' '}
-                                        {trainJob.payload.model_name}? This stops the run and cannot be undone.
+                                        Are you sure you want to interrupt training for {trainJob.payload.model_name}?
+                                        This stops the run and cannot be undone.
                                     </AlertDialog>
                                 </DialogTrigger>
                             )}

--- a/application/ui/src/routes/models/job-table.component.tsx
+++ b/application/ui/src/routes/models/job-table.component.tsx
@@ -150,8 +150,8 @@ export const TrainingRow = ({
                                         Stop training for {trainJob.payload.model_name}?
                                         <br />
                                         <br />
-                                        Your model checkpoint will be saved at the current step. You cannot resume
-                                        this run.
+                                        Your model checkpoint will be saved at the current step. You cannot resume this
+                                        run.
                                     </AlertDialog>
                                 </DialogTrigger>
                             )}

--- a/application/ui/src/routes/models/job-table.component.tsx
+++ b/application/ui/src/routes/models/job-table.component.tsx
@@ -139,11 +139,11 @@ export const TrainingRow = ({
                         <View>
                             {trainJob.status === 'running' && (
                                 <DialogTrigger>
-                                    <Button variant='secondary'>Interrupt</Button>
+                                    <Button variant='secondary'>Stop</Button>
                                     <AlertDialog
                                         onPrimaryAction={onInterrupt}
                                         title='Stop training?'
-                                        variant='warning'
+                                        variant='destructive'
                                         primaryActionLabel='Stop'
                                         cancelLabel='Cancel'
                                     >

--- a/application/ui/src/routes/models/job-table.component.tsx
+++ b/application/ui/src/routes/models/job-table.component.tsx
@@ -1,4 +1,18 @@
-import { ActionButton, Button, Flex, Grid, Item, Key, Menu, MenuTrigger, ProgressBar, Text, View } from '@geti-ui/ui';
+import {
+    ActionButton,
+    AlertDialog,
+    Button,
+    DialogTrigger,
+    Flex,
+    Grid,
+    Item,
+    Key,
+    Menu,
+    MenuTrigger,
+    ProgressBar,
+    Text,
+    View,
+} from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
 
 import { $api } from '../../api/client';
@@ -124,9 +138,19 @@ export const TrainingRow = ({
                         <Text>{trainJob.payload.policy.toUpperCase()}</Text>
                         <View>
                             {trainJob.status === 'running' && (
-                                <Button variant='secondary' onPress={onInterrupt}>
-                                    Interrupt
-                                </Button>
+                                <DialogTrigger>
+                                    <Button variant='secondary'>Interrupt</Button>
+                                    <AlertDialog
+                                        onPrimaryAction={onInterrupt}
+                                        title='Interrupt training'
+                                        variant='warning'
+                                        primaryActionLabel='Interrupt'
+                                        cancelLabel='Cancel'
+                                    >
+                                        Are you sure you want to interrupt training for{' '}
+                                        {trainJob.payload.model_name}? This stops the run and cannot be undone.
+                                    </AlertDialog>
+                                </DialogTrigger>
                             )}
                         </View>
                         <View justifySelf={'end'}>

--- a/application/ui/src/routes/models/train-model-dialog.tsx
+++ b/application/ui/src/routes/models/train-model-dialog.tsx
@@ -476,7 +476,7 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: 
                 <Button variant='secondary' onPress={() => close(undefined)}>
                     Cancel
                 </Button>
-                <Button variant='accent' onPress={save}>
+                <Button variant='accent' onPress={save} isDisabled={!selectedDataset || !selectedPolicy}>
                     Train
                 </Button>
             </ButtonGroup>


### PR DESCRIPTION
## Summary

This PR fixes several UX issues within the UI: 

- 3D viewers (robot-viewer.tsx, setup-robot-viewer.tsx): disabled OrbitControls damping to remove drift/inertia after dragging.
- Robot form (robot-form/form.tsx): added an onSubmit handler so pressing Enter triggers the submit button (respecting its disabled state) instead of reloading the page and discarding form state.
- Environment form (form.tsx, submit-new-environment-button.tsx): autofocus the name field, fixed the label casing (name → Name), and re-enabled real validation (disable submit when name is empty) replacing the hardcoded isDisabled = false.
- New dataset form (new-dataset.component.tsx): made Environment a required picker, moved autofocus off the Task field, and disabled Save until both name and environment are set.
- Datasets empty state (datasets/index.tsx): fixed copy "Currently there are no datasets available."
- Training job table (job-table.component.tsx): wrapped Interrupt in a confirmation AlertDialog.
- Make train button unavailable if no dataset is selected yet.