### PR TITLE
chore(docker): add allow-list ignore for library build context

### DIFF
--- a/library/.dockerignore
+++ b/library/.dockerignore
@@ -1,0 +1,26 @@
+# =============================================================================
+# library/.dockerignore — allow-list approach for `libs` build context
+#
+# Ignore everything by default, then include only files required to build the
+# `physicalai-train` package in Docker builder stages.
+# =============================================================================
+
+# Ignore everything
+*
+
+# ---- Files required for packaging/installing physicalai-train ----
+!pyproject.toml
+!README.md
+!LICENSE
+!src/
+
+# Re-exclude artifacts that may appear inside allowed directories
+**/__pycache__/
+**/*.py[cod]
+**/.venv/
+**/.mypy_cache/
+**/.ruff_cache/
+**/.pytest_cache/
+**/.ipynb_checkpoints/
+**/node_modules/
+**/.DS_Store


### PR DESCRIPTION
Docker Compose sends `additional_contexts.libs` as a separate build context, so root `.dockerignore` does not filter files under `library/`.

Add `library/.dockerignore` with an allow-list to include only package build inputs (`pyproject.toml`, `README.md`, `LICENSE`, `src/`) and exclude caches/artifacts from the `libs` transfer.

This won't have much effect in our CI but should speed up local docker builds, specifically when you've setup a `.venv` in the library directory.