### PR TITLE
feat: distribute application as python package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,11 @@
 !LICENSE
 !README.md
 
+# ---- Application-level files needed by the build ----
+# The hatch build hook reads application/README.md to transform it
+# into the backend's README for the PyPI description.
+!application/README.md
+
 # ---- Application: UI ----
 !application/ui/package.json
 !application/ui/package-lock.json
@@ -29,6 +34,7 @@
 !application/backend/README.md
 !application/backend/run.sh
 !application/backend/src/
+!application/backend/scripts/hatch_build.py
 
 # ---- Application: Docker ----
 # The Dockerfile is referenced via the `file:` parameter in the build

--- a/.github/workflows/publish-app-pypi.yml
+++ b/.github/workflows/publish-app-pypi.yml
@@ -68,11 +68,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version-file: ./application/backend/.python-version
-
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/publish-app-pypi.yml
+++ b/.github/workflows/publish-app-pypi.yml
@@ -1,0 +1,175 @@
+name: Publish Application PyPI
+
+on:
+  push:
+    tags:
+      - 'app/v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Validate app tag
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Validate tag version matches application version
+        if: startsWith(github.ref, 'refs/tags/app/v')
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${TAG#app/v}"
+          APP_VERSION="$(tr -d '[:space:]' < application/VERSION)"
+          PYPROJECT_VERSION="$(grep '^version' application/backend/pyproject.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')"
+
+          echo "Tag version:       ${TAG_VERSION}"
+          echo "application/VERSION: ${APP_VERSION}"
+          echo "pyproject.toml:   ${PYPROJECT_VERSION}"
+
+          if [[ "${TAG_VERSION}" != "${APP_VERSION}" ]]; then
+            echo "::error::Tag version '${TAG_VERSION}' does not match application/VERSION '${APP_VERSION}'"
+            exit 1
+          fi
+
+          if [[ "${TAG_VERSION}" != "${PYPROJECT_VERSION}" ]]; then
+            echo "::error::Tag version '${TAG_VERSION}' does not match application/backend/pyproject.toml '${PYPROJECT_VERSION}'"
+            exit 1
+          fi
+
+  build:
+    name: Build
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: validate
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: false
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            download.pytorch.org:443
+            download-r2.pytorch.org:443
+            files.pythonhosted.org:443
+            github.com:443
+            index.crates.io:443
+            nodejs.org:443
+            pypi.org:443
+            raw.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            releases.astral.sh:443
+            static.crates.io:443
+
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ./application/backend/.python-version
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          cache: false
+          enable-cache: false
+          version: "0.10.4"
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          package-manager-cache: false
+          node-version-file: application/ui/.nvmrc
+
+      - name: Ensure npm supports min-release-age
+        run: npm i -g npm@11.14.0
+
+      - name: Build application package
+        run: bash application/backend/scripts/build_package.sh
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: physicalai-studio-distributions
+          path: application/backend/dist/
+
+  smoke-test:
+    name: Smoke test
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            pypi.org:443
+            release-assets.githubusercontent.com:443
+            releases.astral.sh:443
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          cache: false
+          enable-cache: false
+
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: physicalai-studio-distributions
+          path: dist/
+
+      - name: Verify clean wheel install
+        env:
+          VIRTUAL_ENV: .venv-smoke
+        run: |
+          uv venv .venv-smoke
+          uv pip install dist/*.whl
+          uv run python - <<'PY'
+          import importlib.metadata as metadata
+          import cli
+          print(metadata.version("physicalai-studio"))
+          PY
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: smoke-test
+    if: startsWith(github.ref, 'refs/tags/app/v')
+    permissions:
+      id-token: write  # OIDC trusted publishing
+    environment:
+      name: pypi
+      url: https://pypi.org/p/physicalai-studio
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: physicalai-studio-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/publish-app-pypi.yml
+++ b/.github/workflows/publish-app-pypi.yml
@@ -61,20 +61,7 @@ jobs:
         with:
           disable-sudo: false
           disable-telemetry: true
-          egress-policy: block
-          allowed-endpoints: >
-            download.pytorch.org:443
-            download-r2.pytorch.org:443
-            files.pythonhosted.org:443
-            github.com:443
-            index.crates.io:443
-            nodejs.org:443
-            pypi.org:443
-            raw.githubusercontent.com:443
-            registry.npmjs.org:443
-            release-assets.githubusercontent.com:443
-            releases.astral.sh:443
-            static.crates.io:443
+          egress-policy: audit
 
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -121,14 +108,9 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          disable-sudo: true
+          disable-sudo: false
           disable-telemetry: true
-          egress-policy: block
-          allowed-endpoints: >
-            files.pythonhosted.org:443
-            pypi.org:443
-            release-assets.githubusercontent.com:443
-            releases.astral.sh:443
+          egress-policy: audit
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/publish-app-testpypi.yml
+++ b/.github/workflows/publish-app-testpypi.yml
@@ -23,20 +23,7 @@ jobs:
         with:
           disable-sudo: false
           disable-telemetry: true
-          egress-policy: block
-          allowed-endpoints: >
-            download.pytorch.org:443
-            download-r2.pytorch.org:443
-            files.pythonhosted.org:443
-            github.com:443
-            index.crates.io:443
-            nodejs.org:443
-            pypi.org:443
-            raw.githubusercontent.com:443
-            registry.npmjs.org:443
-            release-assets.githubusercontent.com:443
-            releases.astral.sh:443
-            static.crates.io:443
+          egress-policy: audit
 
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -90,14 +77,9 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          disable-sudo: true
+          disable-sudo: false
           disable-telemetry: true
-          egress-policy: block
-          allowed-endpoints: >
-            files.pythonhosted.org:443
-            pypi.org:443
-            release-assets.githubusercontent.com:443
-            releases.astral.sh:443
+          egress-policy: audit
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/publish-app-testpypi.yml
+++ b/.github/workflows/publish-app-testpypi.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version-file: ./application/backend/.python-version
-
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/publish-app-testpypi.yml
+++ b/.github/workflows/publish-app-testpypi.yml
@@ -1,0 +1,145 @@
+name: Publish Application TestPyPI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: false
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            download.pytorch.org:443
+            download-r2.pytorch.org:443
+            files.pythonhosted.org:443
+            github.com:443
+            index.crates.io:443
+            nodejs.org:443
+            pypi.org:443
+            raw.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            releases.astral.sh:443
+            static.crates.io:443
+
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ./application/backend/.python-version
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          cache: false
+          enable-cache: false
+          version: "0.10.4"
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          package-manager-cache: false
+          node-version-file: application/ui/.nvmrc
+
+      - name: Ensure npm supports min-release-age
+        run: npm i -g npm@11.14.0
+
+      - name: Set dev version for TestPyPI
+        run: |
+          BASE_VERSION="$(tr -d '[:space:]' < application/VERSION)"
+          DEV_VERSION="${BASE_VERSION}.dev$(date -u +%Y%m%d%H%M%S)"
+          echo "VERSION_OVERRIDE=${DEV_VERSION}" >> "$GITHUB_ENV"
+          echo "Building version: ${DEV_VERSION}"
+
+      - name: Build application package
+        run: bash application/backend/scripts/build_package.sh
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: physicalai-studio-distributions
+          path: application/backend/dist/
+
+  smoke-test:
+    name: Smoke test
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            pypi.org:443
+            release-assets.githubusercontent.com:443
+            releases.astral.sh:443
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          cache: false
+          enable-cache: false
+
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: physicalai-studio-distributions
+          path: dist/
+
+      - name: Verify clean wheel install
+        env:
+          VIRTUAL_ENV: .venv-smoke
+        run: |
+          uv venv .venv-smoke
+          uv pip install dist/*.whl
+          uv run python - <<'PY'
+          import importlib.metadata as metadata
+          import cli
+          print(metadata.version("physicalai-studio"))
+          PY
+
+  publish:
+    name: Publish to TestPyPI
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: smoke-test
+    permissions:
+      id-token: write  # OIDC trusted publishing
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/physicalai-studio
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: physicalai-studio-distributions
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/application/backend/docs/distribution.md
+++ b/application/backend/docs/distribution.md
@@ -2,27 +2,13 @@
 
 This document describes how the backend is packaged as the `physicalai-studio` Python distribution, how to test the wheel locally before publishing, and how the GitHub Actions publishing workflows behave.
 
-## Production Usage Overview
+## Usage Overview
 
-The initial PyPI rollout publishes one distribution:
-
-```text
-physicalai-studio
-```
-
-Users select the hardware runtime with package extras:
-
-```text
-physicalai-studio[cpu]
-physicalai-studio[xpu]
-physicalai-studio[cuda]
-```
-
-Because PyTorch publishes hardware-specific wheels on separate package indexes, users must pass the matching PyTorch index to `uvx`.
+Physical AI Studio can be deployed with an XPU, CUDA, or CPU training backend. The matching PyTorch wheel index must be passed via `--index` because wheel metadata cannot carry the source project's index configuration.
 
 ### Intel XPU
 
-Use this on Intel GPU systems:
+Use on Intel GPU systems:
 
 ```bash
 uvx \
@@ -32,21 +18,9 @@ uvx \
   physicalai-studio serve
 ```
 
-### CPU
-
-Use this on systems without a supported GPU, or for simple smoke testing:
-
-```bash
-uvx \
-  --index https://download.pytorch.org/whl/cpu \
-  --index-strategy unsafe-best-match \
-  --from "physicalai-studio[cpu]" \
-  physicalai-studio serve
-```
-
 ### NVIDIA CUDA
 
-Use this on NVIDIA GPU systems compatible with the CUDA 12.8 PyTorch wheels:
+Use on NVIDIA GPU systems:
 
 ```bash
 uvx \
@@ -56,22 +30,16 @@ uvx \
   physicalai-studio serve
 ```
 
-All three commands start the same packaged application and serve the bundled production UI. The selected extra only changes the installed training/inference runtime dependencies.
+### CPU
 
-For headless startup, add:
-
-```bash
---no-browser
-```
-
-For example:
+Use on systems without a supported GPU, or for simple smoke testing:
 
 ```bash
 uvx \
-  --index https://download.pytorch.org/whl/xpu \
+  --index https://download.pytorch.org/whl/cpu \
   --index-strategy unsafe-best-match \
-  --from "physicalai-studio[xpu]" \
-  physicalai-studio serve --no-browser
+  --from "physicalai-studio[cpu]" \
+  physicalai-studio serve
 ```
 
 ## Package Shape
@@ -98,8 +66,10 @@ The wheel contains:
 
 - Backend Python modules from `application/backend/src`.
 - Alembic configuration and migrations.
-- A `physicalai-studio` console script.
+- A `physicalai-studio` console script with a `serve` command that runs the backend and UI together.
 - The production UI build from `application/ui/dist`, packaged into the wheel as `webui/`.
+
+Supported options: `--host 127.0.0.1 --port 7860`.
 
 The UI is included through Hatch `force-include`:
 
@@ -108,92 +78,16 @@ The UI is included through Hatch `force-include`:
 "../ui/dist" = "webui"
 ```
 
-`scripts/hatch_build.py` prevents publishing a wheel without the frontend by failing wheel builds when `application/ui/dist/index.html` is missing. Editable development installs are not blocked.
+`scripts/hatch_build.py` prevents publishing a wheel without the frontend and transforms relative URLs in the app README to absolute GitHub URLs for the PyPI description.
 
-## Build The Wheel Locally
+## GitHub Actions
 
-From the repository root:
+The wheel is build and published using Github Actions.
 
-```bash
-bash application/backend/scripts/build_package.sh
-```
+- **TestPyPI** — Publishes on every push to `main` (or manual dispatch). Appends `.dev<timestamp>` to the version for unique uploads.
+- **PyPI** — Publishes when an `app/vX.Y.Z` tag is pushed. Validates the tag matches `application/VERSION` and `pyproject.toml` before building.
 
-The script performs the release build sequence:
-
-1. Syncs backend dependencies with the XPU extra.
-2. Generates the OpenAPI spec from the backend.
-3. Installs UI dependencies.
-4. Builds OpenAPI TypeScript definitions.
-5. Builds the production UI.
-6. Builds the backend wheel.
-7. Runs `twine check` on the generated distribution.
-
-The generated wheel is written to:
-
-```text
-application/backend/dist/
-```
-
-## Inspect Wheel Contents
-
-Confirm that the wheel contains UI assets and migrations:
-
-```bash
-python - <<'PY'
-from pathlib import Path
-from zipfile import ZipFile
-
-wheel = next(Path("application/backend/dist").glob("*.whl"))
-with ZipFile(wheel) as zf:
-    names = set(zf.namelist())
-
-for name in (
-    "webui/index.html",
-    "alembic.ini",
-    "alembic/env.py",
-):
-    print(f"{name}: {name in names}")
-
-print("webui file count:", sum(name.startswith("webui/") for name in names))
-PY
-```
-
-Expected:
-
-```text
-webui/index.html: True
-alembic.ini: True
-alembic/env.py: True
-webui file count: <non-zero>
-```
-
-## Test The Wheel Locally With uvx
-
-Use the wheel directly, without publishing to PyPI:
-
-```bash
-WHEEL="/home/mark/projects/intel/physical-ai-studio/application/backend/dist/physicalai_studio-0.1.0-py3-none-any.whl"
-
-uvx --isolated --no-cache \
-  --index https://download.pytorch.org/whl/xpu \
-  --index-strategy unsafe-best-match \
-  --from "physicalai-studio[xpu] @ file://${WHEEL}" \
-  physicalai-studio serve
-```
-
-Then open:
-
-```text
-http://127.0.0.1:7860
-```
-
-Use `--no-cache` while iterating locally. The version is usually unchanged during local testing, so `uv` may otherwise reuse a cached wheel.
-
-Use `--isolated` to avoid reusing an installed tool environment.
-
-The PyTorch XPU index is passed explicitly because wheel metadata cannot carry the local `[tool.uv.index]` configuration from `pyproject.toml`.
-
-## Test From TestPyPI
+### Test From TestPyPI
 
 When validating a release candidate from TestPyPI, include all three indexes:
 
@@ -211,80 +105,60 @@ uvx \
   physicalai-studio serve
 ```
 
-For local iteration with the same version number, add `--no-cache --isolated`.
+## Build The Wheel Locally
 
-## Test The Wheel With uv pip
-
-For a clean virtual environment test:
+From the repository root:
 
 ```bash
-tmpdir="$(mktemp -d)"
-uv venv "$tmpdir/venv"
-
-uv pip install \
-  --python "$tmpdir/venv/bin/python" \
-  --index https://download.pytorch.org/whl/xpu \
-  --index-strategy unsafe-best-match \
-  "physicalai-studio[xpu] @ file:///home/mark/projects/intel/physical-ai-studio/application/backend/dist/physicalai_studio-0.1.0-py3-none-any.whl"
-
-uv pip check --python "$tmpdir/venv/bin/python"
-"$tmpdir/venv/bin/physicalai-studio" serve --help
+bash application/backend/scripts/build_package.sh
 ```
 
-## Runtime Behavior
+This syncs dependencies, generates the OpenAPI spec, builds the production UI, optionally patches the version (if `VERSION_OVERRIDE` is set), builds the wheel, and runs `twine check`.
 
-The console script is:
+The generated wheel is written to:
 
 ```text
-physicalai-studio = cli:cli
+application/backend/dist/
 ```
 
-`physicalai-studio serve` does the package-specific setup before importing the FastAPI app:
+### Inspect Wheel Contents
 
-- Points `STATIC_FILES_DIR` at the installed `webui/` directory when it exists.
-- Points Alembic at the installed `alembic.ini` and `alembic/` directory.
-- Uses the platform default storage directory unless `STORAGE_DIR` is set.
-- Runs storage migration and database migrations.
-- Starts Uvicorn on `127.0.0.1:7860` by default.
+Confirm that the wheel contains UI assets and migrations:
 
-Supported options:
+```python
+from pathlib import Path
+from zipfile import ZipFile
+
+wheel = next(Path("application/backend/dist").glob("*.whl"))
+with ZipFile(wheel) as zf:
+    names = set(zf.namelist())
+
+for name in (
+    "webui/index.html",
+    "alembic.ini",
+    "alembic/env.py",
+):
+    print(f"{name}: {name in names}")
+
+print("webui file count:", sum(name.startswith("webui/") for name in names))
+```
+
+Expected:
+
+```text
+webui/index.html: True
+alembic.ini: True
+alembic/env.py: True
+webui file count: <non-zero>
+```
+
+### Test The Wheel Locally With uvx
+
+Use the wheel directly, without publishing to PyPI:
 
 ```bash
-physicalai-studio serve --host 127.0.0.1 --port 7860 --no-browser
-```
+WHEEL="/home/intel/physical-ai-studio/application/backend/dist/physicalai_studio-0.1.0-py3-none-any.whl"
 
-## CPU, XPU, And CUDA Extras
-
-The backend currently defines three hardware extras:
-
-```toml
-[project.optional-dependencies]
-cpu = ["torch<2.13", "torchvision<0.26.0"]
-cuda = ["torch<2.13", "torchvision<0.26.0"]
-xpu = [
-  "torch<2.13",
-  "torchvision<0.26.0",
-  "pytorch-triton-xpu ; sys_platform == 'linux' or sys_platform == 'win32'",
-]
-```
-
-### XPU
-
-XPU is supported in the initial PyPI rollout. Use the XPU PyTorch index for Intel GPU systems.
-
-Published package:
-
-```bash
-uvx \
-  --index https://download.pytorch.org/whl/xpu \
-  --index-strategy unsafe-best-match \
-  --from "physicalai-studio[xpu]" \
-  physicalai-studio serve
-```
-
-Local wheel:
-
-```bash
 uvx --isolated --no-cache \
   --index https://download.pytorch.org/whl/xpu \
   --index-strategy unsafe-best-match \
@@ -292,105 +166,8 @@ uvx --isolated --no-cache \
   physicalai-studio serve
 ```
 
-XPU requires the PyTorch XPU wheel index because `pytorch-triton-xpu` is not available on PyPI.
+Use `--no-cache` while and `--isolated` to avoid reusing an installed tool environment.
 
-### CPU
-
-CPU is supported in the initial PyPI rollout. It is useful for machines without a supported GPU and for smoke testing.
-
-Published package:
-
-```bash
-uvx \
-  --index https://download.pytorch.org/whl/cpu \
-  --index-strategy unsafe-best-match \
-  --from "physicalai-studio[cpu]" \
-  physicalai-studio serve --no-browser
-```
-
-Local wheel:
-
-```bash
-uvx --isolated --no-cache \
-  --index https://download.pytorch.org/whl/cpu \
-  --index-strategy unsafe-best-match \
-  --from "physicalai-studio[cpu] @ file://${WHEEL}" \
-  physicalai-studio serve --no-browser
-```
-
-### CUDA
-
-CUDA is supported in the initial PyPI rollout. It should be used on NVIDIA GPU systems compatible with the CUDA 12.8 PyTorch wheels.
-
-Published package:
-
-```bash
-uvx \
-  --index https://download.pytorch.org/whl/cu128 \
-  --index-strategy unsafe-best-match \
-  --from "physicalai-studio[cuda]" \
-  physicalai-studio serve --no-browser
-```
-
-Local wheel:
-
-```bash
-uvx --isolated --no-cache \
-  --index https://download.pytorch.org/whl/cu128 \
-  --index-strategy unsafe-best-match \
-  --from "physicalai-studio[cuda] @ file://${WHEEL}" \
-  physicalai-studio serve --no-browser
-```
-
-### Why Index Flags Are Required
-
-The source project has `[tool.uv.index]` and `[tool.uv.sources]` entries for local development. Those settings are not standard wheel metadata. Once installed from a wheel, the package dependencies are standard Python requirements, and the installer must be told where hardware-specific PyTorch packages live.
-
-For now, local and published CPU, XPU, and CUDA testing should pass the matching PyTorch index explicitly.
-
-## GitHub Actions
-
-Two app package publishing workflows exist:
-
-```text
-.github/workflows/publish-app-testpypi.yml
-.github/workflows/publish-app-pypi.yml
-```
-
-### TestPyPI
-
-`publish-app-testpypi.yml` runs on `workflow_dispatch`.
-
-It:
-
-1. Checks out the repository.
-2. Sets up Python from `application/backend/.python-version`.
-3. Installs `uv`.
-4. Sets up Node from `application/ui/.nvmrc`.
-5. Installs npm `11.14.0`.
-6. Runs `application/backend/scripts/build_package.sh`.
-7. Uploads `application/backend/dist/` as an artifact.
-8. Smoke-tests the wheel metadata and console script entry point with `--no-deps`.
-9. Publishes to TestPyPI with trusted publishing.
-
-The smoke test intentionally does not install all runtime dependencies. Full dependency resolution, especially XPU, should be validated on a suitable XPU host.
-
-### PyPI
-
-`publish-app-pypi.yml` runs on stable app tags:
-
-```text
-app/vX.Y.Z
-```
-
-It also supports manual `workflow_dispatch`, but publishing only runs for `app/v...` tags.
-
-The workflow validates that:
-
-- The tag version matches `application/VERSION`.
-- The tag version matches `application/backend/pyproject.toml`.
-
-Then it builds, smoke-tests, uploads the artifact, and publishes to PyPI.
 
 ## Common Issues
 
@@ -430,9 +207,3 @@ bash application/backend/scripts/build_package.sh
 ```
 
 Do not build the app wheel before `application/ui/dist/index.html` exists. The Hatch build hook should fail wheel builds when the UI production build is missing.
-
-### Worker Spawn Circular Import Errors
-
-The installed package uses Python's `spawn` multiprocessing mode. Package-level imports must stay lightweight. Avoid importing lifecycle or scheduler code from package `__init__.py` files, because worker subprocesses import modules during unpickling.
-
-In particular, `core/__init__.py` should not import `core.lifecycle`.

--- a/application/backend/docs/distribution.md
+++ b/application/backend/docs/distribution.md
@@ -1,0 +1,438 @@
+# Physical AI Studio Distribution
+
+This document describes how the backend is packaged as the `physicalai-studio` Python distribution, how to test the wheel locally before publishing, and how the GitHub Actions publishing workflows behave.
+
+## Production Usage Overview
+
+The initial PyPI rollout publishes one distribution:
+
+```text
+physicalai-studio
+```
+
+Users select the hardware runtime with package extras:
+
+```text
+physicalai-studio[cpu]
+physicalai-studio[xpu]
+physicalai-studio[cuda]
+```
+
+Because PyTorch publishes hardware-specific wheels on separate package indexes, users must pass the matching PyTorch index to `uvx`.
+
+### Intel XPU
+
+Use this on Intel GPU systems:
+
+```bash
+uvx \
+  --index https://download.pytorch.org/whl/xpu \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[xpu]" \
+  physicalai-studio serve
+```
+
+### CPU
+
+Use this on systems without a supported GPU, or for simple smoke testing:
+
+```bash
+uvx \
+  --index https://download.pytorch.org/whl/cpu \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[cpu]" \
+  physicalai-studio serve
+```
+
+### NVIDIA CUDA
+
+Use this on NVIDIA GPU systems compatible with the CUDA 12.8 PyTorch wheels:
+
+```bash
+uvx \
+  --index https://download.pytorch.org/whl/cu128 \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[cuda]" \
+  physicalai-studio serve
+```
+
+All three commands start the same packaged application and serve the bundled production UI. The selected extra only changes the installed training/inference runtime dependencies.
+
+For headless startup, add:
+
+```bash
+--no-browser
+```
+
+For example:
+
+```bash
+uvx \
+  --index https://download.pytorch.org/whl/xpu \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[xpu]" \
+  physicalai-studio serve --no-browser
+```
+
+## Package Shape
+
+The Python package is built from `application/backend`.
+
+Important files:
+
+```text
+application/backend/
+├── pyproject.toml
+├── scripts/build_package.sh
+├── scripts/hatch_build.py
+├── src/
+│   ├── cli/
+│   ├── main.py
+│   ├── alembic.ini
+│   ├── alembic/
+│   └── ...
+└── dist/
+```
+
+The wheel contains:
+
+- Backend Python modules from `application/backend/src`.
+- Alembic configuration and migrations.
+- A `physicalai-studio` console script.
+- The production UI build from `application/ui/dist`, packaged into the wheel as `webui/`.
+
+The UI is included through Hatch `force-include`:
+
+```toml
+[tool.hatch.build.force-include]
+"../ui/dist" = "webui"
+```
+
+`scripts/hatch_build.py` prevents publishing a wheel without the frontend by failing wheel builds when `application/ui/dist/index.html` is missing. Editable development installs are not blocked.
+
+## Build The Wheel Locally
+
+From the repository root:
+
+```bash
+bash application/backend/scripts/build_package.sh
+```
+
+The script performs the release build sequence:
+
+1. Syncs backend dependencies with the XPU extra.
+2. Generates the OpenAPI spec from the backend.
+3. Installs UI dependencies.
+4. Builds OpenAPI TypeScript definitions.
+5. Builds the production UI.
+6. Builds the backend wheel.
+7. Runs `twine check` on the generated distribution.
+
+The generated wheel is written to:
+
+```text
+application/backend/dist/
+```
+
+## Inspect Wheel Contents
+
+Confirm that the wheel contains UI assets and migrations:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from zipfile import ZipFile
+
+wheel = next(Path("application/backend/dist").glob("*.whl"))
+with ZipFile(wheel) as zf:
+    names = set(zf.namelist())
+
+for name in (
+    "webui/index.html",
+    "alembic.ini",
+    "alembic/env.py",
+):
+    print(f"{name}: {name in names}")
+
+print("webui file count:", sum(name.startswith("webui/") for name in names))
+PY
+```
+
+Expected:
+
+```text
+webui/index.html: True
+alembic.ini: True
+alembic/env.py: True
+webui file count: <non-zero>
+```
+
+## Test The Wheel Locally With uvx
+
+Use the wheel directly, without publishing to PyPI:
+
+```bash
+WHEEL="/home/mark/projects/intel/physical-ai-studio/application/backend/dist/physicalai_studio-0.1.0-py3-none-any.whl"
+
+uvx --isolated --no-cache \
+  --index https://download.pytorch.org/whl/xpu \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[xpu] @ file://${WHEEL}" \
+  physicalai-studio serve
+```
+
+Then open:
+
+```text
+http://127.0.0.1:7860
+```
+
+Use `--no-cache` while iterating locally. The version is usually unchanged during local testing, so `uv` may otherwise reuse a cached wheel.
+
+Use `--isolated` to avoid reusing an installed tool environment.
+
+The PyTorch XPU index is passed explicitly because wheel metadata cannot carry the local `[tool.uv.index]` configuration from `pyproject.toml`.
+
+## Test From TestPyPI
+
+When validating a release candidate from TestPyPI, include all three indexes:
+
+- TestPyPI for `physicalai-studio`
+- PyPI for normal dependencies (`torchao`, `fastapi`, etc.)
+- PyTorch hardware index for `torch`/`torchvision` wheels
+
+```bash
+uvx \
+  --index https://test.pypi.org/simple/ \
+  --index https://pypi.org/simple \
+  --index https://download.pytorch.org/whl/xpu \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[xpu]==0.1.0" \
+  physicalai-studio serve
+```
+
+For local iteration with the same version number, add `--no-cache --isolated`.
+
+## Test The Wheel With uv pip
+
+For a clean virtual environment test:
+
+```bash
+tmpdir="$(mktemp -d)"
+uv venv "$tmpdir/venv"
+
+uv pip install \
+  --python "$tmpdir/venv/bin/python" \
+  --index https://download.pytorch.org/whl/xpu \
+  --index-strategy unsafe-best-match \
+  "physicalai-studio[xpu] @ file:///home/mark/projects/intel/physical-ai-studio/application/backend/dist/physicalai_studio-0.1.0-py3-none-any.whl"
+
+uv pip check --python "$tmpdir/venv/bin/python"
+"$tmpdir/venv/bin/physicalai-studio" serve --help
+```
+
+## Runtime Behavior
+
+The console script is:
+
+```text
+physicalai-studio = cli:cli
+```
+
+`physicalai-studio serve` does the package-specific setup before importing the FastAPI app:
+
+- Points `STATIC_FILES_DIR` at the installed `webui/` directory when it exists.
+- Points Alembic at the installed `alembic.ini` and `alembic/` directory.
+- Uses the platform default storage directory unless `STORAGE_DIR` is set.
+- Runs storage migration and database migrations.
+- Starts Uvicorn on `127.0.0.1:7860` by default.
+
+Supported options:
+
+```bash
+physicalai-studio serve --host 127.0.0.1 --port 7860 --no-browser
+```
+
+## CPU, XPU, And CUDA Extras
+
+The backend currently defines three hardware extras:
+
+```toml
+[project.optional-dependencies]
+cpu = ["torch<2.13", "torchvision<0.26.0"]
+cuda = ["torch<2.13", "torchvision<0.26.0"]
+xpu = [
+  "torch<2.13",
+  "torchvision<0.26.0",
+  "pytorch-triton-xpu ; sys_platform == 'linux' or sys_platform == 'win32'",
+]
+```
+
+### XPU
+
+XPU is supported in the initial PyPI rollout. Use the XPU PyTorch index for Intel GPU systems.
+
+Published package:
+
+```bash
+uvx \
+  --index https://download.pytorch.org/whl/xpu \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[xpu]" \
+  physicalai-studio serve
+```
+
+Local wheel:
+
+```bash
+uvx --isolated --no-cache \
+  --index https://download.pytorch.org/whl/xpu \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[xpu] @ file://${WHEEL}" \
+  physicalai-studio serve
+```
+
+XPU requires the PyTorch XPU wheel index because `pytorch-triton-xpu` is not available on PyPI.
+
+### CPU
+
+CPU is supported in the initial PyPI rollout. It is useful for machines without a supported GPU and for smoke testing.
+
+Published package:
+
+```bash
+uvx \
+  --index https://download.pytorch.org/whl/cpu \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[cpu]" \
+  physicalai-studio serve --no-browser
+```
+
+Local wheel:
+
+```bash
+uvx --isolated --no-cache \
+  --index https://download.pytorch.org/whl/cpu \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[cpu] @ file://${WHEEL}" \
+  physicalai-studio serve --no-browser
+```
+
+### CUDA
+
+CUDA is supported in the initial PyPI rollout. It should be used on NVIDIA GPU systems compatible with the CUDA 12.8 PyTorch wheels.
+
+Published package:
+
+```bash
+uvx \
+  --index https://download.pytorch.org/whl/cu128 \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[cuda]" \
+  physicalai-studio serve --no-browser
+```
+
+Local wheel:
+
+```bash
+uvx --isolated --no-cache \
+  --index https://download.pytorch.org/whl/cu128 \
+  --index-strategy unsafe-best-match \
+  --from "physicalai-studio[cuda] @ file://${WHEEL}" \
+  physicalai-studio serve --no-browser
+```
+
+### Why Index Flags Are Required
+
+The source project has `[tool.uv.index]` and `[tool.uv.sources]` entries for local development. Those settings are not standard wheel metadata. Once installed from a wheel, the package dependencies are standard Python requirements, and the installer must be told where hardware-specific PyTorch packages live.
+
+For now, local and published CPU, XPU, and CUDA testing should pass the matching PyTorch index explicitly.
+
+## GitHub Actions
+
+Two app package publishing workflows exist:
+
+```text
+.github/workflows/publish-app-testpypi.yml
+.github/workflows/publish-app-pypi.yml
+```
+
+### TestPyPI
+
+`publish-app-testpypi.yml` runs on `workflow_dispatch`.
+
+It:
+
+1. Checks out the repository.
+2. Sets up Python from `application/backend/.python-version`.
+3. Installs `uv`.
+4. Sets up Node from `application/ui/.nvmrc`.
+5. Installs npm `11.14.0`.
+6. Runs `application/backend/scripts/build_package.sh`.
+7. Uploads `application/backend/dist/` as an artifact.
+8. Smoke-tests the wheel metadata and console script entry point with `--no-deps`.
+9. Publishes to TestPyPI with trusted publishing.
+
+The smoke test intentionally does not install all runtime dependencies. Full dependency resolution, especially XPU, should be validated on a suitable XPU host.
+
+### PyPI
+
+`publish-app-pypi.yml` runs on stable app tags:
+
+```text
+app/vX.Y.Z
+```
+
+It also supports manual `workflow_dispatch`, but publishing only runs for `app/v...` tags.
+
+The workflow validates that:
+
+- The tag version matches `application/VERSION`.
+- The tag version matches `application/backend/pyproject.toml`.
+
+Then it builds, smoke-tests, uploads the artifact, and publishes to PyPI.
+
+## Common Issues
+
+### `No module named 'pytorch-triton-xpu'`
+
+The PyTorch XPU index was not supplied.
+
+Add:
+
+```bash
+--index https://download.pytorch.org/whl/xpu \
+--index-strategy unsafe-best-match
+```
+
+### Stale Local Wheel Is Used
+
+If you rebuild the wheel without changing the version, `uv` may reuse a cached artifact.
+
+Use:
+
+```bash
+--no-cache --isolated
+```
+
+Or point directly to the wheel file:
+
+```bash
+--from "physicalai-studio[xpu] @ file://${WHEEL}"
+```
+
+### Missing UI Assets In The Wheel
+
+Run:
+
+```bash
+bash application/backend/scripts/build_package.sh
+```
+
+Do not build the app wheel before `application/ui/dist/index.html` exists. The Hatch build hook should fail wheel builds when the UI production build is missing.
+
+### Worker Spawn Circular Import Errors
+
+The installed package uses Python's `spawn` multiprocessing mode. Package-level imports must stay lightweight. Avoid importing lifecycle or scheduler code from package `__init__.py` files, because worker subprocesses import modules during unpickling.
+
+In particular, `core/__init__.py` should not import `core.lifecycle`.

--- a/application/backend/docs/distribution.md
+++ b/application/backend/docs/distribution.md
@@ -71,14 +71,7 @@ The wheel contains:
 
 Supported options: `--host 127.0.0.1 --port 7860`.
 
-The UI is included through Hatch `force-include`:
-
-```toml
-[tool.hatch.build.force-include]
-"../ui/dist" = "webui"
-```
-
-`scripts/hatch_build.py` prevents publishing a wheel without the frontend and transforms relative URLs in the app README to absolute GitHub URLs for the PyPI description.
+The UI is included through a `force_include` entry that `scripts/hatch_build.py` adds to `build_data` during non-editable builds. The hatch hook also prevents publishing a wheel without the frontend and transforms relative URLs in the app README to absolute GitHub URLs for the PyPI description.
 
 ## GitHub Actions
 

--- a/application/backend/docs/distribution.md
+++ b/application/backend/docs/distribution.md
@@ -82,7 +82,7 @@ The UI is included through Hatch `force-include`:
 
 ## GitHub Actions
 
-The wheel is build and published using Github Actions.
+The wheel is build and published using GitHub Actions.
 
 - **TestPyPI** — Publishes on every push to `main` (or manual dispatch). Appends `.dev<timestamp>` to the version for unique uploads.
 - **PyPI** — Publishes when an `app/vX.Y.Z` tag is pushed. Validates the tag matches `application/VERSION` and `pyproject.toml` before building.
@@ -166,8 +166,7 @@ uvx --isolated --no-cache \
   physicalai-studio serve
 ```
 
-Use `--no-cache` while and `--isolated` to avoid reusing an installed tool environment.
-
+Use `--no-cache` and `--isolated` to avoid reusing an installed tool environment.
 
 ## Common Issues
 

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -1,22 +1,3 @@
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-only-include = ["src"]
-sources = ["src"]
-exclude = [
-  "src/**/*.egg-info/**",
-  "src/**/__pycache__/**",
-  "src/regeneragte-readme.py",
-]
-
-[tool.hatch.build.force-include]
-"../ui/dist" = "webui"
-
-[tool.hatch.build.hooks.custom]
-path = "scripts/hatch_build.py"
-
 [project]
 name = "physicalai-studio"
 version = "0.1.0"
@@ -57,6 +38,26 @@ dependencies = [
 
 [project.scripts]
 physicalai-studio = "cli:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["src"]
+sources = ["src"]
+exclude = [
+  "src/**/*.egg-info/**",
+  "src/**/__pycache__/**",
+  "src/regeneragte-readme.py",
+]
+
+[tool.hatch.build.force-include]
+"../ui/dist" = "webui"
+
+[tool.hatch.build.hooks.custom]
+path = "scripts/hatch_build.py"
+
 
 [project.optional-dependencies]
 cpu = [

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "opencv-python",
   "cv2-enumerate-cameras",
   'harvesters; sys_platform != "darwin"',
-  "fastapi[standard]",
+  "fastapi[standard]<1",
   "physicalai-train[pi0,smolvla]",
   "physicalai[robots, capture]",
   "lerobot[feetech]==0.5.1",

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -49,7 +49,6 @@ sources = ["src"]
 exclude = [
   "src/**/*.egg-info/**",
   "src/**/__pycache__/**",
-  "src/regeneragte-readme.py",
 ]
 
 [tool.hatch.build.force-include]

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -51,9 +51,6 @@ exclude = [
   "src/**/__pycache__/**",
 ]
 
-[tool.hatch.build.force-include]
-"../ui/dist" = "webui"
-
 [tool.hatch.build.hooks.custom]
 path = "scripts/hatch_build.py"
 

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -1,3 +1,22 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["src"]
+sources = ["src"]
+exclude = [
+  "src/**/*.egg-info/**",
+  "src/**/__pycache__/**",
+  "src/regeneragte-readme.py",
+]
+
+[tool.hatch.build.force-include]
+"../ui/dist" = "webui"
+
+[tool.hatch.build.hooks.custom]
+path = "scripts/hatch_build.py"
+
 [project]
 name = "physicalai-studio"
 version = "0.1.0"
@@ -38,16 +57,6 @@ dependencies = [
 
 [project.scripts]
 physicalai-studio = "cli:cli"
-
-[build-system]
-requires = ["setuptools>=69", "wheel"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools]
-package-dir = {"" = "src"}
-
-[tool.setuptools.packages.find]
-where = ["src"]
 
 [project.optional-dependencies]
 cpu = [

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "physicalai-studio"
 version = "0.1.0"
-description = "Physical AI Studio server"
+description = "Physical AI Studio"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
 

--- a/application/backend/run.sh
+++ b/application/backend/run.sh
@@ -24,12 +24,4 @@ UV_CMD=${UV_CMD:-uv run --no-sync}
 
 export PYTHONUNBUFFERED=1
 
-# Always run migrations — Alembic is idempotent and will skip
-# already-applied migrations. This ensures the persistent volume
-# has an up-to-date schema regardless of how it was created.
-echo "Running database migrations..."
-$UV_CMD physicalai-studio db migrate
-
-echo "Starting FastAPI server..."
-echo $UV_CMD "$APP_MODULE"
-exec $UV_CMD "$APP_MODULE"
+$UV_CMD physicalai-studio serve

--- a/application/backend/run.sh
+++ b/application/backend/run.sh
@@ -2,26 +2,15 @@
 set -euo pipefail
 
 # -----------------------------------------------------------------------------
-# run.sh - Script to run the Physical AI Studio server
+# run.sh - Entry point to start the Physical AI Studio server
 #
-# Features:
-# - Runs database migrations on every start (idempotent via Alembic)
+# Runs database migrations (idempotent via Alembic) and starts the backend
+# with the bundled UI via the physicalai-studio serve CLI.
 #
 # Usage:
-#   ./run.sh                    # Run server
-#
-# Environment variables:
-#   APP_MODULE    Python module to run (default: src/main.py)
-#   UV_CMD        Command to launch Uvicorn (default: "uv run")
-#
-# Requirements:
-# - 'uv' CLI tool (Uvicorn) installed and available in PATH
-# - Python modules and dependencies installed correctly
+#   ./run.sh
 # -----------------------------------------------------------------------------
-
-APP_MODULE=${APP_MODULE:-src/main.py}
-UV_CMD=${UV_CMD:-uv run --no-sync}
 
 export PYTHONUNBUFFERED=1
 
-$UV_CMD physicalai-studio serve
+exec uv run --no-sync physicalai-studio serve

--- a/application/backend/scripts/build_package.sh
+++ b/application/backend/scripts/build_package.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+APPLICATION_DIR="$(cd -- "${BACKEND_DIR}/.." && pwd)"
+UI_DIR="${APPLICATION_DIR}/ui"
+
+cd "${BACKEND_DIR}"
+
+uv sync --frozen --extra xpu
+uv run physicalai-studio gen-api --target-path openapi-spec.json
+
+cd "${UI_DIR}"
+npm ci
+cp "${BACKEND_DIR}/openapi-spec.json" src/api/openapi-spec.json
+npm run build:api
+npm run build
+
+if [[ ! -f "${UI_DIR}/dist/index.html" ]]; then
+    echo "Missing ${UI_DIR}/dist/index.html after UI build" >&2
+    exit 1
+fi
+
+cd "${BACKEND_DIR}"
+rm -rf dist
+
+# Dev/test builds: override version so TestPyPI accepts re-uploads
+if [[ -n "${VERSION_OVERRIDE:-}" ]]; then
+    sed -i 's/^version = .*/version = "'"${VERSION_OVERRIDE}"'"/' pyproject.toml
+fi
+
+uv run --with build==1.5.0 --with twine==6.2.0 python -m build --wheel
+uv run --with twine==6.2.0 python -m twine check dist/*

--- a/application/backend/scripts/hatch_build.py
+++ b/application/backend/scripts/hatch_build.py
@@ -45,7 +45,7 @@ def _transform_readme(content: str) -> str:
 
 class CustomBuildHook(BuildHookInterface):
     def initialize(self, version: str, build_data: dict) -> None:  # noqa: ARG002
-        if build_data.get("editable", False) or build_data.get("target_name") == "editable":
+        if version == "editable":
             return
 
         ui_dist = Path(self.root).parent / "ui" / "dist"

--- a/application/backend/scripts/hatch_build.py
+++ b/application/backend/scripts/hatch_build.py
@@ -44,7 +44,7 @@ def _transform_readme(content: str) -> str:
 
 
 class CustomBuildHook(BuildHookInterface):
-    def initialize(self, version: str, build_data: dict) -> None:  # noqa: ARG002
+    def initialize(self, version: str, build_data: dict) -> None:
         if version == "editable":
             return
 

--- a/application/backend/scripts/hatch_build.py
+++ b/application/backend/scripts/hatch_build.py
@@ -59,6 +59,8 @@ class CustomBuildHook(BuildHookInterface):
             )
             raise FileNotFoundError(msg)
 
+        build_data["force_include"] = {"../ui/dist": "webui"}
+
         app_readme = Path(self.root).parent / "README.md"
         target = Path(self.root) / "README.md"
         content = app_readme.read_text(encoding="utf-8")

--- a/application/backend/scripts/hatch_build.py
+++ b/application/backend/scripts/hatch_build.py
@@ -45,7 +45,7 @@ def _transform_readme(content: str) -> str:
 
 class CustomBuildHook(BuildHookInterface):
     def initialize(self, version: str, build_data: dict) -> None:  # noqa: ARG002
-        if version == "editable":
+        if build_data.get("editable", False) or build_data.get("target_name") == "editable":
             return
 
         ui_dist = Path(self.root).parent / "ui" / "dist"

--- a/application/backend/scripts/hatch_build.py
+++ b/application/backend/scripts/hatch_build.py
@@ -1,0 +1,66 @@
+import re
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+GITHUB_REPO = "https://github.com/open-edge-platform/physical-ai-studio"
+RAW_REPO = "https://raw.githubusercontent.com/open-edge-platform/physical-ai-studio"
+BRANCH = "main"
+
+_RELATIVE_URL_RE = re.compile(r'(!?)\[([^\]]*)\]\(([^)]+)\)')
+_IMG_SRC_RE = re.compile(r'(<img\s[^>]*src=")([^"]+)(")')
+
+
+def _resolve_relative(url: str) -> str:
+    if url.startswith("./"):
+        return "application/" + url[2:]
+    if url.startswith("../"):
+        return url[3:]
+    return url
+
+
+def _make_link_absolute(match: re.Match) -> str:
+    prefix = match.group(1)
+    text = match.group(2)
+    url = match.group(3)
+    if url.startswith(("http://", "https://", "#", "mailto:")):
+        return match.group(0)
+    resolved = _resolve_relative(url)
+    base = RAW_REPO if prefix == "!" else f"{GITHUB_REPO}/blob"
+    return f"{prefix}[{text}]({base}/{BRANCH}/{resolved})"
+
+
+def _make_img_src_absolute(match: re.Match) -> str:
+    url = match.group(2)
+    if url.startswith(("http://", "https://", "#")):
+        return match.group(0)
+    resolved = _resolve_relative(url)
+    return f'{match.group(1)}{RAW_REPO}/{BRANCH}/{resolved}{match.group(3)}'
+
+
+def _transform_readme(content: str) -> str:
+    content = _RELATIVE_URL_RE.sub(_make_link_absolute, content)
+    content = _IMG_SRC_RE.sub(_make_img_src_absolute, content)
+    return content
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version: str, build_data: dict) -> None:  # noqa: ARG002
+        if version == "editable":
+            return
+
+        ui_dist = Path(self.root).parent / "ui" / "dist"
+        index_html = ui_dist / "index.html"
+
+        if not index_html.exists():
+            msg = (
+                "Missing application/ui/dist/index.html. "
+                "Build the UI before building the package, or run "
+                "application/backend/scripts/build_package.sh."
+            )
+            raise FileNotFoundError(msg)
+
+        app_readme = Path(self.root).parent / "README.md"
+        target = Path(self.root) / "README.md"
+        content = app_readme.read_text(encoding="utf-8")
+        target.write_text(_transform_readme(content), encoding="utf-8")

--- a/application/backend/scripts/hatch_build.py
+++ b/application/backend/scripts/hatch_build.py
@@ -7,7 +7,7 @@ GITHUB_REPO = "https://github.com/open-edge-platform/physical-ai-studio"
 RAW_REPO = "https://raw.githubusercontent.com/open-edge-platform/physical-ai-studio"
 BRANCH = "main"
 
-_RELATIVE_URL_RE = re.compile(r'(!?)\[([^\]]*)\]\(([^)]+)\)')
+_RELATIVE_URL_RE = re.compile(r"(!?)\[([^\]]*)\]\(([^)]+)\)")
 _IMG_SRC_RE = re.compile(r'(<img\s[^>]*src=")([^"]+)(")')
 
 
@@ -35,13 +35,12 @@ def _make_img_src_absolute(match: re.Match) -> str:
     if url.startswith(("http://", "https://", "#")):
         return match.group(0)
     resolved = _resolve_relative(url)
-    return f'{match.group(1)}{RAW_REPO}/{BRANCH}/{resolved}{match.group(3)}'
+    return f"{match.group(1)}{RAW_REPO}/{BRANCH}/{resolved}{match.group(3)}"
 
 
 def _transform_readme(content: str) -> str:
     content = _RELATIVE_URL_RE.sub(_make_link_absolute, content)
-    content = _IMG_SRC_RE.sub(_make_img_src_absolute, content)
-    return content
+    return _IMG_SRC_RE.sub(_make_img_src_absolute, content)
 
 
 class CustomBuildHook(BuildHookInterface):

--- a/application/backend/src/cli/__init__.py
+++ b/application/backend/src/cli/__init__.py
@@ -6,6 +6,7 @@ import click
 
 from cli.database import database
 from cli.models import models
+from cli.serve import serve
 
 
 @click.group()
@@ -31,3 +32,4 @@ def gen_api(target_path: str) -> None:
 
 cli.add_command(database)
 cli.add_command(models)
+cli.add_command(serve)

--- a/application/backend/src/cli/database.py
+++ b/application/backend/src/cli/database.py
@@ -10,6 +10,25 @@ def database() -> None:
     """Database management commands."""
 
 
+def _run_migrations() -> None:
+    from db.migration import MigrationManager
+    from settings import get_settings
+    from storage_migration import StorageMigrationError, migrate_default_storage_dir
+
+    settings = get_settings()
+
+    try:
+        migrate_default_storage_dir(settings)
+    except StorageMigrationError as e:
+        click.echo(f"✗ Storage migration failed: {e}", err=True)
+        sys.exit(1)
+
+    migration_manager = MigrationManager(settings)
+    if not migration_manager.run_migrations():
+        click.echo("✗ Migration failed!", err=True)
+        sys.exit(1)
+
+
 @database.command("init")
 def init_db() -> None:
     """Initialize database with migrations"""
@@ -85,21 +104,6 @@ def check_db() -> None:
 @database.command("migrate")
 def migrate() -> None:
     """Run database migrations."""
-    from db.migration import MigrationManager
-    from settings import get_settings
-    from storage_migration import StorageMigrationError, migrate_default_storage_dir
-
     click.echo("Running database migrations...")
-    settings = get_settings()
-
-    try:
-        migrate_default_storage_dir(settings)
-    except StorageMigrationError as e:
-        click.echo(f"✗ Storage migration failed: {e}", err=True)
-        sys.exit(1)
-
-    migration_manager = MigrationManager(settings)
-    if not migration_manager.run_migrations():
-        click.echo("✗ Migration failed!", err=True)
-        sys.exit(1)
+    _run_migrations()
     click.echo("✓ Migrations completed successfully!")

--- a/application/backend/src/cli/serve.py
+++ b/application/backend/src/cli/serve.py
@@ -1,0 +1,39 @@
+"""Serve backend and frontend CLI commands."""
+
+import os
+from pathlib import Path
+
+import click
+
+from cli.database import _run_migrations
+
+
+def _package_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _configure_packaged_runtime() -> None:
+    package_root = _package_root()
+    bundled_webui = package_root / "webui"
+
+    if bundled_webui.joinpath("index.html").exists():
+        os.environ.setdefault("STATIC_FILES_DIR", str(bundled_webui))
+
+    os.environ.setdefault("ALEMBIC_CONFIG_PATH", str(package_root / "alembic.ini"))
+    os.environ.setdefault("ALEMBIC_SCRIPT_LOCATION", str(package_root / "alembic"))
+
+
+@click.command()
+@click.option("--host", default="127.0.0.1", show_default=True)
+@click.option("--port", default=7860, show_default=True, type=int)
+def serve(host: str, port: int) -> None:
+    """Start the Physical AI Studio web application."""
+    _configure_packaged_runtime()
+    _run_migrations()
+
+    import uvicorn
+
+    from utils.multiprocessing import ensure_spawn_start_method
+
+    ensure_spawn_start_method()
+    uvicorn.run("main:app", host=host, port=port)

--- a/application/backend/src/cli/serve.py
+++ b/application/backend/src/cli/serve.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import click
 
 from cli.database import _run_migrations
+from settings import get_settings
+
+settings = get_settings()
 
 
 def _package_root() -> Path:
@@ -24,8 +27,8 @@ def _configure_packaged_runtime() -> None:
 
 
 @click.command()
-@click.option("--host", default="127.0.0.1", show_default=True)
-@click.option("--port", default=7860, show_default=True, type=int)
+@click.option("--host", default=settings.host, show_default=True)
+@click.option("--port", default=settings.port, show_default=True, type=int)
 def serve(host: str, port: int) -> None:
     """Start the Physical AI Studio web application."""
     _configure_packaged_runtime()

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -2614,7 +2614,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.0" },
     { name = "cv2-enumerate-cameras" },
     { name = "executorch", specifier = ">=1.1.0" },
-    { name = "fastapi", extras = ["standard"] },
+    { name = "fastapi", extras = ["standard"], specifier = "<1" },
     { name = "greenlet", specifier = ">=3.2.4" },
     { name = "harvesters", marker = "sys_platform != 'darwin'" },
     { name = "lerobot", extras = ["feetech"], specifier = "==0.5.1" },

--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -47,15 +47,21 @@ FROM scratch AS app-source
 # Root workspace manifests (needed by uv run for workspace resolution)
 COPY --link pyproject.toml uv.lock LICENSE README.md /app/
 
-# Backend source, entrypoint, and manifests
+# Application-level README (needed by the hatch build hook to transform
+# relative URLs to absolute GitHub URLs for the PyPI description)
+COPY --link application/README.md /app/application/README.md
+
+# Backend source, entrypoint, manifests, and build hook
 COPY --link application/backend/src /app/application/backend/src
 COPY --link application/backend/pyproject.toml application/backend/uv.lock \
     /app/application/backend/
 COPY --link application/backend/README.md /app/application/backend/README.md
 COPY --link application/backend/run.sh /app/application/backend/run.sh
+COPY --link application/backend/scripts/hatch_build.py \
+    /app/application/backend/scripts/hatch_build.py
 
-# Built UI assets
-COPY --link --from=web-ui /home/app/web_ui/dist /app/application/ui/
+# Built UI assets (subdirectory matches the hatch hook's expected path: ../ui/dist/)
+COPY --link --from=web-ui /home/app/web_ui/dist /app/application/ui/dist
 
 # ===========================================================================
 # Stage 4: Python builder base
@@ -234,7 +240,7 @@ ENV PATH="/app/application/backend/.venv/bin:$PATH" \
     CC=/usr/bin/gcc \
     CXX=/usr/bin/g++ \
     UV_NO_SYNC=1 \
-    STATIC_FILES_DIR="/app/application/ui/" \
+    STATIC_FILES_DIR="/app/application/ui/dist/" \
     STORAGE_DIR="/app/storage" \
     AUTO_MIGRATE_STORAGE_DIR="true" \
     PYTHONPATH="/app/application/backend/src:/app/application/backend"


### PR DESCRIPTION
This PR sets up build tooling and github action workflows that lets us publish the Physial AI Studio server + UI into a single package.
This allows users to start the application with,
```bash
uvx --python 3.13 \
    --index https://download.pytorch.org/whl/xpu \
    --index-strategy unsafe-best-match \
    --from "physicalai-studio[xpu]" \
    physicalai-studio serve

uvx --python 3.13 \
    --index https://download.pytorch.org/whl/cu128 \
    --index-strategy unsafe-best-match \
    --from "physicalai-studio[cuda]" \
    physicalai-studio serve

uvx --python 3.13 \
    --index https://download.pytorch.org/whl/cpu \
    --index-strategy unsafe-best-match \
    --from "physicalai-studio[cpu]" \
    physicalai-studio serve
```

and later by simply calling `uvx physicalai-studio serve`.

---

Trusted Publishing has been set to:
- Owner: `open-edge-platform`
- Repository: `physical-ai-studio`
- Workflow name: `publish-app-pypi.yml`
- Environment name: `pypi` (TODO: verify that this has been added)

Trusted Publishing for pypi has been set to:
- Owner: `open-edge-platform`
- Repository: `physical-ai-studio`
- Workflow name: `publish-app-testpypi.yml`
- Environment name: `testpypi` (TODO: verify that this has been added)