### PR TITLE
feat: from_dict for flat observation dicts

### DIFF
--- a/library/src/physicalai/data/observation.py
+++ b/library/src/physicalai/data/observation.py
@@ -165,7 +165,20 @@ class Observation:
         """
         # Filter to only known fields
         field_names = {f.name for f in fields(cls)}
-        filtered_data = {k: v for k, v in data.items() if k in field_names}
+        filtered_data: dict[str, Any] = {}
+        nested: dict[str, dict[str, Any]] = {}
+        for key, value in data.items():
+            if key in field_names:
+                filtered_data[key] = value
+                continue
+            if key.startswith("_") and key.endswith("_keys"):
+                continue
+            if "." in key:
+                head, sub = key.split(".", 1)
+                if head in field_names:
+                    nested.setdefault(head, {})[sub] = value
+        for head, sub_map in nested.items():
+            filtered_data.setdefault(head, sub_map)
         return cls(**filtered_data)
 
     @classmethod

--- a/library/tests/unit/data/test_observation.py
+++ b/library/tests/unit/data/test_observation.py
@@ -206,6 +206,21 @@ class TestObservationFromDict:
         assert torch.equal(restored.state, original.state)
         assert torch.equal(restored.episode_index, original.episode_index)
 
+    def test_from_dict_restores_flattened_image_keys(self):
+        """Test from_dict rebuilds nested image mappings from flattened keys."""
+        top = torch.rand(3, 64, 64)
+        wrist = torch.rand(3, 64, 64)
+
+        obs = Observation.from_dict({
+            "images.top": top,
+            "images.wrist": wrist,
+            "_images_keys": ["images.top", "images.wrist"],
+        })
+
+        assert obs.images is not None
+        assert torch.equal(obs.images["top"], top)
+        assert torch.equal(obs.images["wrist"], wrist)
+
 
 class TestObservationBatching:
     """Test Observation works for both single and batched data."""

--- a/library/tests/unit/data/test_observation.py
+++ b/library/tests/unit/data/test_observation.py
@@ -190,7 +190,8 @@ class TestObservationFromDict:
         assert "top" in obs.images
         assert "wrist" in obs.images
 
-    def test_roundtrip_to_dict_from_dict(self):
+    @pytest.mark.parametrize("flatten", [True, False])
+    def test_roundtrip_to_dict_from_dict(self, flatten):
         """Test to_dict → from_dict roundtrip."""
         original = Observation(
             action=torch.tensor([1.0, 2.0]),
@@ -199,7 +200,7 @@ class TestObservationFromDict:
             episode_index=torch.tensor(5),
         )
 
-        obs_dict = original.to_dict()
+        obs_dict = original.to_dict(flatten=flatten)
         restored = Observation.from_dict(obs_dict)
 
         assert torch.equal(restored.action, original.action)

--- a/library/tests/unit/data/test_observation.py
+++ b/library/tests/unit/data/test_observation.py
@@ -206,6 +206,8 @@ class TestObservationFromDict:
         assert torch.equal(restored.action, original.action)
         assert torch.equal(restored.state, original.state)
         assert torch.equal(restored.episode_index, original.episode_index)
+        assert restored.images is not None
+        assert torch.equal(restored.images["top"], original.images["top"])
 
     def test_from_dict_restores_flattened_image_keys(self):
         """Test from_dict rebuilds nested image mappings from flattened keys."""


### PR DESCRIPTION
# Pull Request

## Description

`Observation.from_dict()` supports non-flat dicts only, while `Observation.to_dict(flatten=True)` produces incompatible dicts. This PR closes that gap: flattened observation dicts are now supported.

As a side-effect, that fixes torch inference via inference repo.

## Examples

```python
    original = Observation(
            action=torch.tensor([1.0, 2.0]),
            state=torch.tensor([0.5, 0.6]),
            images={"top": torch.rand(3, 64, 64)},
            episode_index=torch.tensor(5),
        )

        obs_dict = original.to_dict(flatten=True)
        restored = Observation.from_dict(obs_dict)

        assert torch.equal(restored.action, original.action)
        assert torch.equal(restored.state, original.state)
        assert torch.equal(restored.episode_index, original.episode_index)
```