### PR TITLE
chore: tweak robot layout

### DIFF
--- a/application/ui/src/features/robots/controller/joint-controls.tsx
+++ b/application/ui/src/features/robots/controller/joint-controls.tsx
@@ -127,8 +127,10 @@ export const JointControls = ({
     return (
         <View
             gridArea='controls'
+            zIndex={1}
             backgroundColor={'gray-100'}
             padding='size-100'
+            margin='size-400'
             UNSAFE_style={{
                 border: '1px solid var(--spectrum-global-color-gray-200)',
                 borderRadius: '8px',

--- a/application/ui/src/features/robots/robot-form/preview.tsx
+++ b/application/ui/src/features/robots/robot-form/preview.tsx
@@ -26,18 +26,7 @@ export const Preview = () => {
     const form = useRobotForm();
 
     return (
-        <View
-            backgroundColor={'gray-200'}
-            height={'100%'}
-            padding='size-200'
-            UNSAFE_style={{
-                borderRadius: 'var(--spectrum-alias-border-radius-regular)',
-                borderColor: 'var(--spectrum-global-color-gray-700)',
-                borderWidth: '1px',
-                borderStyle: 'dashed',
-            }}
-            position={'relative'}
-        >
+        <View backgroundColor={'gray-200'} height={'100%'}>
             {form.type !== null ? <RobotViewer robot={form} /> : <EmptyPreview />}
         </View>
     );

--- a/application/ui/src/routes/robots/new.tsx
+++ b/application/ui/src/routes/robots/new.tsx
@@ -57,7 +57,7 @@ export const New = () => {
                     <RobotForm submitButton={<NewRobotSubmitButton />} />
                 </Suspense>
             </View>
-            <View gridArea='controls' backgroundColor={'gray-50'} padding='size-400'>
+            <View gridArea='controls'>
                 <Preview />
             </View>
         </Grid>

--- a/application/ui/src/routes/robots/robot.tsx
+++ b/application/ui/src/routes/robots/robot.tsx
@@ -24,12 +24,10 @@ export const Robot = () => {
     const [isConnected, setIsConnected] = useState(false);
 
     return (
-        <View padding='size-400' height='100%' minHeight='0'>
+        <View height='100%' minHeight='0'>
             <RobotModelsProvider>
                 <Grid
-                    gap='size-200'
-                    UNSAFE_style={{ padding: 'var(--spectrum-global-dimension-size-100)' }}
-                    areas={['actions', 'robot-viewer', 'controls ']}
+                    areas={['actions', 'robot-viewer', 'controls']}
                     rows={['auto', '1fr', 'min-content']}
                     height='100%'
                     maxHeight={'100vh'}
@@ -37,18 +35,11 @@ export const Robot = () => {
                     minHeight={0}
                     minWidth={0}
                 >
-                    <View gridArea='actions'>
-                        <Flex justifyContent={'end'}>
-                            <ButtonGroup>
-                                <Button variant='secondary' onPress={onIdentify}>
-                                    Identify
-                                </Button>
-                            </ButtonGroup>
-                        </Flex>
-                    </View>
                     <View
-                        gridArea='robot-viewer'
+                        gridColumn='1/-1'
+                        gridRow='1/-1'
                         overflow='auto'
+                        zIndex={0}
                         minHeight={0}
                         UNSAFE_style={
                             isConnected
@@ -60,6 +51,15 @@ export const Robot = () => {
                         }
                     >
                         <RobotViewer robot={robot} />
+                    </View>
+                    <View gridArea='actions' zIndex={1} margin='size-400'>
+                        <Flex justifyContent={'end'}>
+                            <ButtonGroup>
+                                <Button variant='secondary' onPress={onIdentify}>
+                                    Identify
+                                </Button>
+                            </ButtonGroup>
+                        </Flex>
                     </View>
                     <JointControls isConnected={isConnected} setIsConnected={setIsConnected} />
                 </Grid>


### PR DESCRIPTION
Tweak the layout of our robot viewer so it looks more consistent. In particular on the robot page the viewer is now behind the joints panel and there is no padding when creating a robot.

## Screenshots

| **Before**  | **After**  |
|:-:|:-:|
| <img width="1920" height="1080" alt="192 168 2 118_3000_projects(Full HD)" src="https://github.com/user-attachments/assets/f5a7afc4-e0e7-40c5-9aba-f91cc79e0ee4" /> | <img width="1920" height="1080" alt="192 168 2 118_3000_projects_6e89a6e5-40f9-4e95-b4ba-6956f2c960d8_environments_c184259d-0225-4323-b2be-7c41e4520043(Full HD) (1)" src="https://github.com/user-attachments/assets/fa241f41-4aa4-4d47-a9f8-72b7c71460cd" />  |
| <img width="1920" height="1080" alt="192 168 2 118_3000_projects_6e89a6e5-40f9-4e95-b4ba-6956f2c960d8_robots_new(Full HD)" src="https://github.com/user-attachments/assets/8ed9ebb4-60e7-46fe-9ccc-1e48e5080099" /> | <img width="1920" height="1080" alt="192 168 2 118_3000_projects_6e89a6e5-40f9-4e95-b4ba-6956f2c960d8_robots_new(Full HD) (2)" src="https://github.com/user-attachments/assets/20c27659-7f72-49a1-ada6-8affdbfa871e" /> |

