### PR TITLE
fix: validation batch handling and progress reporting

### DIFF
--- a/application/backend/src/services/training_service.py
+++ b/application/backend/src/services/training_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import multiprocessing as mp
+import time
 from collections.abc import Mapping
 from multiprocessing.synchronize import Event
 from queue import Empty
@@ -16,6 +17,40 @@ from schemas.base_job import JobStatus, JobType
 from services.event_processor import EventType
 from services.job_service import JobService
 from workers.base import BaseThreadWorker
+
+
+def _safe_progress(global_step: int, max_steps: int) -> int:
+    """Compute step-based training progress clamped to ``[0, 100]``.
+
+    ``trainer.max_steps`` is ``-1`` when unset (epoch-driven runs) and may be ``0``;
+    both would otherwise produce a negative value or a ``ZeroDivisionError``.
+
+    Args:
+        global_step: Current optimizer step.
+        max_steps: Configured maximum number of steps.
+
+    Returns:
+        Progress percentage in ``[0, 100]``; ``0`` when ``max_steps`` is unset.
+    """
+    if max_steps <= 0:
+        return 0
+    return min(100, max(0, round(global_step / max_steps * 100)))
+
+
+def _extract_loss(outputs: Any) -> float | None:
+    """Best-effort scalar loss from a Lightning step output.
+
+    Handles a ``{"loss": tensor}`` mapping (training) or a bare loss tensor
+    (eval-loss validation). Returns ``None`` when no scalar loss is available.
+    """
+    candidate = outputs.get("loss") if isinstance(outputs, Mapping) else outputs
+    detach = getattr(candidate, "detach", None)
+    if detach is None:
+        return None
+    try:
+        return detach().cpu().item()
+    except (RuntimeError, ValueError):
+        return None
 
 
 class ProgressCallback(ProgressBar):
@@ -72,6 +107,11 @@ class TrainingTrackingCallback(Callback):
         self.shutdown_event = shutdown_event  # global stop event in case of shutdown
         self.interrupt_event = interrupt_event  # event for interrupting training gracefully
         self.dispatcher = dispatcher
+        self._last_val_progress: int | None = None
+
+    def _should_stop(self, trainer: "pl.Trainer") -> None:
+        if self.shutdown_event.is_set() or self.interrupt_event.is_set():
+            trainer.should_stop = True
 
     def on_train_batch_end(
         self,
@@ -90,10 +130,9 @@ class TrainingTrackingCallback(Callback):
         else:
             loss_val = None  # safety fallback
 
-        progress = round((trainer.global_step) / trainer.max_steps * 100)
+        progress = _safe_progress(trainer.global_step, trainer.max_steps)
         self.dispatcher.update_progress(progress, extra_info={"train/loss_step": loss_val})
-        if self.shutdown_event.is_set() or self.interrupt_event.is_set():
-            trainer.should_stop = True
+        self._should_stop(trainer)
 
     def on_validation_batch_end(
         self,
@@ -104,11 +143,17 @@ class TrainingTrackingCallback(Callback):
         batch_idx: int,  # noqa ARG002
         dataloader_idx: int = 0,  # noqa ARG002
     ) -> None:
-        """Keep job progress fresh and honor interrupts during validation."""
-        progress = round((trainer.global_step) / trainer.max_steps * 100)
-        self.dispatcher.update_progress(progress, extra_info={"stage": "validation"})
-        if self.shutdown_event.is_set() or self.interrupt_event.is_set():
-            trainer.should_stop = True
+        """Honor interrupts during validation and refresh job progress on change.
+
+        ``global_step`` does not advance during validation, so the step-based
+        progress is constant. Dispatch only when it changes to avoid redundant
+        identical job updates.
+        """
+        progress = _safe_progress(trainer.global_step, trainer.max_steps)
+        if progress != self._last_val_progress:
+            self._last_val_progress = progress
+            self.dispatcher.update_progress(progress, extra_info={"stage": "validation"})
+        self._should_stop(trainer)
 
 
 class TrainingLogCallback(Callback):
@@ -117,6 +162,7 @@ class TrainingLogCallback(Callback):
     def __init__(self):
         super().__init__()
         self.every_n_steps = 1
+        self._val_start_t: float | None = None
 
     def on_fit_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:  # noqa ARG002
         """Resolve logging interval once trainer values are available."""
@@ -153,43 +199,39 @@ class TrainingLogCallback(Callback):
         if not is_first_step and global_step % self.every_n_steps != 0:
             return
 
-        loss_val: float | None = None
-        if isinstance(outputs, Mapping):
-            loss_tensor = outputs.get("loss")
-            if loss_tensor is not None:
-                loss_val = loss_tensor.detach().cpu().item()
+        loss_val = _extract_loss(outputs)
 
         max_steps = max(1, trainer.max_steps)
-        progress = min(100, round(global_step / max_steps * 100))
+        progress = _safe_progress(trainer.global_step, trainer.max_steps)
         logger.info(f"Training progress: step={global_step}/{max_steps} ({progress}%), train/loss_step={loss_val}")
+
+    def on_validation_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:  # noqa ARG002
+        """Mark the start of validation so the following silence is explained."""
+        self._val_start_t = time.monotonic()
+        logger.info(f"Validation started at step={trainer.global_step}/{max(1, trainer.max_steps)}")
 
     def on_validation_batch_end(
         self,
-        trainer: "pl.Trainer",
+        trainer: "pl.Trainer",  # noqa ARG002
         pl_module: "pl.LightningModule",  # noqa ARG002
-        outputs: STEP_OUTPUT,  # noqa ARG002
+        outputs: STEP_OUTPUT,
         batch: Any,  # noqa ARG002
         batch_idx: int,
         dataloader_idx: int = 0,  # noqa ARG002
     ) -> None:
-        total_batches = self._val_total_batches(trainer)
         current = batch_idx + 1
-        is_first = current <= 1
-        is_last = total_batches is not None and current >= total_batches
-        if not (is_first or is_last) and current % self.every_n_steps != 0:
+        if current > 1 and current % self.every_n_steps != 0:
             return
-        total_str = total_batches if total_batches is not None else "?"
-        logger.info(f"Validation progress: batch={current}/{total_str}")
+        logger.info(f"Validation progress: batch={current}, val/loss_step={_extract_loss(outputs)}")
 
-    @staticmethod
-    def _val_total_batches(trainer: "pl.Trainer") -> int | None:
-        """Return the number of validation batches when Lightning knows it."""
-        batches = trainer.num_val_batches
-        if not batches:
-            return None
-        total = batches[0]
-        # Lightning uses float('inf') for unsized/iterable dataloaders.
-        return int(total) if total != float("inf") else None
+    def on_validation_epoch_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:  # noqa ARG002
+        """Summarize validation with the aggregated loss and elapsed time."""
+        val_loss = trainer.callback_metrics.get("val/loss")
+        val_loss_val = val_loss.item() if val_loss is not None else None
+        elapsed = time.monotonic() - self._val_start_t if self._val_start_t is not None else 0.0
+        logger.info(
+            f"Validation finished at step={trainer.global_step}, val/loss={val_loss_val}, elapsed={elapsed:.1f}s"
+        )
 
 
 class TrainingService:

--- a/application/backend/src/services/training_service.py
+++ b/application/backend/src/services/training_service.py
@@ -95,6 +95,21 @@ class TrainingTrackingCallback(Callback):
         if self.shutdown_event.is_set() or self.interrupt_event.is_set():
             trainer.should_stop = True
 
+    def on_validation_batch_end(
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",  # noqa ARG002
+        outputs: STEP_OUTPUT,  # noqa ARG002
+        batch: Any,  # noqa ARG002
+        batch_idx: int,  # noqa ARG002
+        dataloader_idx: int = 0,  # noqa ARG002
+    ) -> None:
+        """Keep job progress fresh and honor interrupts during validation."""
+        progress = round((trainer.global_step) / trainer.max_steps * 100)
+        self.dispatcher.update_progress(progress, extra_info={"stage": "validation"})
+        if self.shutdown_event.is_set() or self.interrupt_event.is_set():
+            trainer.should_stop = True
+
 
 class TrainingLogCallback(Callback):
     """Mirror training progress/metrics to loguru as regular log lines."""
@@ -147,6 +162,34 @@ class TrainingLogCallback(Callback):
         max_steps = max(1, trainer.max_steps)
         progress = min(100, round(global_step / max_steps * 100))
         logger.info(f"Training progress: step={global_step}/{max_steps} ({progress}%), train/loss_step={loss_val}")
+
+    def on_validation_batch_end(
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",  # noqa ARG002
+        outputs: STEP_OUTPUT,  # noqa ARG002
+        batch: Any,  # noqa ARG002
+        batch_idx: int,
+        dataloader_idx: int = 0,  # noqa ARG002
+    ) -> None:
+        total_batches = self._val_total_batches(trainer)
+        current = batch_idx + 1
+        is_first = current <= 1
+        is_last = total_batches is not None and current >= total_batches
+        if not (is_first or is_last) and current % self.every_n_steps != 0:
+            return
+        total_str = total_batches if total_batches is not None else "?"
+        logger.info(f"Validation progress: batch={current}/{total_str}")
+
+    @staticmethod
+    def _val_total_batches(trainer: "pl.Trainer") -> int | None:
+        """Return the number of validation batches when Lightning knows it."""
+        batches = trainer.num_val_batches
+        if not batches:
+            return None
+        total = batches[0]
+        # Lightning uses float('inf') for unsized/iterable dataloaders.
+        return int(total) if total != float("inf") else None
 
 
 class TrainingService:

--- a/application/backend/src/services/training_service.py
+++ b/application/backend/src/services/training_service.py
@@ -121,15 +121,7 @@ class TrainingTrackingCallback(Callback):
         batch: Any,  # noqa ARG002
         batch_idx: int,  # noqa ARG002
     ) -> None:
-        if isinstance(outputs, Mapping):
-            loss_tensor = outputs.get("loss")
-            if loss_tensor is not None:
-                loss_val = loss_tensor.detach().cpu().item()
-            else:
-                loss_val = None  # safety fallback
-        else:
-            loss_val = None  # safety fallback
-
+        loss_val = _extract_loss(outputs)
         progress = _safe_progress(trainer.global_step, trainer.max_steps)
         self.dispatcher.update_progress(progress, extra_info={"train/loss_step": loss_val})
         self._should_stop(trainer)

--- a/application/backend/src/services/training_service.py
+++ b/application/backend/src/services/training_service.py
@@ -206,7 +206,7 @@ class TrainingLogCallback(Callback):
         logger.info(f"Training progress: step={global_step}/{max_steps} ({progress}%), train/loss_step={loss_val}")
 
     def on_validation_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:  # noqa ARG002
-        """Mark the start of validation so the following silence is explained."""
+        """Mark the start of validation."""
         self._val_start_t = time.monotonic()
         logger.info(f"Validation started at step={trainer.global_step}/{max(1, trainer.max_steps)}")
 

--- a/application/backend/tests/services/test_training_service.py
+++ b/application/backend/tests/services/test_training_service.py
@@ -1,0 +1,105 @@
+"""Unit tests for training/validation progress helpers and logging callbacks."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from loguru import logger
+
+from services.training_service import TrainingLogCallback, _extract_loss, _safe_progress
+
+
+def _trainer(**kwargs) -> SimpleNamespace:
+    defaults = {"global_step": 0, "max_steps": -1, "callback_metrics": {}}
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class _Loss:
+    """Minimal stand-in for a torch scalar tensor."""
+
+    def __init__(self, value: float):
+        self._value = value
+
+    def detach(self) -> _Loss:
+        return self
+
+    def cpu(self) -> _Loss:
+        return self
+
+    def item(self) -> float:
+        return self._value
+
+
+@pytest.fixture
+def loguru_messages():
+    """Capture loguru log messages into a list for assertions."""
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        yield messages
+    finally:
+        logger.remove(sink_id)
+
+
+class TestSafeProgress:
+    @pytest.mark.parametrize(
+        ("global_step", "max_steps", "expected"),
+        [
+            (0, -1, 0),  # unset
+            (5, 0, 0),  # zero divisor
+            (0, 100, 0),
+            (50, 100, 50),
+            (100, 100, 100),
+            (200, 100, 100),  # clamped high
+        ],
+    )
+    def test_clamped(self, global_step, max_steps, expected):
+        assert _safe_progress(global_step, max_steps) == expected
+
+
+class TestExtractLoss:
+    def test_from_mapping(self):
+        assert _extract_loss({"loss": _Loss(0.5)}) == 0.5
+
+    def test_from_bare_tensor(self):
+        assert _extract_loss(_Loss(1.25)) == 1.25
+
+    def test_none_and_unsupported(self):
+        assert _extract_loss(None) is None
+        assert _extract_loss({"no_loss": _Loss(1.0)}) is None
+        assert _extract_loss(42) is None
+
+
+class TestValidationLogging:
+    def test_start_marker(self, loguru_messages):
+        cb = TrainingLogCallback()
+        cb.on_validation_start(_trainer(global_step=2400, max_steps=10000), None)
+        assert any("Validation started at step=2400/10000" in m for m in loguru_messages)
+
+    def test_first_batch_logs_with_loss(self, loguru_messages):
+        cb = TrainingLogCallback()
+        cb.every_n_steps = 10
+
+        cb.on_validation_batch_end(_trainer(), None, _Loss(0.3), None, batch_idx=0)
+
+        assert any("Validation progress: batch=1, val/loss_step=0.3" in m for m in loguru_messages)
+
+    def test_respects_cadence(self, loguru_messages):
+        cb = TrainingLogCallback()
+        cb.every_n_steps = 10
+
+        # batch_idx=4 -> current=5; not first and 5 % 10 != 0 -> skipped
+        cb.on_validation_batch_end(_trainer(), None, _Loss(0.3), None, batch_idx=4)
+
+        assert not loguru_messages
+
+    def test_epoch_end_summary(self, loguru_messages):
+        cb = TrainingLogCallback()
+        cb.on_validation_start(_trainer(global_step=2400), None)
+        trainer = _trainer(global_step=2400, callback_metrics={"val/loss": _Loss(0.123)})
+
+        cb.on_validation_epoch_end(trainer, None)
+
+        assert any("Validation finished at step=2400, val/loss=0.123" in m for m in loguru_messages)

--- a/library/src/physicalai/data/datamodules.py
+++ b/library/src/physicalai/data/datamodules.py
@@ -139,7 +139,7 @@ class DataModule(LightningDataModule):
         val_gym: Gym | None = None,
         num_rollouts_val: int = 10,
         val_eval_dataset: Dataset | None = None,
-        val_batch_size: int = 1,
+        val_batch_size: int | None = None,
         test_gym: Gym | None = None,
         num_rollouts_test: int = 10,
         max_episode_steps: int | None = 300,
@@ -155,7 +155,9 @@ class DataModule(LightningDataModule):
             num_rollouts_val (int): Number of rollouts to run for validation environments.
             val_eval_dataset (Dataset | None): Validation dataset for computing eval loss.
                 When provided, validation computes loss on this dataset instead of gym rollouts.
-            val_batch_size (int): Batch size for the eval-loss validation DataLoader. Defaults to 1.
+            val_batch_size (int | None): Batch size for the eval-loss validation DataLoader.
+                ``None`` (default) tracks ``train_batch_size``, including any value chosen by
+                ``auto_scale_batch_size``.
             test_gym (Gym | None): Test environment.
             num_rollouts_test (int): Number of rollouts to run for test environments.
             max_episode_steps (int, None): Maximum steps allowed per episode. If None, no time limit.
@@ -170,7 +172,7 @@ class DataModule(LightningDataModule):
 
         # eval-loss validation dataset
         self.val_eval_dataset: Dataset | None = val_eval_dataset
-        self.val_batch_size: int = val_batch_size
+        self._val_batch_size: int | None = val_batch_size
 
         # gym environments
         self.val_gym: Gym | None = val_gym
@@ -197,6 +199,20 @@ class DataModule(LightningDataModule):
     @batch_size.setter
     def batch_size(self, value: int) -> None:
         self.train_batch_size = value
+
+    @property
+    def val_batch_size(self) -> int:
+        """Effective eval-loss validation batch size.
+
+        Resolves to ``train_batch_size`` when not set explicitly. Read lazily so it
+        reflects a value chosen by ``auto_scale_batch_size``, which mutates
+        ``train_batch_size`` at fit time after ``__init__``.
+        """
+        return self._val_batch_size if self._val_batch_size is not None else self.train_batch_size
+
+    @val_batch_size.setter
+    def val_batch_size(self, value: int | None) -> None:
+        self._val_batch_size = value
 
     def setup(self, stage: str) -> None:
         """Set up datasets depending on the stage (fit or test).

--- a/library/src/physicalai/data/lerobot/datamodule.py
+++ b/library/src/physicalai/data/lerobot/datamodule.py
@@ -142,7 +142,7 @@ class LeRobotDataModule(DataModule):
         # Eval-loss validation
         val_split: float = 0.0,
         val_split_seed: int | None = None,
-        val_batch_size: int = 1,
+        val_batch_size: int | None = None,
         # Base DataModule parameters (val/test gyms)
         val_gym: Gym | None = None,
         num_rollouts_val: int = 10,
@@ -195,8 +195,9 @@ class LeRobotDataModule(DataModule):
                 ``None`` (default) uses the global ``random`` module, which respects
                 ``seed_everything()``. Set an explicit int to use an isolated RNG
                 independent of the global seed. Defaults to ``None``.
-            val_batch_size (int, optional): Batch size for the eval-loss validation DataLoader.
-                Defaults to ``1``.
+            val_batch_size (int | None, optional): Batch size for the eval-loss validation
+                DataLoader. ``None`` (default) tracks ``train_batch_size``, including any value
+                chosen by ``auto_scale_batch_size``.
             val_gym (Gym | None, optional): Validation gym environment.
                 Defaults to `None`.
             num_rollouts_val (int, optional): Number of rollouts for validation.

--- a/library/tests/unit/data/test_datamodules.py
+++ b/library/tests/unit/data/test_datamodules.py
@@ -75,6 +75,38 @@ class TestDataModuleBatchSizeAlias:
         assert dm.batch_size == 64
 
 
+class TestDataModuleValBatchSize:
+    """Tests for the val_batch_size lazy resolution."""
+
+    def test_defaults_to_train_batch_size(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), train_batch_size=32)
+        assert dm.val_batch_size == 32
+
+    def test_explicit_value_overrides(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), train_batch_size=32, val_batch_size=4)
+        assert dm.val_batch_size == 4
+
+    def test_tracks_auto_scaled_batch_size(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        # auto_scale_batch_size mutates train_batch_size at fit time via the
+        # `batch_size` setter; an unset val_batch_size must follow.
+        dm = DataModule(train_dataset=dummy_dataset(), train_batch_size=16)
+        dm.batch_size = 128
+        assert dm.val_batch_size == 128
+
+    def test_explicit_value_ignores_auto_scaling(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), train_batch_size=16, val_batch_size=4)
+        dm.batch_size = 128
+        assert dm.val_batch_size == 4
+
+
 class TestDataModuleValidation:
     """Tests for DataModule validation functionality."""
 


### PR DESCRIPTION
## Description

This pull request introduces improvements to validation progress tracking and batch size handling for validation in both the backend training service and the data modules. By default, a validation batch size of 1 is used which results in incredibly slow validation step of which also no progress was being tracked in the train job logs. 

Fixes #729 

