### PR TITLE
refactor: robot form to be discriminated per type

### DIFF
--- a/application/ui/src/features/robots/robot-form/catalog/actions.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/actions.tsx
@@ -1,0 +1,55 @@
+import { ActionButton, Icon } from '@geti-ui/ui';
+import { Refresh } from '@geti-ui/ui/icons';
+
+import { $api } from '../../../../api/client';
+import type { SchemaRobotInput } from '../../robot-types';
+
+import classes from '../form.module.css';
+
+export const RefreshRobotsButton = () => {
+    const { refetch, isFetching } = $api.useSuspenseQuery('get', '/api/hardware/serial_devices');
+
+    return (
+        <ActionButton
+            isDisabled={isFetching}
+            UNSAFE_className={classes.actionButton}
+            onPress={() => {
+                refetch();
+            }}
+        >
+            <Icon>
+                <Refresh />
+            </Icon>
+        </ActionButton>
+    );
+};
+
+export const useIdentifyMutation = () => {
+    return $api.useMutation('post', '/api/hardware/identify', {
+        meta: { skipInvalidation: true },
+    });
+};
+
+export const IdentifyRobot = ({
+    identifyMutation,
+    robot,
+}: {
+    identifyMutation: ReturnType<typeof useIdentifyMutation>;
+    robot: SchemaRobotInput | null;
+}) => {
+    const isDisabled = robot === null || identifyMutation.isPending;
+
+    const onIdentify = () => {
+        if (isDisabled || robot === null) {
+            return;
+        }
+
+        identifyMutation.mutate({ body: robot });
+    };
+
+    return (
+        <ActionButton isDisabled={isDisabled} UNSAFE_className={classes.actionButton} onPress={onIdentify}>
+            Identify
+        </ActionButton>
+    );
+};

--- a/application/ui/src/features/robots/robot-form/catalog/so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.tsx
@@ -2,9 +2,8 @@ import { Flex, Item, Picker, Text } from '@geti-ui/ui';
 import { v4 as uuidv4 } from 'uuid';
 
 import { $api } from '../../../../api/client';
-import type { SchemaRobot } from '../../robot-types';
+import type { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
 import { PermissionDeniedError } from '../../setup-wizard/so101/diagnostics-step-error';
-import { buildRobotBody } from '../form-data';
 import { useRobotFormFields } from '../provider';
 import { IdentifyRobot, RefreshRobotsButton, useIdentifyMutation } from './actions';
 
@@ -20,13 +19,33 @@ export const getInitialSO101FormData = (robot?: SchemaRobot): SO101FormData => (
     connection_string: robot && 'connection_string' in robot.payload ? robot.payload.connection_string : '',
 });
 
+export const buildSO101Body = (
+    formData: SO101FormData,
+    schemaType: SchemaRobotType,
+    robot_id: string
+): SchemaRobotInput | null => {
+    if (!formData.serial_number) {
+        return null;
+    }
+
+    return {
+        id: robot_id,
+        name: formData.name,
+        type: schemaType,
+        payload: {
+            connection_string: formData.connection_string ?? '',
+            serial_number: formData.serial_number,
+        },
+    } as SchemaRobotInput;
+};
+
 export const SO101FormFields = () => {
     const serialDevicesQuery = $api.useSuspenseQuery('get', '/api/hardware/serial_devices');
 
     const { formData, updateField, activeType } = useRobotFormFields('so101');
 
     const identifyMutation = useIdentifyMutation();
-    const identifyRobot = buildRobotBody('so101', formData, activeType, uuidv4());
+    const identifyRobot = buildSO101Body(formData, activeType, uuidv4());
 
     return (
         <>

--- a/application/ui/src/features/robots/robot-form/catalog/so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.tsx
@@ -42,7 +42,7 @@ export const buildSO101Body = (
 export const SO101FormFields = () => {
     const serialDevicesQuery = $api.useSuspenseQuery('get', '/api/hardware/serial_devices');
 
-    const { formData, updateField, activeType } = useRobotFormFields('so101');
+    const { formData, updateField, activeType } = useRobotFormFields<SO101FormData>();
 
     const identifyMutation = useIdentifyMutation();
     const identifyRobot = buildSO101Body(formData, activeType, uuidv4());

--- a/application/ui/src/features/robots/robot-form/catalog/so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.tsx
@@ -2,6 +2,7 @@ import { Flex, Item, Picker, Text } from '@geti-ui/ui';
 import { v4 as uuidv4 } from 'uuid';
 
 import { $api } from '../../../../api/client';
+import type { SchemaRobot } from '../../robot-types';
 import { PermissionDeniedError } from '../../setup-wizard/so101/diagnostics-step-error';
 import { buildRobotBody } from '../form-data';
 import { useRobotFormFields } from '../provider';
@@ -13,10 +14,10 @@ export interface SO101FormData {
     connection_string: string;
 }
 
-export const getInitialSO101FormData = (existing?: Partial<SO101FormData>): SO101FormData => ({
-    name: existing?.name ?? '',
-    serial_number: existing?.serial_number ?? '',
-    connection_string: existing?.connection_string ?? '',
+export const getInitialSO101FormData = (robot?: SchemaRobot): SO101FormData => ({
+    name: robot?.name ?? '',
+    serial_number: robot?.payload?.serial_number ?? '',
+    connection_string: robot && 'connection_string' in robot.payload ? robot.payload.connection_string : '',
 });
 
 export const SO101FormFields = () => {

--- a/application/ui/src/features/robots/robot-form/catalog/so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.tsx
@@ -1,0 +1,64 @@
+import { Flex, Item, Picker, Text } from '@geti-ui/ui';
+import { v4 as uuidv4 } from 'uuid';
+
+import { $api } from '../../../../api/client';
+import { PermissionDeniedError } from '../../setup-wizard/so101/diagnostics-step-error';
+import { buildRobotBody } from '../form-data';
+import { useRobotFormFields } from '../provider';
+import { IdentifyRobot, RefreshRobotsButton, useIdentifyMutation } from './actions';
+
+export interface SO101FormData {
+    name: string;
+    serial_number: string;
+    connection_string: string;
+}
+
+export const getInitialSO101FormData = (existing?: Partial<SO101FormData>): SO101FormData => ({
+    name: existing?.name ?? '',
+    serial_number: existing?.serial_number ?? '',
+    connection_string: existing?.connection_string ?? '',
+});
+
+export const SO101FormFields = () => {
+    const serialDevicesQuery = $api.useSuspenseQuery('get', '/api/hardware/serial_devices');
+
+    const { formData, updateField, activeType } = useRobotFormFields('so101');
+
+    const identifyMutation = useIdentifyMutation();
+    const identifyRobot = buildRobotBody('so101', formData, activeType, uuidv4());
+
+    return (
+        <>
+            <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>
+                <Picker
+                    label='Select robot'
+                    isRequired
+                    width='100%'
+                    selectedKey={formData.serial_number}
+                    onSelectionChange={(serial_number) => {
+                        const device = serialDevicesQuery.data.find((d) => d.serial_number === serial_number);
+
+                        updateField('serial_number', String(serial_number));
+                        updateField('connection_string', device?.connection_string ?? '');
+                    }}
+                >
+                    {serialDevicesQuery.data.map((serial_device) => {
+                        return (
+                            <Item key={serial_device.serial_number} textValue={serial_device.serial_number}>
+                                <Text>{serial_device.serial_number}</Text>
+                                <Text slot='description'>{serial_device.connection_string}</Text>
+                            </Item>
+                        );
+                    })}
+                </Picker>
+
+                <Flex gap='size-100'>
+                    <RefreshRobotsButton />
+                    <IdentifyRobot identifyMutation={identifyMutation} robot={identifyRobot} />
+                </Flex>
+            </Flex>
+
+            {identifyMutation.isError && <PermissionDeniedError port={formData.connection_string} />}
+        </>
+    );
+};

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
@@ -1,0 +1,78 @@
+import { Flex, TextField, View } from '@geti-ui/ui';
+import { v4 as uuidv4 } from 'uuid';
+
+import { buildRobotBody } from '../form-data';
+import { useRobotFormFields } from '../provider';
+import { IdentifyRobot, useIdentifyMutation } from './actions';
+
+export interface BimanualFormData {
+    name: string;
+    connection_string_left: string;
+    connection_string_right: string;
+    serial_number: string;
+}
+
+export const getInitialBimanualFormData = (existing?: Partial<BimanualFormData>): BimanualFormData => ({
+    name: existing?.name ?? '',
+    connection_string_left: existing?.connection_string_left ?? '',
+    connection_string_right: existing?.connection_string_right ?? '',
+    serial_number: existing?.serial_number ?? '',
+});
+
+export const BiManualWidowxAIFormFields = () => {
+    const { formData, updateField } = useRobotFormFields('bimanual');
+
+    const identifyMutation = useIdentifyMutation();
+    const leftIdentifyRobot = buildRobotBody(
+        'widowx',
+        { name: formData.name, connection_string: formData.connection_string_left, serial_number: '' },
+        'Trossen_WidowXAI_Follower',
+        uuidv4()
+    );
+    const rightIdentifyRobot = buildRobotBody(
+        'widowx',
+        { name: formData.name, connection_string: formData.connection_string_right, serial_number: '' },
+        'Trossen_WidowXAI_Follower',
+        uuidv4()
+    );
+
+    return (
+        <>
+            <Flex direction='column' gap='size-100' width='100%'>
+                <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>
+                    <TextField
+                        isRequired
+                        label='Left arm IP address'
+                        width='100%'
+                        value={formData.connection_string_left}
+                        onChange={(connection_string_left) => {
+                            updateField('connection_string_left', connection_string_left);
+                            updateField('serial_number', '');
+                        }}
+                        placeholder='192.168.1.2'
+                    />
+                    <View>
+                        <IdentifyRobot identifyMutation={identifyMutation} robot={leftIdentifyRobot} />
+                    </View>
+                </Flex>
+            </Flex>
+
+            <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>
+                <TextField
+                    isRequired
+                    label='Right arm IP address'
+                    width='100%'
+                    value={formData.connection_string_right}
+                    onChange={(connection_string_right) => {
+                        updateField('connection_string_right', connection_string_right);
+                        updateField('serial_number', '');
+                    }}
+                    placeholder='192.168.1.3'
+                />
+                <View>
+                    <IdentifyRobot identifyMutation={identifyMutation} robot={rightIdentifyRobot} />
+                </View>
+            </Flex>
+        </>
+    );
+};

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
@@ -44,7 +44,7 @@ export const buildBimanualBody = (
 };
 
 export const BiManualWidowxAIFormFields = () => {
-    const { formData, updateField } = useRobotFormFields('bimanual_widowx');
+    const { formData, updateField } = useRobotFormFields<BimanualFormData>();
 
     const identifyMutation = useIdentifyMutation();
     const leftIdentifyRobot = buildWidowxBody(

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
@@ -1,10 +1,10 @@
 import { Flex, TextField, View } from '@geti-ui/ui';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { SchemaRobot } from '../../robot-types';
-import { buildRobotBody } from '../form-data';
+import type { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
 import { useRobotFormFields } from '../provider';
 import { IdentifyRobot, useIdentifyMutation } from './actions';
+import { buildWidowxBody } from './widowxai';
 
 export interface BimanualFormData {
     name: string;
@@ -22,18 +22,37 @@ export const getInitialBimanualFormData = (robot?: SchemaRobot): BimanualFormDat
     serial_number: robot?.payload?.serial_number ?? '',
 });
 
+export const buildBimanualBody = (
+    formData: BimanualFormData,
+    schemaType: SchemaRobotType,
+    robot_id: string
+): SchemaRobotInput | null => {
+    if (!formData.connection_string_left || !formData.connection_string_right) {
+        return null;
+    }
+
+    return {
+        id: robot_id,
+        name: formData.name,
+        type: schemaType,
+        payload: {
+            connection_string_left: formData.connection_string_left,
+            connection_string_right: formData.connection_string_right,
+            serial_number: formData.serial_number ?? '',
+        },
+    } as SchemaRobotInput;
+};
+
 export const BiManualWidowxAIFormFields = () => {
     const { formData, updateField } = useRobotFormFields('bimanual_widowx');
 
     const identifyMutation = useIdentifyMutation();
-    const leftIdentifyRobot = buildRobotBody(
-        'widowx',
+    const leftIdentifyRobot = buildWidowxBody(
         { name: formData.name, connection_string: formData.connection_string_left, serial_number: '' },
         'Trossen_WidowXAI_Follower',
         uuidv4()
     );
-    const rightIdentifyRobot = buildRobotBody(
-        'widowx',
+    const rightIdentifyRobot = buildWidowxBody(
         { name: formData.name, connection_string: formData.connection_string_right, serial_number: '' },
         'Trossen_WidowXAI_Follower',
         uuidv4()

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
@@ -20,7 +20,7 @@ export const getInitialBimanualFormData = (existing?: Partial<BimanualFormData>)
 });
 
 export const BiManualWidowxAIFormFields = () => {
-    const { formData, updateField } = useRobotFormFields('bimanual');
+    const { formData, updateField } = useRobotFormFields('bimanual_widowx');
 
     const identifyMutation = useIdentifyMutation();
     const leftIdentifyRobot = buildRobotBody(

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
@@ -1,6 +1,7 @@
 import { Flex, TextField, View } from '@geti-ui/ui';
 import { v4 as uuidv4 } from 'uuid';
 
+import type { SchemaRobot } from '../../robot-types';
 import { buildRobotBody } from '../form-data';
 import { useRobotFormFields } from '../provider';
 import { IdentifyRobot, useIdentifyMutation } from './actions';
@@ -12,11 +13,13 @@ export interface BimanualFormData {
     serial_number: string;
 }
 
-export const getInitialBimanualFormData = (existing?: Partial<BimanualFormData>): BimanualFormData => ({
-    name: existing?.name ?? '',
-    connection_string_left: existing?.connection_string_left ?? '',
-    connection_string_right: existing?.connection_string_right ?? '',
-    serial_number: existing?.serial_number ?? '',
+export const getInitialBimanualFormData = (robot?: SchemaRobot): BimanualFormData => ({
+    name: robot?.name ?? '',
+    connection_string_left:
+        robot && 'connection_string_left' in robot.payload ? robot.payload.connection_string_left : '',
+    connection_string_right:
+        robot && 'connection_string_right' in robot.payload ? robot.payload.connection_string_right : '',
+    serial_number: robot?.payload?.serial_number ?? '',
 });
 
 export const BiManualWidowxAIFormFields = () => {

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
@@ -1,6 +1,7 @@
 import { Flex, TextField } from '@geti-ui/ui';
 import { v4 as uuidv4 } from 'uuid';
 
+import type { SchemaRobot } from '../../robot-types';
 import { buildRobotBody } from '../form-data';
 import { useRobotFormFields } from '../provider';
 import { IdentifyRobot, useIdentifyMutation } from './actions';
@@ -11,10 +12,10 @@ export interface WidowxFormData {
     serial_number: string;
 }
 
-export const getInitialWidowxFormData = (existing?: Partial<WidowxFormData>): WidowxFormData => ({
-    name: existing?.name ?? '',
-    connection_string: existing?.connection_string ?? '',
-    serial_number: existing?.serial_number ?? '',
+export const getInitialWidowxFormData = (robot?: SchemaRobot): WidowxFormData => ({
+    name: robot?.name ?? '',
+    connection_string: robot && 'connection_string' in robot.payload ? robot.payload.connection_string : '',
+    serial_number: robot?.payload?.serial_number ?? '',
 });
 
 export const WidowxAIFormFields = () => {

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
@@ -38,7 +38,7 @@ export const buildWidowxBody = (
 };
 
 export const WidowxAIFormFields = () => {
-    const { formData, updateField, activeType } = useRobotFormFields('widowx');
+    const { formData, updateField, activeType } = useRobotFormFields<WidowxFormData>();
 
     const identifyMutation = useIdentifyMutation();
     const identifyRobot = buildWidowxBody(formData, activeType, uuidv4());

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
@@ -1,0 +1,44 @@
+import { Flex, TextField } from '@geti-ui/ui';
+import { v4 as uuidv4 } from 'uuid';
+
+import { buildRobotBody } from '../form-data';
+import { useRobotFormFields } from '../provider';
+import { IdentifyRobot, useIdentifyMutation } from './actions';
+
+export interface WidowxFormData {
+    name: string;
+    connection_string: string;
+    serial_number: string;
+}
+
+export const getInitialWidowxFormData = (existing?: Partial<WidowxFormData>): WidowxFormData => ({
+    name: existing?.name ?? '',
+    connection_string: existing?.connection_string ?? '',
+    serial_number: existing?.serial_number ?? '',
+});
+
+export const WidowxAIFormFields = () => {
+    const { formData, updateField, activeType } = useRobotFormFields('widowx');
+
+    const identifyMutation = useIdentifyMutation();
+    const identifyRobot = buildRobotBody('widowx', formData, activeType, uuidv4());
+
+    return (
+        <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>
+            <TextField
+                isRequired
+                label='Robot IP address'
+                width='100%'
+                value={formData.connection_string}
+                onChange={(connection_string) => {
+                    updateField('connection_string', connection_string);
+                    updateField('serial_number', '');
+                }}
+                placeholder='192.168.1.2'
+            />
+            <Flex gap='size-100'>
+                <IdentifyRobot identifyMutation={identifyMutation} robot={identifyRobot} />
+            </Flex>
+        </Flex>
+    );
+};

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
@@ -1,8 +1,7 @@
 import { Flex, TextField } from '@geti-ui/ui';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { SchemaRobot } from '../../robot-types';
-import { buildRobotBody } from '../form-data';
+import type { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
 import { useRobotFormFields } from '../provider';
 import { IdentifyRobot, useIdentifyMutation } from './actions';
 
@@ -18,11 +17,31 @@ export const getInitialWidowxFormData = (robot?: SchemaRobot): WidowxFormData =>
     serial_number: robot?.payload?.serial_number ?? '',
 });
 
+export const buildWidowxBody = (
+    formData: WidowxFormData,
+    schemaType: SchemaRobotType,
+    robot_id: string
+): SchemaRobotInput | null => {
+    if (!formData.connection_string) {
+        return null;
+    }
+
+    return {
+        id: robot_id,
+        name: formData.name,
+        type: schemaType,
+        payload: {
+            connection_string: formData.connection_string,
+            serial_number: formData.serial_number ?? '',
+        },
+    } as SchemaRobotInput;
+};
+
 export const WidowxAIFormFields = () => {
     const { formData, updateField, activeType } = useRobotFormFields('widowx');
 
     const identifyMutation = useIdentifyMutation();
-    const identifyRobot = buildRobotBody('widowx', formData, activeType, uuidv4());
+    const identifyRobot = buildWidowxBody(formData, activeType, uuidv4());
 
     return (
         <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>

--- a/application/ui/src/features/robots/robot-form/form-data.ts
+++ b/application/ui/src/features/robots/robot-form/form-data.ts
@@ -29,5 +29,7 @@ export const buildRobotBody = (
         case 'Trossen_Bimanual_WidowXAI_Follower':
         case 'Trossen_Bimanual_WidowXAI_Leader':
             return buildBimanualBody(formData as BimanualFormData, schemaType, robot_id);
+        default:
+            return null;
     }
 };

--- a/application/ui/src/features/robots/robot-form/form-data.ts
+++ b/application/ui/src/features/robots/robot-form/form-data.ts
@@ -3,14 +3,14 @@ import type { SO101FormData } from './catalog/so101';
 import type { WidowxFormData } from './catalog/widowxai';
 import type { BimanualFormData } from './catalog/widowxai-bimanual';
 
-export type RobotType = 'so101' | 'widowx' | 'bimanual';
+export type RobotType = 'so101' | 'widowx' | 'bimanual_widowx';
 
 export type AnyRobotFormData = SO101FormData | WidowxFormData | BimanualFormData;
 
 export type RobotTypeData = {
     so101: SO101FormData;
     widowx: WidowxFormData;
-    bimanual: BimanualFormData;
+    bimanual_widowx: BimanualFormData;
 };
 
 export const typeForSchema: Record<SchemaRobotType, RobotType> = {
@@ -18,8 +18,8 @@ export const typeForSchema: Record<SchemaRobotType, RobotType> = {
     SO101_Leader: 'so101',
     Trossen_WidowXAI_Follower: 'widowx',
     Trossen_WidowXAI_Leader: 'widowx',
-    Trossen_Bimanual_WidowXAI_Follower: 'bimanual',
-    Trossen_Bimanual_WidowXAI_Leader: 'bimanual',
+    Trossen_Bimanual_WidowXAI_Follower: 'bimanual_widowx',
+    Trossen_Bimanual_WidowXAI_Leader: 'bimanual_widowx',
 };
 
 export const buildRobotBody = (
@@ -61,7 +61,7 @@ export const buildRobotBody = (
                 },
             };
         }
-        case 'bimanual': {
+        case 'bimanual_widowx': {
             const data = formData as BimanualFormData;
             if (!data.connection_string_left || !data.connection_string_right) {
                 return null;

--- a/application/ui/src/features/robots/robot-form/form-data.ts
+++ b/application/ui/src/features/robots/robot-form/form-data.ts
@@ -23,12 +23,11 @@ export const typeForSchema: Record<SchemaRobotType, RobotType> = {
 };
 
 export const buildRobotBody = (
-    robotType: RobotType,
     formData: AnyRobotFormData,
     schemaType: SchemaRobotType,
     robot_id: string
 ): SchemaRobotInput | null => {
-    switch (robotType) {
+    switch (typeForSchema[schemaType]) {
         case 'so101':
             return buildSO101Body(formData as SO101FormData, schemaType, robot_id);
         case 'widowx':

--- a/application/ui/src/features/robots/robot-form/form-data.ts
+++ b/application/ui/src/features/robots/robot-form/form-data.ts
@@ -43,7 +43,7 @@ export const buildRobotBody = (
                     connection_string: data.connection_string ?? '',
                     serial_number: data.serial_number,
                 },
-            };
+            } as SchemaRobotInput;
         }
         case 'widowx': {
             const data = formData as WidowxFormData;
@@ -59,7 +59,7 @@ export const buildRobotBody = (
                     connection_string: data.connection_string,
                     serial_number: data.serial_number ?? '',
                 },
-            };
+            } as SchemaRobotInput;
         }
         case 'bimanual_widowx': {
             const data = formData as BimanualFormData;
@@ -76,7 +76,7 @@ export const buildRobotBody = (
                     connection_string_right: data.connection_string_right,
                     serial_number: data.serial_number ?? '',
                 },
-            };
+            } as SchemaRobotInput;
         }
     }
 };

--- a/application/ui/src/features/robots/robot-form/form-data.ts
+++ b/application/ui/src/features/robots/robot-form/form-data.ts
@@ -3,23 +3,15 @@ import { buildSO101Body, type SO101FormData } from './catalog/so101';
 import { buildWidowxBody, type WidowxFormData } from './catalog/widowxai';
 import { buildBimanualBody, type BimanualFormData } from './catalog/widowxai-bimanual';
 
-export type RobotType = 'so101' | 'widowx' | 'bimanual_widowx';
-
 export type AnyRobotFormData = SO101FormData | WidowxFormData | BimanualFormData;
 
-export type RobotTypeData = {
-    so101: SO101FormData;
-    widowx: WidowxFormData;
-    bimanual_widowx: BimanualFormData;
-};
-
-export const typeForSchema: Record<SchemaRobotType, RobotType> = {
-    SO101_Follower: 'so101',
-    SO101_Leader: 'so101',
-    Trossen_WidowXAI_Follower: 'widowx',
-    Trossen_WidowXAI_Leader: 'widowx',
-    Trossen_Bimanual_WidowXAI_Follower: 'bimanual_widowx',
-    Trossen_Bimanual_WidowXAI_Leader: 'bimanual_widowx',
+export type FormDataForSchema = {
+    SO101_Follower: SO101FormData;
+    SO101_Leader: SO101FormData;
+    Trossen_WidowXAI_Follower: WidowxFormData;
+    Trossen_WidowXAI_Leader: WidowxFormData;
+    Trossen_Bimanual_WidowXAI_Follower: BimanualFormData;
+    Trossen_Bimanual_WidowXAI_Leader: BimanualFormData;
 };
 
 export const buildRobotBody = (
@@ -27,12 +19,15 @@ export const buildRobotBody = (
     schemaType: SchemaRobotType,
     robot_id: string
 ): SchemaRobotInput | null => {
-    switch (typeForSchema[schemaType]) {
-        case 'so101':
+    switch (schemaType) {
+        case 'SO101_Follower':
+        case 'SO101_Leader':
             return buildSO101Body(formData as SO101FormData, schemaType, robot_id);
-        case 'widowx':
+        case 'Trossen_WidowXAI_Follower':
+        case 'Trossen_WidowXAI_Leader':
             return buildWidowxBody(formData as WidowxFormData, schemaType, robot_id);
-        case 'bimanual_widowx':
+        case 'Trossen_Bimanual_WidowXAI_Follower':
+        case 'Trossen_Bimanual_WidowXAI_Leader':
             return buildBimanualBody(formData as BimanualFormData, schemaType, robot_id);
     }
 };

--- a/application/ui/src/features/robots/robot-form/form-data.ts
+++ b/application/ui/src/features/robots/robot-form/form-data.ts
@@ -1,7 +1,7 @@
 import { SchemaRobotInput, SchemaRobotType } from '../robot-types';
-import type { SO101FormData } from './catalog/so101';
-import type { WidowxFormData } from './catalog/widowxai';
-import type { BimanualFormData } from './catalog/widowxai-bimanual';
+import { buildSO101Body, type SO101FormData } from './catalog/so101';
+import { buildWidowxBody, type WidowxFormData } from './catalog/widowxai';
+import { buildBimanualBody, type BimanualFormData } from './catalog/widowxai-bimanual';
 
 export type RobotType = 'so101' | 'widowx' | 'bimanual_widowx';
 
@@ -29,54 +29,11 @@ export const buildRobotBody = (
     robot_id: string
 ): SchemaRobotInput | null => {
     switch (robotType) {
-        case 'so101': {
-            const data = formData as SO101FormData;
-            if (!data.serial_number) {
-                return null;
-            }
-
-            return {
-                id: robot_id,
-                name: data.name,
-                type: schemaType,
-                payload: {
-                    connection_string: data.connection_string ?? '',
-                    serial_number: data.serial_number,
-                },
-            } as SchemaRobotInput;
-        }
-        case 'widowx': {
-            const data = formData as WidowxFormData;
-            if (!data.connection_string) {
-                return null;
-            }
-
-            return {
-                id: robot_id,
-                name: data.name,
-                type: schemaType,
-                payload: {
-                    connection_string: data.connection_string,
-                    serial_number: data.serial_number ?? '',
-                },
-            } as SchemaRobotInput;
-        }
-        case 'bimanual_widowx': {
-            const data = formData as BimanualFormData;
-            if (!data.connection_string_left || !data.connection_string_right) {
-                return null;
-            }
-
-            return {
-                id: robot_id,
-                name: data.name,
-                type: schemaType,
-                payload: {
-                    connection_string_left: data.connection_string_left,
-                    connection_string_right: data.connection_string_right,
-                    serial_number: data.serial_number ?? '',
-                },
-            } as SchemaRobotInput;
-        }
+        case 'so101':
+            return buildSO101Body(formData as SO101FormData, schemaType, robot_id);
+        case 'widowx':
+            return buildWidowxBody(formData as WidowxFormData, schemaType, robot_id);
+        case 'bimanual_widowx':
+            return buildBimanualBody(formData as BimanualFormData, schemaType, robot_id);
     }
 };

--- a/application/ui/src/features/robots/robot-form/form-data.ts
+++ b/application/ui/src/features/robots/robot-form/form-data.ts
@@ -1,0 +1,82 @@
+import { SchemaRobotInput, SchemaRobotType } from '../robot-types';
+import type { SO101FormData } from './catalog/so101';
+import type { WidowxFormData } from './catalog/widowxai';
+import type { BimanualFormData } from './catalog/widowxai-bimanual';
+
+export type RobotType = 'so101' | 'widowx' | 'bimanual';
+
+export type AnyRobotFormData = SO101FormData | WidowxFormData | BimanualFormData;
+
+export type RobotTypeData = {
+    so101: SO101FormData;
+    widowx: WidowxFormData;
+    bimanual: BimanualFormData;
+};
+
+export const typeForSchema: Record<SchemaRobotType, RobotType> = {
+    SO101_Follower: 'so101',
+    SO101_Leader: 'so101',
+    Trossen_WidowXAI_Follower: 'widowx',
+    Trossen_WidowXAI_Leader: 'widowx',
+    Trossen_Bimanual_WidowXAI_Follower: 'bimanual',
+    Trossen_Bimanual_WidowXAI_Leader: 'bimanual',
+};
+
+export const buildRobotBody = (
+    robotType: RobotType,
+    formData: AnyRobotFormData,
+    schemaType: SchemaRobotType,
+    robot_id: string
+): SchemaRobotInput | null => {
+    switch (robotType) {
+        case 'so101': {
+            const data = formData as SO101FormData;
+            if (!data.serial_number) {
+                return null;
+            }
+
+            return {
+                id: robot_id,
+                name: data.name,
+                type: schemaType,
+                payload: {
+                    connection_string: data.connection_string ?? '',
+                    serial_number: data.serial_number,
+                },
+            };
+        }
+        case 'widowx': {
+            const data = formData as WidowxFormData;
+            if (!data.connection_string) {
+                return null;
+            }
+
+            return {
+                id: robot_id,
+                name: data.name,
+                type: schemaType,
+                payload: {
+                    connection_string: data.connection_string,
+                    serial_number: data.serial_number ?? '',
+                },
+            };
+        }
+        case 'bimanual': {
+            const data = formData as BimanualFormData;
+            if (!data.connection_string_left || !data.connection_string_right) {
+                return null;
+            }
+
+            return {
+                id: robot_id,
+                name: data.name,
+                type: schemaType,
+                payload: {
+                    connection_string_left: data.connection_string_left,
+                    connection_string_right: data.connection_string_right,
+                    serial_number: data.serial_number ?? '',
+                },
+            };
+        }
+    }
+};

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -24,7 +24,9 @@ const RobotType = () => {
             width='100%'
             selectedKey={activeType}
             onSelectionChange={(selected) => {
-                setActiveType(selected as SchemaRobotType);
+                if (selected !== null) {
+                    setActiveType(selected as SchemaRobotType);
+                }
             }}
         >
             <Item key={'SO101_Follower'}>SO101 Follower</Item>

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -1,204 +1,30 @@
 import { useRef, type FormEvent } from 'react';
 
-import {
-    ActionButton,
-    Button,
-    Divider,
-    Flex,
-    Form,
-    Heading,
-    Icon,
-    Item,
-    Picker,
-    Text,
-    TextField,
-    View,
-} from '@geti-ui/ui';
-import { ChevronLeft, Refresh } from '@geti-ui/ui/icons';
-import { v4 as uuidv4 } from 'uuid';
+import { Button, Divider, Flex, Form, Heading, Icon, Item, Picker, TextField } from '@geti-ui/ui';
+import { ChevronLeft } from '@geti-ui/ui/icons';
 
-import { $api } from '../../../api/client';
 import { useProjectId } from '../../../features/projects/use-project';
 import { paths } from '../../../router';
 import { SchemaRobotType } from '../robot-types';
-import { PermissionDeniedError } from '../setup-wizard/so101/diagnostics-step-error';
-import { buildRobotBodyFromForm, useRobotForm, useSetRobotForm, type RobotForm as RobotFormType } from './provider';
+import { typeForSchema } from './form-data';
+import { useRobotForm, useRobotFormFields, useSetRobotForm } from './provider';
+import { BiManualWidowxAIFormFields } from './catalog/widowxai-bimanual';
+import { SO101FormFields } from './catalog/so101';
+import { WidowxAIFormFields } from './catalog/widowxai';
 import { SubmitNewRobotButton } from './submit-new-robot-button';
 
-import classes from './form.module.css';
-
-export const SO101FormFields = () => {
-    const serialDevicesQuery = $api.useSuspenseQuery('get', '/api/hardware/serial_devices');
-
-    const robotForm = useRobotForm();
-    const setRobotForm = useSetRobotForm();
-
-    const identifyMutation = useIdentifyMutation();
-
-    return (
-        <>
-            <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>
-                <Picker
-                    label='Select robot'
-                    isRequired
-                    width='100%'
-                    selectedKey={robotForm.serial_number}
-                    onSelectionChange={(serial_number) => {
-                        const device = serialDevicesQuery.data.find((d) => d.serial_number === serial_number);
-
-                        setRobotForm((oldForm) => ({
-                            ...oldForm,
-                            serial_number: String(serial_number),
-                            connection_string: device?.connection_string ?? '',
-                        }));
-                    }}
-                >
-                    {serialDevicesQuery.data.map((serial_device) => {
-                        return (
-                            <Item key={serial_device.serial_number} textValue={serial_device.serial_number}>
-                                <Text>{serial_device.serial_number}</Text>
-                                <Text slot='description'>{serial_device.connection_string}</Text>
-                            </Item>
-                        );
-                    })}
-                </Picker>
-
-                <Flex gap='size-100'>
-                    <RefreshRobotsButton />
-                    <IdentifyRobot identifyMutation={identifyMutation} robotForm={robotForm} />
-                </Flex>
-            </Flex>
-
-            {identifyMutation.isError && <PermissionDeniedError port={robotForm.connection_string} />}
-        </>
-    );
-};
-
-export const WidowxAIFormFields = () => {
-    const robotForm = useRobotForm();
-    const setRobotForm = useSetRobotForm();
-
-    const identifyMutation = useIdentifyMutation();
-
-    return (
-        <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>
-            <TextField
-                isRequired
-                label='Robot IP address'
-                width='100%'
-                value={robotForm.connection_string ?? ''}
-                onChange={(connection_string) => {
-                    setRobotForm((oldForm) => ({
-                        ...oldForm,
-                        connection_string,
-                        serial_number: '',
-                    }));
-                }}
-                placeholder='192.168.1.2'
-            />
-            <Flex gap='size-100'>
-                <IdentifyRobot identifyMutation={identifyMutation} robotForm={robotForm} />
-            </Flex>
-        </Flex>
-    );
-};
-
-export const BiManualWidowxAIFormFields = () => {
-    const robotForm = useRobotForm();
-    const setRobotForm = useSetRobotForm();
-
-    const identifyMutation = useIdentifyMutation();
-
-    return (
-        <>
-            <Flex direction='column' gap='size-100' width='100%'>
-                <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>
-                    <TextField
-                        isRequired
-                        label='Left arm IP address'
-                        width='100%'
-                        value={robotForm.connection_string_left ?? ''}
-                        onChange={(connection_string_left) => {
-                            setRobotForm((oldForm) => ({
-                                ...oldForm,
-                                connection_string_left,
-                                serial_number: '',
-                            }));
-                        }}
-                        placeholder='192.168.1.2'
-                    />
-                    <View>
-                        <IdentifyRobot
-                            identifyMutation={identifyMutation}
-                            robotForm={{
-                                ...robotForm,
-                                type: 'Trossen_WidowXAI_Follower',
-                                connection_string: robotForm.connection_string_left,
-                            }}
-                        />
-                    </View>
-                </Flex>
-            </Flex>
-
-            <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>
-                <TextField
-                    isRequired
-                    label='Right arm IP address'
-                    width='100%'
-                    value={robotForm.connection_string_right ?? ''}
-                    onChange={(connection_string_right) => {
-                        setRobotForm((oldForm) => ({
-                            ...oldForm,
-                            connection_string_right,
-                            serial_number: '',
-                        }));
-                    }}
-                    placeholder='192.168.1.3'
-                />
-                <View>
-                    <IdentifyRobot
-                        identifyMutation={identifyMutation}
-                        robotForm={{
-                            ...robotForm,
-                            type: 'Trossen_WidowXAI_Follower',
-                            connection_string: robotForm.connection_string_right,
-                        }}
-                    />
-                </View>
-            </Flex>
-        </>
-    );
-};
-
 const RobotType = () => {
-    const setRobotForm = useSetRobotForm();
-    const robotForm = useRobotForm();
+    const { activeType } = useRobotForm();
+    const { setActiveType } = useSetRobotForm();
 
     return (
         <Picker
             isRequired
             label='Robot type'
             width='100%'
-            selectedKey={robotForm.type}
+            selectedKey={activeType}
             onSelectionChange={(selected) => {
-                const newType = selected as typeof robotForm.type;
-
-                const wasSerial = robotForm.type?.toLowerCase().startsWith('so101') ?? false;
-                const isSerial = newType?.toLowerCase().startsWith('so101') ?? false;
-
-                setRobotForm((oldForm) => ({
-                    ...oldForm,
-                    type: newType,
-                    ...(wasSerial !== isSerial
-                        ? {
-                              // Only reset when switching families (SO -> Trossen, etc)
-                              serial_number: '',
-                              connection_string: '',
-                              connection_string_left: '',
-                              connection_string_right: '',
-                          }
-                        : {}),
-                }));
+                setActiveType(selected as SchemaRobotType);
             }}
         >
             <Item key={'SO101_Follower'}>SO101 Follower</Item>
@@ -208,55 +34,6 @@ const RobotType = () => {
             <Item key={'Trossen_Bimanual_WidowXAI_Follower'}>Trossen Bimanual WidowX AI Follower</Item>
             <Item key={'Trossen_Bimanual_WidowXAI_Leader'}>Trossen Bimanual WidowX AI Leader</Item>
         </Picker>
-    );
-};
-
-const RefreshRobotsButton = () => {
-    const { refetch, isFetching } = $api.useSuspenseQuery('get', '/api/hardware/serial_devices');
-
-    return (
-        <ActionButton
-            isDisabled={isFetching}
-            UNSAFE_className={classes.actionButton}
-            onPress={() => {
-                refetch();
-            }}
-        >
-            <Icon>
-                <Refresh />
-            </Icon>
-        </ActionButton>
-    );
-};
-
-const useIdentifyMutation = () => {
-    return $api.useMutation('post', '/api/hardware/identify', {
-        meta: { skipInvalidation: true },
-    });
-};
-
-const IdentifyRobot = ({
-    identifyMutation,
-    robotForm,
-}: {
-    identifyMutation: ReturnType<typeof useIdentifyMutation>;
-    robotForm: RobotFormType;
-}) => {
-    const robot = buildRobotBodyFromForm(robotForm, uuidv4());
-    const isDisabled = robot === null || identifyMutation.isPending;
-
-    const onIdentify = () => {
-        if (isDisabled || robot === null) {
-            return;
-        }
-
-        identifyMutation.mutate({ body: robot });
-    };
-
-    return (
-        <ActionButton isDisabled={isDisabled} UNSAFE_className={classes.actionButton} onPress={onIdentify}>
-            Identify
-        </ActionButton>
     );
 };
 
@@ -277,8 +54,9 @@ const FormFields = ({ robotType }: { robotType: SchemaRobotType }) => {
 export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNewRobotButton /> }) => {
     const { project_id } = useProjectId();
 
-    const robotForm = useRobotForm();
-    const setRobotForm = useSetRobotForm();
+    const { activeType } = useRobotForm();
+    const robotType = typeForSchema[activeType];
+    const { formData: activeFormData, updateField } = useRobotFormFields(robotType);
 
     const submitContainerRef = useRef<HTMLDivElement>(null);
 
@@ -315,16 +93,16 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
                             label='Robot name'
                             width='100%'
                             onChange={(name) => {
-                                setRobotForm((oldForm) => ({ ...oldForm, name }));
+                                updateField('name', name);
                             }}
-                            value={robotForm.name}
+                            value={activeFormData.name}
                         />
 
                         {/* Put robot type first as we can use it to visualize the robot
                           and determine how to connect with it */}
                         <RobotType />
 
-                        <FormFields robotType={robotForm.type} />
+                        <FormFields robotType={activeType} />
                     </Flex>
                     <Divider orientation='horizontal' size='S' />
                     <div ref={submitContainerRef}>{submitButton}</div>

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -9,7 +9,6 @@ import { SchemaRobotType } from '../robot-types';
 import { SO101FormFields } from './catalog/so101';
 import { WidowxAIFormFields } from './catalog/widowxai';
 import { BiManualWidowxAIFormFields } from './catalog/widowxai-bimanual';
-import { typeForSchema } from './form-data';
 import { useRobotForm, useRobotFormFields, useSetRobotForm } from './provider';
 import { SubmitNewRobotButton } from './submit-new-robot-button';
 
@@ -57,8 +56,7 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
     const { project_id } = useProjectId();
 
     const { activeType } = useRobotForm();
-    const robotType = typeForSchema[activeType];
-    const { formData: activeFormData, updateField } = useRobotFormFields(robotType);
+    const { formData: activeFormData, updateField } = useRobotFormFields();
 
     const submitContainerRef = useRef<HTMLDivElement>(null);
 

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -6,11 +6,11 @@ import { ChevronLeft } from '@geti-ui/ui/icons';
 import { useProjectId } from '../../../features/projects/use-project';
 import { paths } from '../../../router';
 import { SchemaRobotType } from '../robot-types';
-import { typeForSchema } from './form-data';
-import { useRobotForm, useRobotFormFields, useSetRobotForm } from './provider';
-import { BiManualWidowxAIFormFields } from './catalog/widowxai-bimanual';
 import { SO101FormFields } from './catalog/so101';
 import { WidowxAIFormFields } from './catalog/widowxai';
+import { BiManualWidowxAIFormFields } from './catalog/widowxai-bimanual';
+import { typeForSchema } from './form-data';
+import { useRobotForm, useRobotFormFields, useSetRobotForm } from './provider';
 import { SubmitNewRobotButton } from './submit-new-robot-button';
 
 const RobotType = () => {

--- a/application/ui/src/features/robots/robot-form/preview.tsx
+++ b/application/ui/src/features/robots/robot-form/preview.tsx
@@ -27,7 +27,7 @@ export const Preview = () => {
 
     return (
         <View backgroundColor={'gray-200'} height={'100%'}>
-            {activeType !== null ? <RobotViewer robot={{ type: activeType }} /> : <EmptyPreview />}
+            {activeType != null ? <RobotViewer robot={{ type: activeType }} /> : <EmptyPreview />}
         </View>
     );
 };

--- a/application/ui/src/features/robots/robot-form/preview.tsx
+++ b/application/ui/src/features/robots/robot-form/preview.tsx
@@ -23,11 +23,11 @@ const EmptyPreview = () => {
 };
 
 export const Preview = () => {
-    const form = useRobotForm();
+    const { activeType } = useRobotForm();
 
     return (
         <View backgroundColor={'gray-200'} height={'100%'}>
-            {form.type !== null ? <RobotViewer robot={form} /> : <EmptyPreview />}
+            {activeType !== null ? <RobotViewer robot={{ type: activeType }} /> : <EmptyPreview />}
         </View>
     );
 };

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -25,44 +25,12 @@ type SetRobotFormContextType = {
 
 const SetRobotFormContext = createContext<SetRobotFormContextType | null>(null);
 
-const getInitialState = (robot?: SchemaRobot): RobotFormState => {
-    const activeType = robot?.type ?? 'SO101_Follower';
-    const robotType = typeForSchema[activeType];
-
-    return {
-        activeType,
-        so101: getInitialSO101FormData(
-            robotType === 'so101' && robot
-                ? {
-                      name: robot.name,
-                      serial_number: robot.payload.serial_number,
-                      connection_string: 'connection_string' in robot.payload ? robot.payload.connection_string : '',
-                  }
-                : undefined
-        ),
-        widowx: getInitialWidowxFormData(
-            robotType === 'widowx' && robot
-                ? {
-                      name: robot.name,
-                      connection_string: 'connection_string' in robot.payload ? robot.payload.connection_string : '',
-                      serial_number: robot.payload.serial_number,
-                  }
-                : undefined
-        ),
-        bimanual_widowx: getInitialBimanualFormData(
-            robotType === 'bimanual_widowx' && robot
-                ? {
-                      name: robot.name,
-                      connection_string_left:
-                          'connection_string_left' in robot.payload ? robot.payload.connection_string_left : '',
-                      connection_string_right:
-                          'connection_string_right' in robot.payload ? robot.payload.connection_string_right : '',
-                      serial_number: robot.payload.serial_number,
-                  }
-                : undefined
-        ),
-    };
-};
+const getInitialState = (robot?: SchemaRobot): RobotFormState => ({
+    activeType: robot?.type ?? 'SO101_Follower',
+    so101: getInitialSO101FormData(robot),
+    widowx: getInitialWidowxFormData(robot),
+    bimanual_widowx: getInitialBimanualFormData(robot),
+});
 
 export const RobotFormProvider = ({ children, robot }: { children: ReactNode; robot?: SchemaRobot }) => {
     const [state, setState] = useState(() => getInitialState(robot));

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -10,7 +10,7 @@ type RobotFormState = {
     activeType: SchemaRobotType;
     so101: RobotTypeData['so101'];
     widowx: RobotTypeData['widowx'];
-    bimanual: RobotTypeData['bimanual'];
+    bimanual_widowx: RobotTypeData['bimanual_widowx'];
 };
 
 const RobotFormContext = createContext<RobotFormState | null>(null);
@@ -49,8 +49,8 @@ const getInitialState = (robot?: SchemaRobot): RobotFormState => {
                   }
                 : undefined
         ),
-        bimanual: getInitialBimanualFormData(
-            robotType === 'bimanual' && robot
+        bimanual_widowx: getInitialBimanualFormData(
+            robotType === 'bimanual_widowx' && robot
                 ? {
                       name: robot.name,
                       connection_string_left:

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -112,8 +112,7 @@ export const useRobotFormBody = (robot_id: string): SchemaRobotInput | null => {
         throw new Error('useRobotFormBody was used outside of RobotFormProvider');
     }
 
-    const robotType = typeForSchema[state.activeType];
-    const formData = state[robotType] as AnyRobotFormData;
+    const formData = state[typeForSchema[state.activeType]] as AnyRobotFormData;
 
-    return buildRobotBody(robotType, formData, state.activeType, robot_id);
+    return buildRobotBody(formData, state.activeType, robot_id);
 };

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -109,7 +109,7 @@ export const useRobotFormBody = (robot_id: string): SchemaRobotInput | null => {
     const state = useContext(RobotFormContext);
 
     if (state === null) {
-        return null;
+        throw new Error('useRobotFormBody was used outside of RobotFormProvider');
     }
 
     const robotType = typeForSchema[state.activeType];

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -1,16 +1,10 @@
 import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 
 import { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../robot-types';
-import {
-    buildRobotBody,
-    typeForSchema,
-    type RobotType,
-    type RobotTypeData,
-    type AnyRobotFormData,
-} from './form-data';
 import { getInitialSO101FormData } from './catalog/so101';
 import { getInitialWidowxFormData } from './catalog/widowxai';
 import { getInitialBimanualFormData } from './catalog/widowxai-bimanual';
+import { buildRobotBody, typeForSchema, type AnyRobotFormData, type RobotType, type RobotTypeData } from './form-data';
 
 type RobotFormState = {
     activeType: SchemaRobotType;
@@ -42,8 +36,7 @@ const getInitialState = (robot?: SchemaRobot): RobotFormState => {
                 ? {
                       name: robot.name,
                       serial_number: robot.payload.serial_number,
-                      connection_string:
-                          'connection_string' in robot.payload ? robot.payload.connection_string : '',
+                      connection_string: 'connection_string' in robot.payload ? robot.payload.connection_string : '',
                   }
                 : undefined
         ),
@@ -51,8 +44,7 @@ const getInitialState = (robot?: SchemaRobot): RobotFormState => {
             robotType === 'widowx' && robot
                 ? {
                       name: robot.name,
-                      connection_string:
-                          'connection_string' in robot.payload ? robot.payload.connection_string : '',
+                      connection_string: 'connection_string' in robot.payload ? robot.payload.connection_string : '',
                       serial_number: robot.payload.serial_number,
                   }
                 : undefined
@@ -104,15 +96,21 @@ export const RobotFormProvider = ({ children, robot }: { children: ReactNode; ro
     );
 };
 
-export const useRobotForm = () => {
+export function useRobotForm(): { activeType: SchemaRobotType; robotForm: AnyRobotFormData };
+export function useRobotForm<R extends RobotType>(
+    robotType: R
+): { activeType: SchemaRobotType; robotForm: RobotTypeData[R] };
+export function useRobotForm(robotType?: RobotType) {
     const context = useContext(RobotFormContext);
 
     if (context === null) {
         throw new Error('useRobotForm was used outside of RobotFormProvider');
     }
 
-    return context;
-};
+    const rt = robotType ?? typeForSchema[context.activeType];
+
+    return { activeType: context.activeType, robotForm: context[rt] };
+}
 
 export const useSetRobotForm = () => {
     const context = useContext(SetRobotFormContext);
@@ -125,8 +123,12 @@ export const useSetRobotForm = () => {
 };
 
 export const useRobotFormFields = <R extends RobotType>(robotType: R) => {
-    const state = useRobotForm();
+    const state = useContext(RobotFormContext);
     const { updateFormData } = useSetRobotForm();
+
+    if (state === null) {
+        throw new Error('useRobotFormFields was used outside of RobotFormProvider');
+    }
 
     const updateField = <K extends keyof RobotTypeData[R]>(field: K, value: RobotTypeData[R][K]) => {
         updateFormData(robotType, { [field]: value } as unknown as Partial<RobotTypeData[R]>);
@@ -136,7 +138,12 @@ export const useRobotFormFields = <R extends RobotType>(robotType: R) => {
 };
 
 export const useRobotFormBody = (robot_id: string): SchemaRobotInput | null => {
-    const state = useRobotForm();
+    const state = useContext(RobotFormContext);
+
+    if (state === null) {
+        return null;
+    }
+
     const robotType = typeForSchema[state.activeType];
     const formData = state[robotType] as AnyRobotFormData;
 

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -4,22 +4,25 @@ import { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../robot-types';
 import { getInitialSO101FormData } from './catalog/so101';
 import { getInitialWidowxFormData } from './catalog/widowxai';
 import { getInitialBimanualFormData } from './catalog/widowxai-bimanual';
-import { buildRobotBody, typeForSchema, type AnyRobotFormData, type RobotType, type RobotTypeData } from './form-data';
+import { buildRobotBody, type AnyRobotFormData, type FormDataForSchema } from './form-data';
 
 type RobotFormState = {
     activeType: SchemaRobotType;
-    so101: RobotTypeData['so101'];
-    widowx: RobotTypeData['widowx'];
-    bimanual_widowx: RobotTypeData['bimanual_widowx'];
+    SO101_Follower: FormDataForSchema['SO101_Follower'];
+    SO101_Leader: FormDataForSchema['SO101_Leader'];
+    Trossen_WidowXAI_Follower: FormDataForSchema['Trossen_WidowXAI_Follower'];
+    Trossen_WidowXAI_Leader: FormDataForSchema['Trossen_WidowXAI_Leader'];
+    Trossen_Bimanual_WidowXAI_Follower: FormDataForSchema['Trossen_Bimanual_WidowXAI_Follower'];
+    Trossen_Bimanual_WidowXAI_Leader: FormDataForSchema['Trossen_Bimanual_WidowXAI_Leader'];
 };
 
 const RobotFormContext = createContext<RobotFormState | null>(null);
 
 type SetRobotFormContextType = {
     setActiveType: (type: SchemaRobotType) => void;
-    updateFormData: <R extends RobotType>(
-        robotType: R,
-        update: Partial<RobotTypeData[R]> | ((prev: RobotTypeData[R]) => RobotTypeData[R])
+    updateFormData: <K extends SchemaRobotType>(
+        schemaType: K,
+        update: Partial<FormDataForSchema[K]> | ((prev: FormDataForSchema[K]) => FormDataForSchema[K])
     ) => void;
 };
 
@@ -27,9 +30,12 @@ const SetRobotFormContext = createContext<SetRobotFormContextType | null>(null);
 
 const getInitialState = (robot?: SchemaRobot): RobotFormState => ({
     activeType: robot?.type ?? 'SO101_Follower',
-    so101: getInitialSO101FormData(robot),
-    widowx: getInitialWidowxFormData(robot),
-    bimanual_widowx: getInitialBimanualFormData(robot),
+    SO101_Follower: getInitialSO101FormData(robot),
+    SO101_Leader: getInitialSO101FormData(robot),
+    Trossen_WidowXAI_Follower: getInitialWidowxFormData(robot),
+    Trossen_WidowXAI_Leader: getInitialWidowxFormData(robot),
+    Trossen_Bimanual_WidowXAI_Follower: getInitialBimanualFormData(robot),
+    Trossen_Bimanual_WidowXAI_Leader: getInitialBimanualFormData(robot),
 });
 
 export const RobotFormProvider = ({ children, robot }: { children: ReactNode; robot?: SchemaRobot }) => {
@@ -40,16 +46,18 @@ export const RobotFormProvider = ({ children, robot }: { children: ReactNode; ro
     }, []);
 
     const updateFormData = useCallback(
-        <R extends RobotType>(
-            robotType: R,
-            update: Partial<RobotTypeData[R]> | ((prev: RobotTypeData[R]) => RobotTypeData[R])
+        <K extends SchemaRobotType>(
+            schemaType: K,
+            update: Partial<FormDataForSchema[K]> | ((prev: FormDataForSchema[K]) => FormDataForSchema[K])
         ) => {
             setState((prev) => ({
                 ...prev,
-                [robotType]:
+                [schemaType]:
                     typeof update === 'function'
-                        ? (update as (prev: RobotTypeData[R]) => RobotTypeData[R])(prev[robotType])
-                        : { ...prev[robotType], ...update },
+                        ? (update as (prev: FormDataForSchema[K]) => FormDataForSchema[K])(
+                              prev[schemaType] as FormDataForSchema[K]
+                          )
+                        : { ...(prev[schemaType] as FormDataForSchema[K]), ...update },
             }));
         },
         []
@@ -65,19 +73,19 @@ export const RobotFormProvider = ({ children, robot }: { children: ReactNode; ro
 };
 
 export function useRobotForm(): { activeType: SchemaRobotType; robotForm: AnyRobotFormData };
-export function useRobotForm<R extends RobotType>(
-    robotType: R
-): { activeType: SchemaRobotType; robotForm: RobotTypeData[R] };
-export function useRobotForm(robotType?: RobotType) {
+export function useRobotForm<K extends SchemaRobotType>(
+    schemaType: K
+): { activeType: SchemaRobotType; robotForm: FormDataForSchema[K] };
+export function useRobotForm(schemaType?: SchemaRobotType) {
     const context = useContext(RobotFormContext);
 
     if (context === null) {
         throw new Error('useRobotForm was used outside of RobotFormProvider');
     }
 
-    const rt = robotType ?? typeForSchema[context.activeType];
+    const rt = schemaType ?? context.activeType;
 
-    return { activeType: context.activeType, robotForm: context[rt] };
+    return { activeType: context.activeType, robotForm: context[rt] as AnyRobotFormData };
 }
 
 export const useSetRobotForm = () => {
@@ -90,19 +98,21 @@ export const useSetRobotForm = () => {
     return context;
 };
 
-export const useRobotFormFields = <R extends RobotType>(robotType: R) => {
-    const state = useContext(RobotFormContext);
+export const useRobotFormFields = <T extends AnyRobotFormData = AnyRobotFormData>() => {
+    const context = useContext(RobotFormContext);
     const { updateFormData } = useSetRobotForm();
 
-    if (state === null) {
+    if (context === null) {
         throw new Error('useRobotFormFields was used outside of RobotFormProvider');
     }
 
-    const updateField = <K extends keyof RobotTypeData[R]>(field: K, value: RobotTypeData[R][K]) => {
-        updateFormData(robotType, { [field]: value } as unknown as Partial<RobotTypeData[R]>);
+    const formData = context[context.activeType] as T;
+
+    const updateField = <K extends keyof T>(field: K, value: T[K]) => {
+        updateFormData(context.activeType, { [field]: value } as Partial<FormDataForSchema[typeof context.activeType]>);
     };
 
-    return { formData: state[robotType] as RobotTypeData[R], activeType: state.activeType, updateField };
+    return { formData, activeType: context.activeType, updateField };
 };
 
 export const useRobotFormBody = (robot_id: string): SchemaRobotInput | null => {
@@ -112,7 +122,7 @@ export const useRobotFormBody = (robot_id: string): SchemaRobotInput | null => {
         throw new Error('useRobotFormBody was used outside of RobotFormProvider');
     }
 
-    const formData = state[typeForSchema[state.activeType]] as AnyRobotFormData;
+    const formData = state[state.activeType] as AnyRobotFormData;
 
     return buildRobotBody(formData, state.activeType, robot_id);
 };

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -28,21 +28,52 @@ type SetRobotFormContextType = {
 
 const SetRobotFormContext = createContext<SetRobotFormContextType | null>(null);
 
+const FORM_DATA_FAMILY: Record<SchemaRobotType, string> = {
+    SO101_Follower: 'so101',
+    SO101_Leader: 'so101',
+    Trossen_WidowXAI_Follower: 'widowx',
+    Trossen_WidowXAI_Leader: 'widowx',
+    Trossen_Bimanual_WidowXAI_Follower: 'bimanual',
+    Trossen_Bimanual_WidowXAI_Leader: 'bimanual',
+};
+
 const getInitialState = (robot?: SchemaRobot): RobotFormState => ({
     activeType: robot?.type ?? 'SO101_Follower',
-    SO101_Follower: getInitialSO101FormData(robot),
-    SO101_Leader: getInitialSO101FormData(robot),
-    Trossen_WidowXAI_Follower: getInitialWidowxFormData(robot),
-    Trossen_WidowXAI_Leader: getInitialWidowxFormData(robot),
-    Trossen_Bimanual_WidowXAI_Follower: getInitialBimanualFormData(robot),
-    Trossen_Bimanual_WidowXAI_Leader: getInitialBimanualFormData(robot),
+    SO101_Follower: getInitialSO101FormData(robot?.type === 'SO101_Follower' ? robot : undefined),
+    SO101_Leader: getInitialSO101FormData(robot?.type === 'SO101_Leader' ? robot : undefined),
+    Trossen_WidowXAI_Follower: getInitialWidowxFormData(
+        robot?.type === 'Trossen_WidowXAI_Follower' ? robot : undefined
+    ),
+    Trossen_WidowXAI_Leader: getInitialWidowxFormData(robot?.type === 'Trossen_WidowXAI_Leader' ? robot : undefined),
+    Trossen_Bimanual_WidowXAI_Follower: getInitialBimanualFormData(
+        robot?.type === 'Trossen_Bimanual_WidowXAI_Follower' ? robot : undefined
+    ),
+    Trossen_Bimanual_WidowXAI_Leader: getInitialBimanualFormData(
+        robot?.type === 'Trossen_Bimanual_WidowXAI_Leader' ? robot : undefined
+    ),
 });
 
 export const RobotFormProvider = ({ children, robot }: { children: ReactNode; robot?: SchemaRobot }) => {
     const [state, setState] = useState(() => getInitialState(robot));
 
-    const setActiveType = useCallback((type: SchemaRobotType) => {
-        setState((prev) => ({ ...prev, activeType: type }));
+    const setActiveType = useCallback(<T extends SchemaRobotType>(type: T) => {
+        setState((prev) => {
+            if (prev.activeType === type) return prev;
+
+            const oldSlice = prev[prev.activeType] as AnyRobotFormData;
+            const sameFamily = FORM_DATA_FAMILY[prev.activeType] === FORM_DATA_FAMILY[type];
+
+            if (sameFamily) {
+                return { ...prev, activeType: type, [type]: { ...oldSlice } as FormDataForSchema[T] };
+            }
+
+            return {
+                ...prev,
+                activeType: type,
+                // Don't overwrite robot name as name is presented before robot type picker
+                [type]: { ...(prev[type] as FormDataForSchema[T]), name: oldSlice.name },
+            };
+        });
     }, []);
 
     const updateFormData = useCallback(

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -1,109 +1,105 @@
-import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 
 import { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../robot-types';
+import {
+    buildRobotBody,
+    typeForSchema,
+    type RobotType,
+    type RobotTypeData,
+    type AnyRobotFormData,
+} from './form-data';
+import { getInitialSO101FormData } from './catalog/so101';
+import { getInitialWidowxFormData } from './catalog/widowxai';
+import { getInitialBimanualFormData } from './catalog/widowxai-bimanual';
 
-export type RobotForm = {
-    name: string;
-    type: SchemaRobotType;
-    connection_string: string;
-    serial_number: string;
-    connection_string_left: string;
-    connection_string_right: string;
+type RobotFormState = {
+    activeType: SchemaRobotType;
+    so101: RobotTypeData['so101'];
+    widowx: RobotTypeData['widowx'];
+    bimanual: RobotTypeData['bimanual'];
 };
 
-export type RobotFormState = RobotForm | null;
+const RobotFormContext = createContext<RobotFormState | null>(null);
 
-export const RobotFormContext = createContext<RobotFormState>(null);
-export const SetRobotFormContext = createContext<Dispatch<SetStateAction<RobotForm>> | null>(null);
-
-export const buildRobotBodyFromForm = (robotForm: RobotForm, robot_id: string): SchemaRobotInput | null => {
-    if (!robotForm.type) {
-        return null;
-    }
-
-    switch (robotForm.type) {
-        case 'SO101_Follower':
-        case 'SO101_Leader':
-            if (!robotForm.serial_number) {
-                return null;
-            }
-
-            return {
-                id: robot_id,
-                name: robotForm.name,
-                type: robotForm.type,
-                payload: {
-                    connection_string: robotForm.connection_string ?? '',
-                    serial_number: robotForm.serial_number,
-                },
-            };
-        case 'Trossen_WidowXAI_Follower':
-        case 'Trossen_WidowXAI_Leader':
-            if (!robotForm.connection_string) {
-                return null;
-            }
-
-            return {
-                id: robot_id,
-                name: robotForm.name,
-                type: robotForm.type,
-                payload: {
-                    connection_string: robotForm.connection_string,
-                    serial_number: robotForm.serial_number ?? '',
-                },
-            };
-        case 'Trossen_Bimanual_WidowXAI_Follower':
-        case 'Trossen_Bimanual_WidowXAI_Leader':
-            if (!robotForm.connection_string_left || !robotForm.connection_string_right) {
-                return null;
-            }
-
-            return {
-                id: robot_id,
-                name: robotForm.name,
-                type: robotForm.type,
-                payload: {
-                    connection_string_left: robotForm.connection_string_left,
-                    connection_string_right: robotForm.connection_string_right,
-                    serial_number: robotForm.serial_number ?? '',
-                },
-            };
-        default:
-            return null;
-    }
+type SetRobotFormContextType = {
+    setActiveType: (type: SchemaRobotType) => void;
+    updateFormData: <R extends RobotType>(
+        robotType: R,
+        update: Partial<RobotTypeData[R]> | ((prev: RobotTypeData[R]) => RobotTypeData[R])
+    ) => void;
 };
 
-export const useRobotFormBody = (robot_id: string): SchemaRobotInput | null => {
-    const robotForm = useRobotForm();
+const SetRobotFormContext = createContext<SetRobotFormContextType | null>(null);
 
-    if (robotForm === undefined) {
-        return null;
-    }
+const getInitialState = (robot?: SchemaRobot): RobotFormState => {
+    const activeType = robot?.type ?? 'SO101_Follower';
+    const robotType = typeForSchema[activeType];
 
-    return buildRobotBodyFromForm(robotForm, robot_id);
+    return {
+        activeType,
+        so101: getInitialSO101FormData(
+            robotType === 'so101' && robot
+                ? {
+                      name: robot.name,
+                      serial_number: robot.payload.serial_number,
+                      connection_string:
+                          'connection_string' in robot.payload ? robot.payload.connection_string : '',
+                  }
+                : undefined
+        ),
+        widowx: getInitialWidowxFormData(
+            robotType === 'widowx' && robot
+                ? {
+                      name: robot.name,
+                      connection_string:
+                          'connection_string' in robot.payload ? robot.payload.connection_string : '',
+                      serial_number: robot.payload.serial_number,
+                  }
+                : undefined
+        ),
+        bimanual: getInitialBimanualFormData(
+            robotType === 'bimanual' && robot
+                ? {
+                      name: robot.name,
+                      connection_string_left:
+                          'connection_string_left' in robot.payload ? robot.payload.connection_string_left : '',
+                      connection_string_right:
+                          'connection_string_right' in robot.payload ? robot.payload.connection_string_right : '',
+                      serial_number: robot.payload.serial_number,
+                  }
+                : undefined
+        ),
+    };
 };
 
 export const RobotFormProvider = ({ children, robot }: { children: ReactNode; robot?: SchemaRobot }) => {
-    const initialConnectionString =
-        robot !== undefined && 'connection_string' in robot.payload ? robot.payload.connection_string : '';
-    const initialSerialNumber = robot?.payload.serial_number ?? '';
-    const initialLeftConnection =
-        robot !== undefined && 'connection_string_left' in robot.payload ? robot.payload.connection_string_left : '';
-    const initialRightConnection =
-        robot !== undefined && 'connection_string_right' in robot.payload ? robot.payload.connection_string_right : '';
+    const [state, setState] = useState(() => getInitialState(robot));
 
-    const [value, setValue] = useState<RobotForm>({
-        name: robot?.name ?? '',
-        type: robot?.type ?? 'SO101_Follower',
-        connection_string: initialConnectionString,
-        serial_number: initialSerialNumber,
-        connection_string_left: initialLeftConnection,
-        connection_string_right: initialRightConnection,
-    });
+    const setActiveType = useCallback((type: SchemaRobotType) => {
+        setState((prev) => ({ ...prev, activeType: type }));
+    }, []);
+
+    const updateFormData = useCallback(
+        <R extends RobotType>(
+            robotType: R,
+            update: Partial<RobotTypeData[R]> | ((prev: RobotTypeData[R]) => RobotTypeData[R])
+        ) => {
+            setState((prev) => ({
+                ...prev,
+                [robotType]:
+                    typeof update === 'function'
+                        ? (update as (prev: RobotTypeData[R]) => RobotTypeData[R])(prev[robotType])
+                        : { ...prev[robotType], ...update },
+            }));
+        },
+        []
+    );
+
+    const setContextValue = useMemo(() => ({ setActiveType, updateFormData }), [setActiveType, updateFormData]);
 
     return (
-        <RobotFormContext.Provider value={value}>
-            <SetRobotFormContext.Provider value={setValue}>{children}</SetRobotFormContext.Provider>
+        <RobotFormContext.Provider value={state}>
+            <SetRobotFormContext.Provider value={setContextValue}>{children}</SetRobotFormContext.Provider>
         </RobotFormContext.Provider>
     );
 };
@@ -126,4 +122,23 @@ export const useSetRobotForm = () => {
     }
 
     return context;
+};
+
+export const useRobotFormFields = <R extends RobotType>(robotType: R) => {
+    const state = useRobotForm();
+    const { updateFormData } = useSetRobotForm();
+
+    const updateField = <K extends keyof RobotTypeData[R]>(field: K, value: RobotTypeData[R][K]) => {
+        updateFormData(robotType, { [field]: value } as unknown as Partial<RobotTypeData[R]>);
+    };
+
+    return { formData: state[robotType] as RobotTypeData[R], activeType: state.activeType, updateField };
+};
+
+export const useRobotFormBody = (robot_id: string): SchemaRobotInput | null => {
+    const state = useRobotForm();
+    const robotType = typeForSchema[state.activeType];
+    const formData = state[robotType] as AnyRobotFormData;
+
+    return buildRobotBody(robotType, formData, state.activeType, robot_id);
 };

--- a/application/ui/src/features/robots/setup-wizard/so101/setup-wizard.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/setup-wizard.tsx
@@ -84,11 +84,11 @@ function useHighlights(): JointHighlight[] {
  * - VERIFICATION: live-synced viewer (sync is driven by VerificationStep)
  */
 const ViewerPanel = () => {
-    const robotForm = useRobotForm();
+    const { activeType } = useRobotForm();
     const { currentStep, calibrationPhase } = useSetupState();
     const highlights = useHighlights();
 
-    const robotType = robotForm.type || null;
+    const robotType = activeType as SchemaRobotType | null;
 
     const isCentering =
         currentStep === WizardStep.CALIBRATION &&

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -139,7 +139,7 @@ export const VerificationStep = () => {
     });
 
     const robotBody: SchemaRobotInput | null = activeType.startsWith('SO101')
-        ? buildRobotBody('so101', robotForm, activeType, robotId)
+        ? buildRobotBody(robotForm, activeType, robotId)
         : null;
 
     const hasCalibration = wsState.calibrationResult !== null;

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -201,7 +201,7 @@ export const VerificationStep = () => {
                     <Heading level={4}>Robot Details</Heading>
                     <Flex direction='column' gap='size-50'>
                         <Text>
-                            <strong>Name:</strong> {so101.name}
+                            <strong>Name:</strong> {robotForm.name}
                         </Text>
                         <Text>
                             <strong>Type:</strong> {robotType}

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -9,7 +9,8 @@ import { $api } from '../../../../api/client';
 import { SchemaCalibration } from '../../../../api/openapi-spec';
 import { paths } from '../../../../router';
 import { useProjectId } from '../../../projects/use-project';
-import { buildRobotBodyFromForm, useRobotForm } from '../../robot-form/provider';
+import { buildRobotBody } from '../../robot-form/form-data';
+import { useRobotForm } from '../../robot-form/provider';
 import { useRobotModels } from '../../robot-models-context';
 import { SchemaRobotInput } from '../../robot-types';
 import { InlineAlert } from '../shared/inline-alert';
@@ -101,10 +102,10 @@ export const VerificationStep = () => {
     const { project_id } = useProjectId();
     const { goBack } = useSetupActions();
     const { wsState } = useSetupState();
-    const robotForm = useRobotForm();
+    const { activeType, so101 } = useRobotForm();
 
-    const serialNumber = robotForm.serial_number ?? '';
-    const robotType = robotForm.type ?? '';
+    const serialNumber = so101.serial_number;
+    const robotType = activeType ?? '';
 
     const [robotId] = useState(() => uuidv4());
     const [calibrationId] = useState(() => uuidv4());
@@ -137,7 +138,7 @@ export const VerificationStep = () => {
         },
     });
 
-    const robotBody: SchemaRobotInput | null = buildRobotBodyFromForm(robotForm, robotId);
+    const robotBody: SchemaRobotInput | null = buildRobotBody('so101', so101, activeType, robotId);
 
     const hasCalibration = wsState.calibrationResult !== null;
 
@@ -200,7 +201,7 @@ export const VerificationStep = () => {
                     <Heading level={4}>Robot Details</Heading>
                     <Flex direction='column' gap='size-50'>
                         <Text>
-                            <strong>Name:</strong> {robotForm.name}
+                            <strong>Name:</strong> {so101.name}
                         </Text>
                         <Text>
                             <strong>Type:</strong> {robotType}

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -102,7 +102,7 @@ export const VerificationStep = () => {
     const { project_id } = useProjectId();
     const { goBack } = useSetupActions();
     const { wsState } = useSetupState();
-    const { activeType, robotForm } = useRobotForm('so101');
+    const { activeType, robotForm } = useRobotForm();
 
     const serialNumber = robotForm.serial_number;
     const robotType = activeType ?? '';

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -138,7 +138,8 @@ export const VerificationStep = () => {
         },
     });
 
-    const robotBody: SchemaRobotInput | null = buildRobotBody('so101', robotForm, activeType, robotId);
+    const robotBody: SchemaRobotInput | null =
+        activeType.startsWith('SO101') ? buildRobotBody('so101', robotForm, activeType, robotId) : null;
 
     const hasCalibration = wsState.calibrationResult !== null;
 

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -102,9 +102,9 @@ export const VerificationStep = () => {
     const { project_id } = useProjectId();
     const { goBack } = useSetupActions();
     const { wsState } = useSetupState();
-    const { activeType, so101 } = useRobotForm();
+    const { activeType, robotForm } = useRobotForm('so101');
 
-    const serialNumber = so101.serial_number;
+    const serialNumber = robotForm.serial_number;
     const robotType = activeType ?? '';
 
     const [robotId] = useState(() => uuidv4());
@@ -138,7 +138,7 @@ export const VerificationStep = () => {
         },
     });
 
-    const robotBody: SchemaRobotInput | null = buildRobotBody('so101', so101, activeType, robotId);
+    const robotBody: SchemaRobotInput | null = buildRobotBody('so101', robotForm, activeType, robotId);
 
     const hasCalibration = wsState.calibrationResult !== null;
 

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -138,8 +138,9 @@ export const VerificationStep = () => {
         },
     });
 
-    const robotBody: SchemaRobotInput | null =
-        activeType.startsWith('SO101') ? buildRobotBody('so101', robotForm, activeType, robotId) : null;
+    const robotBody: SchemaRobotInput | null = activeType.startsWith('SO101')
+        ? buildRobotBody('so101', robotForm, activeType, robotId)
+        : null;
 
     const hasCalibration = wsState.calibrationResult !== null;
 

--- a/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
@@ -79,7 +79,7 @@ const SetupActionsContext = createContext<SetupActions | null>(null);
 
 export const SetupWizardProvider = ({ children }: { children: ReactNode }) => {
     const { project_id: projectId } = useProjectId();
-    const { activeType, robotForm } = useRobotForm('so101');
+    const { activeType, robotForm } = useRobotForm();
 
     // -----------------------------------------------------------------------
     // Wizard step state

--- a/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
@@ -79,7 +79,7 @@ const SetupActionsContext = createContext<SetupActions | null>(null);
 
 export const SetupWizardProvider = ({ children }: { children: ReactNode }) => {
     const { project_id: projectId } = useProjectId();
-    const robotForm = useRobotForm();
+    const { activeType, so101 } = useRobotForm();
 
     // -----------------------------------------------------------------------
     // Wizard step state
@@ -159,8 +159,8 @@ export const SetupWizardProvider = ({ children }: { children: ReactNode }) => {
     // WebSocket hook
     // -----------------------------------------------------------------------
 
-    const serialNumber = robotForm.serial_number ?? '';
-    const robotType = robotForm.type ?? '';
+    const serialNumber = so101.serial_number;
+    const robotType = activeType ?? '';
     const wsEnabled = !!serialNumber && !!robotType;
 
     const { state: wsState, commands } = useSetupWebSocket({

--- a/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
@@ -161,7 +161,7 @@ export const SetupWizardProvider = ({ children }: { children: ReactNode }) => {
 
     const serialNumber = robotForm.serial_number;
     const robotType = activeType ?? '';
-    const wsEnabled = !!serialNumber && !!robotType;
+    const wsEnabled = !!serialNumber && robotType.startsWith('SO101');
 
     const { state: wsState, commands } = useSetupWebSocket({
         projectId,

--- a/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
@@ -79,7 +79,7 @@ const SetupActionsContext = createContext<SetupActions | null>(null);
 
 export const SetupWizardProvider = ({ children }: { children: ReactNode }) => {
     const { project_id: projectId } = useProjectId();
-    const { activeType, so101 } = useRobotForm();
+    const { activeType, robotForm } = useRobotForm('so101');
 
     // -----------------------------------------------------------------------
     // Wizard step state
@@ -159,7 +159,7 @@ export const SetupWizardProvider = ({ children }: { children: ReactNode }) => {
     // WebSocket hook
     // -----------------------------------------------------------------------
 
-    const serialNumber = so101.serial_number;
+    const serialNumber = robotForm.serial_number;
     const robotType = activeType ?? '';
     const wsEnabled = !!serialNumber && !!robotType;
 

--- a/application/ui/src/routes/robots/new.tsx
+++ b/application/ui/src/routes/robots/new.tsx
@@ -24,17 +24,17 @@ const CenteredLoading = () => {
  * - Other types (Trossen): directly creates the robot via POST (default behavior)
  */
 const NewRobotSubmitButton = () => {
-    const robotForm = useRobotForm();
+    const { activeType, so101 } = useRobotForm();
     const navigate = useNavigate();
     const { project_id } = useProjectId();
 
-    const isSO101 = robotForm.type?.toLowerCase().startsWith('so101') ?? false;
+    const isSO101 = activeType?.toLowerCase().startsWith('so101') ?? false;
 
     if (!isSO101) {
         return <SubmitNewRobotButton />;
     }
 
-    const isDisabled = !robotForm.name || !robotForm.type || !robotForm.serial_number;
+    const isDisabled = !so101.name || !activeType || !so101.serial_number;
 
     return (
         <Button

--- a/application/ui/src/routes/robots/new.tsx
+++ b/application/ui/src/routes/robots/new.tsx
@@ -24,7 +24,7 @@ const CenteredLoading = () => {
  * - Other types (Trossen): directly creates the robot via POST (default behavior)
  */
 const NewRobotSubmitButton = () => {
-    const { activeType, so101 } = useRobotForm();
+    const { activeType, robotForm } = useRobotForm('so101');
     const navigate = useNavigate();
     const { project_id } = useProjectId();
 
@@ -34,7 +34,7 @@ const NewRobotSubmitButton = () => {
         return <SubmitNewRobotButton />;
     }
 
-    const isDisabled = !so101.name || !activeType || !so101.serial_number;
+    const isDisabled = !robotForm.name || !activeType || !robotForm.serial_number;
 
     return (
         <Button

--- a/application/ui/src/routes/robots/new.tsx
+++ b/application/ui/src/routes/robots/new.tsx
@@ -24,7 +24,7 @@ const CenteredLoading = () => {
  * - Other types (Trossen): directly creates the robot via POST (default behavior)
  */
 const NewRobotSubmitButton = () => {
-    const { activeType, robotForm } = useRobotForm('so101');
+    const { activeType, robotForm } = useRobotForm();
     const navigate = useNavigate();
     const { project_id } = useProjectId();
 


### PR DESCRIPTION
This PR does refactor work to make it easier to add new robot types (soon via a plugin architecture) to the UI. It only contains refactor work: it doesn't add new features or fix bugs.

In particular:
- form fields of specific types are included in their own file under a `catalog` folder
- robot form provider has been changed to include state per robot type, instead of 1 state that represents all, e.g.:
```typescript
type RobotFormState = {
    activeType: SchemaRobotType;
    SO101_Follower: FormDataForSchema['SO101_Follower'];
    SO101_Leader: FormDataForSchema['SO101_Leader'];
    Trossen_WidowXAI_Follower: FormDataForSchema['Trossen_WidowXAI_Follower'];
    Trossen_WidowXAI_Leader: FormDataForSchema['Trossen_WidowXAI_Leader'];
    Trossen_Bimanual_WidowXAI_Follower: FormDataForSchema['Trossen_Bimanual_WidowXAI_Follower'];
    Trossen_Bimanual_WidowXAI_Leader: FormDataForSchema['Trossen_Bimanual_WidowXAI_Leader'];
};
```

where for instance `FormDataForSchema['SO101_Follower']` equals,
```typescript
FormDataForSchema['SO101_Follower'] = {
    name: string;
    serial_number: string;
    connection_string: string;
}
```

vs (old)

```typescript
export type RobotForm = {
    name: string;
    type: SchemaRobotType;
    connection_string: string; # SO101, Trossen specific
    serial_number: string; # SO101, Trossen specific
    connection_string_left: string; # Bimanual Trossen specific
    connection_string_right: string; # Bimanual Trossen specific
};
```
which would get very messy when adding more robots.

The new setup is more verbose but makes it easier to deal with new states when adding more robots and reduces risk of setting variables in the form state that are not applicable to the selected robot.