### PR TITLE
fix: improve UI setup

### DIFF
--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -11,7 +11,7 @@
         "build": "rsbuild build",
         "build:api": "npx openapi-typescript ./src/api/openapi-spec.json -o ./src/api/openapi-spec.d.ts  --root-types && prettier --write src/api/openapi-spec.d.ts",
         "build:api:download": "curl -o ./src/api/openapi-spec.json http://localhost:7860/api/openapi.json && prettier --write src/api/openapi-spec.json",
-        "clone-so101": "npx tiged git@github.com:TheRobotStudio/SO-ARM100.git/Simulation/SO101 public/SO101 --force",
+        "clone-so101": "npx tiged github:TheRobotStudio/SO-ARM100/Simulation/SO101 public/SO101 --force",
         "clone-widowx": "npx tiged github:TrossenRobotics/trossen_arm_description public/widowx --force",
         "cyclic-deps-check": "npx madge --circular src/**/*.ts*",
         "start": "rsbuild dev",

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "type": "module",
     "engines": {
-        "node": "v24.2.0",
+        "node": ">=24.2.0",
         "npm": ">=11.14.0"
     },
     "scripts": {


### PR DESCRIPTION
Add small tweaks to initial ui setup that makes onboarding a bit simpler:
1. Don't require an ssh key when cloning urdf files from git (note: this probably will be further simplified after our robot plugin design)
2. Don't restrict node version on a specific version