### PR TITLE
feat(RT 1/5): centralize training progress logging callback in physicalai.train

### DIFF
--- a/library/src/physicalai/train/__init__.py
+++ b/library/src/physicalai/train/__init__.py
@@ -7,9 +7,9 @@ from importlib.metadata import version
 
 import physicalai.devices.xpu  # noqa: F401 - ensure xpu device is registered if available
 
-from .callbacks import IterationTimer
+from .callbacks import IterationTimer, ProgressReportingCallback
 from .trainer import Trainer
 
 __version__ = version("physicalai-train")
 
-__all__ = ["IterationTimer", "Trainer", "__version__"]
+__all__ = ["IterationTimer", "ProgressReportingCallback", "Trainer", "__version__"]

--- a/library/src/physicalai/train/callbacks.py
+++ b/library/src/physicalai/train/callbacks.py
@@ -5,6 +5,7 @@
 
 import time
 from collections.abc import Callable, Mapping
+from typing import cast
 
 import lightning as L  # noqa: N812
 from lightning.pytorch.callbacks import Callback
@@ -65,11 +66,40 @@ class ProgressReportingCallback(Callback):
             total_steps: Configured maximum number of steps.
 
         Returns:
-            Cadence: at least every 100 steps, targeting ~1000 entries overall.
+            Cadence in steps. Targets ~1000 entries for budgets up to 100k steps,
+            then caps at every 100 steps. Above 100k steps the cap dominates and
+            the total entry count grows past 1000.
         """
         if total_steps <= 0:
             return 1
         return min(100, max(1, total_steps // 1000))
+
+    @staticmethod
+    def _to_scalar(value: object) -> float | None:
+        """Coerce a metric to a float, handling tensors and plain scalars.
+
+        Args:
+            value: A 0-d tensor, a Python scalar, or None.
+
+        Returns:
+            The float value, or None when ``value`` is None.
+        """
+        if value is None:
+            return None
+        item = getattr(value, "item", None)
+        if callable(item):
+            return float(cast("float", item()))
+        return float(value)  # type: ignore[arg-type]
+
+    @staticmethod
+    def _max_steps(trainer: L.Trainer) -> int | None:
+        """Return the configured step budget, or None when unset/disabled.
+
+        Lightning uses -1 (or any non-positive value) to signal an unbounded step
+        budget. Surface that as None so consumers do not misread it as a real
+        limit, keeping the value consistent with ``_progress`` returning 0.
+        """
+        return trainer.max_steps if trainer.max_steps > 0 else None
 
     @staticmethod
     def _extract_loss(outputs: object) -> float | None:
@@ -96,12 +126,16 @@ class ProgressReportingCallback(Callback):
 
         Returns:
             Completion percentage clamped to 0-100. Returns 0 when ``max_steps``
-            is unset (-1) or otherwise non-positive.
+            is unset (-1) or otherwise non-positive. Emits 100 only once
+            ``global_step >= max_steps`` so partial steps never round up to
+            completion.
         """
         max_steps = trainer.max_steps
         if max_steps <= 0:
             return 0
-        return min(100, round(trainer.global_step / max_steps * 100))
+        if trainer.global_step >= max_steps:
+            return 100
+        return min(99, int(trainer.global_step / max_steps * 100))
 
     def _check_stop(self, trainer: L.Trainer) -> None:
         """Stop the trainer cooperatively when cancellation was requested."""
@@ -127,7 +161,7 @@ class ProgressReportingCallback(Callback):
         # Attach the detailed cadence fields so consumers can throttle logs.
         if global_step <= 1 or global_step % self._every_n_steps == 0:
             extra["global_step"] = global_step
-            extra["max_steps"] = max(1, trainer.max_steps)
+            extra["max_steps"] = self._max_steps(trainer)
             extra["epoch"] = trainer.current_epoch
         self._report(self._progress(trainer), None, extra)
         self._check_stop(trainer)
@@ -138,7 +172,7 @@ class ProgressReportingCallback(Callback):
         self._report(
             self._progress(trainer),
             None,
-            {"val_event": "start", "global_step": trainer.global_step, "max_steps": max(1, trainer.max_steps)},
+            {"val_event": "start", "global_step": trainer.global_step, "max_steps": self._max_steps(trainer)},
         )
         self._check_stop(trainer)
 
@@ -164,7 +198,7 @@ class ProgressReportingCallback(Callback):
     def on_validation_epoch_end(self, trainer: L.Trainer, _pl_module: L.LightningModule) -> None:
         """Report the validation summary with aggregated loss and elapsed time."""
         val_loss = trainer.callback_metrics.get("val/loss")
-        val_loss_val = val_loss.item() if val_loss is not None else None
+        val_loss_val = self._to_scalar(val_loss)
         elapsed = time.monotonic() - self._val_start_t if self._val_start_t is not None else 0.0
         self._report(
             self._progress(trainer),

--- a/library/src/physicalai/train/callbacks.py
+++ b/library/src/physicalai/train/callbacks.py
@@ -4,11 +4,178 @@
 """Callbacks for training."""
 
 import time
+from collections.abc import Callable, Mapping
 
 import lightning as L  # noqa: N812
 from lightning.pytorch.callbacks import Callback
 
 from physicalai.train.utils import reformat_dataset_to_match_policy
+
+ReportFn = Callable[[int, str | None, dict[str, object]], None]
+"""Telemetry sink: ``(progress, message, extra_info)`` with progress in 0-100."""
+
+StopFn = Callable[[], bool]
+"""Cooperative cancellation probe: returns True when training should stop."""
+
+
+class ProgressReportingCallback(Callback):
+    """Stream standardized training/validation telemetry to a sink.
+
+    Forwards progress, step loss, and validation events through a ``report``
+    callable so any consumer (a job store, an SSE stream, or logs) sees an
+    identical telemetry schema, and honors cooperative cancellation via
+    ``should_stop``. This keeps in-process and remote runners emitting the same
+    data without duplicating the Lightning hook logic.
+
+    ``report`` receives ``(progress, message, extra_info)`` where ``progress``
+    is 0-100 and ``extra_info`` carries:
+
+    - train batch: ``{"train/loss_step": float | None}``, plus
+      ``{"global_step", "max_steps", "epoch"}`` on the logging cadence.
+    - validation start: ``{"val_event": "start", "global_step", "max_steps"}``.
+    - validation batch: ``{"val_event": "batch", "val_batch", "val/loss_step"}``
+      (throttled to the logging cadence).
+    - validation end: ``{"val_event": "end", "global_step", "val/loss",
+      "val_elapsed_s"}``.
+
+    Example:
+        >>> cb = ProgressReportingCallback(report=sink, should_stop=lambda: False)
+        >>> trainer = Trainer(callbacks=[cb])
+    """
+
+    def __init__(self, *, report: ReportFn, should_stop: StopFn) -> None:
+        """Store the telemetry sink and cancellation probe.
+
+        Args:
+            report: Sink called with ``(progress, message, extra_info)``.
+            should_stop: Returns True when training should stop cooperatively.
+        """
+        super().__init__()
+        self._report = report
+        self._should_stop = should_stop
+        # Logging cadence in steps; resolved from the step budget on fit start.
+        self._every_n_steps = 1
+        self._val_start_t: float | None = None
+
+    @staticmethod
+    def _auto_every_n_steps(total_steps: int) -> int:
+        """Pick a logging cadence in steps.
+
+        Args:
+            total_steps: Configured maximum number of steps.
+
+        Returns:
+            Cadence: at least every 100 steps, targeting ~1000 entries overall.
+        """
+        if total_steps <= 0:
+            return 1
+        return min(100, max(1, total_steps // 1000))
+
+    @staticmethod
+    def _extract_loss(outputs: object) -> float | None:
+        """Return a scalar loss from a step output, or None when unavailable.
+
+        Handles a ``{"loss": tensor}`` mapping (training) or a bare loss tensor
+        (eval-loss validation).
+        """
+        candidate = outputs.get("loss") if isinstance(outputs, Mapping) else outputs
+        detach = getattr(candidate, "detach", None)
+        if detach is None:
+            return None
+        try:
+            return detach().cpu().item()
+        except (RuntimeError, ValueError):
+            return None
+
+    @staticmethod
+    def _progress(trainer: L.Trainer) -> int:
+        """Compute step-based completion.
+
+        Args:
+            trainer: The active Lightning trainer.
+
+        Returns:
+            Completion percentage clamped to 0-100. Returns 0 when ``max_steps``
+            is unset (-1) or otherwise non-positive.
+        """
+        max_steps = trainer.max_steps
+        if max_steps <= 0:
+            return 0
+        return min(100, round(trainer.global_step / max_steps * 100))
+
+    def _check_stop(self, trainer: L.Trainer) -> None:
+        """Stop the trainer cooperatively when cancellation was requested."""
+        if self._should_stop():
+            trainer.should_stop = True
+
+    def on_fit_start(self, trainer: L.Trainer, _pl_module: L.LightningModule) -> None:
+        """Resolve the logging cadence and honor a cancel requested before training."""
+        self._every_n_steps = self._auto_every_n_steps(trainer.max_steps)
+        self._check_stop(trainer)
+
+    def on_train_batch_end(
+        self,
+        trainer: L.Trainer,
+        _pl_module: L.LightningModule,
+        outputs: object,
+        _batch: object,
+        _batch_idx: int,
+    ) -> None:
+        """Report step progress and loss; honor cancellation."""
+        global_step = trainer.global_step
+        extra: dict[str, object] = {"train/loss_step": self._extract_loss(outputs)}
+        # Attach the detailed cadence fields so consumers can throttle logs.
+        if global_step <= 1 or global_step % self._every_n_steps == 0:
+            extra["global_step"] = global_step
+            extra["max_steps"] = max(1, trainer.max_steps)
+            extra["epoch"] = trainer.current_epoch
+        self._report(self._progress(trainer), None, extra)
+        self._check_stop(trainer)
+
+    def on_validation_start(self, trainer: L.Trainer, _pl_module: L.LightningModule) -> None:
+        """Report the start of a validation pass; honor cancellation."""
+        self._val_start_t = time.monotonic()
+        self._report(
+            self._progress(trainer),
+            None,
+            {"val_event": "start", "global_step": trainer.global_step, "max_steps": max(1, trainer.max_steps)},
+        )
+        self._check_stop(trainer)
+
+    def on_validation_batch_end(
+        self,
+        trainer: L.Trainer,
+        _pl_module: L.LightningModule,
+        outputs: object,
+        _batch: object,
+        batch_idx: int,
+        dataloader_idx: int = 0,  # noqa: ARG002  # Lightning hook signature; unused here.
+    ) -> None:
+        """Report a throttled validation batch; honor cancellation."""
+        current = batch_idx + 1
+        if current == 1 or current % self._every_n_steps == 0:
+            self._report(
+                self._progress(trainer),
+                None,
+                {"val_event": "batch", "val_batch": current, "val/loss_step": self._extract_loss(outputs)},
+            )
+        self._check_stop(trainer)
+
+    def on_validation_epoch_end(self, trainer: L.Trainer, _pl_module: L.LightningModule) -> None:
+        """Report the validation summary with aggregated loss and elapsed time."""
+        val_loss = trainer.callback_metrics.get("val/loss")
+        val_loss_val = val_loss.item() if val_loss is not None else None
+        elapsed = time.monotonic() - self._val_start_t if self._val_start_t is not None else 0.0
+        self._report(
+            self._progress(trainer),
+            None,
+            {
+                "val_event": "end",
+                "global_step": trainer.global_step,
+                "val/loss": val_loss_val,
+                "val_elapsed_s": elapsed,
+            },
+        )
 
 
 class IterationTimer(Callback):

--- a/library/tests/unit/train/test_callbacks.py
+++ b/library/tests/unit/train/test_callbacks.py
@@ -94,6 +94,51 @@ class TestProgressReportingCallback:
         assert extra["val/loss"] == 0.15
         assert isinstance(extra["val_elapsed_s"], float)
 
+    def test_validation_end_handles_scalar_val_loss(self) -> None:
+        # callback_metrics may hold a plain Python scalar without ``.item()``.
+        cb, report = self._callback()
+        trainer = _trainer(global_step=500, max_steps=1000)
+        trainer.callback_metrics = {"val/loss": 0.25}
+        cb.on_validation_start(trainer, MagicMock())
+
+        cb.on_validation_epoch_end(trainer, MagicMock())
+
+        _, _, extra = report.call_args[0]
+        assert extra["val/loss"] == 0.25
+
+    def test_progress_floors_and_never_rounds_up_before_completion(self) -> None:
+        # 995/1000 must not report 100% just because it rounds up.
+        cb, report = self._callback()
+        trainer = _trainer(global_step=995, max_steps=1000)
+        cb.on_fit_start(trainer, MagicMock())
+
+        cb.on_train_batch_end(trainer, MagicMock(), {"loss": _loss(0.1)}, None, 0)
+
+        progress = report.call_args[0][0]
+        assert progress == 99
+
+    def test_progress_reports_100_only_when_complete(self) -> None:
+        cb, report = self._callback()
+        trainer = _trainer(global_step=1000, max_steps=1000)
+        cb.on_fit_start(trainer, MagicMock())
+
+        cb.on_train_batch_end(trainer, MagicMock(), {"loss": _loss(0.1)}, None, 0)
+
+        progress = report.call_args[0][0]
+        assert progress == 100
+
+    def test_unset_max_steps_emits_none_sentinel(self) -> None:
+        # Lightning uses -1 for an unbounded step budget; surface it as None.
+        cb, report = self._callback()
+        trainer = _trainer(global_step=1, max_steps=-1)
+        cb.on_fit_start(trainer, MagicMock())
+
+        cb.on_train_batch_end(trainer, MagicMock(), {"loss": _loss(0.5)}, None, 0)
+
+        progress, _, extra = report.call_args[0]
+        assert progress == 0
+        assert extra["max_steps"] is None
+
     def test_honors_should_stop(self) -> None:
         cb, _ = self._callback(should_stop=True)
         trainer = _trainer(global_step=1, max_steps=10)

--- a/library/tests/unit/train/test_callbacks.py
+++ b/library/tests/unit/train/test_callbacks.py
@@ -7,7 +7,110 @@ from unittest.mock import MagicMock
 
 import lightning as L
 
-from physicalai.train.callbacks import IterationTimer
+from physicalai.train.callbacks import IterationTimer, ProgressReportingCallback
+
+
+def _loss(value: float) -> MagicMock:
+    """Build a fake loss tensor whose ``.detach().cpu().item()`` is ``value``."""
+    tensor = MagicMock()
+    tensor.detach.return_value.cpu.return_value.item.return_value = value
+    return tensor
+
+
+def _trainer(*, global_step: int, max_steps: int, epoch: int = 0) -> MagicMock:
+    trainer = MagicMock(spec=L.Trainer)
+    trainer.global_step = global_step
+    trainer.max_steps = max_steps
+    trainer.current_epoch = epoch
+    trainer.should_stop = False
+    trainer.callback_metrics = {}
+    return trainer
+
+
+class TestProgressReportingCallback:
+    """Tests for the shared progress/telemetry callback."""
+
+    def _callback(self, *, should_stop: bool = False) -> tuple[ProgressReportingCallback, MagicMock]:
+        report = MagicMock()
+        cb = ProgressReportingCallback(report=report, should_stop=lambda: should_stop)
+        return cb, report
+
+    def test_train_batch_reports_loss_and_cadence_fields(self) -> None:
+        cb, report = self._callback()
+        trainer = _trainer(global_step=1, max_steps=1000, epoch=0)
+        cb.on_fit_start(trainer, MagicMock())
+
+        cb.on_train_batch_end(trainer, MagicMock(), {"loss": _loss(0.5)}, None, 0)
+
+        progress, message, extra = report.call_args[0]
+        assert progress == 0  # 1/1000 -> 0%
+        assert message is None
+        assert extra == {"train/loss_step": 0.5, "global_step": 1, "max_steps": 1000, "epoch": 0}
+
+    def test_train_batch_off_cadence_reports_only_loss(self) -> None:
+        cb, report = self._callback()
+        trainer = _trainer(global_step=3, max_steps=10)
+        cb.on_fit_start(trainer, MagicMock())  # cadence -> every 1 step for small budgets
+
+        # Force a coarse cadence so step 3 is off-cadence.
+        cb._every_n_steps = 5
+        cb.on_train_batch_end(trainer, MagicMock(), {"loss": _loss(0.2)}, None, 0)
+
+        _, _, extra = report.call_args[0]
+        assert extra == {"train/loss_step": 0.2}
+
+    def test_validation_start_emits_event(self) -> None:
+        cb, report = self._callback()
+        trainer = _trainer(global_step=500, max_steps=1000)
+
+        cb.on_validation_start(trainer, MagicMock())
+
+        _, _, extra = report.call_args[0]
+        assert extra == {"val_event": "start", "global_step": 500, "max_steps": 1000}
+
+    def test_validation_batch_throttled(self) -> None:
+        cb, report = self._callback()
+        trainer = _trainer(global_step=500, max_steps=1000)
+        cb._every_n_steps = 3
+
+        cb.on_validation_batch_end(trainer, MagicMock(), {"loss": _loss(0.4)}, None, 0)  # batch 1 -> emits
+        cb.on_validation_batch_end(trainer, MagicMock(), {"loss": _loss(0.4)}, None, 1)  # batch 2 -> off cadence
+
+        assert report.call_count == 1
+        _, _, extra = report.call_args[0]
+        assert extra == {"val_event": "batch", "val_batch": 1, "val/loss_step": 0.4}
+
+    def test_validation_end_emits_summary(self) -> None:
+        cb, report = self._callback()
+        trainer = _trainer(global_step=500, max_steps=1000)
+        trainer.callback_metrics = {"val/loss": MagicMock(**{"item.return_value": 0.15})}
+        cb.on_validation_start(trainer, MagicMock())
+
+        cb.on_validation_epoch_end(trainer, MagicMock())
+
+        _, _, extra = report.call_args[0]
+        assert extra["val_event"] == "end"
+        assert extra["global_step"] == 500
+        assert extra["val/loss"] == 0.15
+        assert isinstance(extra["val_elapsed_s"], float)
+
+    def test_honors_should_stop(self) -> None:
+        cb, _ = self._callback(should_stop=True)
+        trainer = _trainer(global_step=1, max_steps=10)
+        cb.on_fit_start(trainer, MagicMock())
+
+        cb.on_train_batch_end(trainer, MagicMock(), {"loss": _loss(0.5)}, None, 0)
+
+        assert trainer.should_stop is True
+
+    def test_fit_start_honors_pending_cancel(self) -> None:
+        # A cancel requested before training starts must stop before the first batch.
+        cb, _ = self._callback(should_stop=True)
+        trainer = _trainer(global_step=0, max_steps=10)
+
+        cb.on_fit_start(trainer, MagicMock())
+
+        assert trainer.should_stop is True
 
 
 class TestIterationTimer:


### PR DESCRIPTION
## Summary

Centralize the training-progress logging callback in the `physicalai.train` package so local and remote training emit identical telemetry from one source of truth.

## What changed

- Add `ProgressReportingCallback` (and supporting exports) to `physicalai.train`.
- Update `physicalai/train/__init__.py` exports.
- Unit tests for the callback.

## Why

Both the in-process (local) and offloaded (remote) training paths need to produce the same job-log lines and progress cadence. Owning this in the library removes duplicated formatting logic in the backend.

## Notes

- First PR in a 5-part stack splitting the remote-training feature.

## Test plan

- [ ] `uv run pytest library/tests/unit/train/test_callbacks.py`

