### PR TITLE
fix: fix teleoperation from a robot without velocities

### DIFF
--- a/application/backend/src/workers/teleoperate_worker.py
+++ b/application/backend/src/workers/teleoperate_worker.py
@@ -88,7 +88,7 @@ class TeleoperateWorker(BaseProcessWorker):
         with self._action_read_state.get_lock():
             self._action_read_state.value = value
 
-    def _feature_values(
+    def _align_feature_values(
         self,
         source_state: dict[str, float],
         follower_state: dict[str, float] | None = None,
@@ -121,7 +121,7 @@ class TeleoperateWorker(BaseProcessWorker):
         # Set current actions to current follower state.
         # Features missing from follower state silently default to 0.0.
         state = (self.follower.read_state())["state"]
-        self._set_actions(self._feature_values(state))
+        self._set_actions(self._align_feature_values(state))
 
         self.loaded_event.set()
 
@@ -132,10 +132,10 @@ class TeleoperateWorker(BaseProcessWorker):
             while not self.should_stop():
                 async with run_at_frequency(self.frequency):
                     state = (self.follower.read_state())["state"]
-                    self._set_state(self._feature_values(state))
+                    self._set_state(self._align_feature_values(state))
                     if self.get_action_read_state() == ActionReadState.TELEOPERATION and self.leader is not None:
                         actions = (self.leader.read_state())["state"]
-                        filtered = self._feature_values(actions, follower_state=state)
+                        filtered = self._align_feature_values(actions, follower_state=state)
                         self.follower.set_joints_state(dict(zip(self.features, filtered)), goal_time * 2)
                         self._set_actions(filtered)
                     elif self.get_action_read_state() == ActionReadState.FROM_ACTIONS:

--- a/application/backend/src/workers/teleoperate_worker.py
+++ b/application/backend/src/workers/teleoperate_worker.py
@@ -88,6 +88,26 @@ class TeleoperateWorker(BaseProcessWorker):
         with self._action_read_state.get_lock():
             self._action_read_state.value = value
 
+    def _feature_values(
+        self,
+        leader_state: dict[str, float],
+        follower_state: dict[str, float] | None = None,
+    ) -> list[float]:
+        # Leader observations may not expose all follower features
+        # (e.g. follower has .vel keys while leader only publishes .pos).
+        # When a feature is missing from the leader state, fall back to
+        # the follower's current state so we always have a value for
+        # every feature in the shared memory buffer.
+        values: list[float] = []
+        for key in self.features:
+            if key in leader_state:
+                values.append(leader_state[key])
+            elif follower_state is not None and key in follower_state:
+                values.append(follower_state[key])
+            else:
+                values.append(0.0)
+        return values
+
     async def wait_for_loading_to_complete(self) -> None:
         await asyncio.to_thread(self.loaded_event.wait)
 
@@ -99,8 +119,9 @@ class TeleoperateWorker(BaseProcessWorker):
         self.follower.connect()
 
         # Set current actions to current follower state.
+        # Features missing from follower state silently default to 0.0.
         state = (self.follower.read_state())["state"]
-        self._set_actions([state[key] for key in self.features])
+        self._set_actions(self._feature_values(state))
 
         self.loaded_event.set()
 
@@ -111,11 +132,12 @@ class TeleoperateWorker(BaseProcessWorker):
             while not self.should_stop():
                 async with run_at_frequency(self.frequency):
                     state = (self.follower.read_state())["state"]
-                    self._set_state([state[key] for key in self.features])
+                    self._set_state(self._feature_values(state))
                     if self.get_action_read_state() == ActionReadState.TELEOPERATION and self.leader is not None:
                         actions = (self.leader.read_state())["state"]
-                        self.follower.set_joints_state(actions, goal_time * 2)
-                        self._set_actions([actions[key] for key in self.features])
+                        filtered = self._feature_values(actions, follower_state=state)
+                        self.follower.set_joints_state(dict(zip(self.features, filtered)), goal_time * 2)
+                        self._set_actions(filtered)
                     elif self.get_action_read_state() == ActionReadState.FROM_ACTIONS:
                         raw_actions = self.get_actions()
                         actions = {i: raw_actions[k] for k, i in enumerate(self.features)}

--- a/application/backend/src/workers/teleoperate_worker.py
+++ b/application/backend/src/workers/teleoperate_worker.py
@@ -90,18 +90,18 @@ class TeleoperateWorker(BaseProcessWorker):
 
     def _feature_values(
         self,
-        leader_state: dict[str, float],
+        source_state: dict[str, float],
         follower_state: dict[str, float] | None = None,
     ) -> list[float]:
         # Leader observations may not expose all follower features
         # (e.g. follower has .vel keys while leader only publishes .pos).
-        # When a feature is missing from the leader state, fall back to
+        # When a feature is missing from the source state, fall back to
         # the follower's current state so we always have a value for
         # every feature in the shared memory buffer.
         values: list[float] = []
         for key in self.features:
-            if key in leader_state:
-                values.append(leader_state[key])
+            if key in source_state:
+                values.append(source_state[key])
             elif follower_state is not None and key in follower_state:
                 values.append(follower_state[key])
             else:

--- a/application/backend/tests/workers/test_teleoperate_worker.py
+++ b/application/backend/tests/workers/test_teleoperate_worker.py
@@ -156,6 +156,41 @@ class TestTeleoperateWorkerRunLoop:
         follower.set_joints_state.assert_called()
         assert worker.get_actions() == [10.0, 20.0, 30.0]
 
+    def test_falls_back_to_follower_state_when_leader_missing_features(self):
+        stop_event = mp.Event()
+        features = ["j1.pos", "j1.vel", "j2.pos"]
+        follower_state = {"j1.pos": 1.0, "j1.vel": 2.0, "j2.pos": 3.0}
+        leader_state = {"j1.pos": 10.0, "j2.pos": 30.0}  # no .vel
+
+        follower = MagicMock()
+        follower.features.return_value = features
+        call_count = 0
+
+        def read_state():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                stop_event.set()
+            return {"state": follower_state}
+
+        follower.read_state.side_effect = read_state
+
+        leader = MagicMock()
+        leader.read_state.return_value = {"state": leader_state}
+
+        worker = _make_worker(follower=follower, leader=leader, stop_event=stop_event)
+        worker.set_action_read_state(ActionReadState.TELEOPERATION)
+        with patch("workers.teleoperate_worker.run_at_frequency", _noop_frequency):
+            asyncio.run(worker.run_loop())
+
+        # set_joints_state should receive all features, with .vel falling back to follower
+        expected_joints = {"j1.pos": 10.0, "j1.vel": 2.0, "j2.pos": 30.0}
+        follower.set_joints_state.assert_called()
+        assert follower.set_joints_state.call_args[0][0] == expected_joints
+
+        # actions should also include the fallback .vel value
+        assert worker.get_actions() == [10.0, 2.0, 30.0]
+
     def test_from_leader_ignored_when_no_leader(self):
         stop_event = mp.Event()
         follower = _make_client()


### PR DESCRIPTION
Before when teleoperating a follower robot that records `.vel` states while using a leader that only uses `.pos` states the teleoperate worker would crash due to a missing index.

This specific scenario occurred while testing the `rebot-b601-dm` (follower) arm with a `stararm` (leader). The rebot arm does record velocities but the stararm does not.