### PR TITLE
fix: use connection string (usb port) as a fallback if robot has no serial number

### DIFF
--- a/application/backend/src/api/hardware.py
+++ b/application/backend/src/api/hardware.py
@@ -4,10 +4,11 @@ from fastapi import APIRouter, Query
 from loguru import logger
 from physicalai.capture import DeviceInfo, discover_all
 
+from api.dependencies import RobotConnectionManagerDep
 from schemas import Camera, CameraProfile, Robot, SerialPortInfo
 from schemas.robot import RobotType
 from utils.camera_factory import DRIVER_KEY_MAP
-from utils.serial_robot_tools import find_robots, identify_so101_robot_visually
+from utils.serial_robot_tools import identify_so101_robot_visually
 from utils.trossen_robot_tools import identify_trossen_robot_visually
 
 router = APIRouter(prefix="/api/hardware", tags=["Hardware"])
@@ -52,16 +53,17 @@ async def get_cameras(
 
 
 @router.get("/serial_devices")
-async def get_robots() -> list[SerialPortInfo]:
+async def get_robots(robot_manager: RobotConnectionManagerDep) -> list[SerialPortInfo]:
     """Get all connected Robots"""
-    return await find_robots()
+    await robot_manager.find_robots()
+    return robot_manager.robots
 
 
 @router.post("/identify")
-async def identify_robot(robot: Robot, joint: str | None = None) -> None:
+async def identify_robot(robot_manager: RobotConnectionManagerDep, robot: Robot, joint: str | None = None) -> None:
     """Visually identify the robot by moving given joint on robot"""
     if robot.type in {RobotType.SO101_LEADER, RobotType.SO101_FOLLOWER}:
-        await identify_so101_robot_visually(robot, joint)
+        await identify_so101_robot_visually(robot_manager, robot, joint)
 
     if robot.type in {RobotType.TROSSEN_WIDOWXAI_LEADER, RobotType.TROSSEN_WIDOWXAI_FOLLOWER}:
         await identify_trossen_robot_visually(robot)

--- a/application/backend/src/api/robot_setup.py
+++ b/application/backend/src/api/robot_setup.py
@@ -5,7 +5,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, WebSocket, status
 from loguru import logger
 
-from api.dependencies import get_project_id
+from api.dependencies import RobotConnectionManagerDep, get_project_id
+from schemas import SerialPortInfo
 from schemas.robot import RobotType
 from workers.robots.so101_setup_worker import SO101SetupWorker
 from workers.transport.websocket_transport import WebSocketTransport
@@ -16,15 +17,18 @@ router = APIRouter(prefix="/api/projects/{project_id}/robots", tags=["Robot Setu
 @router.websocket("/setup/ws")
 async def robot_setup_websocket(
     _project_id: Annotated[str, Depends(get_project_id)],
+    robot_manager: RobotConnectionManagerDep,
     websocket: WebSocket,
     robot_type: str,
-    serial_number: str,
+    serial_number: str = "",
+    connection_string: str = "",
 ) -> None:
     """Establish a WebSocket connection for the SO101 robot setup wizard.
 
     Query parameters:
         robot_type: "SO101_Follower" or "SO101_Leader"
-        serial_number: USB serial number of the robot's controller board
+        serial_number: USB serial number of the robot's controller board (preferred)
+        connection_string: serial port path (fallback when serial_number is unavailable)
     """
     # Validate robot type
     if robot_type not in {RobotType.SO101_FOLLOWER, RobotType.SO101_LEADER}:
@@ -39,12 +43,12 @@ async def robot_setup_websocket(
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
 
-    if not serial_number:
+    if serial_number == "" and connection_string == "":
         await websocket.accept()
         await websocket.send_json(
             {
                 "event": "error",
-                "message": "serial_number is required",
+                "message": "Either serial_number or connection_string is required",
                 "error_code": "invalid_config",
             }
         )
@@ -54,10 +58,15 @@ async def robot_setup_websocket(
     await websocket.accept()
 
     try:
+        serial_port = SerialPortInfo(
+            connection_string=connection_string or None,
+            serial_number=serial_number or None,
+        )
         worker = SO101SetupWorker(
             transport=WebSocketTransport(websocket),
             robot_type=robot_type,
-            serial_number=serial_number,
+            serial_port=serial_port,
+            robot_manager=robot_manager,
         )
 
         await worker.run()

--- a/application/backend/src/robots/discovery/manager.py
+++ b/application/backend/src/robots/discovery/manager.py
@@ -1,7 +1,7 @@
 from robots.discovery.ip import IPDiscovery
 from robots.discovery.serial import SerialDiscovery
 from schemas import Robot
-from schemas.robot import RobotType
+from schemas.robot import RobotType, SO101Robot
 from utils.serial_robot_tools import RobotConnectionManager, find_so101_port, serial_port_from_so101
 
 _IP_SINGLE_TYPES = {RobotType.TROSSEN_WIDOWXAI_LEADER, RobotType.TROSSEN_WIDOWXAI_FOLLOWER}
@@ -19,6 +19,8 @@ class DiscoveryManager:
 
     async def is_robot_online(self, robot: Robot) -> bool:
         if robot.type in {RobotType.SO101_LEADER, RobotType.SO101_FOLLOWER}:
+            if not isinstance(robot, SO101Robot):
+                return False
             return await find_so101_port(self.serial_manager, serial_port_from_so101(robot)) is not None
         if robot.type in _IP_SINGLE_TYPES:
             return await self.ip.is_reachable(robot)

--- a/application/backend/src/robots/discovery/manager.py
+++ b/application/backend/src/robots/discovery/manager.py
@@ -2,7 +2,7 @@ from robots.discovery.ip import IPDiscovery
 from robots.discovery.serial import SerialDiscovery
 from schemas import Robot
 from schemas.robot import RobotType
-from utils.serial_robot_tools import RobotConnectionManager
+from utils.serial_robot_tools import RobotConnectionManager, find_so101_port, serial_port_from_so101
 
 _IP_SINGLE_TYPES = {RobotType.TROSSEN_WIDOWXAI_LEADER, RobotType.TROSSEN_WIDOWXAI_FOLLOWER}
 _IP_BIMANUAL_TYPES = {RobotType.TROSSEN_BIMANUAL_WIDOWXAI_LEADER, RobotType.TROSSEN_BIMANUAL_WIDOWXAI_FOLLOWER}
@@ -19,7 +19,7 @@ class DiscoveryManager:
 
     async def is_robot_online(self, robot: Robot) -> bool:
         if robot.type in {RobotType.SO101_LEADER, RobotType.SO101_FOLLOWER}:
-            return robot.payload.serial_number in [cs.serial_number for cs in self.serial_manager.robots]
+            return await find_so101_port(self.serial_manager, serial_port_from_so101(robot)) is not None
         if robot.type in _IP_SINGLE_TYPES:
             return await self.ip.is_reachable(robot)
         if robot.type in _IP_BIMANUAL_TYPES:

--- a/application/backend/src/robots/robot_client_factory.py
+++ b/application/backend/src/robots/robot_client_factory.py
@@ -8,8 +8,8 @@ from robots.physicalai_adapter import PhysicalAIRobotAdapter, PhysicalAIRobotAda
 from robots.robot_client import RobotClient
 from schemas.calibration import Calibration
 from schemas.robot import Robot, RobotType, SO101Robot, TrossenBimanualRobot
-from services.robot_calibration_service import RobotCalibrationService, find_robot_port
-from utils.serial_robot_tools import RobotConnectionManager
+from services.robot_calibration_service import RobotCalibrationService
+from utils.serial_robot_tools import RobotConnectionManager, find_so101_port, serial_port_from_so101
 
 
 class RobotClientFactory:
@@ -82,7 +82,7 @@ class RobotClientFactory:
         )
 
     async def _build_so101(self, robot: SO101Robot) -> PhysicalAIRobotAdapter:
-        port = await self._find_robot_port(robot)
+        port = await self.find_robot_port(robot)
         calibration = await self._get_robot_calibration(robot)
 
         if calibration is None:
@@ -116,11 +116,11 @@ class RobotClientFactory:
             ),
         )
 
-    async def _find_robot_port(self, robot: SO101Robot) -> str:
-        port = await find_robot_port(self.robot_manager, robot)
+    async def find_robot_port(self, robot: SO101Robot) -> str:
+        port = await find_so101_port(self.robot_manager, serial_port_from_so101(robot))
         if port is None:
-            raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
-
+            resource_key = robot.payload.serial_number or robot.payload.connection_string
+            raise ResourceNotFoundError(ResourceType.ROBOT, resource_key)
         return port
 
     async def _get_robot_calibration(self, robot: SO101Robot) -> Calibration | None:

--- a/application/backend/src/schemas/robot.py
+++ b/application/backend/src/schemas/robot.py
@@ -3,15 +3,14 @@ from enum import StrEnum
 from typing import Annotated, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
 from schemas.base import BaseIDModel
 
 
 class SerialPortInfo(BaseModel):
-    connection_string: str
-    serial_number: str
-    robot_type: str
+    connection_string: str | None
+    serial_number: str | None
 
 
 class BaseRobotConfig(BaseModel):
@@ -54,7 +53,13 @@ class SO101RobotPayload(BaseModel):
         default="",
         description="Serial port path; leave empty to auto-discover via serial_number",
     )
-    serial_number: str = Field(..., description="Unique serial number for the robot")
+    serial_number: str = Field(default="", description="USB serial number of the robot (when available)")
+
+    @model_validator(mode="after")
+    def validate_identifier(self) -> "SO101RobotPayload":
+        if self.connection_string == "" and self.serial_number == "":
+            raise ValueError("Either serial_number or connection_string is required for SO101 robots")
+        return self
 
 
 class TrossenSingleArmPayload(BaseModel):

--- a/application/backend/src/services/robot_calibration_service.py
+++ b/application/backend/src/services/robot_calibration_service.py
@@ -92,6 +92,8 @@ class RobotCalibrationService:
     async def get_robot_motor_calibration(self, robot: Robot) -> dict[str, MotorCalibration]:
         if robot.type not in (RobotType.SO101_FOLLOWER, RobotType.SO101_LEADER):
             raise ValueError(f"Trying to identify unsupported robot: {robot.type}")
+        if not isinstance(robot, SO101Robot):
+            raise ValueError(f"Trying to identify unsupported robot: {robot.type}")
 
         port = await find_robot_port(self.robot_manager, robot)
 

--- a/application/backend/src/services/robot_calibration_service.py
+++ b/application/backend/src/services/robot_calibration_service.py
@@ -10,24 +10,16 @@ from db.engine import get_async_db_session_ctx
 from exceptions import ResourceNotFoundError, ResourceType
 from repositories.robot_calibration_repo import RobotCalibrationRepository
 from schemas.calibration import Calibration
-from schemas.robot import Robot, RobotType
+from schemas.robot import Robot, RobotType, SO101Robot
 from settings import Settings
-from utils.serial_robot_tools import RobotConnectionManager
+from utils.serial_robot_tools import RobotConnectionManager, find_so101_port, serial_port_from_so101
 
 
 async def find_robot_port(manager: RobotConnectionManager, robot: Robot) -> str | None:
     """Find the port associated with a robot."""
-    for managed_robot in manager.robots:
-        if managed_robot.serial_number == robot.payload.serial_number:
-            return managed_robot.connection_string
-
-    await manager.find_robots()
-
-    for managed_robot in manager.robots:
-        if managed_robot.serial_number == robot.payload.serial_number:
-            return managed_robot.connection_string
-
-    return None
+    if not isinstance(robot, SO101Robot):
+        return None
+    return await find_so101_port(manager, serial_port_from_so101(robot))
 
 
 class RobotCalibrationService:
@@ -104,7 +96,8 @@ class RobotCalibrationService:
         port = await find_robot_port(self.robot_manager, robot)
 
         if port is None:
-            raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
+            resource_key = robot.payload.serial_number or robot.payload.connection_string
+            raise ResourceNotFoundError(ResourceType.ROBOT, resource_key)
 
         # TODO: make this depend on the robot type
         # Assume follower since leader shares same FeetechMotorBus layout

--- a/application/backend/src/utils/serial_robot_tools.py
+++ b/application/backend/src/utils/serial_robot_tools.py
@@ -9,14 +9,27 @@ from schemas import Robot, SerialPortInfo
 from schemas.robot import SO101Robot
 
 
-def from_port(port: ListPortInfo, robot_type: str) -> SerialPortInfo | None:
+def serial_port_from_so101(robot: SO101Robot) -> SerialPortInfo:
+    """Build a serial identity from an SO101 robot configuration."""
+    connection_string = robot.payload.connection_string or None
+    serial_number = robot.payload.serial_number or None
+    return SerialPortInfo(connection_string=connection_string, serial_number=serial_number)
+
+
+def from_port(port: ListPortInfo) -> SerialPortInfo | None:
     """Detect if the device is a SO-100 robot."""
+    serial_number = getattr(port, "serial_number", None)
+
+    # Ignore internal hardware
+    if port.device.startswith("/dev/ttyS"):
+        return None
+
     # The Feetech UART board CH340 has PID 29987
-    if port.pid in {21971, 29987}:
-        # The serial number is not always available
-        serial_number = port.serial_number or "no_serial"
-        return SerialPortInfo(connection_string=port.device, serial_number=serial_number, robot_type=robot_type)
-    return None
+    if port.pid not in {21971, 29987}:
+        logger.debug("Found usb port with unexpected PID, {device}: {pid}", device=port.device, pid=port.pid)
+        return None
+
+    return SerialPortInfo(connection_string=port.device, serial_number=serial_number or None)
 
 
 class RobotConnectionManager:
@@ -53,48 +66,51 @@ class RobotConnectionManager:
                 logger.debug(f"Skipping {port.device}: already connected (or alias).")
                 continue
 
-            for name in [
-                "so-100",
-            ]:
-                # logger.debug(f"Trying to connect to {name} on {port.device}.")
-                robot = from_port(port, robot_type=name)
-                if robot is None:
-                    # logger.debug(f"Failed to create robot from {name} on {port.device}.")
-                    continue
-                logger.debug(f"Robot created: {robot}")
-                # await robot.connect()
+            robot = from_port(port)
+            if robot is None:
+                continue
 
-                if robot is not None:
-                    logger.debug(f"Connected to {name} on {port.device}.")
-                    self._all_robots.append(robot)
-                    # Mark both device and serial as connected
-                    connected_devices.add(port.device)
-                    if serial_num:
-                        connected_serials.add(serial_num)
-                    break  # stop trying other classes on this port
+            logger.debug(f"Robot created: {robot}")
+            self._all_robots.append(robot)
+            connected_devices.add(port.device)
+            if serial_num:
+                connected_serials.add(serial_num)
 
         if not self._all_robots:
             logger.debug("No robot connected.")
 
 
-async def find_robots() -> list[SerialPortInfo]:
-    """Find all robots connected via serial"""
-    manager = RobotConnectionManager()
+def _resolve_serial_port(discovered: list[SerialPortInfo], target: SerialPortInfo) -> str | None:
+    if target.serial_number is not None:
+        for serial_port in discovered:
+            if serial_port.serial_number == target.serial_number:
+                return serial_port.connection_string
+        return None
+
+    for serial_port in discovered:
+        if serial_port.connection_string == target.connection_string:
+            return serial_port.connection_string
+    return None
+
+
+async def find_so101_port(
+    manager: RobotConnectionManager,
+    serial_port: SerialPortInfo,
+) -> str | None:
+    """Find the current port for an SO101 robot by serial number or configured port."""
+    port = _resolve_serial_port(manager.robots, serial_port)
+    if port is not None:
+        return port
+
     await manager.find_robots()
-    return manager.robots
+    return _resolve_serial_port(manager.robots, serial_port)
 
 
-def find_port_for_serial(serial_number: str) -> str:
-    """Find the serial port path given the serial number of the device"""
-    ports = list_ports.comports()
-    for port in ports:
-        serial_num = getattr(port, "serial_number", None)
-        if serial_num == serial_number:
-            return port.device
-    return ""
-
-
-async def identify_so101_robot_visually(robot: Robot, joint: str | None = None) -> None:
+async def identify_so101_robot_visually(
+    manager: RobotConnectionManager,
+    robot: Robot,
+    joint: str | None = None,
+) -> None:
     """Identify the robot by moving the joint from current to min to max to initial position"""
     if not isinstance(robot, SO101Robot):
         raise ValueError(f"Trying to identify unsupported robot: {robot.type}")
@@ -102,14 +118,12 @@ async def identify_so101_robot_visually(robot: Robot, joint: str | None = None) 
     if joint is None:
         joint = "gripper"
 
-    connection_string = robot.payload.connection_string
-    serial_number = robot.payload.serial_number
+    connection_string = await find_so101_port(manager, serial_port_from_so101(robot))
 
-    if connection_string == "" and serial_number != "":
-        connection_string = find_port_for_serial(serial_number)
-
-    if connection_string == "":
-        raise ValueError(f"Could not find the serial port for serial number {serial_number}")
+    if connection_string is None:
+        if robot.payload.serial_number:
+            raise ValueError(f"Could not find the serial port for serial number {robot.payload.serial_number}")
+        raise ValueError("Could not resolve a serial port from connection_string")
     # Assume follower since leader shares same FeetechMotorBus layout
     connection = SOFollower(SOFollowerRobotConfig(port=connection_string))
     connection.bus.connect()

--- a/application/backend/src/workers/robots/so101_setup_worker.py
+++ b/application/backend/src/workers/robots/so101_setup_worker.py
@@ -21,7 +21,8 @@ from lerobot.motors.feetech.feetech import FeetechMotorsBus
 from lerobot.motors.motors_bus import Motor, MotorCalibration, MotorNormMode
 from loguru import logger
 
-from utils.serial_robot_tools import find_port_for_serial
+from schemas import SerialPortInfo
+from utils.serial_robot_tools import RobotConnectionManager, find_so101_port
 from workers.transport.worker_transport import WorkerTransport
 from workers.transport_worker import TransportWorker, WorkerState
 
@@ -140,11 +141,13 @@ class SO101SetupWorker(TransportWorker):
         self,
         transport: WorkerTransport,
         robot_type: str,
-        serial_number: str,
+        serial_port: SerialPortInfo,
+        robot_manager: RobotConnectionManager,
     ) -> None:
         super().__init__(transport)
         self.robot_type = robot_type  # "SO101_Follower" or "SO101_Leader"
-        self.serial_number = serial_number
+        self.serial_port = serial_port
+        self.robot_manager = robot_manager
         self.phase = SetupPhase.CONNECTING
 
         self.bus: FeetechMotorsBus | None = None
@@ -242,16 +245,18 @@ class SO101SetupWorker(TransportWorker):
     # ------------------------------------------------------------------
 
     async def _connect_bus(self) -> None:
-        """Resolve serial number and open the motor bus."""
+        """Resolve the device path and open the motor bus."""
         self.phase = SetupPhase.CONNECTING
-        await self._send_phase_status("Resolving serial port...")
+        await self._send_phase_status("Resolving connection port...")
 
-        port = find_port_for_serial(self.serial_number)
-        if not port:
-            raise ConnectionError(f"No USB device found with serial number '{self.serial_number}'")
+        port = await find_so101_port(self.robot_manager, self.serial_port)
+        if port is None:
+            if self.serial_port.serial_number:
+                raise ConnectionError(f"No USB device found with serial number '{self.serial_port.serial_number}'")
+            raise ConnectionError(f"No USB device found at '{self.serial_port.connection_string or ''}'")
 
         self.port = port
-        logger.info(f"Setup worker: connecting to {port} (serial={self.serial_number})")
+        logger.info(f"Setup worker: connecting to {port} (serial={self.serial_port.serial_number})")
 
         self.bus = FeetechMotorsBus(port=port, motors=self.motors)
         try:

--- a/application/backend/tests/api/test_hardware.py
+++ b/application/backend/tests/api/test_hardware.py
@@ -1,10 +1,15 @@
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
 import pytest
+from fastapi.testclient import TestClient
 from physicalai.capture import DeviceInfo
 
+from api.dependencies import get_robot_manager_service
 from api.hardware import _fingerprint_from_device_info, get_cameras
+from main import app
+from schemas import SerialPortInfo
 
 
 def _make_device(
@@ -92,3 +97,94 @@ class TestGetCameras:
         with patch("api.hardware.discover_all", side_effect=fake_discover):
             cameras = event_loop.run_until_complete(get_cameras(all=False))
         assert len(cameras) == 1
+
+
+class _StubRobotManager:
+    def __init__(self, robots: list[SerialPortInfo]):
+        self.robots = robots
+        self.find_robots = AsyncMock()
+
+
+class TestHardwareApi:
+    def test_serial_devices_returns_devices_without_serial_numbers(self):
+        robot_manager = _StubRobotManager(
+            [
+                SerialPortInfo(connection_string="/dev/ttyUSB0", serial_number="ABC123"),
+                SerialPortInfo(connection_string="/dev/ttyUSB1", serial_number=None),
+            ]
+        )
+        app.dependency_overrides[get_robot_manager_service] = lambda: robot_manager
+
+        try:
+            client = TestClient(app)
+            response = client.get("/api/hardware/serial_devices")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200, response.text
+        assert response.json() == [
+            {"connection_string": "/dev/ttyUSB0", "serial_number": "ABC123"},
+            {"connection_string": "/dev/ttyUSB1", "serial_number": None},
+        ]
+        robot_manager.find_robots.assert_awaited_once()
+
+    def test_identify_so101_uses_robot_manager_dependency(self):
+        robot_manager = _StubRobotManager([])
+        app.dependency_overrides[get_robot_manager_service] = lambda: robot_manager
+
+        try:
+            client = TestClient(app)
+            with patch("api.hardware.identify_so101_robot_visually", new_callable=AsyncMock) as identify:
+                response = client.post(
+                    "/api/hardware/identify",
+                    params={"joint": "gripper"},
+                    json={
+                        "id": str(uuid4()),
+                        "name": "Test SO101",
+                        "type": "SO101_Follower",
+                        "payload": {
+                            "connection_string": "/dev/ttyUSB0",
+                            "serial_number": "",
+                        },
+                        "active_calibration_id": None,
+                    },
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200, response.text
+        identify.assert_awaited_once()
+        manager_arg, robot_arg, joint_arg = identify.await_args.args
+        assert manager_arg is robot_manager
+        assert robot_arg.type == "SO101_Follower"
+        assert robot_arg.payload.connection_string == "/dev/ttyUSB0"
+        assert joint_arg == "gripper"
+
+    def test_identify_trossen_calls_trossen_identifier(self):
+        robot_manager = _StubRobotManager([])
+        app.dependency_overrides[get_robot_manager_service] = lambda: robot_manager
+
+        try:
+            client = TestClient(app)
+            with patch("api.hardware.identify_trossen_robot_visually", new_callable=AsyncMock) as identify:
+                response = client.post(
+                    "/api/hardware/identify",
+                    json={
+                        "id": str(uuid4()),
+                        "name": "Test Trossen",
+                        "type": "Trossen_WidowXAI_Follower",
+                        "payload": {
+                            "connection_string": "192.168.1.100",
+                            "serial_number": "",
+                        },
+                        "active_calibration_id": None,
+                    },
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200, response.text
+        identify.assert_awaited_once()
+        (robot_arg,) = identify.await_args.args
+        assert robot_arg.type == "Trossen_WidowXAI_Follower"
+        assert robot_arg.payload.connection_string == "192.168.1.100"

--- a/application/ui/src/features/robots/robot-form/catalog/so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.tsx
@@ -76,13 +76,13 @@ export const SO101FormFields = () => {
                     isRequired
                     width='100%'
                     selectedKey={selectedKey}
-                    onSelectionChange={(selectedKey) => {
+                    onSelectionChange={(key) => {
                         const device = serialDevicesQuery.data.find(
                             (d) =>
                                 getDeviceKey({
                                     serial_number: d.serial_number ?? '',
                                     connection_string: d.connection_string,
-                                }) === String(selectedKey)
+                                }) === String(key)
                         );
 
                         if (device === undefined) {

--- a/application/ui/src/features/robots/robot-form/catalog/so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.tsx
@@ -24,7 +24,7 @@ export const buildSO101Body = (
     schemaType: SchemaRobotType,
     robot_id: string
 ): SchemaRobotInput | null => {
-    if (!formData.serial_number) {
+    if (!formData.serial_number && !formData.connection_string) {
         return null;
     }
 
@@ -39,6 +39,19 @@ export const buildSO101Body = (
     } as SchemaRobotInput;
 };
 
+const getDeviceKey = ({
+    serial_number,
+    connection_string,
+}: {
+    serial_number: string;
+    connection_string: string | null;
+}) => {
+    if (serial_number !== '') {
+        return `serial:${serial_number}`;
+    }
+    return `port:${connection_string ?? ''}`;
+};
+
 export const SO101FormFields = () => {
     const serialDevicesQuery = $api.useSuspenseQuery('get', '/api/hardware/serial_devices');
 
@@ -46,27 +59,57 @@ export const SO101FormFields = () => {
 
     const identifyMutation = useIdentifyMutation();
     const identifyRobot = buildSO101Body(formData, activeType, uuidv4());
+    const selectedKey =
+        formData.serial_number !== '' || formData.connection_string !== ''
+            ? getDeviceKey({
+                  serial_number: formData.serial_number,
+                  connection_string: formData.connection_string,
+              })
+            : null;
 
     return (
         <>
             <Flex gap='size-100' justifyContent={'space-between'} alignItems={'end'}>
                 <Picker
+                    name='payload.device_key'
                     label='Select robot'
                     isRequired
                     width='100%'
-                    selectedKey={formData.serial_number}
-                    onSelectionChange={(serial_number) => {
-                        const device = serialDevicesQuery.data.find((d) => d.serial_number === serial_number);
+                    selectedKey={selectedKey}
+                    onSelectionChange={(selectedKey) => {
+                        const device = serialDevicesQuery.data.find(
+                            (d) =>
+                                getDeviceKey({
+                                    serial_number: d.serial_number ?? '',
+                                    connection_string: d.connection_string,
+                                }) === String(selectedKey)
+                        );
 
-                        updateField('serial_number', String(serial_number));
-                        updateField('connection_string', device?.connection_string ?? '');
+                        if (device === undefined) {
+                            return;
+                        }
+
+                        const serial_number = device.serial_number ?? '';
+
+                        updateField('serial_number', serial_number);
+                        updateField('connection_string', device.connection_string ?? '');
                     }}
                 >
                     {serialDevicesQuery.data.map((serial_device) => {
+                        const serial_number = serial_device.serial_number ?? '';
+                        const hasSerial = serial_number !== '';
+                        const label = hasSerial ? serial_number : 'No serial number';
+
                         return (
-                            <Item key={serial_device.serial_number} textValue={serial_device.serial_number}>
-                                <Text>{serial_device.serial_number}</Text>
-                                <Text slot='description'>{serial_device.connection_string}</Text>
+                            <Item
+                                key={getDeviceKey({
+                                    serial_number,
+                                    connection_string: serial_device.connection_string,
+                                })}
+                                textValue={label}
+                            >
+                                <Text>{label}</Text>
+                                <Text slot='description'>{serial_device.connection_string ?? ''}</Text>
                             </Item>
                         );
                     })}

--- a/application/ui/src/features/robots/setup-wizard/so101/use-setup-websocket.ts
+++ b/application/ui/src/features/robots/setup-wizard/so101/use-setup-websocket.ts
@@ -125,6 +125,7 @@ interface UseSetupWebSocketOptions {
     projectId: string;
     robotType: string;
     serialNumber: string;
+    connectionString: string;
     enabled?: boolean;
 }
 
@@ -157,7 +158,13 @@ export interface SetupWebSocketState {
     isConnected: boolean;
 }
 
-export function useSetupWebSocket({ projectId, robotType, serialNumber, enabled = true }: UseSetupWebSocketOptions) {
+export function useSetupWebSocket({
+    projectId,
+    robotType,
+    serialNumber,
+    connectionString,
+    enabled = true,
+}: UseSetupWebSocketOptions) {
     const [state, setState] = useState<SetupWebSocketState>({
         phase: null,
         statusMessage: null,
@@ -237,12 +244,13 @@ export function useSetupWebSocket({ projectId, robotType, serialNumber, enabled 
         }
     }, []);
 
-    const url =
-        enabled && robotType && serialNumber
-            ? `/api/projects/${projectId}/robots/setup/ws` +
-              `?robot_type=${encodeURIComponent(robotType)}` +
-              `&serial_number=${encodeURIComponent(serialNumber)}`
-            : null;
+    const hasIdentifier = !!serialNumber || !!connectionString;
+    const query =
+        `?robot_type=${encodeURIComponent(robotType)}` +
+        `&serial_number=${encodeURIComponent(serialNumber)}` +
+        `&connection_string=${encodeURIComponent(connectionString)}`;
+
+    const url = enabled && robotType && hasIdentifier ? `/api/projects/${projectId}/robots/setup/ws${query}` : null;
 
     const { sendJsonMessage, readyState } = useWebSocket(url, {
         onMessage: handleMessage,

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -104,8 +104,9 @@ export const VerificationStep = () => {
     const { wsState } = useSetupState();
     const { activeType, robotForm } = useRobotForm();
 
-    const serialNumber = robotForm.serial_number;
-    const robotType = activeType ?? '';
+    const serialNumber = robotForm.serial_number ?? '';
+    const connectionString = 'connection_string' in robotForm ? (robotForm.connection_string ?? '') : '';
+    const robotType = activeType;
 
     const [robotId] = useState(() => uuidv4());
     const [calibrationId] = useState(() => uuidv4());
@@ -209,7 +210,10 @@ export const VerificationStep = () => {
                             <strong>Type:</strong> {robotType}
                         </Text>
                         <Text>
-                            <strong>Serial:</strong> {serialNumber}
+                            <strong>Serial:</strong> {serialNumber || 'Unavailable'}
+                        </Text>
+                        <Text>
+                            <strong>USB Port:</strong> {connectionString || 'Unavailable'}
                         </Text>
                         <Text>
                             <strong>Calibration:</strong>{' '}

--- a/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
@@ -158,15 +158,17 @@ export const SetupWizardProvider = ({ children }: { children: ReactNode }) => {
     // -----------------------------------------------------------------------
     // WebSocket hook
     // -----------------------------------------------------------------------
+    const serialNumber = robotForm.serial_number ?? '';
+    const robotType = activeType;
+    const connectionString = 'connection_string' in robotForm ? (robotForm.connection_string ?? '') : '';
 
-    const serialNumber = robotForm.serial_number;
-    const robotType = activeType ?? '';
-    const wsEnabled = !!serialNumber && robotType.startsWith('SO101');
+    const wsEnabled = (!!serialNumber || !!connectionString) && robotType.startsWith('SO101');
 
     const { state: wsState, commands } = useSetupWebSocket({
         projectId,
         robotType,
         serialNumber,
+        connectionString,
         enabled: wsEnabled,
     });
 


### PR DESCRIPTION
Some robots don't have a serial number, in which case we use its connection string (usb port) as a fallback.

In particular this will fix connection issues with virtual usbs, with the rebot and stararm as well as other so101 arms that use a control board that our team didn't test before.