### PR TITLE
chore: make setup/ws arguments optional

### DIFF
--- a/application/backend/src/api/robot_setup.py
+++ b/application/backend/src/api/robot_setup.py
@@ -20,8 +20,8 @@ async def robot_setup_websocket(
     robot_manager: RobotConnectionManagerDep,
     websocket: WebSocket,
     robot_type: str,
-    serial_number: str = "",
-    connection_string: str = "",
+    serial_number: str | None = None,
+    connection_string: str | None = None,
 ) -> None:
     """Establish a WebSocket connection for the SO101 robot setup wizard.
 
@@ -59,8 +59,8 @@ async def robot_setup_websocket(
 
     try:
         serial_port = SerialPortInfo(
-            connection_string=connection_string or None,
-            serial_number=serial_number or None,
+            connection_string=connection_string,
+            serial_number=serial_number,
         )
         worker = SO101SetupWorker(
             transport=WebSocketTransport(websocket),

--- a/application/backend/src/api/robot_setup.py
+++ b/application/backend/src/api/robot_setup.py
@@ -43,7 +43,7 @@ async def robot_setup_websocket(
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
 
-    if serial_number == "" and connection_string == "":
+    if not serial_number and not connection_string:
         await websocket.accept()
         await websocket.send_json(
             {

--- a/application/ui/src/features/robots/setup-wizard/so101/use-setup-websocket.ts
+++ b/application/ui/src/features/robots/setup-wizard/so101/use-setup-websocket.ts
@@ -124,8 +124,8 @@ export type SetupEvent =
 interface UseSetupWebSocketOptions {
     projectId: string;
     robotType: string;
-    serialNumber: string;
-    connectionString: string;
+    serialNumber?: string;
+    connectionString?: string;
     enabled?: boolean;
 }
 
@@ -244,13 +244,21 @@ export function useSetupWebSocket({
         }
     }, []);
 
-    const hasIdentifier = !!serialNumber || !!connectionString;
-    const query =
-        `?robot_type=${encodeURIComponent(robotType)}` +
-        `&serial_number=${encodeURIComponent(serialNumber)}` +
-        `&connection_string=${encodeURIComponent(connectionString)}`;
+    const searchParams = new URLSearchParams({
+        robot_type: robotType,
+    });
 
-    const url = enabled && robotType && hasIdentifier ? `/api/projects/${projectId}/robots/setup/ws${query}` : null;
+    if (serialNumber) {
+        searchParams.set('serial_number', serialNumber);
+    }
+
+    if (connectionString) {
+        searchParams.set('connection_string', connectionString);
+    }
+
+    const query = `?${searchParams.toString()}`;
+
+    const url = enabled && robotType ? `/api/projects/${projectId}/robots/setup/ws${query}` : null;
 
     const { sendJsonMessage, readyState } = useWebSocket(url, {
         onMessage: handleMessage,


### PR DESCRIPTION
Follow up code improvement of #760, making `serial_number` and `connection_string` during setup explicitly `None`.