### PR TITLE
refactor(robot-form): move name field into form fields

### DIFF
--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -39,24 +39,44 @@ const RobotType = () => {
 };
 
 const FormFields = ({ robotType }: { robotType: SchemaRobotType }) => {
+    const { formData, updateField } = useRobotFormFields();
+
+    let formFields = null;
     switch (robotType) {
         case 'SO101_Follower':
         case 'SO101_Leader':
-            return <SO101FormFields />;
+            formFields = <SO101FormFields />;
+            break;
         case 'Trossen_WidowXAI_Follower':
         case 'Trossen_WidowXAI_Leader':
-            return <WidowxAIFormFields />;
+            formFields = <WidowxAIFormFields />;
+            break;
         case 'Trossen_Bimanual_WidowXAI_Leader':
         case 'Trossen_Bimanual_WidowXAI_Follower':
-            return <BiManualWidowxAIFormFields />;
+            formFields = <BiManualWidowxAIFormFields />;
+            break;
     }
+
+    return (
+        <>
+            <TextField
+                isRequired
+                label='Robot name'
+                width='100%'
+                onChange={(name) => {
+                    updateField('name', name);
+                }}
+                value={formData.name}
+            />
+            {formFields}
+        </>
+    );
 };
 
 export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNewRobotButton /> }) => {
     const { project_id } = useProjectId();
 
     const { activeType } = useRobotForm();
-    const { formData: activeFormData, updateField } = useRobotFormFields();
 
     const submitContainerRef = useRef<HTMLDivElement>(null);
 
@@ -88,18 +108,6 @@ export const RobotForm = ({ heading = 'Add new robot', submitButton = <SubmitNew
             <Form onSubmit={handleSubmit}>
                 <Flex direction='column' gap='size-200'>
                     <Flex direction='column' gap='size-200' width='100%'>
-                        <TextField
-                            isRequired
-                            label='Robot name'
-                            width='100%'
-                            onChange={(name) => {
-                                updateField('name', name);
-                            }}
-                            value={activeFormData.name}
-                        />
-
-                        {/* Put robot type first as we can use it to visualize the robot
-                          and determine how to connect with it */}
                         <RobotType />
 
                         <FormFields robotType={activeType} />

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -67,12 +67,7 @@ export const RobotFormProvider = ({ children, robot }: { children: ReactNode; ro
                 return { ...prev, activeType: type, [type]: { ...oldSlice } as FormDataForSchema[T] };
             }
 
-            return {
-                ...prev,
-                activeType: type,
-                // Don't overwrite robot name as name is presented before robot type picker
-                [type]: { ...(prev[type] as FormDataForSchema[T]), name: oldSlice.name },
-            };
+            return { ...prev, activeType: type };
         });
     }, []);
 


### PR DESCRIPTION
A minor change that moves the robot type picker to be the first element in the robot form and moves the name text field each respective robot's `FormField` component.
This change mainly makes it easier to implement #761 as we can reuse `FormFields` when we reconfigure the robot.

## Screenshots

<img width="1280" height="720" alt="Robot type picker has been moved to be before robot name" src="https://github.com/user-attachments/assets/29154bbb-fe92-4a97-8ed4-326a2a516705" />
