### PR TITLE
fix: clear settings cache before serving studio

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,7 @@
 !application/backend/README.md
 !application/backend/run.sh
 !application/backend/src/
+application/backend/src/static/robot-assets
 !application/backend/scripts/hatch_build.py
 
 # ---- Application: Docker ----

--- a/application/backend/docs/distribution.md
+++ b/application/backend/docs/distribution.md
@@ -68,10 +68,11 @@ The wheel contains:
 - Alembic configuration and migrations.
 - A `physicalai-studio` console script with a `serve` command that runs the backend and UI together.
 - The production UI build from `application/ui/dist`, packaged into the wheel as `webui/`.
+- Built-in robot URDF and mesh assets, packaged into the wheel as `static/robot-assets/`.
 
 Supported options: `--host 127.0.0.1 --port 7860`.
 
-The UI is included through a `force_include` entry that `scripts/hatch_build.py` adds to `build_data` during non-editable builds. The hatch hook also prevents publishing a wheel without the frontend and transforms relative URLs in the app README to absolute GitHub URLs for the PyPI description.
+The UI and robot assets are included through `force_include` entries that `scripts/hatch_build.py` adds to `build_data` during non-editable builds. The hatch hook also prevents publishing a wheel without the frontend, validates required robot assets are present, and transforms relative URLs in the app README to absolute GitHub URLs for the PyPI description.
 
 ## GitHub Actions
 
@@ -116,7 +117,7 @@ application/backend/dist/
 
 ### Inspect Wheel Contents
 
-Confirm that the wheel contains UI assets and migrations:
+Confirm that the wheel contains UI assets, robot assets, and migrations:
 
 ```python
 from pathlib import Path
@@ -128,21 +129,29 @@ with ZipFile(wheel) as zf:
 
 for name in (
     "webui/index.html",
+    "static/robot-assets/SO101/so101_new_calib.urdf",
+    "static/robot-assets/widowx/urdf/generated/wxai/wxai_follower.urdf",
+    "static/robot-assets/widowx/urdf/generated/stationary_ai.urdf",
     "alembic.ini",
     "alembic/env.py",
 ):
     print(f"{name}: {name in names}")
 
 print("webui file count:", sum(name.startswith("webui/") for name in names))
+print("robot asset file count:", sum(name.startswith("static/robot-assets/") for name in names))
 ```
 
 Expected:
 
 ```text
 webui/index.html: True
+static/robot-assets/SO101/so101_new_calib.urdf: True
+static/robot-assets/widowx/urdf/generated/wxai/wxai_follower.urdf: True
+static/robot-assets/widowx/urdf/generated/stationary_ai.urdf: True
 alembic.ini: True
 alembic/env.py: True
 webui file count: <non-zero>
+robot asset file count: <non-zero>
 ```
 
 ### Test The Wheel Locally With uvx
@@ -191,6 +200,14 @@ Or point directly to the wheel file:
 ```
 
 ### Missing UI Assets In The Wheel
+
+Run:
+
+```bash
+bash application/backend/scripts/build_package.sh
+```
+
+### Missing Robot Assets In The Wheel
 
 Run:
 

--- a/application/backend/scripts/build_package.sh
+++ b/application/backend/scripts/build_package.sh
@@ -10,6 +10,7 @@ cd "${BACKEND_DIR}"
 
 uv sync --frozen --extra xpu
 uv run physicalai-studio gen-api --target-path openapi-spec.json
+uv run physicalai-studio sync-robot-assets
 
 cd "${UI_DIR}"
 npm ci

--- a/application/backend/scripts/hatch_build.py
+++ b/application/backend/scripts/hatch_build.py
@@ -81,7 +81,6 @@ class CustomBuildHook(BuildHookInterface):
 
         build_data["force_include"] = {
             "../ui/dist": "webui",
-            "src/static/robot-assets": "static/robot-assets",
         }
 
         app_readme = Path(self.root).parent / "README.md"

--- a/application/backend/scripts/hatch_build.py
+++ b/application/backend/scripts/hatch_build.py
@@ -9,6 +9,11 @@ BRANCH = "main"
 
 _RELATIVE_URL_RE = re.compile(r"(!?)\[([^\]]*)\]\(([^)]+)\)")
 _IMG_SRC_RE = re.compile(r'(<img\s[^>]*src=")([^"]+)(")')
+_REQUIRED_ROBOT_ASSET_PATHS = (
+    Path("SO101/so101_new_calib.urdf"),
+    Path("widowx/urdf/generated/wxai/wxai_follower.urdf"),
+    Path("widowx/urdf/generated/stationary_ai.urdf"),
+)
 
 
 def _resolve_relative(url: str) -> str:
@@ -59,7 +64,25 @@ class CustomBuildHook(BuildHookInterface):
             )
             raise FileNotFoundError(msg)
 
-        build_data["force_include"] = {"../ui/dist": "webui"}
+        robot_assets_root = Path(self.root) / "src" / "static" / "robot-assets"
+        missing_assets = [
+            str(relative_path)
+            for relative_path in _REQUIRED_ROBOT_ASSET_PATHS
+            if not (robot_assets_root / relative_path).exists()
+        ]
+        if missing_assets:
+            msg = (
+                "Missing required robot assets in application/backend/src/static/robot-assets: "
+                + ", ".join(missing_assets)
+                + ". Run 'physicalai-studio sync-robot-assets' before building the package, "
+                "or run application/backend/scripts/build_package.sh."
+            )
+            raise FileNotFoundError(msg)
+
+        build_data["force_include"] = {
+            "../ui/dist": "webui",
+            "src/static/robot-assets": "static/robot-assets",
+        }
 
         app_readme = Path(self.root).parent / "README.md"
         target = Path(self.root) / "README.md"

--- a/application/backend/scripts/hatch_build.py
+++ b/application/backend/scripts/hatch_build.py
@@ -79,9 +79,18 @@ class CustomBuildHook(BuildHookInterface):
             )
             raise FileNotFoundError(msg)
 
-        build_data["force_include"] = {
+        force_include = {
             "../ui/dist": "webui",
         }
+
+        # When building from a git checkout, Hatch respects .gitignore and would
+        # skip src/static/robot-assets by default. In Docker/CI contexts without
+        # .git metadata, these files are already discovered under src and forcing
+        # them again would create duplicate archive entries.
+        if (Path(self.root).parent.parent / ".git").exists():
+            force_include["src/static/robot-assets"] = "static/robot-assets"
+
+        build_data["force_include"] = force_include
 
         app_readme = Path(self.root).parent / "README.md"
         target = Path(self.root) / "README.md"

--- a/application/backend/src/cli/serve.py
+++ b/application/backend/src/cli/serve.py
@@ -12,8 +12,6 @@ from robots.catalog.assets import builtin_robot_assets_are_available
 from robots.catalog.sync_robot_assets import sync_robot_assets
 from settings import get_settings
 
-settings = get_settings()
-
 
 def _package_root() -> Path:
     return Path(__file__).resolve().parent.parent
@@ -29,10 +27,13 @@ def _configure_packaged_runtime() -> None:
     os.environ.setdefault("ALEMBIC_CONFIG_PATH", str(package_root / "alembic.ini"))
     os.environ.setdefault("ALEMBIC_SCRIPT_LOCATION", str(package_root / "alembic"))
 
+    # Refresh cached settings so downstream DB/migration modules observe packaged paths.
+    get_settings.cache_clear()
+
 
 @click.command()
-@click.option("--host", default=settings.host, show_default=True)
-@click.option("--port", default=settings.port, show_default=True, type=int)
+@click.option("--host", default=lambda: get_settings().host, show_default=True)
+@click.option("--port", default=lambda: get_settings().port, show_default=True, type=int)
 def serve(host: str, port: int) -> None:
     """Start the Physical AI Studio web application."""
     _configure_packaged_runtime()

--- a/application/backend/tests/cli/test_serve.py
+++ b/application/backend/tests/cli/test_serve.py
@@ -1,4 +1,5 @@
 import importlib
+from pathlib import Path
 
 import pytest
 
@@ -47,3 +48,32 @@ def test_sync_missing_robot_assets_exits_when_sync_fails(monkeypatch) -> None:
 
     with pytest.raises(SystemExit):
         serve_module._sync_missing_robot_assets()
+
+
+def test_configure_packaged_runtime_refreshes_cached_settings(monkeypatch) -> None:
+    settings_module = importlib.import_module("settings")
+    settings_module.get_settings.cache_clear()
+
+    stale_settings = settings_module.get_settings()
+    assert stale_settings.alembic_script_location == "src/alembic"
+
+    fake_package_root = Path("/tmp/packaged-root")
+    monkeypatch.setattr(serve_module, "_package_root", lambda: fake_package_root)
+
+    monkeypatch.delenv("ALEMBIC_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("ALEMBIC_SCRIPT_LOCATION", raising=False)
+    monkeypatch.delenv("STATIC_FILES_DIR", raising=False)
+
+    serve_module._configure_packaged_runtime()
+
+    refreshed_settings = settings_module.get_settings()
+    assert refreshed_settings.alembic_config_path == str(fake_package_root / "alembic.ini")
+    assert refreshed_settings.alembic_script_location == str(fake_package_root / "alembic")
+
+
+def test_serve_click_defaults_are_lazy_and_use_settings() -> None:
+    host_option = next(param for param in serve_module.serve.params if param.name == "host")
+    port_option = next(param for param in serve_module.serve.params if param.name == "port")
+
+    assert callable(host_option.default)
+    assert callable(port_option.default)

--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -176,6 +176,20 @@ RUN uv pip uninstall --python .venv/bin/python \
     expecttest hypothesis sortedcontainers kgb parameterized
 
 # ===========================================================================
+# Stage 4d: Robot assets builder
+#
+# Sync backend-owned robot assets once so all runtime targets can copy the
+# exact same files before the backend wheel install step.
+# ===========================================================================
+FROM builder-base AS robot-assets
+
+COPY --link --from=app-source /app/application/backend/src /app/application/backend/src
+
+RUN PYTHONPATH=/app/application/backend/src \
+    /app/application/backend/.venv/bin/python -c \
+    "from robots.catalog.sync_robot_assets import sync_robot_assets; sync_robot_assets()"
+
+# ===========================================================================
 # Stage 5: Runtime base — shared across all hardware targets
 #
 # Provides the non-root user, common runtime libraries, environment
@@ -252,11 +266,12 @@ ARG APP_GID=1000
 COPY --link --from=builder-cpu --chown=${APP_UID}:${APP_GID} \
     /app/application/backend/.venv /app/application/backend/.venv
 COPY --link --from=app-source --chown=${APP_UID}:${APP_GID} /app /app
+COPY --link --from=robot-assets --chown=${APP_UID}:${APP_GID} \
+    /app/application/backend/src/static/robot-assets /app/application/backend/src/static/robot-assets
 RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps /app/application/backend
 
 WORKDIR /app/application/backend
 USER appuser
-RUN physicalai-studio sync-robot-assets
 CMD ["./run.sh"]
 
 # ===========================================================================
@@ -306,11 +321,12 @@ ARG APP_GID=1000
 COPY --link --from=builder-xpu --chown=${APP_UID}:${APP_GID} \
     /app/application/backend/.venv /app/application/backend/.venv
 COPY --link --from=app-source --chown=${APP_UID}:${APP_GID} /app /app
+COPY --link --from=robot-assets --chown=${APP_UID}:${APP_GID} \
+    /app/application/backend/src/static/robot-assets /app/application/backend/src/static/robot-assets
 RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps /app/application/backend
 
 WORKDIR /app/application/backend
 USER appuser
-RUN physicalai-studio sync-robot-assets
 CMD ["./run.sh"]
 
 # ===========================================================================
@@ -379,9 +395,10 @@ ARG APP_GID=1000
 COPY --link --from=builder-cuda --chown=${APP_UID}:${APP_GID} \
     /app/application/backend/.venv /app/application/backend/.venv
 COPY --link --from=app-source --chown=${APP_UID}:${APP_GID} /app /app
+COPY --link --from=robot-assets --chown=${APP_UID}:${APP_GID} \
+    /app/application/backend/src/static/robot-assets /app/application/backend/src/static/robot-assets
 RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps /app/application/backend
 
 WORKDIR /app/application/backend
 USER appuser
-RUN physicalai-studio sync-robot-assets
 CMD ["./run.sh"]

--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -252,7 +252,7 @@ ARG APP_GID=1000
 COPY --link --from=builder-cpu --chown=${APP_UID}:${APP_GID} \
     /app/application/backend/.venv /app/application/backend/.venv
 COPY --link --from=app-source --chown=${APP_UID}:${APP_GID} /app /app
-RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps /app/application/backend
+RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps -e /app/application/backend
 
 WORKDIR /app/application/backend
 USER appuser
@@ -306,7 +306,7 @@ ARG APP_GID=1000
 COPY --link --from=builder-xpu --chown=${APP_UID}:${APP_GID} \
     /app/application/backend/.venv /app/application/backend/.venv
 COPY --link --from=app-source --chown=${APP_UID}:${APP_GID} /app /app
-RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps /app/application/backend
+RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps -e /app/application/backend
 
 WORKDIR /app/application/backend
 USER appuser
@@ -379,7 +379,7 @@ ARG APP_GID=1000
 COPY --link --from=builder-cuda --chown=${APP_UID}:${APP_GID} \
     /app/application/backend/.venv /app/application/backend/.venv
 COPY --link --from=app-source --chown=${APP_UID}:${APP_GID} /app /app
-RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps /app/application/backend
+RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps -e /app/application/backend
 
 WORKDIR /app/application/backend
 USER appuser

--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -252,7 +252,7 @@ ARG APP_GID=1000
 COPY --link --from=builder-cpu --chown=${APP_UID}:${APP_GID} \
     /app/application/backend/.venv /app/application/backend/.venv
 COPY --link --from=app-source --chown=${APP_UID}:${APP_GID} /app /app
-RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps -e /app/application/backend
+RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps /app/application/backend
 
 WORKDIR /app/application/backend
 USER appuser
@@ -306,7 +306,7 @@ ARG APP_GID=1000
 COPY --link --from=builder-xpu --chown=${APP_UID}:${APP_GID} \
     /app/application/backend/.venv /app/application/backend/.venv
 COPY --link --from=app-source --chown=${APP_UID}:${APP_GID} /app /app
-RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps -e /app/application/backend
+RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps /app/application/backend
 
 WORKDIR /app/application/backend
 USER appuser
@@ -379,7 +379,7 @@ ARG APP_GID=1000
 COPY --link --from=builder-cuda --chown=${APP_UID}:${APP_GID} \
     /app/application/backend/.venv /app/application/backend/.venv
 COPY --link --from=app-source --chown=${APP_UID}:${APP_GID} /app /app
-RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps -e /app/application/backend
+RUN uv pip install --python /app/application/backend/.venv/bin/python --no-deps /app/application/backend
 
 WORKDIR /app/application/backend
 USER appuser


### PR DESCRIPTION
This PR is a follow up of #764 that makes it so that our build script includes the URDF files of SO101 and Widowx AI arms in our python distribution.

It also includes an important fix (last commit) that makes it so that we clear our settings cache before serving studio. This is important as we overwrite `STATIC_FILES_DIR`, `ALEMBIC_CONFIG_PATH` and `ALEMBIC_SCRIPT_LOCATION` to target files relative to the packaged application.
Without these we'd get an error when serving the application outside of the `application/backend` directory.
This broke when `settings = get_settings()` was moved to the outer scope of `cli/serve.py`.