### PR TITLE
fix: do allow setup of SO101 if there's no serial number

### DIFF
--- a/application/ui/src/features/robots/robot-form/submit-new-robot-button.tsx
+++ b/application/ui/src/features/robots/robot-form/submit-new-robot-button.tsx
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { $api } from '../../../api/client';
 import { useProjectId } from '../../../features/projects/use-project';
 import { paths } from '../../../router';
-import { useRobotFormBody } from './provider';
+import { useRobotForm, useRobotFormBody } from './provider';
 
 export const SubmitNewRobotButton = () => {
     const navigate = useNavigate();
@@ -22,6 +22,9 @@ export const SubmitNewRobotButton = () => {
 
     const body = useRobotFormBody(uuidv4());
 
+    const { activeType } = useRobotForm();
+    const isSO101 = activeType === 'SO101_Follower' || activeType === 'SO101_Leader';
+
     return (
         <Button
             variant='accent'
@@ -30,6 +33,10 @@ export const SubmitNewRobotButton = () => {
             onPress={async () => {
                 if (body === null) {
                     return;
+                }
+
+                if (isSO101) {
+                    return navigate(paths.project.robots.so101Setup({ project_id }));
                 }
 
                 await addRobotMutation.mutateAsync(
@@ -45,7 +52,7 @@ export const SubmitNewRobotButton = () => {
                 );
             }}
         >
-            Add robot
+            {isSO101 ? 'Begin setup' : 'Add robot'}
         </Button>
     );
 };

--- a/application/ui/src/routes/robots/new.tsx
+++ b/application/ui/src/routes/robots/new.tsx
@@ -1,14 +1,10 @@
 import { Suspense } from 'react';
 
-import { Button, Flex, Grid, Loading, minmax, View } from '@geti-ui/ui';
-import { useNavigate } from 'react-router';
+import { Flex, Grid, Loading, minmax, View } from '@geti-ui/ui';
 
-import { useProjectId } from '../../features/projects/use-project';
 import { RobotForm } from '../../features/robots/robot-form/form';
 import { Preview } from '../../features/robots/robot-form/preview';
-import { useRobotForm } from '../../features/robots/robot-form/provider';
 import { SubmitNewRobotButton } from '../../features/robots/robot-form/submit-new-robot-button';
-import { paths } from '../../router';
 
 const CenteredLoading = () => {
     return (
@@ -18,49 +14,12 @@ const CenteredLoading = () => {
     );
 };
 
-const BeginSO101SetupButton = ({ activeType }: { activeType: 'SO101_Follower' | 'SO101_Leader' }) => {
-    const { robotForm } = useRobotForm(activeType);
-    const navigate = useNavigate();
-    const { project_id } = useProjectId();
-
-    const isDisabled = !robotForm.name || !activeType || (!robotForm.serial_number && !robotForm.connection_string);
-
-    return (
-        <Button
-            variant='accent'
-            isDisabled={isDisabled}
-            onPress={() => {
-                navigate(paths.project.robots.so101Setup({ project_id }));
-            }}
-        >
-            Begin Setup
-        </Button>
-    );
-};
-
-/**
- * Submit button that adapts to the selected robot type:
- * - SO101 types: navigates to the setup wizard (sibling route under same layout)
- * - Other types (Trossen): directly creates the robot via POST (default behavior)
- */
-const NewRobotSubmitButton = () => {
-    const { activeType } = useRobotForm();
-
-    const isSO101 = activeType === 'SO101_Follower' || activeType === 'SO101_Leader';
-
-    if (isSO101) {
-        return <BeginSO101SetupButton activeType={activeType} />;
-    }
-
-    return <SubmitNewRobotButton />;
-};
-
 export const New = () => {
     return (
         <Grid areas={['robot controls']} columns={[minmax('size-6000', 'auto'), '1fr']} height={'100%'}>
             <View gridArea='robot' backgroundColor={'gray-100'} padding='size-400'>
                 <Suspense fallback={<CenteredLoading />}>
-                    <RobotForm submitButton={<NewRobotSubmitButton />} />
+                    <RobotForm submitButton={<SubmitNewRobotButton />} />
                 </Suspense>
             </View>
             <View gridArea='controls'>

--- a/application/ui/src/routes/robots/new.tsx
+++ b/application/ui/src/routes/robots/new.tsx
@@ -18,23 +18,12 @@ const CenteredLoading = () => {
     );
 };
 
-/**
- * Submit button that adapts to the selected robot type:
- * - SO101 types: navigates to the setup wizard (sibling route under same layout)
- * - Other types (Trossen): directly creates the robot via POST (default behavior)
- */
-const NewRobotSubmitButton = () => {
-    const { activeType, robotForm } = useRobotForm();
+const BeginSO101SetupButton = ({ activeType }: { activeType: 'SO101_Follower' | 'SO101_Leader' }) => {
+    const { robotForm } = useRobotForm(activeType);
     const navigate = useNavigate();
     const { project_id } = useProjectId();
 
-    const isSO101 = activeType?.toLowerCase().startsWith('so101') ?? false;
-
-    if (!isSO101) {
-        return <SubmitNewRobotButton />;
-    }
-
-    const isDisabled = !robotForm.name || !activeType || !robotForm.serial_number;
+    const isDisabled = !robotForm.name || !activeType || (!robotForm.serial_number && !robotForm.connection_string);
 
     return (
         <Button
@@ -47,6 +36,23 @@ const NewRobotSubmitButton = () => {
             Begin Setup
         </Button>
     );
+};
+
+/**
+ * Submit button that adapts to the selected robot type:
+ * - SO101 types: navigates to the setup wizard (sibling route under same layout)
+ * - Other types (Trossen): directly creates the robot via POST (default behavior)
+ */
+const NewRobotSubmitButton = () => {
+    const { activeType } = useRobotForm();
+
+    const isSO101 = activeType === 'SO101_Follower' || activeType === 'SO101_Leader';
+
+    if (isSO101) {
+        return <BeginSO101SetupButton activeType={activeType} />;
+    }
+
+    return <SubmitNewRobotButton />;
 };
 
 export const New = () => {


### PR DESCRIPTION
We were still doing a check on the serial number during the SO101 setup. I don't have a SO101 without serial number so forgot to verify this.