### PR TITLE
chore(ci): add `skill-scan`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -90,6 +90,15 @@
       schedule: ["* * 1,15 * *"], // twice a month
     },
 
+    // Custom semver versioning for geti-ci actions to support tags like zizmor/v0.1.0
+    {
+      groupName: "GitHub Actions",
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["open-edge-platform/geti-ci"],
+      schedule: ["* * 1 * *"], // every month
+      versioning: "regex:^(?<compatibility>[^/]+)/v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+    },
+
     // uv version used in GitHub Actions is updated manually
     {
       enabled: false,

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -98,7 +98,7 @@ jobs:
       - *checkout
 
       - name: Run Bandit scan
-        uses: open-edge-platform/geti-ci/actions/bandit@7e686c1248b3939f8ee8e04e2612da727e379d91
+        uses: open-edge-platform/geti-ci/actions/bandit@d5b1283a2618b816cfce50d597754e8b8ea3a2b6 # bandit/v0.1.1
         with:
           scan-scope: ${{ github.event_name == 'pull_request' && 'changed' || 'all' }}
           severity-level: ${{ github.event_name == 'pull_request' && 'MEDIUM' || 'LOW' }}

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -81,6 +81,7 @@ jobs:
           disable-telemetry: true
           egress-policy: block
           allowed-endpoints: >
+            api.github.com:443
             github.com:443
             raw.githubusercontent.com:443
             files.pythonhosted.org:443
@@ -95,7 +96,7 @@ jobs:
       - name: Run SkillSpector scan
         uses: open-edge-platform/geti-ci/actions/skill-scan@78e175e3e91f997e168a09aadd1933da95c1ac98 # skill-scan/v0.1.0
         with:
-          severity-level: ${{ github.event_name == 'pull_request' && (inputs.severity || 'HIGH') || 'LOW' }}
+          severity-level: ${{ github.event_name == 'pull_request' && 'HIGH' || github.event.inputs.severity || 'LOW' }}
           fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
           skills-path: skills
 

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           severity-level: ${{ github.event_name == 'pull_request' && (inputs.severity || 'HIGH') || 'LOW' }}
           fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-          skills-path: .github/skills
+          skills-path: skills
 
   required-check:
     name: Required Check skills

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -4,20 +4,19 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "skills/**"
-      - ".claude/skills/**"
-      - ".agents/skills/**"
-      - ".github/scripts/skills/**"
-      - ".github/workflows/skills.yml"
   pull_request:
-    paths:
-      - "skills/**"
-      - ".claude/skills/**"
-      - ".agents/skills/**"
-      - ".github/scripts/skills/**"
-      - ".github/workflows/skills.yml"
   workflow_dispatch:
+    inputs:
+      severity:
+        description: "Severity level (CRITICAL, HIGH, MEDIUM, LOW)"
+        required: false
+        default: "LOW"
+        type: choice
+        options:
+          - CRITICAL
+          - HIGH
+          - MEDIUM
+          - LOW
 
 permissions: {}
 
@@ -26,9 +25,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
+  check-paths:
+    name: Check if workflow should run
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    outputs:
+      run_workflow: ${{ steps.check_paths.outputs.run }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check paths
+        id: check_paths
+        uses: open-edge-platform/geti-ci/actions/check-paths@7e686c1248b3939f8ee8e04e2612da727e379d91
+        with:
+          files_yaml: |
+            test:
+              - skills/**
+              - .claude/skills/**
+              - .agents/skills/**
+              - .github/scripts/skills/**
+              - .github/workflows/skills.yml
+
+  layout-check:
     name: Validate skills layout
     runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
     permissions:
       contents: read
     steps:
@@ -39,3 +65,45 @@ jobs:
 
       - name: Validate skills and adapter symlinks
         run: python3 .github/scripts/skills/agent_skills.py validate
+
+  skill-scan:
+    name: SkillSpector scan
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run SkillSpector scan
+        uses: open-edge-platform/geti-ci/actions/skill-scan@78e175e3e91f997e168a09aadd1933da95c1ac98 # skill-scan/v0.1.0
+        with:
+          severity-level: ${{ github.event_name == 'pull_request' && (inputs.severity || 'HIGH') || 'LOW' }}
+          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          skills-path: .github/skills
+
+  required-check:
+    name: Required Check skills
+    needs:
+      - check-paths
+      - layout-check
+      - skill-scan
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    env:
+      CHECKS: ${{ join(needs.*.result, ' ') }}
+    if: always() && !cancelled()
+    steps:
+      - name: Check jobs results
+        run: |
+          for check in ${CHECKS}; do
+            echo "::notice::check=${check}"
+            if [[ "$check" != "success" && "$check" != "skipped" ]]; then
+              echo "::error ::Required status checks failed. They must succeed before this pull request can be merged."
+              exit 1
+            fi
+          done

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -74,6 +74,18 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            raw.githubusercontent.com:443
+            files.pythonhosted.org:443
+            pypi.org:443
+
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
This PR adds a new “SkillSpector” scan to the Skills CI workflow and refactors workflow triggering to be path-aware via an initial `check-paths` gate.