### PR TITLE
fix(backend): use actual upload size for import disk checks

### DIFF
--- a/application/backend/src/api/dataset_import.py
+++ b/application/backend/src/api/dataset_import.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from pathlib import Path
 from typing import Annotated
 from uuid import UUID
@@ -49,7 +50,7 @@ def _resolve_upload_size_estimate(archive: UploadFile, content_length_header: st
     actual_size: int | None = None
     try:
         current_pos = archive.file.tell()
-        archive.file.seek(0, 2)
+        archive.file.seek(0, os.SEEK_END)
         actual_size = archive.file.tell()
         archive.file.seek(current_pos)
     except (AttributeError, OSError, ValueError):

--- a/application/backend/src/api/dataset_import.py
+++ b/application/backend/src/api/dataset_import.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile, status
 
 from api.dependencies import get_dataset_import_service, get_job_service, get_project_id
 from exceptions import InvalidArchiveError, ZipBombDetectedError
@@ -38,6 +38,37 @@ async def _persist_uploaded_archive(file: UploadFile, payload: DatasetImportJobP
     destination.parent.mkdir(parents=True, exist_ok=True)
     await asyncio.to_thread(_write_archive_to_disk, file, destination)
     return destination
+
+
+def _resolve_upload_size_estimate(archive: UploadFile, content_length_header: str | None, fallback: int) -> int:
+    """Best-effort upload-size estimate used for disk-headroom checks.
+
+    Prefer the actual staged file size from the uploaded file object. If that
+    cannot be determined, fall back to the request Content-Length header.
+    """
+    actual_size: int | None = None
+    try:
+        current_pos = archive.file.tell()
+        archive.file.seek(0, 2)
+        actual_size = archive.file.tell()
+        archive.file.seek(current_pos)
+    except (AttributeError, OSError, ValueError):
+        actual_size = None
+
+    if actual_size is not None and actual_size >= 0:
+        return actual_size
+
+    if content_length_header is not None:
+        content_length: int | None = None
+        try:
+            content_length = int(content_length_header)
+        except ValueError:
+            content_length = None
+
+        if content_length is not None and content_length >= 0:
+            return content_length
+
+    return fallback
 
 
 async def get_awaiting_upload_job(
@@ -95,6 +126,7 @@ async def prepare_dataset_import_job(
 
 @router.put("/datasets/{job_id}:upload", status_code=status.HTTP_202_ACCEPTED)
 async def upload_dataset_import_archive(
+    request: Request,
     project_id: ProjectID,
     job_id: UUID,
     archive: Annotated[UploadFile, File(description="Dataset archive ZIP")],
@@ -118,7 +150,10 @@ async def upload_dataset_import_archive(
     # Check if there is enough space for dataset import
     settings = get_settings()
     cache_dir = settings.cache_dir / "imports" / "datasets"
-    upload_size_estimate = settings.data_import_max_upload_bytes
+    upload_size_estimate = _resolve_upload_size_estimate(
+        archive, request.headers.get("content-length"), settings.data_import_max_upload_bytes
+    )
+
     check_disk_headroom(cache_dir, upload_size_estimate, settings.data_import_min_free_bytes)
 
     # Make sure we are safe against zip bomb attacks

--- a/application/backend/tests/api/test_dataset_import_upload_safety.py
+++ b/application/backend/tests/api/test_dataset_import_upload_safety.py
@@ -374,6 +374,9 @@ def test_upload_disk_headroom_uses_actual_archive_size_not_configured_max() -> N
     assert response.status_code == 202
     assert len(stub.calls) == 1
 
+    staged_path = Settings().cache_dir / "imports" / "datasets" / f"{_FIXED_STAGING_ID}.zip"
+    staged_path.unlink(missing_ok=True)
+
 
 def test_resolve_upload_size_estimate_falls_back_to_content_length() -> None:
     """Use Content-Length fallback when uploaded file object size cannot be read."""

--- a/application/backend/tests/api/test_dataset_import_upload_safety.py
+++ b/application/backend/tests/api/test_dataset_import_upload_safety.py
@@ -1,11 +1,13 @@
 import io
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
+from api.dataset_import import _resolve_upload_size_estimate
 from api.dependencies import get_dataset_import_service, get_job_service
 from main import app
 from schemas.base_job import JobStatus, JobType
@@ -326,3 +328,63 @@ def test_upload_rejects_when_cache_dir_has_insufficient_free_space() -> None:
     body = response.json()
     assert body["error_code"] == "insufficient_disk_space"
     assert stub.calls == []
+
+
+def test_upload_disk_headroom_uses_actual_archive_size_not_configured_max() -> None:
+    """Disk guard should use real upload size so large configured max does not over-reject."""
+    project_id = uuid4()
+    job_id = uuid4()
+    stub = _StubDatasetImportService(project_id)
+    job_stub = _StubJobService(project_id, job_id)
+    app.dependency_overrides[get_dataset_import_service] = lambda: stub
+    app.dependency_overrides[get_job_service] = lambda: job_stub
+
+    archive_bytes = _make_zip_bytes(
+        {"meta/info.json": b"{}"},
+        compression=zipfile.ZIP_STORED,
+    )
+
+    import shutil
+
+    min_free_bytes = 1024
+    required_from_actual_size = len(archive_bytes)
+    fake_free_bytes = required_from_actual_size + min_free_bytes
+    _fake_usage = shutil.disk_usage("/")._replace(free=fake_free_bytes)
+
+    with (
+        patch("api.dataset_import.get_settings") as mock_get_settings,
+        patch("services.archive_safety.shutil.disk_usage", return_value=_fake_usage),
+    ):
+        settings = mock_get_settings.return_value
+        settings.cache_dir = Settings().cache_dir
+        settings.datasets_dir = Settings().datasets_dir
+        settings.data_import_max_upload_bytes = 10 * 1024 * 1024 * 1024  # would fail if used for headroom
+        settings.data_import_min_free_bytes = min_free_bytes
+        settings.data_import_max_uncompressed_bytes = 5 * 1024 * 1024 * 1024
+
+        try:
+            client = TestClient(app)
+            response = client.put(
+                f"/api/projects/{project_id}/imports/datasets/{job_id}:upload",
+                files={"archive": ("dataset.zip", archive_bytes, "application/zip")},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    assert response.status_code == 202
+    assert len(stub.calls) == 1
+
+
+def test_resolve_upload_size_estimate_falls_back_to_content_length() -> None:
+    """Use Content-Length fallback when uploaded file object size cannot be read."""
+
+    class _UnreadableUploadFile:
+        def __init__(self) -> None:
+            self.file = SimpleNamespace(tell=self._fail, seek=self._fail)
+
+        @staticmethod
+        def _fail(*_args, **_kwargs):
+            raise OSError("cannot seek")
+
+    archive = _UnreadableUploadFile()
+    assert _resolve_upload_size_estimate(archive, "1234", fallback=9999) == 1234


### PR DESCRIPTION
Fixes a bug where we were using `get_settings().data_import_max_upload_bytes` as an estimate for the uploaded dataset. This resulted in the system always checking that you'd have at least 100Gb of space leftover before doing a dataset import.

We now check the actual archive size, and use the `Content-Lenght` or `data_import_max_upload_bytes` as a fallback.