### PR TITLE
refactor(backend): make dataset read/write split explicit at construction

### DIFF
--- a/application/backend/src/api/dataset.py
+++ b/application/backend/src/api/dataset.py
@@ -18,7 +18,7 @@ from api.dependencies import (
 from api.utils import safe_archive_name
 from internal_datasets.lerobot.lerobot_dataset import InternalLeRobotDataset
 from internal_datasets.mutations.delete_episode_mutation import DeleteEpisodesMutation
-from internal_datasets.utils import get_internal_dataset
+from internal_datasets.utils import get_internal_read_dataset
 from schemas import Dataset, Episode, EpisodeInfo
 from services import DatasetDownloadService, DatasetService, EpisodeThumbnailService
 
@@ -41,7 +41,7 @@ async def get_episodes_of_dataset(
 ) -> list[EpisodeInfo]:
     """Get dataset episodes of dataset by id."""
     dataset = await dataset_service.get_dataset_by_id(dataset_id)
-    internal_dataset = get_internal_dataset(dataset)
+    internal_dataset = get_internal_read_dataset(dataset)
     return internal_dataset.get_episode_infos()
 
 
@@ -53,7 +53,7 @@ async def get_single_episode_of_dataset(
 ) -> Episode | None:
     """Get one dataset episode by index."""
     dataset = await dataset_service.get_dataset_by_id(dataset_id)
-    internal_dataset = get_internal_dataset(dataset)
+    internal_dataset = get_internal_read_dataset(dataset)
     return internal_dataset.find_episode(episode_index)
 
 
@@ -70,7 +70,7 @@ async def get_episode_thumbnail(  # noqa: PLR0913
 ) -> Response:
     """Get a thumbnail image for one episode."""
     dataset = await dataset_service.get_dataset_by_id(dataset_id)
-    internal_dataset = get_internal_dataset(dataset)
+    internal_dataset = get_internal_read_dataset(dataset)
 
     if not isinstance(internal_dataset, InternalLeRobotDataset):
         raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Thumbnail is unsupported")
@@ -110,7 +110,7 @@ async def delete_episodes_of_dataset(
 ) -> list[Episode]:
     """Get dataset episodes of dataset by id."""
     dataset = await dataset_service.get_dataset_by_id(dataset_id)
-    dataset_client = get_internal_dataset(dataset)
+    dataset_client = get_internal_read_dataset(dataset)
     mutation = DeleteEpisodesMutation(dataset_client)
     result = mutation.delete_episodes(episode_indices)
     return result.get_episodes()

--- a/application/backend/src/api/models.py
+++ b/application/backend/src/api/models.py
@@ -21,7 +21,7 @@ from api.dependencies import (
 )
 from api.utils import safe_archive_name
 from exceptions import ResourceNotFoundError, ResourceType
-from internal_datasets.utils import get_internal_dataset
+from internal_datasets.utils import get_internal_read_dataset
 from schemas import ModelDetailResponse
 from schemas.job import TrainJob
 from services import DatasetService, JobService, ModelDownloadService, ModelMetricsService, ModelService
@@ -66,7 +66,7 @@ async def get_tasks_of_model(
     if model.dataset_id is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Model has no dataset associated.")
     dataset = await dataset_service.get_dataset_by_id(model.dataset_id)
-    return get_internal_dataset(dataset).get_tasks()
+    return get_internal_read_dataset(dataset).get_tasks()
 
 
 @router.get("/{model_id}/download")

--- a/application/backend/src/api/project.py
+++ b/application/backend/src/api/project.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, status
 
 from api.dependencies import get_model_service, get_project_id, get_project_service
-from internal_datasets.utils import get_internal_dataset
+from internal_datasets.utils import get_internal_read_dataset
 from schemas import Model, Project
 from services import ModelService, ProjectService
 
@@ -65,6 +65,6 @@ async def get_tasks_for_dataset(
     res = {}
 
     for dataset in project.datasets:
-        res[dataset.name] = get_internal_dataset(dataset).get_tasks()
+        res[dataset.name] = get_internal_read_dataset(dataset).get_tasks()
 
     return res

--- a/application/backend/src/internal_datasets/access_mode.py
+++ b/application/backend/src/internal_datasets/access_mode.py
@@ -1,0 +1,6 @@
+from enum import StrEnum
+
+
+class DatasetAccessMode(StrEnum):
+    READ_ONLY = "read_only"
+    RECORDING_MUTATION = "recording_mutation"

--- a/application/backend/src/internal_datasets/lerobot/lerobot_dataset.py
+++ b/application/backend/src/internal_datasets/lerobot/lerobot_dataset.py
@@ -55,14 +55,18 @@ class InternalLeRobotDataset(DatasetClient):
     def load_dataset(self) -> None:
         """Load dataset."""
         if self._check_repository_exists(self.path):
-            self._dataset = LeRobotDataset(
-                str(uuid4()),
-                self.path,
-            )
-            self.has_episodes = self._dataset.num_episodes > 0
-
             if self._access_mode is DatasetAccessMode.RECORDING_MUTATION:
-                self._resume_for_writing(getattr(self._dataset, "repo_id", None))
+                self._dataset = LeRobotDataset.resume(
+                    repo_id=str(uuid4()),
+                    root=self.path,
+                    **self._resolved_streaming_encoding_settings(),
+                )
+            else:
+                self._dataset = LeRobotDataset(
+                    str(uuid4()),
+                    self.path,
+                )
+            self.has_episodes = self._dataset.num_episodes > 0
 
     def _resolved_streaming_encoding_settings(self) -> dict:
         return self._streaming_encoding_settings.with_resolved_vcodec().model_dump()

--- a/application/backend/src/internal_datasets/lerobot/lerobot_dataset.py
+++ b/application/backend/src/internal_datasets/lerobot/lerobot_dataset.py
@@ -1,4 +1,3 @@
-import base64
 import copy
 import shutil
 from pathlib import Path
@@ -16,6 +15,7 @@ from lerobot.processor.pipeline import RobotProcessorPipeline
 from lerobot.utils.constants import ACTION, OBS_STR
 from loguru import logger
 
+from internal_datasets.access_mode import DatasetAccessMode
 from internal_datasets.dataset_client import DatasetClient
 from internal_datasets.lerobot.streaming_encoding_settings import StreamingEncodingSettings
 from internal_datasets.mutations.recording_mutation import RecordingMutation
@@ -34,15 +34,18 @@ class InternalLeRobotDataset(DatasetClient):
     _robot_action_processor: RobotProcessorPipeline
     _robot_observation_processor: RobotProcessorPipeline
     _streaming_encoding_settings: StreamingEncodingSettings
+    _access_mode: DatasetAccessMode
 
     def __init__(
         self,
         dataset_path: Path,
         *,
         streaming_encoding_settings: StreamingEncodingSettings = StreamingEncodingSettings(),
+        access_mode: DatasetAccessMode = DatasetAccessMode.READ_ONLY,
     ):
         self.path = dataset_path
-        self._streaming_encoding_settings = streaming_encoding_settings.with_resolved_vcodec()
+        self._streaming_encoding_settings = streaming_encoding_settings
+        self._access_mode = access_mode
         self.load_dataset()
 
         self._teleop_action_processor, self._robot_action_processor, self._robot_observation_processor = (
@@ -55,9 +58,26 @@ class InternalLeRobotDataset(DatasetClient):
             self._dataset = LeRobotDataset(
                 str(uuid4()),
                 self.path,
-                **self._streaming_encoding_settings.model_dump(),
             )
             self.has_episodes = self._dataset.num_episodes > 0
+
+            if self._access_mode is DatasetAccessMode.RECORDING_MUTATION:
+                self._resume_for_writing(getattr(self._dataset, "repo_id", None))
+
+    def _resolved_streaming_encoding_settings(self) -> dict:
+        return self._streaming_encoding_settings.with_resolved_vcodec().model_dump()
+
+    def _resume_for_writing(self, repo_id: str | None = None) -> None:
+        if not self._check_repository_exists(self.path):
+            raise ValueError(f"Cannot resume non-existing dataset at {self.path}")
+
+        resolved_repo_id = repo_id or getattr(getattr(self, "_dataset", None), "repo_id", str(uuid4()))
+        self._dataset = LeRobotDataset.resume(
+            repo_id=resolved_repo_id,
+            root=self.path,
+            **self._resolved_streaming_encoding_settings(),
+        )
+        self.has_episodes = self._dataset.num_episodes > 0
 
     def create(
         self,
@@ -75,7 +95,7 @@ class InternalLeRobotDataset(DatasetClient):
             features=features,
             robot_type=robot_type,
             use_videos=True,
-            **self._streaming_encoding_settings.model_dump(),
+            **self._resolved_streaming_encoding_settings(),
         )
         self.has_episodes = False
 
@@ -240,7 +260,7 @@ class InternalLeRobotDataset(DatasetClient):
         )
         if self.exists_on_disk:
             shutil.copytree(self.path, cache_dir)
-            cache_dataset.load_dataset()
+            cache_dataset._resume_for_writing(getattr(self._dataset, "repo_id", None))
         else:
             cache_dataset.create(fps=fps, features=features, robot_type=robot_type)
 
@@ -294,7 +314,7 @@ class InternalLeRobotDataset(DatasetClient):
         if self._dataset is None:
             raise Exception("No dataset loaded.")
 
-        episode_buffer = copy.deepcopy(self._dataset.writer.episode_buffer)
+        episode_buffer = self._get_episode_buffer_snapshot()
         if episode_buffer is None:
             raise Exception("Attempting to save episode, but no episode in buffer.")
 
@@ -362,15 +382,19 @@ class InternalLeRobotDataset(DatasetClient):
 
     def _build_thumbnail_png_bytes(self, episode: dict, image_key: str, width: int, height: int) -> bytes | None:
         if image_key not in self._dataset.meta.camera_keys:
+            logger.warning("Unknown thumbnail camera key '{}'", image_key)
             return None
 
         from_idx = int(episode["dataset_from_index"])
+        item = self._read_dataset_item_for_thumbnail(from_idx)
+        if item is None:
+            logger.warning("Could not read dataset item for thumbnail at index {}", from_idx)
+            return None
+
         try:
-            reader = self._dataset._ensure_reader()
-            if reader.hf_dataset is None:
-                reader.load_and_activate()
-            image = reader.get_item(from_idx)[image_key].permute(1, 2, 0).detach().numpy()
+            image = item[image_key].permute(1, 2, 0).detach().numpy()
         except Exception:
+            logger.exception("Could not extract image '{}' for thumbnail", image_key)
             return None
 
         rescaled = (image * 255).clip(0, 255).astype(np.uint8)
@@ -378,17 +402,41 @@ class InternalLeRobotDataset(DatasetClient):
         bgr_image = cv2.cvtColor(resized, cv2.COLOR_RGB2BGR)
         encoded, imagebytes = cv2.imencode(".png", bgr_image)
         if not encoded:
+            logger.warning("Failed to encode thumbnail PNG for image key '{}'", image_key)
             return None
 
         return imagebytes.tobytes()
 
-    def _build_thumbnail(self, episode: dict, image_key: str) -> str:
-        thumbnail_size = (320, 240)
+    def _get_episode_buffer_snapshot(self) -> dict | None:
+        writer = self._dataset.writer
+        if writer is None:
+            return None
+        return copy.deepcopy(writer.episode_buffer)
 
-        from_idx = episode["dataset_from_index"]
-        image = self._dataset[from_idx][image_key].permute(1, 2, 0).detach().numpy()
-        rescaled = (image * 255).clip(0, 255).astype(np.uint8)
-        resized = cv2.resize(rescaled, thumbnail_size)
-        thumbnail = cv2.cvtColor(resized, cv2.COLOR_BGR2RGB)
-        _, imagebytes = cv2.imencode(".jpg", thumbnail)
-        return base64.b64encode(imagebytes).decode()
+    def _read_dataset_item_for_thumbnail(self, index: int) -> dict | None:
+        try:
+            return self._dataset[index]
+        except RuntimeError as exc:
+            if "Cannot read from a dataset that is being recorded" not in str(exc):
+                logger.exception("Could not read dataset item for thumbnail")
+                return None
+
+            logger.warning("Dataset is in recording mode during thumbnail read; using reader fallback")
+            try:
+                if self._dataset.reader is None:
+                    _ = self._dataset.hf_dataset
+
+                reader = self._dataset.reader
+                if reader is None:
+                    return None
+
+                if reader.hf_dataset is None:
+                    reader.load_and_activate()
+
+                return reader.get_item(index)
+            except Exception:
+                logger.exception("Could not read dataset item from reader fallback")
+                return None
+        except Exception:
+            logger.exception("Could not read dataset item for thumbnail")
+            return None

--- a/application/backend/src/internal_datasets/lerobot/streaming_encoding_settings.py
+++ b/application/backend/src/internal_datasets/lerobot/streaming_encoding_settings.py
@@ -1,5 +1,6 @@
 import logging
 from fractions import Fraction
+from functools import cache
 
 from pydantic import BaseModel
 
@@ -12,21 +13,10 @@ class StreamingEncodingSettings(BaseModel):
 
     def with_resolved_vcodec(self) -> "StreamingEncodingSettings":
         # - If vcodec is already explicit (or streaming is disabled),
-        #   _resolve_vcodec returns the original value.
-        # - If vcodec is "auto", _resolve_vcodec probes candidates and picks
-        #   the first usable encoder.
-        return self.model_copy(update={"vcodec": self._resolve_vcodec()})
-
-    def _resolve_vcodec(self) -> str:
-        if not self.streaming_encoding or self.vcodec != "auto":
-            return self.vcodec
-
-        for candidate in self._vcodec_candidates():
-            if self._is_vcodec_usable(candidate):
-                logging.info(f"Auto-selected vcodec '{candidate}'")
-                return candidate
-
-        raise RuntimeError("No usable video encoder found for streaming encoding")
+        #   resolve_vcodec returns the original value.
+        # - If vcodec is "auto", resolve_vcodec probes candidates once and
+        #   picks the first usable encoder.
+        return self.model_copy(update={"vcodec": _resolve_vcodec(self.vcodec, self.streaming_encoding)})
 
     @staticmethod
     def _vcodec_candidates() -> list[str]:
@@ -60,3 +50,17 @@ class StreamingEncodingSettings(BaseModel):
         except Exception as exc:
             logging.warning(f"Skipping unavailable vcodec '{vcodec}': {exc}")
             return False
+
+
+@cache
+def _resolve_vcodec(vcodec: str, streaming_encoding: bool) -> str:
+    """Probe usable vcodec once per process; result is cached."""
+    if not streaming_encoding or vcodec != "auto":
+        return vcodec
+
+    for candidate in StreamingEncodingSettings._vcodec_candidates():
+        if StreamingEncodingSettings._is_vcodec_usable(candidate):
+            logging.info(f"Auto-selected vcodec '{candidate}'")
+            return candidate
+
+    raise RuntimeError("No usable video encoder found for streaming encoding")

--- a/application/backend/src/internal_datasets/utils.py
+++ b/application/backend/src/internal_datasets/utils.py
@@ -1,33 +1,21 @@
 from pathlib import Path
 
+from internal_datasets.access_mode import DatasetAccessMode
 from internal_datasets.dataset_client import DatasetClient
 from internal_datasets.lerobot.lerobot_dataset import InternalLeRobotDataset
 from schemas import Dataset
 
-# path -> (dataset_instance, mtime_of_meta_info_json_at_load_time)
-_cache: dict[Path, tuple[InternalLeRobotDataset, float | None]] = {}
+
+def get_internal_dataset(dataset: Dataset, mode: DatasetAccessMode = DatasetAccessMode.READ_ONLY) -> DatasetClient:
+    """Load dataset from dataset data class."""
+    return InternalLeRobotDataset(Path(dataset.path), access_mode=mode)
 
 
-def _info_mtime(path: Path) -> float | None:
-    info = path / "meta/info.json"
-    return info.stat().st_mtime if info.is_file() else None
+def get_internal_read_dataset(dataset: Dataset) -> DatasetClient:
+    """Load a dataset in read-only mode for API endpoints."""
+    return get_internal_dataset(dataset, mode=DatasetAccessMode.READ_ONLY)
 
 
-def get_internal_dataset(dataset: Dataset) -> DatasetClient:
-    """Load dataset from dataset data class, using a mtime-keyed cache."""
-    path = Path(dataset.path)
-    current_mtime = _info_mtime(path)
-
-    if path in _cache:
-        cached_ds, cached_mtime = _cache[path]
-        if current_mtime == cached_mtime:
-            return cached_ds
-
-    ds = InternalLeRobotDataset(path)
-    _cache[path] = (ds, current_mtime)
-    return ds
-
-
-def invalidate_dataset_cache(path: Path) -> None:
-    """Evict a path from the dataset cache (e.g. after a mutation commits)."""
-    _cache.pop(path, None)
+def get_internal_recording_dataset(dataset: Dataset) -> DatasetClient:
+    """Load a dataset in recording-mutation mode for worker flows."""
+    return get_internal_dataset(dataset, mode=DatasetAccessMode.RECORDING_MUTATION)

--- a/application/backend/src/workers/robot_control_worker.py
+++ b/application/backend/src/workers/robot_control_worker.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from control.environment_integration import EnvironmentIntegration
 from control.sync_mixed_model_integration import SyncMixedModelIntegration
+from internal_datasets.access_mode import DatasetAccessMode
 from internal_datasets.dataset_client import DatasetClient
 from internal_datasets.lerobot.lerobot_dataset import InternalLeRobotDataset
 from internal_datasets.mutations.recording_mutation import RecordingMutation
@@ -92,7 +93,7 @@ class RobotControlWorker(BaseThreadWorker):
         self._report_state()
 
     def load_dataset(self, dataset: Dataset) -> None:
-        self.dataset = InternalLeRobotDataset(Path(dataset.path))
+        self.dataset = InternalLeRobotDataset(Path(dataset.path), access_mode=DatasetAccessMode.RECORDING_MUTATION)
         self.events.start_recording_mutation.set()
 
     def start_recording(self, task: str) -> None:

--- a/application/backend/tests/internal_datasets/test_lerobot_dataset_thumbnail.py
+++ b/application/backend/tests/internal_datasets/test_lerobot_dataset_thumbnail.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from internal_datasets.lerobot.lerobot_dataset import InternalLeRobotDataset
+
+
+def test_thumbnail_reader_fallback_on_recording_runtime_error() -> None:
+    dataset = InternalLeRobotDataset.__new__(InternalLeRobotDataset)
+    reader = MagicMock()
+    reader.hf_dataset = object()
+    reader.get_item.return_value = {"observation.images.main": MagicMock()}
+    reader.get_item.return_value[
+        "observation.images.main"
+    ].permute.return_value.detach.return_value.numpy.return_value = np.zeros((8, 8, 3), dtype=np.float32)
+
+    def _getitem(_index: int):
+        raise RuntimeError(
+            "Cannot read from a dataset that is being recorded. Call finalize() first, then access items."
+        )
+
+    dataset._dataset = MagicMock()
+    dataset._dataset.__getitem__.side_effect = _getitem
+    dataset._dataset.reader = reader
+
+    result = dataset._read_dataset_item_for_thumbnail(0)
+
+    assert result is not None
+    reader.get_item.assert_called_once_with(0)
+
+
+def test_thumbnail_reader_fallback_activates_reader_when_needed() -> None:
+    dataset = InternalLeRobotDataset.__new__(InternalLeRobotDataset)
+
+    reader = MagicMock()
+    reader.hf_dataset = None
+    reader.get_item.return_value = {"observation.images.main": MagicMock()}
+
+    def _getitem(_index: int):
+        raise RuntimeError(
+            "Cannot read from a dataset that is being recorded. Call finalize() first, then access items."
+        )
+
+    dataset._dataset = MagicMock()
+    dataset._dataset.__getitem__.side_effect = _getitem
+    dataset._dataset.reader = reader
+
+    result = dataset._read_dataset_item_for_thumbnail(0)
+
+    assert result is not None
+    reader.load_and_activate.assert_called_once()

--- a/application/backend/tests/internal_datasets/test_utils.py
+++ b/application/backend/tests/internal_datasets/test_utils.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+from uuid import uuid4
+
+from internal_datasets.access_mode import DatasetAccessMode
+from internal_datasets.utils import get_internal_read_dataset, get_internal_recording_dataset
+from schemas.dataset import Dataset
+
+
+def _make_dataset() -> Dataset:
+    return Dataset.model_validate(
+        {
+            "id": str(uuid4()),
+            "name": "dataset",
+            "path": "/tmp/dataset",
+            "default_task": "task",
+            "project_id": str(uuid4()),
+            "environment_id": str(uuid4()),
+        }
+    )
+
+
+def test_get_internal_read_dataset_uses_read_only_mode() -> None:
+    dataset = _make_dataset()
+    with patch("internal_datasets.utils.InternalLeRobotDataset") as mocked_cls:
+        get_internal_read_dataset(dataset)
+
+    mocked_cls.assert_called_once()
+    _, kwargs = mocked_cls.call_args
+    assert kwargs["access_mode"] is DatasetAccessMode.READ_ONLY
+
+
+def test_get_internal_recording_dataset_uses_recording_mode() -> None:
+    dataset = _make_dataset()
+    with patch("internal_datasets.utils.InternalLeRobotDataset") as mocked_cls:
+        get_internal_recording_dataset(dataset)
+
+    mocked_cls.assert_called_once()
+    _, kwargs = mocked_cls.call_args
+    assert kwargs["access_mode"] is DatasetAccessMode.RECORDING_MUTATION


### PR DESCRIPTION
The read-vs-recording separation was already functionally correct, but the code relied on implicit conventions.
Nothing prevented read endpoints from accidentally getting writer-enabled handles.

This refactoring makes the split obvious at the type level by introducing dedicated factory functions.
Read endpoints use `get_internal_read_dataset()` the recording worker uses an explicit `RECORDING_MUTATION` mode.

> [!NOTE]
> Initially I worked on this when looking into #500, but since that PR already fixed the issue I didn't continue with this minor refactor.
> While working on #780 though I've found that there were some issues where the application would become very slow due to it spinning up too many recording sessions. Part of the reason was that we didn't make a good distinction between recording and reading datasets.