### PR TITLE
feat: support virtual usb robot with socat

### DIFF
--- a/application/README.md
+++ b/application/README.md
@@ -36,6 +36,7 @@ The application provides a graphical interface to:
 | [Update Existing Installation](./docs/02-update-existing-installation.md) | Refresh Docker images, dependencies, and services after pulling changes.          |
 | [Getting Started](./docs/03-getting-started.md)                           | Create a project, set up hardware, record data, train a model, and run inference. |
 | [Environment Setup](./docs/04-environment-setup.md)                       | Configure robots, cameras, and environments.                                      |
+| [Virtual USB Ports](./docs/08-virtual-usb-ports.md) (optional)            | Connect to robot serial devices over TCP using `socat` virtual ports.             |
 | [Recording Datasets](./docs/05-recording-datasets.md)                     | Record, review, import, and export demonstration datasets.                        |
 | [Training Policies](./docs/06-training-policies.md)                       | Train model policies from recorded datasets.                                      |
 | [Deploying Model Policies](./docs/07-deploying-model-policies.md)         | Run trained policies in Studio or deploy them externally.                         |

--- a/application/backend/src/utils/serial_robot_tools.py
+++ b/application/backend/src/utils/serial_robot_tools.py
@@ -21,7 +21,8 @@ def from_port(port: ListPortInfo) -> SerialPortInfo | None:
     serial_number = getattr(port, "serial_number", None)
 
     # Ignore internal hardware (e.g. /dev/ttyS0..ttyS31)
-    if port.device.startswith("/dev/ttyS") and port.device[9:10].isdigit():
+    ttys_suffix = port.device.removeprefix("/dev/ttyS")
+    if ttys_suffix[:1].isdigit():
         return None
 
     # The Feetech UART board CH340 has PID 29987

--- a/application/backend/src/utils/serial_robot_tools.py
+++ b/application/backend/src/utils/serial_robot_tools.py
@@ -20,12 +20,13 @@ def from_port(port: ListPortInfo) -> SerialPortInfo | None:
     """Detect if the device is a SO-100 robot."""
     serial_number = getattr(port, "serial_number", None)
 
-    # Ignore internal hardware
-    if port.device.startswith("/dev/ttyS"):
+    # Ignore internal hardware (e.g. /dev/ttyS0..ttyS31)
+    if port.device.startswith("/dev/ttyS") and port.device[9:10].isdigit():
         return None
 
     # The Feetech UART board CH340 has PID 29987
-    if port.pid not in {21971, 29987}:
+    # Also accept virtual/PTY ports (pid is None) like socat-created devices
+    if port.pid is not None and port.pid not in {21971, 29987}:
         logger.debug("Found usb port with unexpected PID, {device}: {pid}", device=port.device, pid=port.pid)
         return None
 

--- a/application/docs/08-virtual-usb-ports.md
+++ b/application/docs/08-virtual-usb-ports.md
@@ -25,6 +25,8 @@ Run on the NUC (or other machine physically connected to the robot):
 socat TCP-LISTEN:7001,reuseaddr,fork FILE:/dev/ttyACM0,raw,echo=0,b1000000
 ```
 
+`TCP-LISTEN` is unencrypted and unauthenticated. Use only on a trusted network, or tunnel this traffic through SSH/VPN.
+
 | Flag                | Purpose                                                                            |
 |---------------------|------------------------------------------------------------------------------------|
 | `TCP-LISTEN:7001`   | Listen on TCP port 7001.                                                           |
@@ -42,7 +44,7 @@ Run on the workstation where Studio is running:
 
 ```bash
 sudo socat \
-  PTY,link=/dev/ttyVACM0,raw,echo=0,user=$(whoami),group=$(whoami),mode=660 \
+  PTY,link=/dev/ttyVACM0,raw,echo=0,user=$(id -un),group=$(id -gn),mode=660 \
   TCP:192.168.2.8:7001
 ```
 
@@ -109,7 +111,7 @@ docker compose up -d --force-recreate
 Recreate the local PTY with explicit ownership and mode:
 
 ```bash
-sudo socat PTY,link=/dev/ttyVACM0,raw,echo=0,user=$(whoami),group=$(whoami),mode=660 TCP:192.168.2.8:7001
+sudo socat PTY,link=/dev/ttyVACM0,raw,echo=0,user=$(id -un),group=$(id -gn),mode=660 TCP:192.168.2.8:7001
 ```
 
 ### TCP connection fails

--- a/application/docs/08-virtual-usb-ports.md
+++ b/application/docs/08-virtual-usb-ports.md
@@ -87,6 +87,21 @@ for p in list_ports.comports():
 "
 ```
 
+If you run Studio with Docker Compose, also ensure the container can access the virtual device.
+Add these mounts to your service in `application/docker/docker-compose.yaml`:
+
+```yaml
+volumes:
+  - /dev/ttyVACM0:/dev/ttyVACM0
+  - /dev/pts:/dev/pts
+```
+
+Then restart the container:
+
+```bash
+docker compose up -d --force-recreate
+```
+
 ## Troubleshooting
 
 ### Permission denied on `/dev/ttyVACM0`

--- a/application/docs/08-virtual-usb-ports.md
+++ b/application/docs/08-virtual-usb-ports.md
@@ -1,0 +1,135 @@
+# Virtual USB Ports
+
+Use this guide when your robot is connected by USB to a different machine (for example, a NUC), but you run Physical AI Studio on your workstation.
+
+You can forward the robot serial device over TCP with `socat` and expose it locally as a virtual serial port (for example, `/dev/ttyVACM0`). Studio then discovers it like a normal USB serial device.
+
+The serial settings in this document are tuned for SO101 (including the `b1000000` baud rate). If you use a different robot or control board, update the device path and serial parameters to match your hardware requirements.
+
+## Architecture
+
+```text
+Robot USB <-> NUC  <------> Workstation
+                    TCP       |
+                              |
+                       /dev/ttyVACM0 (socat PTY)
+                              |
+                      Physical AI Studio
+```
+
+## 1. Start serial-to-TCP forwarding on the robot-side machine
+
+Run on the NUC (or other machine physically connected to the robot):
+
+```bash
+socat TCP-LISTEN:7001,reuseaddr,fork FILE:/dev/ttyACM0,raw,echo=0,b1000000
+```
+
+| Flag                | Purpose                                                                            |
+|---------------------|------------------------------------------------------------------------------------|
+| `TCP-LISTEN:7001`   | Listen on TCP port 7001.                                                           |
+| `reuseaddr`         | Allow quick restart of the process.                                                |
+| `fork`              | Handle multiple client connections.                                                |
+| `FILE:/dev/ttyACM0` | Robot serial device on the NUC.                                                    |
+| `raw,echo=0`        | Raw mode, no local echo.                                                           |
+| `b1000000`          | SO101 default: set baud rate to 1 Mbps (required for Feetech motor communication). |
+
+If your robot platform uses a different baud rate or serial profile, replace `b1000000` with the correct value for that platform.
+
+## 2. Create a local virtual serial port on the workstation
+
+Run on the workstation where Studio is running:
+
+```bash
+sudo socat \
+  PTY,link=/dev/ttyVACM0,raw,echo=0,user=$(whoami),group=$(whoami),mode=660 \
+  TCP:192.168.2.8:7001
+```
+
+Replace `192.168.2.8` with your NUC IP.
+
+| Flag                     | Purpose                                     |
+|--------------------------|---------------------------------------------|
+| `PTY,link=/dev/ttyVACM0` | Create a local PTY at a stable path.        |
+| `user,group,mode`        | Grant backend process access to the PTY.    |
+| `TCP:192.168.2.8:7001`   | Connect to the robot-side `socat` listener. |
+
+## 3. Verify Studio can detect the virtual port
+
+Check backend serial devices:
+
+```bash
+curl http://localhost:7860/api/hardware/serial_devices | jq
+```
+
+Expected output includes:
+
+```json
+{
+  "connection_string": "/dev/ttyVACM0",
+  "serial_number": null
+}
+```
+
+If it is missing, verify the symlink exists:
+
+```bash
+ls -la /dev/ttyVACM0
+```
+
+Then verify pyserial enumeration from `application/backend`:
+
+```bash
+uv run python3 -c "
+from serial.tools import list_ports
+for p in list_ports.comports():
+    print(p.device, p.pid)
+"
+```
+
+## Troubleshooting
+
+### Permission denied on `/dev/ttyVACM0`
+
+Recreate the local PTY with explicit ownership and mode:
+
+```bash
+sudo socat PTY,link=/dev/ttyVACM0,raw,echo=0,user=$(whoami),group=$(whoami),mode=660 TCP:192.168.2.8:7001
+```
+
+### TCP connection fails
+
+Check network reachability and listener status:
+
+```bash
+nc -zv 192.168.2.8 7001
+```
+
+### Motor handshake fails (for example, missing motor IDs)
+
+Most often this is a baud-rate mismatch. For SO101, confirm the robot-side command includes `b1000000` and verify serial speed:
+
+```bash
+stty -F /dev/ttyACM0
+# Expected: speed 1000000 baud
+```
+
+### End-to-end echo test
+
+On the robot-side machine:
+
+```bash
+socat TCP-LISTEN:7001,reuseaddr,fork -,raw,echo=0
+```
+
+On the workstation:
+
+```bash
+echo hello > /dev/ttyVACM0
+```
+
+If `hello` appears on the robot-side terminal, the tunnel is working end to end.
+
+## Next
+
+- Continue with [Environment Setup](./04-environment-setup.md).


### PR DESCRIPTION
Add documentation on how to use [socat](https://man7.org/linux/man-pages/man1/socat.1.html) to connect to a remote usb port over TCP.
The document explains how I was able to set this up on my external nuc using a SO101 robot. For other robots / control boards the settings might differ.

I've slightly tweaked the way we filter out usb ports discovered by `list_ports.comports()` so that it mainly tries to reject any `/dev/ttyS...` devices which are known to be internal hardware devices.
This should fix most edge cases. Unless a user were to add a virtual usb that strarts with `/dev/ttyS123` then we don't show it.

An alternative for this could be that we allow users to manually provide the path to their usb port. But let's consider this only after getting some feedback about this.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/5188c151-1add-4f46-9252-509f0a386639" />

The `/dev/ttySO101Left` mentioned in the screenshot is my "virtual usb".