### PR TITLE
fix: disable environment form when no robots were added

### DIFF
--- a/application/ui/src/features/robots/environment-form/submit-new-environment-button.test.tsx
+++ b/application/ui/src/features/robots/environment-form/submit-new-environment-button.test.tsx
@@ -36,7 +36,14 @@ describe('SubmitNewEnvironmentButton', () => {
         it('when the project has robots but none were added to the environment', async () => {
             server.use(
                 http.get(ROBOTS_PATH, () =>
-                    HttpResponse.json([{ id: 'robot-1', type: 'SO101_Follower', name: 'Test Robot' }])
+                    HttpResponse.json([
+                        {
+                            id: 'robot-1',
+                            type: 'SO101_Follower',
+                            name: 'Test Robot',
+                            payload: { connection_string: '', serial_number: '' },
+                        },
+                    ])
                 )
             );
 
@@ -58,7 +65,14 @@ describe('SubmitNewEnvironmentButton', () => {
         it('when the name is set and at least one robot was added to the environment', async () => {
             server.use(
                 http.get(ROBOTS_PATH, () =>
-                    HttpResponse.json([{ id: 'robot-1', type: 'SO101_Follower', name: 'Test Robot' }])
+                    HttpResponse.json([
+                        {
+                            id: 'robot-1',
+                            type: 'SO101_Follower',
+                            name: 'Test Robot',
+                            payload: { connection_string: '', serial_number: '' },
+                        },
+                    ])
                 )
             );
 

--- a/application/ui/src/features/robots/environment-form/submit-new-environment-button.test.tsx
+++ b/application/ui/src/features/robots/environment-form/submit-new-environment-button.test.tsx
@@ -1,0 +1,73 @@
+import { screen } from '@testing-library/react';
+import { HttpResponse } from 'msw';
+
+import { http } from '../../../api/utils';
+import { server } from '../../../msw-node-setup';
+import { render } from '../../../test-utils/render';
+import { EnvironmentForm, EnvironmentFormProvider } from './provider';
+import { SubmitNewEnvironmentButton } from './submit-new-environment-button';
+
+const PROJECT_ID = 'test-project-id';
+
+const ROBOTS_PATH = '/api/projects/{project_id}/robots';
+
+const renderButton = (environment: Partial<EnvironmentForm> = {}) => {
+    return render(
+        <EnvironmentFormProvider environment={{ name: '', robots: [], cameras: [], ...environment }}>
+            <SubmitNewEnvironmentButton />
+        </EnvironmentFormProvider>,
+        {
+            route: `/projects/${PROJECT_ID}/environments/new`,
+            path: '/projects/:project_id/environments/new',
+        }
+    );
+};
+
+describe('SubmitNewEnvironmentButton', () => {
+    describe('is disabled', () => {
+        it('when the environment name is empty', async () => {
+            server.use(http.get(ROBOTS_PATH, () => HttpResponse.json([])));
+
+            renderButton({ name: '' });
+
+            expect(await screen.findByRole('button', { name: /add environment/i })).toBeDisabled();
+        });
+
+        it('when the project has robots but none were added to the environment', async () => {
+            server.use(
+                http.get(ROBOTS_PATH, () =>
+                    HttpResponse.json([{ id: 'robot-1', type: 'SO101_Follower', name: 'Test Robot' }])
+                )
+            );
+
+            renderButton({ name: 'My Environment', robots: [] });
+
+            expect(await screen.findByRole('button', { name: /add environment/i })).toBeDisabled();
+        });
+    });
+
+    describe('is enabled', () => {
+        it('when the name is set and the project has no robots', async () => {
+            server.use(http.get(ROBOTS_PATH, () => HttpResponse.json([])));
+
+            renderButton({ name: 'My Environment' });
+
+            expect(await screen.findByRole('button', { name: /add environment/i })).not.toBeDisabled();
+        });
+
+        it('when the name is set and at least one robot was added to the environment', async () => {
+            server.use(
+                http.get(ROBOTS_PATH, () =>
+                    HttpResponse.json([{ id: 'robot-1', type: 'SO101_Follower', name: 'Test Robot' }])
+                )
+            );
+
+            renderButton({
+                name: 'My Environment',
+                robots: [{ robot_id: 'robot-1', teleoperator: { type: 'none' } }],
+            });
+
+            expect(await screen.findByRole('button', { name: /add environment/i })).not.toBeDisabled();
+        });
+    });
+});

--- a/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
+++ b/application/ui/src/features/robots/environment-form/submit-new-environment-button.tsx
@@ -7,6 +7,23 @@ import { useProjectId } from '../../../features/projects/use-project';
 import { paths } from '../../../router';
 import { useEnvironmentFormBody } from './provider';
 
+const useIsDisabled = (body: ReturnType<typeof useEnvironmentFormBody>) => {
+    const { project_id } = useProjectId();
+    const robotsQuery = $api.useSuspenseQuery('get', '/api/projects/{project_id}/robots', {
+        params: { path: { project_id } },
+    });
+
+    if (body.name.trim().length === 0) {
+        return true;
+    }
+
+    if (robotsQuery.data.length > 0 && body.robots.length === 0) {
+        return true;
+    }
+
+    return false;
+};
+
 export const SubmitNewEnvironmentButton = () => {
     const navigate = useNavigate();
     const { project_id } = useProjectId();
@@ -19,7 +36,7 @@ export const SubmitNewEnvironmentButton = () => {
 
     const environment_id = uuidv4();
     const body = useEnvironmentFormBody(environment_id);
-    const isDisabled = body.name.trim().length === 0;
+    const isDisabled = useIsDisabled(body);
 
     return (
         <Button


### PR DESCRIPTION
Before the "Add environment" button would be enabled if the user was creating an environment, but didn't add their robots yet.
It's easy to miss that you'd need to click the "Add" button on the robot first before it is actually stored, so this PR disables the "Add environment" button if the user has robots but hasn't added them yet.

Note: we currently do allow adding an empty environment if the user doesn't have any robots stored. This is currently needed to allow importing datasets without an environment. It's a bug in our UX flow that we should fix but will require some more work.