### PR TITLE
refactor: move robot factory builder methods

### DIFF
--- a/application/backend/src/robots/catalog/so101.py
+++ b/application/backend/src/robots/catalog/so101.py
@@ -1,6 +1,10 @@
-from schemas.robot import RobotType
+from physicalai.robot.so101 import SO101, SO101Calibration
 
-from .types import RobotCatalogDefinition
+from exceptions import ResourceNotFoundError, ResourceType
+from schemas.calibration import Calibration
+from schemas.robot import RobotType, SO101Robot, SO101RobotPayload
+
+from .types import CatalogRobot, CatalogRobotFactory, RobotAdapterOptions, RobotCatalogDefinition
 
 _SO101_TO_URDF = {
     "shoulder_pan.pos": ["shoulder_pan"],
@@ -10,6 +14,37 @@ _SO101_TO_URDF = {
     "wrist_roll.pos": ["wrist_roll"],
     "gripper.pos": ["gripper"],
 }
+
+
+def _to_so101_calibration(calibration: Calibration) -> SO101Calibration:
+    return SO101Calibration.from_dict(
+        {
+            name: {
+                "id": val.id,
+                "drive_mode": val.drive_mode,
+                "homing_offset": val.homing_offset,
+                "range_min": val.range_min,
+                "range_max": val.range_max,
+            }
+            for name, val in calibration.values.items()
+        }
+    )
+
+
+async def _build_so101_driver(robot: CatalogRobot[SO101RobotPayload], factory: CatalogRobotFactory) -> SO101:
+    if not isinstance(robot, SO101Robot):
+        raise TypeError("Expected SO101Robot")
+    port = await factory.find_port_by_serial(robot.payload.serial_number)
+    calibration = await factory.get_calibration_by_id(robot.active_calibration_id)
+
+    if port is None:
+        raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
+
+    if calibration is None:
+        raise ResourceNotFoundError(ResourceType.ROBOT_CALIBRATION, robot.payload.serial_number)
+
+    role = "follower" if robot.type == RobotType.SO101_FOLLOWER else "leader"
+    return SO101(port=port, calibration=_to_so101_calibration(calibration), role=role, unit="normalized")
 
 
 def get_definitions() -> list[RobotCatalogDefinition]:
@@ -25,6 +60,8 @@ def get_definitions() -> list[RobotCatalogDefinition]:
             package_map={"SO101": f"/api/robots/catalog/{RobotType.SO101_FOLLOWER}"},
             joint_map=_SO101_TO_URDF,
             urdf_relative_path=urdf_relative_path,
+            robot_builder=_build_so101_driver,
+            adapter_options=RobotAdapterOptions(goal_time_scale=1.0, external_effort_gain=None),
         ),
         RobotCatalogDefinition(
             type=RobotType.SO101_LEADER,
@@ -34,5 +71,7 @@ def get_definitions() -> list[RobotCatalogDefinition]:
             package_map={"SO101": f"/api/robots/catalog/{RobotType.SO101_LEADER}"},
             joint_map=_SO101_TO_URDF,
             urdf_relative_path=urdf_relative_path,
+            robot_builder=_build_so101_driver,
+            adapter_options=RobotAdapterOptions(goal_time_scale=1.0, external_effort_gain=None),
         ),
     ]

--- a/application/backend/src/robots/catalog/so101.py
+++ b/application/backend/src/robots/catalog/so101.py
@@ -34,11 +34,8 @@ def _to_so101_calibration(calibration: Calibration) -> SO101Calibration:
 async def _build_so101_driver(robot: CatalogRobot[SO101RobotPayload], factory: CatalogRobotFactory) -> SO101:
     if not isinstance(robot, SO101Robot):
         raise TypeError("Expected SO101Robot")
-    port = await factory.find_port_by_serial(robot.payload.serial_number)
+    port = await factory.find_so101_port(robot)
     calibration = await factory.get_calibration_by_id(robot.active_calibration_id)
-
-    if port is None:
-        raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
 
     if calibration is None:
         raise ResourceNotFoundError(ResourceType.ROBOT_CALIBRATION, robot.payload.serial_number)

--- a/application/backend/src/robots/catalog/types.py
+++ b/application/backend/src/robots/catalog/types.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from schemas.calibration import Calibration
+    from schemas.robot import SO101Robot
 
 
 @dataclass(frozen=True)
@@ -23,6 +24,8 @@ class RobotAdapterOptions:
 
 
 class CatalogRobotFactory(Protocol):
+    async def find_so101_port(self, robot: SO101Robot) -> str: ...
+
     async def find_port_by_serial(self, serial_number: str) -> str | None: ...
 
     async def get_calibration_by_id(self, calibration_id: UUID | None) -> Calibration | None: ...

--- a/application/backend/src/robots/catalog/types.py
+++ b/application/backend/src/robots/catalog/types.py
@@ -18,8 +18,13 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class RobotAdapterOptions:
+    # Adapter tuning options used when wrapping catalog robots into the PhysicalAI robot interface.
+    # Defaults are conservative so existing robots keep current behavior unless overridden.
+    # Include joint velocity values in the adapted observation/state output.
     include_velocities: bool = False
+    # Multiplier applied to goal timing (1.0 keeps original goal timing).
     goal_time_scale: float = 1.0
+    # Optional gain for externally provided effort/torque signals; None disables it.
     external_effort_gain: float | None = 0.1
 
 

--- a/application/backend/src/robots/catalog/types.py
+++ b/application/backend/src/robots/catalog/types.py
@@ -1,10 +1,50 @@
 from __future__ import annotations
 
-from typing import Literal
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
 
+from physicalai.robot.interface import Robot as PhysicalAIRobot
 from pydantic import BaseModel, Field
 
 from schemas.robot import RobotType
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from schemas.calibration import Calibration
+
+
+@dataclass(frozen=True)
+class RobotAdapterOptions:
+    include_velocities: bool = False
+    goal_time_scale: float = 1.0
+    external_effort_gain: float | None = 0.1
+
+
+class CatalogRobotFactory(Protocol):
+    async def find_port_by_serial(self, serial_number: str) -> str | None: ...
+
+    async def get_calibration_by_id(self, calibration_id: UUID | None) -> Calibration | None: ...
+
+
+_PayloadT = TypeVar("_PayloadT")
+
+
+class PayloadContainer(Protocol[_PayloadT]):
+    payload: _PayloadT
+
+
+class CatalogRobot(PayloadContainer[_PayloadT], Protocol[_PayloadT]):
+    type: RobotType
+    active_calibration_id: UUID | None
+
+
+_RobotT = TypeVar("_RobotT", bound=CatalogRobot[Any])
+_FactoryT = TypeVar("_FactoryT", bound="CatalogRobotFactory")
+
+
+BuildRobotCallable = Callable[[_RobotT, _FactoryT], Awaitable[PhysicalAIRobot]]
 
 
 class RobotCatalogDefinition(BaseModel):
@@ -18,6 +58,9 @@ class RobotCatalogDefinition(BaseModel):
         description="Observation joint name to URDF joint(s) mapping",
     )
     urdf_relative_path: str = Field(..., description="Relative path to the robot URDF asset")
+
+    robot_builder: BuildRobotCallable
+    adapter_options: RobotAdapterOptions = RobotAdapterOptions()
 
     @property
     def robot_type(self) -> RobotType:

--- a/application/backend/src/robots/catalog/widowxai.py
+++ b/application/backend/src/robots/catalog/widowxai.py
@@ -1,6 +1,8 @@
-from schemas.robot import RobotType
+from physicalai.robot.trossen import BimanualWidowXAI, WidowXAI
 
-from .types import RobotCatalogDefinition
+from schemas.robot import RobotType, TrossenBimanualPayload, TrossenSingleArmPayload
+
+from .types import CatalogRobot, CatalogRobotFactory, RobotAdapterOptions, RobotCatalogDefinition
 
 _TROSSEN_TO_URDF = {
     "shoulder_pan.pos": ["joint_0"],
@@ -30,6 +32,22 @@ _BIMANUAL_TROSSEN_TO_URDF = {
 }
 
 
+async def _build_trossen_single_arm_driver(
+    robot: CatalogRobot[TrossenSingleArmPayload], _factory: CatalogRobotFactory
+) -> WidowXAI:
+    role = "follower" if robot.type == RobotType.TROSSEN_WIDOWXAI_FOLLOWER else "leader"
+    return WidowXAI(ip=robot.payload.connection_string, role=role)
+
+
+async def _build_trossen_bimanual_driver(
+    robot: CatalogRobot[TrossenBimanualPayload], _factory: CatalogRobotFactory
+) -> BimanualWidowXAI:
+    mode = "follower" if robot.type == RobotType.TROSSEN_BIMANUAL_WIDOWXAI_FOLLOWER else "leader"
+    left_driver = WidowXAI(ip=robot.payload.connection_string_left, role=mode)
+    right_driver = WidowXAI(ip=robot.payload.connection_string_right, role=mode)
+    return BimanualWidowXAI(left=left_driver, right=right_driver)
+
+
 def get_definitions() -> list[RobotCatalogDefinition]:
     """Return built-in WidowX AI robot catalog definitions."""
     return [
@@ -43,6 +61,8 @@ def get_definitions() -> list[RobotCatalogDefinition]:
             },
             joint_map=_TROSSEN_TO_URDF,
             urdf_relative_path="widowx/urdf/generated/wxai/wxai_follower.urdf",
+            robot_builder=_build_trossen_single_arm_driver,
+            adapter_options=RobotAdapterOptions(include_velocities=True, goal_time_scale=1.0, external_effort_gain=0.1),
         ),
         RobotCatalogDefinition(
             type=RobotType.TROSSEN_WIDOWXAI_LEADER,
@@ -54,6 +74,8 @@ def get_definitions() -> list[RobotCatalogDefinition]:
             },
             joint_map=_TROSSEN_TO_URDF,
             urdf_relative_path="widowx/urdf/generated/wxai/wxai_follower.urdf",
+            robot_builder=_build_trossen_single_arm_driver,
+            adapter_options=RobotAdapterOptions(include_velocities=True, goal_time_scale=1.0, external_effort_gain=0.1),
         ),
         RobotCatalogDefinition(
             type=RobotType.TROSSEN_BIMANUAL_WIDOWXAI_FOLLOWER,
@@ -65,6 +87,8 @@ def get_definitions() -> list[RobotCatalogDefinition]:
             },
             joint_map=_BIMANUAL_TROSSEN_TO_URDF,
             urdf_relative_path="widowx/urdf/generated/stationary_ai.urdf",
+            robot_builder=_build_trossen_bimanual_driver,
+            adapter_options=RobotAdapterOptions(include_velocities=True, goal_time_scale=1.0, external_effort_gain=0.1),
         ),
         RobotCatalogDefinition(
             type=RobotType.TROSSEN_BIMANUAL_WIDOWXAI_LEADER,
@@ -76,5 +100,7 @@ def get_definitions() -> list[RobotCatalogDefinition]:
             },
             joint_map=_BIMANUAL_TROSSEN_TO_URDF,
             urdf_relative_path="widowx/urdf/generated/stationary_ai.urdf",
+            robot_builder=_build_trossen_bimanual_driver,
+            adapter_options=RobotAdapterOptions(include_velocities=True, goal_time_scale=1.0, external_effort_gain=0.1),
         ),
     ]

--- a/application/backend/src/robots/physicalai_adapter.py
+++ b/application/backend/src/robots/physicalai_adapter.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 from loguru import logger
@@ -27,20 +28,18 @@ class PhysicalAIRobotAdapter(RobotClient):
         *,
         robot: Robot,
         robot_type: RobotType,
+        robot_role: Literal["follower", "leader"] | None = None,
         config: PhysicalAIRobotAdapterConfig | None = None,
     ) -> None:
         resolved_config = config or PhysicalAIRobotAdapterConfig()
         self._robot = robot
         self._robot_type = robot_type
+        self._robot_role = robot_role
         self._config = resolved_config
         self.is_controlled = False
 
     def _is_follower(self) -> bool:
-        return self._robot_type in {
-            RobotType.SO101_FOLLOWER,
-            RobotType.TROSSEN_WIDOWXAI_FOLLOWER,
-            RobotType.TROSSEN_BIMANUAL_WIDOWXAI_FOLLOWER,
-        }
+        return self._robot_role == "follower"
 
     def _observation_to_state(self, observation: RobotObservation) -> dict[str, float]:
         state: dict[str, float] = {}

--- a/application/backend/src/robots/physicalai_adapter.py
+++ b/application/backend/src/robots/physicalai_adapter.py
@@ -28,7 +28,7 @@ class PhysicalAIRobotAdapter(RobotClient):
         *,
         robot: Robot,
         robot_type: RobotType,
-        robot_role: Literal["follower", "leader"] | None = None,
+        robot_role: Literal["follower", "leader"],
         config: PhysicalAIRobotAdapterConfig | None = None,
     ) -> None:
         resolved_config = config or PhysicalAIRobotAdapterConfig()

--- a/application/backend/src/robots/robot_client_factory.py
+++ b/application/backend/src/robots/robot_client_factory.py
@@ -7,7 +7,7 @@ from robots.robot_client import RobotClient
 from schemas.calibration import Calibration
 from schemas.robot import Robot, SO101Robot
 from services.robot_calibration_service import RobotCalibrationService
-from utils.serial_robot_tools import RobotConnectionManager
+from utils.serial_robot_tools import RobotConnectionManager, find_so101_port, serial_port_from_so101
 
 
 class RobotClientFactory:
@@ -46,10 +46,11 @@ class RobotClientFactory:
             ),
         )
 
-    async def find_robot_port(self, robot: SO101Robot) -> str:
-        port = await self.find_port_by_serial(robot.payload.serial_number)
+    async def find_so101_port(self, robot: SO101Robot) -> str:
+        port = await find_so101_port(self.robot_manager, serial_port_from_so101(robot))
         if port is None:
-            raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
+            resource_key = robot.payload.serial_number or robot.payload.connection_string
+            raise ResourceNotFoundError(ResourceType.ROBOT, resource_key)
         return port
 
     # NOTE: this is a bit awkward due to how SO101 is implemented,

--- a/application/backend/src/robots/robot_client_factory.py
+++ b/application/backend/src/robots/robot_client_factory.py
@@ -1,130 +1,71 @@
-from typing import Literal
-
-from physicalai.robot.so101 import SO101, SO101Calibration
-from physicalai.robot.trossen import BimanualWidowXAI, WidowXAI
+from uuid import UUID
 
 from exceptions import ResourceNotFoundError, ResourceType
+from robots.catalog.registry import RobotCatalogRegistry
 from robots.physicalai_adapter import PhysicalAIRobotAdapter, PhysicalAIRobotAdapterConfig
 from robots.robot_client import RobotClient
 from schemas.calibration import Calibration
-from schemas.robot import Robot, RobotType, SO101Robot, TrossenBimanualRobot
+from schemas.robot import Robot, SO101Robot
 from services.robot_calibration_service import RobotCalibrationService
-from utils.serial_robot_tools import RobotConnectionManager, find_so101_port, serial_port_from_so101
+from utils.serial_robot_tools import RobotConnectionManager
 
 
 class RobotClientFactory:
     calibration_service: RobotCalibrationService
     robot_manager: RobotConnectionManager
+    catalog_registry: RobotCatalogRegistry
 
     def __init__(
         self,
         robot_manager: RobotConnectionManager,
         calibration_service: RobotCalibrationService,
+        catalog_registry: RobotCatalogRegistry | None = None,
     ) -> None:
         self.robot_manager = robot_manager
         self.calibration_service = calibration_service
+        self.catalog_registry = catalog_registry or RobotCatalogRegistry()
 
     async def build(self, robot: Robot) -> RobotClient:
-        match robot.type:
-            case RobotType.TROSSEN_WIDOWXAI_FOLLOWER:
-                robot_driver = WidowXAI(ip=robot.payload.connection_string, role="follower")
-                return PhysicalAIRobotAdapter(
-                    robot=robot_driver,
-                    robot_type=RobotType.TROSSEN_WIDOWXAI_FOLLOWER,
-                    config=PhysicalAIRobotAdapterConfig(
-                        include_velocities=True,
-                        goal_time_scale=1.0,
-                        external_effort_gain=0.1,
-                    ),
-                )
-            case RobotType.TROSSEN_WIDOWXAI_LEADER:
-                robot_driver = WidowXAI(ip=robot.payload.connection_string, role="leader")
-                return PhysicalAIRobotAdapter(
-                    robot=robot_driver,
-                    robot_type=RobotType.TROSSEN_WIDOWXAI_LEADER,
-                    config=PhysicalAIRobotAdapterConfig(
-                        include_velocities=True,
-                        goal_time_scale=1.0,
-                        external_effort_gain=0.1,
-                    ),
-                )
-            case RobotType.TROSSEN_BIMANUAL_WIDOWXAI_FOLLOWER:
-                return self._build_bimanual_widowxai(robot, mode="follower")
-            case RobotType.TROSSEN_BIMANUAL_WIDOWXAI_LEADER:
-                return self._build_bimanual_widowxai(robot, mode="leader")
-            case RobotType.SO101_FOLLOWER:
-                return await self._build_so101(robot)
-            case RobotType.SO101_LEADER:
-                return await self._build_so101(robot)
-            case _:
-                raise ValueError(f"Unsupported robot type: {robot.type}")
+        definition = self.catalog_registry.get_definition(robot.type)
 
-    @staticmethod
-    def _build_bimanual_widowxai(
-        robot: TrossenBimanualRobot, mode: Literal["follower", "leader"]
-    ) -> PhysicalAIRobotAdapter:
-        left_driver = WidowXAI(ip=robot.payload.connection_string_left, role=mode)
-        right_driver = WidowXAI(ip=robot.payload.connection_string_right, role=mode)
-        bimanual_robot = BimanualWidowXAI(left=left_driver, right=right_driver)
-        robot_type = (
-            RobotType.TROSSEN_BIMANUAL_WIDOWXAI_FOLLOWER
-            if mode == "follower"
-            else RobotType.TROSSEN_BIMANUAL_WIDOWXAI_LEADER
-        )
+        if definition is None:
+            raise ValueError(f"Robot type is not part of the catalog: {robot.type}")
+
+        builder = definition.robot_builder
+
+        robot_driver = await builder(robot, self)
+        adapter_options = definition.adapter_options
         return PhysicalAIRobotAdapter(
-            robot=bimanual_robot,
-            robot_type=robot_type,
-            config=PhysicalAIRobotAdapterConfig(
-                include_velocities=True,
-                goal_time_scale=1.0,
-                external_effort_gain=0.1,
-            ),
-        )
-
-    async def _build_so101(self, robot: SO101Robot) -> PhysicalAIRobotAdapter:
-        port = await self.find_robot_port(robot)
-        calibration = await self._get_robot_calibration(robot)
-
-        if calibration is None:
-            raise ResourceNotFoundError(ResourceType.ROBOT_CALIBRATION, robot.payload.serial_number)
-        if port is None:
-            raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
-
-        role = "follower" if robot.type == RobotType.SO101_FOLLOWER else "leader"
-
-        so101_cal = SO101Calibration.from_dict(
-            {
-                name: {
-                    "id": val.id,
-                    "drive_mode": val.drive_mode,
-                    "homing_offset": val.homing_offset,
-                    "range_min": val.range_min,
-                    "range_max": val.range_max,
-                }
-                for name, val in calibration.values.items()
-            }
-        )
-
-        so101 = SO101(port=port, calibration=so101_cal, role=role, unit="normalized")
-        return PhysicalAIRobotAdapter(
-            robot=so101,
+            robot=robot_driver,
             robot_type=robot.type,
+            robot_role=definition.role,
             config=PhysicalAIRobotAdapterConfig(
-                include_velocities=False,
-                goal_time_scale=1.0,
-                external_effort_gain=None,
+                include_velocities=adapter_options.include_velocities,
+                goal_time_scale=adapter_options.goal_time_scale,
+                external_effort_gain=adapter_options.external_effort_gain,
             ),
         )
 
     async def find_robot_port(self, robot: SO101Robot) -> str:
-        port = await find_so101_port(self.robot_manager, serial_port_from_so101(robot))
+        port = await self.find_port_by_serial(robot.payload.serial_number)
         if port is None:
-            resource_key = robot.payload.serial_number or robot.payload.connection_string
-            raise ResourceNotFoundError(ResourceType.ROBOT, resource_key)
+            raise ResourceNotFoundError(ResourceType.ROBOT, robot.payload.serial_number)
         return port
 
-    async def _get_robot_calibration(self, robot: SO101Robot) -> Calibration | None:
+    # NOTE: this is a bit awkward due to how SO101 is implemented,
+    # perhaps we can add the Calibration into the SO101RobotPayload
+    async def get_robot_calibration(self, robot: SO101Robot) -> Calibration | None:
         if robot.active_calibration_id is None:
             return None
-
         return await self.calibration_service.get_calibration(robot.active_calibration_id)
+
+    async def find_port_by_serial(self, serial_number: str) -> str | None:
+        for managed_robot in self.robot_manager.robots:
+            if managed_robot.serial_number == serial_number:
+                return managed_robot.connection_string
+        return None
+
+    async def get_calibration_by_id(self, calibration_id: UUID | None) -> Calibration | None:
+        if calibration_id is None:
+            return None
+        return await self.calibration_service.get_calibration(calibration_id)

--- a/application/backend/tests/robots/test_bimanual_widowxai_adapter.py
+++ b/application/backend/tests/robots/test_bimanual_widowxai_adapter.py
@@ -44,6 +44,7 @@ def _make_adapter(mode: str = "follower") -> tuple[PhysicalAIRobotAdapter, Magic
     adapter = PhysicalAIRobotAdapter(
         robot=robot,
         robot_type=robot_type,
+        robot_role=mode,
         config=PhysicalAIRobotAdapterConfig(
             include_velocities=True,
             goal_time_scale=1.0,

--- a/application/backend/tests/robots/test_robot_adapter.py
+++ b/application/backend/tests/robots/test_robot_adapter.py
@@ -23,9 +23,11 @@ def _make_adapter(
 ) -> tuple[PhysicalAIRobotAdapter, MagicMock]:
     robot = _make_mock_robot()
     robot_type = RobotType.SO101_FOLLOWER if mode == "follower" else RobotType.SO101_LEADER
+    robot_role = "follower" if mode == "follower" else "leader"
     adapter = PhysicalAIRobotAdapter(
         robot=robot,
         robot_type=robot_type,
+        robot_role=robot_role,
         config=PhysicalAIRobotAdapterConfig(
             include_velocities=False,
             goal_time_scale=1.0,


### PR DESCRIPTION
Prepare for robot plugin design by moving builders from a complicated `RobotClientFactory` into their own files. The goal is that each robot file (`so101.py`, `widowx.py`) will resemble a plugin. 
Plugin authors need to implement a similar interface to get their robot into studio.

Next step:
- Move the payload and robot interface into the plugin file
- Move discovery methods into plugin file