### PR TITLE
feat: check lockfile is up to date in precommit

### DIFF
--- a/application/backend/.pre-commit-config.yaml
+++ b/application/backend/.pre-commit-config.yaml
@@ -65,6 +65,18 @@ repos:
       - id: gitleaks
 
   # ========================================================================== #
+  # DEPENDENCY LOCKFILE CHECKS                                                 #
+  # ========================================================================== #
+  - repo: local
+    hooks:
+      - id: check-uv-lock
+        name: Check uv.lock is up to date
+        entry: uv lock --check
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|uv\.lock)$
+
+  # ========================================================================== #
   # ALEMBIC MIGRATION CHECKS                                                   #
   # ========================================================================== #
   - repo: local

--- a/application/trainer/.pre-commit-config.yaml
+++ b/application/trainer/.pre-commit-config.yaml
@@ -63,3 +63,15 @@ repos:
     rev: v8.30.1
     hooks:
       - id: gitleaks
+
+  # ========================================================================== #
+  # DEPENDENCY LOCKFILE CHECKS                                                 #
+  # ========================================================================== #
+  - repo: local
+    hooks:
+      - id: check-uv-lock
+        name: Check uv.lock is up to date
+        entry: uv lock --check
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|uv\.lock)$

--- a/library/.pre-commit-config.yaml
+++ b/library/.pre-commit-config.yaml
@@ -67,6 +67,18 @@ repos:
       - id: gitleaks
 
   # ========================================================================== #
+  # DEPENDENCY LOCKFILE CHECKS                                                 #
+  # ========================================================================== #
+  - repo: local
+    hooks:
+      - id: check-uv-lock
+        name: Check uv.lock is up to date
+        entry: uv lock --check
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|uv\.lock)$
+
+  # ========================================================================== #
   # DOCUMENTATION & FORMATTING                                                 #
   # ========================================================================== #
   - repo: https://github.com/rbubley/mirrors-prettier


### PR DESCRIPTION
While working on the lerobot upgrade (#780) I noticed that our pre commit checks didn't verify that our lockfiles have been updated. This is cheap check and quite useful to have when having agents try to resolve any dependency issues.

Note: in the CI we run this both in prek and as a prerequisite step for some of our workflows like unit and integration tests. 
Initially I was considering removing these checks but I ended up leaving them as it's a fast and quick check so having it here will help these tests fail fast in case of issues.