### PR TITLE
feat(ui): allow exporting an SO101 robot's calibration

### DIFF
--- a/application/ui/src/features/robots/robots-list.test.tsx
+++ b/application/ui/src/features/robots/robots-list.test.tsx
@@ -1,0 +1,137 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse } from 'msw';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { http } from '../../api/utils';
+import { server } from '../../msw-node-setup';
+import { render } from '../../test-utils/render';
+import { RobotsList } from './robots-list';
+
+const PROJECT_ID = 'test-project-id';
+const ROBOT_ID = 'robot-id';
+const CALIBRATION_ID = 'calibration-id';
+const ROBOTS_PATH = '/api/projects/{project_id}/robots';
+const ONLINE_ROBOTS_PATH = '/api/projects/{project_id}/robots/online';
+
+const so101Robot = {
+    id: ROBOT_ID,
+    name: 'Test SO101',
+    type: 'SO101_Follower' as const,
+    payload: { connection_string: '', serial_number: 'SO101-001' },
+    active_calibration_id: CALIBRATION_ID,
+};
+
+const renderRobotsList = () =>
+    render(<RobotsList />, {
+        route: `/projects/${PROJECT_ID}/robots`,
+        path: '/projects/:project_id/robots',
+    });
+
+const openRobotMenu = async (user: ReturnType<typeof userEvent.setup>) => {
+    await screen.findByText(so101Robot.name);
+    await user.click(screen.getByRole('button', { name: `Actions for ${so101Robot.name}` }));
+};
+
+describe('RobotsList', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('only shows Export calibration for SO101 robots', async () => {
+        server.use(
+            http.get(ROBOTS_PATH, () =>
+                HttpResponse.json([
+                    so101Robot,
+                    {
+                        id: 'widowx-id',
+                        name: 'Test WidowX',
+                        type: 'Trossen_WidowXAI_Follower',
+                        payload: { connection_string: '', serial_number: 'widowx-001' },
+                    },
+                ])
+            ),
+            http.get(ONLINE_ROBOTS_PATH, () => HttpResponse.json([]))
+        );
+
+        const user = userEvent.setup();
+        renderRobotsList();
+
+        await openRobotMenu(user);
+
+        expect(await screen.findByText('Export calibration', { selector: '[role]' })).toBeEnabled();
+    });
+
+    it('disables Export calibration when no calibration is active', async () => {
+        server.use(
+            http.get(ROBOTS_PATH, () => HttpResponse.json([{ ...so101Robot, active_calibration_id: null }])),
+            http.get(ONLINE_ROBOTS_PATH, () => HttpResponse.json([]))
+        );
+
+        const user = userEvent.setup();
+        renderRobotsList();
+
+        await openRobotMenu(user);
+
+        const exportCalibration = await screen.findByText('Export calibration', { selector: '[role]' });
+        expect(exportCalibration.closest('[aria-disabled]')).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('downloads the active calibration in import-compatible format', async () => {
+        const NativeURL = URL;
+        const createObjectUrl = vi.fn<(blob: Blob) => string>(() => 'blob:calibration');
+        const revokeObjectUrl = vi.fn();
+        const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+        vi.stubGlobal(
+            'URL',
+            class extends NativeURL {
+                static createObjectURL = createObjectUrl;
+                static revokeObjectURL = revokeObjectUrl;
+            }
+        );
+        server.use(
+            http.get(ROBOTS_PATH, () => HttpResponse.json([so101Robot])),
+            http.get(ONLINE_ROBOTS_PATH, () => HttpResponse.json([])),
+            http.get('/api/projects/{project_id}/robots/{robot_id}/calibrations/{calibration_id}', () =>
+                HttpResponse.json({
+                    id: CALIBRATION_ID,
+                    robot_id: ROBOT_ID,
+                    file_path: '/calibration.json',
+                    values: {
+                        shoulder_pan: {
+                            id: 1,
+                            joint_name: 'shoulder_pan',
+                            drive_mode: 0,
+                            homing_offset: 10,
+                            range_min: -100,
+                            range_max: 100,
+                        },
+                    },
+                })
+            )
+        );
+
+        const user = userEvent.setup();
+        renderRobotsList();
+
+        await openRobotMenu(user);
+        await user.click(await screen.findByText('Export calibration', { selector: '[role]' }));
+
+        await waitFor(() => expect(createObjectUrl).toHaveBeenCalledOnce());
+
+        const blob = createObjectUrl.mock.calls[0]?.[0];
+        expect(blob).toBeDefined();
+        expect(JSON.parse(await blob.text())).toEqual({
+            shoulder_pan: {
+                id: 1,
+                drive_mode: 0,
+                homing_offset: 10,
+                range_min: -100,
+                range_max: 100,
+            },
+        });
+        expect(click).toHaveBeenCalledOnce();
+        expect(revokeObjectUrl).toHaveBeenCalledWith('blob:calibration');
+    });
+});

--- a/application/ui/src/features/robots/robots-list.test.tsx
+++ b/application/ui/src/features/robots/robots-list.test.tsx
@@ -39,7 +39,7 @@ describe('RobotsList', () => {
         vi.unstubAllGlobals();
     });
 
-    it('only shows Export calibration for SO101 robots', async () => {
+    it('shows Export calibration for SO101 robots', async () => {
         server.use(
             http.get(ROBOTS_PATH, () =>
                 HttpResponse.json([

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -80,9 +80,9 @@ const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
                         ? ['export-calibration']
                         : []
                 }
-                onAction={(action) => {
+                onAction={async (action) => {
                     if (action === 'delete') {
-                        deleteRobotMutation.mutate(
+                        await deleteRobotMutation.mutateAsync(
                             { params: { path: { project_id, robot_id: robot.id } } },
                             {
                                 onError: (error) => {
@@ -98,7 +98,11 @@ const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
                         );
                     }
                     if (action === 'export-calibration') {
-                        exportCalibration(project_id, robot);
+                        try {
+                            await exportCalibration(project_id, robot);
+                        } catch {
+                            toast.negative('Failed to export calibration.');
+                        }
                     }
                 }}
             >

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -4,7 +4,7 @@ import { Add, MoreMenu } from '@geti-ui/ui/icons';
 import { clsx } from 'clsx';
 import { NavLink } from 'react-router-dom';
 
-import { $api } from '../../api/client';
+import { $api, fetchClient } from '../../api/client';
 import { getApiErrorMessage, isResourceInUseError } from '../../api/errors';
 import { paths } from '../../router';
 import { useProjectId } from '../projects/use-project';
@@ -13,7 +13,44 @@ import { SchemaRobot } from './robot-types';
 
 import classes from './robots-list.module.css';
 
-const MenuActions = ({ robot_id }: { robot_id: string }) => {
+const exportCalibration = async (project_id: string, robot: SchemaRobot) => {
+    if (robot.active_calibration_id === null || robot.active_calibration_id === undefined) {
+        return;
+    }
+
+    const { data, error } = await fetchClient.GET(
+        '/api/projects/{project_id}/robots/{robot_id}/calibrations/{calibration_id}',
+        { params: { path: { project_id, robot_id: robot.id, calibration_id: robot.active_calibration_id } } }
+    );
+
+    if (error || !data) {
+        toast.negative(getApiErrorMessage(error) ?? 'Failed to export calibration.');
+        return;
+    }
+
+    const calibration = Object.fromEntries(
+        Object.entries(data.values).map(([jointName, value]) => [
+            jointName,
+            {
+                id: value.id,
+                drive_mode: value.drive_mode,
+                homing_offset: value.homing_offset,
+                range_min: value.range_min,
+                range_max: value.range_max,
+            },
+        ])
+    );
+    const downloadUrl = URL.createObjectURL(
+        new Blob([JSON.stringify(calibration, null, 4)], { type: 'application/json' })
+    );
+    const link = document.createElement('a');
+    link.href = downloadUrl;
+    link.download = `${robot.name}-calibration.json`;
+    link.click();
+    URL.revokeObjectURL(downloadUrl);
+};
+
+const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
     const { project_id } = useProjectId();
     const deleteRobotMutation = $api.useMutation('delete', '/api/projects/{project_id}/robots/{robot_id}', {
         meta: {
@@ -24,19 +61,29 @@ const MenuActions = ({ robot_id }: { robot_id: string }) => {
         },
     });
 
-    const editPath = paths.project.robots.edit({ project_id, robot_id });
+    const editPath = paths.project.robots.edit({ project_id, robot_id: robot.id });
+    const isSO101 = robot.type === 'SO101_Follower' || robot.type === 'SO101_Leader';
 
     return (
         <MenuTrigger>
-            <ActionButton isQuiet UNSAFE_style={{ fill: 'var(--spectrum-gray-900)' }}>
+            <ActionButton
+                aria-label={`Actions for ${robot.name}`}
+                isQuiet
+                UNSAFE_style={{ fill: 'var(--spectrum-gray-900)' }}
+            >
                 <MoreMenu />
             </ActionButton>
             <Menu
                 selectionMode='single'
+                disabledKeys={
+                    robot.active_calibration_id === null || robot.active_calibration_id === undefined
+                        ? ['export-calibration']
+                        : []
+                }
                 onAction={(action) => {
                     if (action === 'delete') {
                         deleteRobotMutation.mutate(
-                            { params: { path: { project_id, robot_id } } },
+                            { params: { path: { project_id, robot_id: robot.id } } },
                             {
                                 onError: (error) => {
                                     if (isResourceInUseError(error)) {
@@ -50,11 +97,15 @@ const MenuActions = ({ robot_id }: { robot_id: string }) => {
                             }
                         );
                     }
+                    if (action === 'export-calibration') {
+                        exportCalibration(project_id, robot);
+                    }
                 }}
             >
                 <Item key='edit' href={editPath}>
                     Edit
                 </Item>
+                {isSO101 ? <Item key='export-calibration'>Export calibration</Item> : null}
                 <Item key='delete'>Delete</Item>
             </Menu>
         </MenuTrigger>
@@ -145,7 +196,7 @@ const RobotListItem = ({
                         </ul>
                     </View>
                     <View alignSelf={'end'}>
-                        <MenuActions robot_id={robot.id} />
+                        <MenuActions robot={robot} />
                     </View>
                 </Flex>
             </Flex>


### PR DESCRIPTION
This PR allows users of an SO101 robot to export their calibration as a JSON file having the same structure as a lerobot calibration format:
```json
{
    "shoulder_pan": {
        "id": 1,
        "drive_mode": 0,
        "homing_offset": 135,
        "range_min": 732,
        "range_max": 3454
    },
    "shoulder_lift": {
        "id": 2,
        "drive_mode": 0,
        "homing_offset": 263,
        "range_min": 821,
        "range_max": 3195
    },
    "elbow_flex": {
        "id": 3,
        "drive_mode": 0,
        "homing_offset": 1149,
        "range_min": 851,
        "range_max": 3074
    },
    "wrist_flex": {
        "id": 4,
        "drive_mode": 0,
        "homing_offset": -1606,
        "range_min": 860,
        "range_max": 3188
    },
    "wrist_roll": {
        "id": 5,
        "drive_mode": 0,
        "homing_offset": 612,
        "range_min": 124,
        "range_max": 3956
    },
    "gripper": {
        "id": 6,
        "drive_mode": 0,
        "homing_offset": 1088,
        "range_min": 1938,
        "range_max": 3416
    }
}
```

Later we will implement #786 allowing users to reuse this calibration file to import it when creating a new SO101 robot.
Another thing we could do is allow users to edit a current robot and override its calibration. This will require a bit more work though as we should then overwrite both the calibration that's stored in the backend and the values on the robot's control board. 

<img width="1920" height="1080" alt="192 168 2 117_3000_projects_9df639c6-d7cf-4735-8f80-ef605f2f3041_robots(Full HD)" src="https://github.com/user-attachments/assets/f77c87d3-39d5-444c-99af-ef90ee485c3e" />
