### PR TITLE
fix: extract `ElapsedDuration` component

### DIFF
--- a/application/ui/src/components/elapsed-duration.component.test.tsx
+++ b/application/ui/src/components/elapsed-duration.component.test.tsx
@@ -1,0 +1,26 @@
+import { act, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render } from '../test-utils/render';
+import { ElapsedDuration } from './elapsed-duration.component';
+
+describe('ElapsedDuration', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-14T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('updates the displayed duration every second', () => {
+        render(<ElapsedDuration date='2026-07-14T11:59:58Z' />);
+
+        expect(screen.getByText('2s')).toBeInTheDocument();
+
+        act(() => vi.advanceTimersByTime(1000));
+
+        expect(screen.getByText('3s')).toBeInTheDocument();
+    });
+});

--- a/application/ui/src/components/elapsed-duration.component.tsx
+++ b/application/ui/src/components/elapsed-duration.component.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+import { formatDuration } from '../routes/models/utils';
+
+export const elapsedSince = (dateString: string): string => {
+    const normalized = /Z|[+-]\d\d:\d\d$/.test(dateString) ? dateString : `${dateString}Z`;
+
+    return formatDuration(new Date().getTime() - new Date(normalized).getTime());
+};
+
+export const ElapsedDuration = ({ date }: { date: string }) => {
+    const [elapsed, setElapsed] = useState(() => elapsedSince(date));
+
+    useEffect(() => {
+        const updateElapsed = () => setElapsed(elapsedSince(date));
+        updateElapsed();
+
+        const intervalId = window.setInterval(updateElapsed, 1000);
+
+        return () => window.clearInterval(intervalId);
+    }, [date]);
+
+    return elapsed;
+};

--- a/application/ui/src/routes/models/job-table.component.tsx
+++ b/application/ui/src/routes/models/job-table.component.tsx
@@ -16,12 +16,13 @@ import {
 import { MoreMenu } from '@geti-ui/ui/icons';
 
 import { $api } from '../../api/client';
+import { ElapsedDuration } from '../../components/elapsed-duration.component';
 import { CollapsableRow } from './collapsable-row.component';
 import { GRID_COLUMNS } from './constants';
 import { JobRowContent } from './job-row-content.component';
 import { SingleBadge, SplitBadge } from './split-badge.component';
 import { SchemaTrainJob } from './train-model-dialog';
-import { durationBetween, elapsedSince } from './utils';
+import { durationBetween } from './utils';
 
 import classes from './model-table.module.css';
 
@@ -48,7 +49,8 @@ const TrainJobStatus = ({ job }: { job: SchemaTrainJob }) => {
                 </Flex>
                 {job.start_time ? (
                     <Text UNSAFE_className={classes.modelInfo}>
-                        Started: {new Date(job.start_time).toLocaleString()} | Elapsed: {elapsedSince(job.start_time)}
+                        Started: {new Date(job.start_time).toLocaleString()} | Elapsed:{' '}
+                        <ElapsedDuration date={job.start_time} />
                     </Text>
                 ) : (
                     <></>

--- a/application/ui/src/routes/models/utils.ts
+++ b/application/ui/src/routes/models/utils.ts
@@ -12,11 +12,3 @@ export const formatDuration = (ms: number): string => {
 export const durationBetween = (start: string, end: string): string => {
     return formatDuration(new Date(end).getTime() - new Date(start).getTime());
 };
-
-export const elapsedSince = (dateString: string): string => {
-    const normalized = /Z|[+-]\d\d:\d\d$/.test(dateString) ? dateString : `${dateString}Z`;
-
-    const startDate = new Date(normalized).getTime();
-
-    return formatDuration(new Date().getTime() - startDate);
-};


### PR DESCRIPTION
Before a job's elapsed duration would only accidentally update when `TrainJobStatus` would rerender, leading to potentially stale elapsed information.
We now make the UI responsible for rerendering this string every second.