### PR TITLE
chore(ui): align UI pre-commit hooks with CI lint checks

### DIFF
--- a/.github/instructions/ui.instructions.md
+++ b/.github/instructions/ui.instructions.md
@@ -1,0 +1,6 @@
+---
+applyTo: "application/ui/**"
+description: UI-specific development guidance for the React frontend. Apply when writing, editing, or reviewing code under `application/ui/`.
+---
+
+Follow [`application/ui/AGENTS.md`](../../application/ui/AGENTS.md).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@
 #   - library/.pre-commit-config.yaml
 #   - application/backend/.pre-commit-config.yaml
 #   - application/trainer/.pre-commit-config.yaml (kept in sync with backend)
+#   - application/ui/.pre-commit-config.yaml
 
 default_language_version:
   node: 22.10.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Physical AI Studio is the training-side repo for the Physical AI workflow: colle
 - Run repo hooks with `prek run --all-files` from the repo root.
 - Limit hooks to the library with `prek run --all-files library/`.
 - Limit hooks to the backend with `prek run --all-files application/backend/`.
+- Limit hooks to the UI with `prek run --all-files application/ui/` (requires `npm install` in `application/ui/` first).
 - Regenerate UI API types with `npm run build:api:download && npm run build:api` from `application/ui/` while the backend is serving OpenAPI.
 
 ## Cross-Repo Rules

--- a/application/ui/.pre-commit-config.yaml
+++ b/application/ui/.pre-commit-config.yaml
@@ -4,12 +4,12 @@
 # UI-specific pre-commit configuration for prek workspace mode
 # This config applies only to files in application/ui/
 #
-# Mirrors the "Eslint checks" job in .github/workflows/ui.yml so formatting,
+# Mirrors the "ESLint checks" job in .github/workflows/ui.yml so formatting,
 # lint, and import-cycle issues are caught locally instead of only surfacing
 # in CI. Requires `npm install` (or `npm ci`) to have been run at least once
 # in application/ui/ so node_modules/.bin is populated.
 #
-# The "Typescript" step (`npm run type-check`) is intentionally NOT wired up
+# The "TypeScript" step (`npm run type-check`) is intentionally NOT wired up
 # here: it type-checks against the generated, gitignored
 # `src/api/openapi-spec.d.ts`, which is regenerated fresh from a live backend
 # on every CI run but can silently go stale locally (e.g. after switching
@@ -22,21 +22,21 @@ repos:
     hooks:
       - id: ui-prettier-check
         name: UI Prettier format check
-        entry: node_modules/.bin/prettier --check --cache
+        entry: npm run format:check --silent
         language: system
         files: ^src/.*\.(js|jsx|ts|tsx|css)$
         pass_filenames: true
 
       - id: ui-eslint
-        name: UI Eslint
+        name: UI ESLint
         entry: npm run lint --silent
         language: system
-        files: ^src/.*\.(ts|tsx)$
-        pass_filenames: false
+        files: ^(src/.*\.(ts|tsx)|package(-lock)?\.json|tsconfig.*\.json|eslint(\.shared)?\.config\.js)$
+        pass_filenames: true
 
       - id: ui-cyclic-deps-check
-        name: UI Eslint cyclic imports
+        name: UI ESLint cyclic imports
         entry: npm run cyclic-deps-check --silent
         language: system
-        files: ^src/.*\.(ts|tsx)$
+        files: ^(src/.*\.(ts|tsx)|package(-lock)?\.json|tsconfig.*\.json|eslint(\.shared)?\.config\.js)$
         pass_filenames: false

--- a/application/ui/.pre-commit-config.yaml
+++ b/application/ui/.pre-commit-config.yaml
@@ -4,10 +4,18 @@
 # UI-specific pre-commit configuration for prek workspace mode
 # This config applies only to files in application/ui/
 #
-# Mirrors the `npm run format:check` step from .github/workflows/ui.yml so
-# formatting issues in JS/TS/CSS source files are caught locally instead of
-# only surfacing in CI. Requires `npm ci` to have been run at least once so
-# node_modules/.bin/prettier is available.
+# Mirrors the "Eslint checks" job in .github/workflows/ui.yml so formatting,
+# lint, and import-cycle issues are caught locally instead of only surfacing
+# in CI. Requires `npm ci` to have been run at least once in application/ui/
+# so node_modules/.bin is populated.
+#
+# The "Typescript" step (`npm run type-check`) is intentionally NOT wired up
+# here: it type-checks against the generated, gitignored
+# `src/api/openapi-spec.d.ts`, which is regenerated fresh from a live backend
+# on every CI run but can silently go stale locally (e.g. after switching
+# branches) and produce false failures unrelated to the change being
+# committed. Run `npm run type-check` manually (after `npm run
+# build:api:download && npm run build:api`) when you need that check.
 
 repos:
   - repo: local
@@ -18,3 +26,17 @@ repos:
         language: system
         files: ^src/.*\.(js|jsx|ts|tsx|css)$
         pass_filenames: true
+
+      - id: ui-eslint
+        name: UI Eslint
+        entry: npm run lint --silent
+        language: system
+        files: ^src/.*\.(ts|tsx)$
+        pass_filenames: false
+
+      - id: ui-cyclic-deps-check
+        name: UI Eslint cyclic imports
+        entry: npm run cyclic-deps-check --silent
+        language: system
+        files: ^src/.*\.(ts|tsx)$
+        pass_filenames: false

--- a/application/ui/.pre-commit-config.yaml
+++ b/application/ui/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# UI-specific pre-commit configuration for prek workspace mode
+# This config applies only to files in application/ui/
+#
+# Mirrors the `npm run format:check` step from .github/workflows/ui.yml so
+# formatting issues in JS/TS/CSS source files are caught locally instead of
+# only surfacing in CI. Requires `npm ci` to have been run at least once so
+# node_modules/.bin/prettier is available.
+
+repos:
+  - repo: local
+    hooks:
+      - id: ui-prettier-check
+        name: UI Prettier format check
+        entry: node_modules/.bin/prettier --check
+        language: system
+        files: ^src/.*\.(js|jsx|ts|tsx|css)$
+        pass_filenames: true

--- a/application/ui/.pre-commit-config.yaml
+++ b/application/ui/.pre-commit-config.yaml
@@ -6,8 +6,8 @@
 #
 # Mirrors the "Eslint checks" job in .github/workflows/ui.yml so formatting,
 # lint, and import-cycle issues are caught locally instead of only surfacing
-# in CI. Requires `npm ci` to have been run at least once in application/ui/
-# so node_modules/.bin is populated.
+# in CI. Requires `npm install` (or `npm ci`) to have been run at least once
+# in application/ui/ so node_modules/.bin is populated.
 #
 # The "Typescript" step (`npm run type-check`) is intentionally NOT wired up
 # here: it type-checks against the generated, gitignored
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: ui-prettier-check
         name: UI Prettier format check
-        entry: node_modules/.bin/prettier --check
+        entry: node_modules/.bin/prettier --check --cache
         language: system
         files: ^src/.*\.(js|jsx|ts|tsx|css)$
         pass_filenames: true

--- a/application/ui/.pre-commit-config.yaml
+++ b/application/ui/.pre-commit-config.yaml
@@ -9,13 +9,11 @@
 # in CI. Requires `npm install` (or `npm ci`) to have been run at least once
 # in application/ui/ so node_modules/.bin is populated.
 #
-# The "TypeScript" step (`npm run type-check`) is intentionally NOT wired up
-# here: it type-checks against the generated, gitignored
-# `src/api/openapi-spec.d.ts`, which is regenerated fresh from a live backend
-# on every CI run but can silently go stale locally (e.g. after switching
-# branches) and produce false failures unrelated to the change being
-# committed. Run `npm run type-check` manually (after `npm run
-# build:api:download && npm run build:api`) when you need that check.
+# The TypeScript hook retries once after regenerating the OpenAPI types when
+# its initial type check fails. This handles a stale
+# `src/api/openapi-spec.d.ts` after, for example, switching branches. The
+# fallback uses the backend CLI and requires its uv environment to be synced;
+# it fails the commit if generation or the retried TypeScript check fails.
 
 repos:
   - repo: local
@@ -37,6 +35,14 @@ repos:
       - id: ui-cyclic-deps-check
         name: UI ESLint cyclic imports
         entry: npm run cyclic-deps-check --silent
+        language: system
+        files: ^(src/.*\.(ts|tsx)|package(-lock)?\.json|tsconfig.*\.json|eslint(\.shared)?\.config\.js)$
+        pass_filenames: false
+
+      - id: ui-type-check
+        name: UI TypeScript
+        entry: >-
+          /bin/sh -c 'npm run type-check --silent || { (cd ../backend && uv run physicalai-studio gen-api --target-path ../ui/src/api/openapi-spec.json) && npm run build:api --silent && npm run type-check --silent; }'
         language: system
         files: ^(src/.*\.(ts|tsx)|package(-lock)?\.json|tsconfig.*\.json|eslint(\.shared)?\.config\.js)$
         pass_filenames: false

--- a/application/ui/.pre-commit-config.yaml
+++ b/application/ui/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 # UI-specific pre-commit configuration for prek workspace mode


### PR DESCRIPTION
## Summary
Adds local `prek`/pre-commit hooks for `application/ui/` that mirror the checks in the CI "Eslint checks" job (`.github/workflows/ui.yml`):
| CI step (`npm run ...`) | Local hook | Status |
|---|---|---|
| `format:check` (Prettier) | `ui-prettier-check` | added |
| `lint` (Eslint) | `ui-eslint` | added |
| `cyclic-deps-check` (import cycles) | `ui-cyclic-deps-check` | added |
| `type-check` (`tsc --noEmit`) | `ui-type-check` | added |

## Why
Previously, none of these were caught locally — the root pre-commit config's prettier hook only covers `markdown, yaml, json` and explicitly excludes `application/`, and `library/`'s config is Python/markdown-only. A dev could push formatting/lint/import-cycle issues and only find out after CI ran.
