### PR TITLE
fix: [LIBERO GYM] Do env reset before the env init

### DIFF
--- a/library/pyrefly-baseline.json
+++ b/library/pyrefly-baseline.json
@@ -1019,10 +1019,10 @@
       "severity": "error"
     },
     {
-      "line": 368,
-      "column": 13,
-      "stop_line": 368,
-      "stop_column": 36,
+      "line": 370,
+      "column": 23,
+      "stop_line": 370,
+      "stop_column": 46,
       "path": "src/physicalai/gyms/libero.py",
       "code": -2,
       "name": "missing-attribute",

--- a/library/src/physicalai/gyms/libero.py
+++ b/library/src/physicalai/gyms/libero.py
@@ -363,11 +363,11 @@ class LiberoGym(Gym):
         if seed is not None:
             self.env.seed(seed)
 
+        raw_obs = self.env.reset()
+
         # Apply init state if available
         if self.init_states and self._init_states is not None:
-            self.env.set_init_state(self._init_states[self._init_state_id])
-
-        raw_obs = self.env.reset()
+            raw_obs = self.env.set_init_state(self._init_states[self._init_state_id])
 
         # After reset, objects may be unstable (slightly floating, intersecting, etc.).
         # Step the simulator with a no-op action for a few frames so everything settles.


### PR DESCRIPTION
## Description
The `env.reset` from the LIBERO GYM is moved above the the `env._init_states` call - resetting the environment before the new initialization.
This is aligned with the original LIBERO API usage
https://github.com/Lifelong-Robot-Learning/LIBERO/blob/master/libero/lifelong/evaluate.py#L247-L261
And fixes some edge cases which appear with a specific seed:

> [!NOTE]  
> I was able to reproduce this bug only with a specific seed (used by the XR0 model https://github.com/daniil-lyakhov/physical-ai-studio/blob/64d384f4d2f989e4369932049890a7a001b13a82/liber_xr0.py#L257-L262)

Before the fix:
libero_10 task0 - the orange juice pack is falling on its side
<img width="535" height="523" alt="image" src="https://github.com/user-attachments/assets/70317bae-6711-4612-b603-200be6f0a670" />
libero_10 task 1 - There is no butter on the table
<img width="532" height="535" alt="image" src="https://github.com/user-attachments/assets/86e21355-7a07-43fe-bf25-41f42137322c" />
After the fix:
libero_10 task 0 - the orange juice pack is standing as expected
<img width="534" height="526" alt="image" src="https://github.com/user-attachments/assets/a6ee7ec1-b8f0-4b94-9153-e9fe5ff069a4" />

libero_10 task 1 - The butter is present on the table
<img width="537" height="530" alt="image" src="https://github.com/user-attachments/assets/17ff75aa-5941-4b79-a322-9fdfcdb30473" />



## Related Issues

<!-- Fixes #123 -->
