### PR TITLE
fix: fix loading a trained model's hyper parameters

### DIFF
--- a/application/backend/src/services/model_service.py
+++ b/application/backend/src/services/model_service.py
@@ -1,5 +1,6 @@
 import shutil
 from pathlib import Path
+from typing import Any
 from uuid import UUID
 
 import yaml
@@ -12,12 +13,27 @@ from schemas.job import TrainJob
 from schemas.model import BackendExportDetail, Model, TrainingSummary
 
 
-class SafeLoaderIgnoreUnknown(yaml.SafeLoader):
-    def ignore_unknown(self, node):
-        return None
+class SafeLoaderLegacyPythonTags(yaml.SafeLoader):
+    """Safe loader with support for legacy ``!!python/*`` YAML tags."""
 
 
-SafeLoaderIgnoreUnknown.add_constructor(None, SafeLoaderIgnoreUnknown.ignore_unknown)
+def _construct_legacy_python_tag(
+    loader: yaml.SafeLoader,
+    tag_suffix: str,
+    node: yaml.Node,
+) -> Any:
+    # pyrefly/mypy: tag_suffix is intentionally unused; constructor signature is fixed by PyYAML.
+    del tag_suffix
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    return None
+
+
+SafeLoaderLegacyPythonTags.add_multi_constructor("tag:yaml.org,2002:python/", _construct_legacy_python_tag)
 
 
 class ModelService:
@@ -96,10 +112,16 @@ class ModelService:
             return None
         try:
             with hparams_path.open(encoding="utf-8") as f:
-                return yaml.load(f, Loader=SafeLoaderIgnoreUnknown)
+                loader = SafeLoaderLegacyPythonTags(f)
+                try:
+                    data = loader.get_single_data()
+                finally:
+                    loader.dispose()
         except yaml.YAMLError:
             logger.warning("Could not parse model hparams YAML at {}", hparams_path)
             return None
+
+        return data if isinstance(data, dict) else None
 
     @staticmethod
     def get_training_summary(training_job: TrainJob | None) -> TrainingSummary | None:

--- a/application/backend/src/services/model_service.py
+++ b/application/backend/src/services/model_service.py
@@ -3,12 +3,21 @@ from pathlib import Path
 from uuid import UUID
 
 import yaml
+from loguru import logger
 
 from db import get_async_db_session_ctx
 from exceptions import ResourceNotFoundError, ResourceType
 from repositories import ModelRepository, SnapshotRepository
 from schemas.job import TrainJob
 from schemas.model import BackendExportDetail, Model, TrainingSummary
+
+
+class SafeLoaderIgnoreUnknown(yaml.SafeLoader):
+    def ignore_unknown(self, node):
+        return None
+
+
+SafeLoaderIgnoreUnknown.add_constructor(None, SafeLoaderIgnoreUnknown.ignore_unknown)
 
 
 class ModelService:
@@ -85,8 +94,12 @@ class ModelService:
         hparams_path = Path(model.path) / "version_0" / "hparams.yaml"
         if not hparams_path.is_file():
             return None
-        with hparams_path.open() as f:
-            return yaml.safe_load(f)
+        try:
+            with hparams_path.open(encoding="utf-8") as f:
+                return yaml.load(f, Loader=SafeLoaderIgnoreUnknown)
+        except yaml.YAMLError:
+            logger.warning("Could not parse model hparams YAML at {}", hparams_path)
+            return None
 
     @staticmethod
     def get_training_summary(training_job: TrainJob | None) -> TrainingSummary | None:

--- a/application/backend/tests/services/test_model_service.py
+++ b/application/backend/tests/services/test_model_service.py
@@ -53,6 +53,22 @@ def test_get_hparams_handles_legacy_python_tuple_tag(tmp_path) -> None:
     assert hparams["image_size"] == [384, 384]
 
 
+def test_get_hparams_handles_unknown_python_tag_suffix(tmp_path) -> None:
+    model = _make_model()
+    model.path = str(tmp_path)
+    version_dir = tmp_path / "version_0"
+    version_dir.mkdir(parents=True)
+    (version_dir / "hparams.yaml").write_text(
+        "future_value: !!python/some_future_tag [1, 2, 3]\n",
+        encoding="utf-8",
+    )
+
+    hparams = ModelService.get_hparams(model)
+
+    assert hparams is not None
+    assert hparams["future_value"] == [1, 2, 3]
+
+
 def test_get_hparams_returns_none_when_yaml_invalid(tmp_path) -> None:
     model = _make_model()
     model.path = str(tmp_path)

--- a/application/backend/tests/services/test_model_service.py
+++ b/application/backend/tests/services/test_model_service.py
@@ -37,6 +37,32 @@ def test_get_backend_details_delegates_to_backend_export_detail(tmp_path) -> Non
     mock_from_backend_dir.assert_called_once_with(backend_dir)
 
 
+def test_get_hparams_handles_legacy_python_tuple_tag(tmp_path) -> None:
+    model = _make_model()
+    model.path = str(tmp_path)
+    version_dir = tmp_path / "version_0"
+    version_dir.mkdir(parents=True)
+    (version_dir / "hparams.yaml").write_text(
+        "image_size: !!python/tuple\n- 384\n- 384\n",
+        encoding="utf-8",
+    )
+
+    hparams = ModelService.get_hparams(model)
+
+    assert hparams is not None
+    assert hparams["image_size"] == [384, 384]
+
+
+def test_get_hparams_returns_none_when_yaml_invalid(tmp_path) -> None:
+    model = _make_model()
+    model.path = str(tmp_path)
+    version_dir = tmp_path / "version_0"
+    version_dir.mkdir(parents=True)
+    (version_dir / "hparams.yaml").write_text("image_size: [1, 2\n", encoding="utf-8")
+
+    assert ModelService.get_hparams(model) is None
+
+
 @pytest.mark.anyio
 async def test_delete_model_deletes_snapshot_when_snapshot_id_set() -> None:
     """When model.snapshot_id is set, delete_model should also delete the snapshot row."""


### PR DESCRIPTION
The hyper parameter file that's generated by the trainer uses a yaml tag that was unrecognized by our safe yaml loader.

```yaml
chunk_size: 100
dataset_stats: null
dim_feedforward: 3200
dim_model: 512
dropout: 0.1
feedforward_activation: relu
image_size: !!python/tuple
- 384
- 384
kl_weight: 10.0
latent_dim: 32
n_action_steps: 100
n_decoder_layers: 1
n_encoder_layers: 4
n_heads: 8
n_obs_steps: 1
n_vae_encoder_layers: 4
optimizer_grad_clip_norm: 10000.0
optimizer_lr: 0.0001
optimizer_weight_decay: 0.0001
pre_norm: false
pretrained_backbone_weights: ResNet18_Weights.IMAGENET1K_V1
replace_final_stride_with_dilation: false
temporal_ensemble_coeff: null
use_vae: true
vision_backbone: resnet18
```

The `image_size: !!python/tuple` line makes it so that our safe yaml loader crashes with:
```
yaml.constructor.ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/tuple'
  in "/home/mark/.local/share/physicalai/models/a2595067-1998-4cbc-b31a-9f061543db2d/version_0/hparams.yaml", line 7, column 13
```

It is unclear to me why this is yaml tag is being added. From my initial investigation it looks like pytorch lightening's `CSVLogger` is responsible for this.