### PR TITLE
fix: Switch docker build workflow to self-hosted runner

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -50,13 +50,6 @@ runs:
       with:
         type: all
 
-    - name: Fix Docker socket permissions
-      shell: bash
-      run: |
-        if [ -e /var/run/docker.sock ]; then
-          sudo chmod 666 /var/run/docker.sock
-        fi
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -50,6 +50,13 @@ runs:
       with:
         type: all
 
+    - name: Fix Docker socket permissions
+      shell: bash
+      run: |
+        if [ -e /var/run/docker.sock ]; then
+          sudo chmod 666 /var/run/docker.sock
+        fi
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -72,7 +72,7 @@ jobs:
   build:
     name: Build (${{ matrix.device }})
     needs: check-paths
-    if: needs.check-paths.outputs.run_workflow == 'true' && github.event.pull_request.head.repo.fork == false
+    if: needs.check-paths.outputs.run_workflow == 'true'
     runs-on: [self-hosted, linux, x64]
     permissions:
       contents: read # Checkout code

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -73,7 +73,7 @@ jobs:
     name: Build (${{ matrix.device }})
     needs: check-paths
     if: needs.check-paths.outputs.run_workflow == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read # Checkout code
       packages: write # Push/pull registry build cache on GHCR

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -72,7 +72,7 @@ jobs:
   build:
     name: Build (${{ matrix.device }})
     needs: check-paths
-    if: needs.check-paths.outputs.run_workflow == 'true'
+    if: needs.check-paths.outputs.run_workflow == 'true' && github.event.pull_request.head.repo.fork == false
     runs-on: [self-hosted, linux, x64]
     permissions:
       contents: read # Checkout code

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -73,7 +73,7 @@ jobs:
     name: Build (${{ matrix.device }})
     needs: check-paths
     if: needs.check-paths.outputs.run_workflow == 'true'
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: read # Checkout code
       packages: write # Push/pull registry build cache on GHCR


### PR DESCRIPTION
## Description

Switch the docker build workflow step to the self-hosted runner to prevent issues with storage. 

## Related Issues

<!-- Fixes #123 -->
