### PR TITLE
feat(tests): add end-to-end integration tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -120,7 +120,33 @@ jobs:
       - name: Run python tests
         working-directory: application/backend
         run: |
-          uv run pytest tests
+          uv run pytest tests -m "not slow"
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
+    permissions:
+      contents: read # to checkout code
+    steps:
+      - *harden-runner
+
+      - *checkout
+
+      - *set-up-python
+
+      - *set-up-uv
+
+      - name: Prepare venv and install Python dependencies
+        working-directory: application/backend
+        run: |
+          uv lock --check
+          uv sync --frozen --extra cpu --extra tests
+
+      - name: Run e2e integration tests
+        working-directory: application/backend
+        run: |
+          uv run pytest tests/integration -m slow -v
 
   required-check:
     name: Required Check backend
@@ -128,6 +154,7 @@ jobs:
       - check-paths
       - code-quality
       - unit-tests
+      - integration-tests
     runs-on: ubuntu-latest
     env:
       CHECKS: ${{ join(needs.*.result, ' ') }}

--- a/application/backend/src/repositories/base.py
+++ b/application/backend/src/repositories/base.py
@@ -87,7 +87,7 @@ class BaseRepository(Generic[ModelType, SchemaType], metaclass=abc.ABCMeta):
     async def update(self, item: ModelType, partial_update: dict) -> ModelType:
         # note: model_copy does not validate the model, so we need to validate explicitly
         to_update = item.model_copy(update=partial_update, deep=True)
-        item.__class__.model_validate(to_update.model_dump())
+        to_update = cast("ModelType", item.__class__.model_validate(to_update.model_dump()))
         schema_item: SchemaType = self.to_schema(to_update)
         await self.db.merge(schema_item)
         await self.db.commit()

--- a/application/backend/tests/conftest.py
+++ b/application/backend/tests/conftest.py
@@ -1,3 +1,19 @@
+import os
+import tempfile
+
+# Isolate the test session from the developer's real Studio storage/database.
+#
+# `db/engine.py` builds its SQLAlchemy engines from `settings.get_settings()` at
+# *module import time*, and the first test module imported anywhere in the
+# session (directly or transitively via `main.app`) freezes that choice for
+# the rest of the process. Setting STORAGE_DIR here - before any other import
+# in this file, and before pytest imports any test module - guarantees every
+# test in the session (including real-DB integration tests) reads and writes
+# under an isolated temp directory instead of the user's `~/.local/share`
+# (or platform equivalent) Studio installation. `setdefault` still lets CI or
+# a developer point STORAGE_DIR at a specific location explicitly.
+os.environ.setdefault("STORAGE_DIR", tempfile.mkdtemp(prefix="physicalai-backend-tests-"))
+
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np

--- a/application/backend/tests/conftest.py
+++ b/application/backend/tests/conftest.py
@@ -1,4 +1,7 @@
+# ruff: noqa: E402
+
 import os
+import shutil
 import tempfile
 
 # Isolate the test session from the developer's real Studio storage/database.
@@ -12,7 +15,11 @@ import tempfile
 # under an isolated temp directory instead of the user's `~/.local/share`
 # (or platform equivalent) Studio installation. `setdefault` still lets CI or
 # a developer point STORAGE_DIR at a specific location explicitly.
-os.environ.setdefault("STORAGE_DIR", tempfile.mkdtemp(prefix="physicalai-backend-tests-"))
+_TEST_STORAGE_DIR = os.environ.get("STORAGE_DIR")
+_STORAGE_DIR_CREATED = _TEST_STORAGE_DIR is None
+if _STORAGE_DIR_CREATED:
+    _TEST_STORAGE_DIR = tempfile.mkdtemp(prefix="physicalai-backend-tests-")
+    os.environ["STORAGE_DIR"] = _TEST_STORAGE_DIR
 
 from unittest.mock import AsyncMock, MagicMock
 
@@ -24,6 +31,13 @@ from robots.robot_client_factory import RobotClientFactory
 from schemas.dataset import Dataset
 from schemas.environment import EnvironmentWithRelations
 from schemas.model import Model
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Remove test storage when this conftest created it."""
+    if _STORAGE_DIR_CREATED:
+        assert _TEST_STORAGE_DIR is not None
+        shutil.rmtree(_TEST_STORAGE_DIR, ignore_errors=True)
 
 
 @pytest.fixture

--- a/application/backend/tests/integration/conftest.py
+++ b/application/backend/tests/integration/conftest.py
@@ -12,13 +12,20 @@ import os
 import shutil
 import sys
 import zipfile
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import numpy as np
 import pytest
 
-if TYPE_CHECKING:
-    from pathlib import Path
+_INTEGRATION_TESTS_DIRECTORY = Path(__file__).parent
+_exitstatus: int | None = None
+_hard_exit = False
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    """Enable the shutdown workaround only for selected integration tests."""
+    global _hard_exit  # noqa: PLW0603
+    _hard_exit = any(item.path.is_relative_to(_INTEGRATION_TESTS_DIRECTORY) for item in session.items)
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -44,12 +51,10 @@ def pytest_unconfigure(config: pytest.Config) -> None:
     bypass it. `pytest_unconfigure` is pytest's last hook, called strictly
     after the terminal summary is printed, so this can't truncate any output.
     """
-    sys.stdout.flush()
-    sys.stderr.flush()
-    os._exit(_exitstatus if _exitstatus is not None else 1)
-
-
-_exitstatus: int | None = None
+    if _hard_exit:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(_exitstatus if _exitstatus is not None else 1)
 
 
 @pytest.fixture(scope="session")

--- a/application/backend/tests/integration/conftest.py
+++ b/application/backend/tests/integration/conftest.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import io
 import os
 import shutil
+import sys
 import zipfile
 from typing import TYPE_CHECKING
 
@@ -17,34 +18,38 @@ import numpy as np
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
     from pathlib import Path
 
-# The ExecuTorch/ONNX export path goes through `torch.export`/AOTInductor
-# lowering, which lazily spins up PyTorch Inductor's persistent async-compile
-# worker pool (a subprocess manager thread plus a per-core `ThreadPoolExecutor`).
-# That pool is never shut down by the export code and is a well-known cause of
-# pytest hanging at process exit (the worker threads/subprocesses are still
-# alive and never join). Setting this before torch is imported anywhere in the
-# test session avoids spawning the pool at all, since a single compile thread
-# doesn't need subprocess workers.
-os.environ.setdefault("TORCHINDUCTOR_COMPILE_THREADS", "1")
 
+@pytest.hookimpl(tryfirst=True)
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Stash the exit status for `pytest_unconfigure` to hard-exit with.
 
-@pytest.fixture(scope="session", autouse=True)
-def _shutdown_torch_inductor_compile_workers() -> Iterator[None]:
-    """Belt-and-suspenders: explicitly stop any Inductor compile workers.
-
-    Guards against the pool still being started (e.g. by code that overrides
-    `TORCHINDUCTOR_COMPILE_THREADS`), which would otherwise hang the test
-    process at exit waiting on non-daemon worker threads/subprocesses.
+    Reporting (terminal summary, warnings, junit-xml, ...) happens in other
+    `pytest_sessionfinish`/`pytest_terminal_summary` implementations that run
+    after this one, so we can't force-exit here without truncating it.
     """
-    yield
-    try:
-        from torch._inductor.async_compile import shutdown_compile_workers
-    except ImportError:
-        return
-    shutdown_compile_workers()
+    global _exitstatus  # noqa: PLW0603
+    _exitstatus = int(exitstatus)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Hard-exit once pytest is fully done, instead of hanging forever.
+
+    The training/export path pulls in pyarrow, HuggingFace `datasets`, and
+    PyTorch, which can leave native worker threads running that were never
+    designed to be joined (e.g. pyarrow's global CPU thread pool). CPython's
+    normal interpreter shutdown blocks forever trying to join them, so we
+    bypass it. `pytest_unconfigure` is pytest's last hook, called strictly
+    after the terminal summary is printed, so this can't truncate any output.
+    """
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(_exitstatus if _exitstatus is not None else 1)
+
+
+_exitstatus: int | None = None
 
 
 @pytest.fixture(scope="session")

--- a/application/backend/tests/integration/conftest.py
+++ b/application/backend/tests/integration/conftest.py
@@ -1,0 +1,115 @@
+"""Fixtures shared by the backend end-to-end integration tests.
+
+These tests exercise the real FastAPI app, real services, and a real
+(isolated) SQLite database instead of stubbing services out, so they need a
+migrated schema and a small on-disk LeRobot v3 dataset to upload.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import zipfile
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(scope="session")
+def migrated_db() -> None:
+    """Run Alembic migrations once against the session's isolated STORAGE_DIR.
+
+    `application/backend/tests/conftest.py` points STORAGE_DIR at a fresh temp
+    directory before any other module is imported, so the sqlite file backing
+    `db.engine` is empty until migrations create the schema.
+    """
+    from db.migration import MigrationManager
+    from settings import get_settings
+
+    manager = MigrationManager(get_settings())
+    assert manager.initialize_database(), "Failed to initialize the isolated test database"
+
+
+def _build_synthetic_lerobot_v3_dataset(
+    destination: Path,
+    *,
+    num_episodes: int = 2,
+    frames_per_episode: int = 8,
+    fps: int = 10,
+    image_size: int = 64,
+    task: str = "do the thing",
+) -> Path:
+    """Write a tiny, fully-synthetic LeRobot v3 dataset to *destination*.
+
+    Uses the real `lerobot` dataset writer (`LeRobotDataset.create` /
+    `add_frame` / `save_episode` / `finalize`) so the on-disk layout matches
+    exactly what both the backend's dataset-import adapter (`meta/info.json`,
+    `meta/tasks.parquet`, `data/chunk-*/file-*.parquet`) and
+    `physicalai.data.lerobot.LeRobotDataModule` expect - no hand-authored
+    parquet/JSON fixtures to keep in sync with either format.
+
+    Images are stored uncompressed (``use_videos=False``) rather than encoded
+    to video, since encoding is unnecessary overhead for a 2-episode fixture
+    and ACT resizes to its configured `image_size` regardless of source
+    resolution.
+    """
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    if destination.exists():
+        shutil.rmtree(destination)
+
+    features = {
+        "observation.state": {"dtype": "float32", "shape": (2,), "names": ["x", "y"]},
+        "action": {"dtype": "float32", "shape": (2,), "names": ["x", "y"]},
+        "observation.images.top": {
+            "dtype": "image",
+            "shape": (image_size, image_size, 3),
+            "names": ["height", "width", "channels"],
+        },
+    }
+
+    dataset = LeRobotDataset.create(
+        repo_id="physicalai-studio-tests/synthetic-e2e",
+        fps=fps,
+        features=features,
+        root=destination,
+        robot_type="test_robot",
+        use_videos=False,
+    )
+
+    rng = np.random.default_rng(seed=0)
+    for _episode in range(num_episodes):
+        for _frame in range(frames_per_episode):
+            dataset.add_frame(
+                {
+                    "observation.state": rng.random(2).astype(np.float32),
+                    "action": rng.random(2).astype(np.float32),
+                    "observation.images.top": rng.integers(0, 255, size=(image_size, image_size, 3), dtype=np.uint8),
+                    "task": task,
+                }
+            )
+        dataset.save_episode()
+
+    dataset.finalize()
+    return destination
+
+
+def _zip_directory(directory: Path) -> bytes:
+    """Zip *directory*'s contents (relative paths, no enclosing folder)."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(directory.rglob("*")):
+            if path.is_file():
+                archive.write(path, arcname=str(path.relative_to(directory)))
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def synthetic_dataset_archive_bytes(tmp_path: Path) -> bytes:
+    """Zip bytes for a tiny synthetic LeRobot v3 dataset (2 episodes, 8 frames each)."""
+    dataset_dir = _build_synthetic_lerobot_v3_dataset(tmp_path / "synthetic_dataset")
+    return _zip_directory(dataset_dir)

--- a/application/backend/tests/integration/conftest.py
+++ b/application/backend/tests/integration/conftest.py
@@ -8,6 +8,7 @@ migrated schema and a small on-disk LeRobot v3 dataset to upload.
 from __future__ import annotations
 
 import io
+import os
 import shutil
 import zipfile
 from typing import TYPE_CHECKING
@@ -16,7 +17,34 @@ import numpy as np
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
+
+# The ExecuTorch/ONNX export path goes through `torch.export`/AOTInductor
+# lowering, which lazily spins up PyTorch Inductor's persistent async-compile
+# worker pool (a subprocess manager thread plus a per-core `ThreadPoolExecutor`).
+# That pool is never shut down by the export code and is a well-known cause of
+# pytest hanging at process exit (the worker threads/subprocesses are still
+# alive and never join). Setting this before torch is imported anywhere in the
+# test session avoids spawning the pool at all, since a single compile thread
+# doesn't need subprocess workers.
+os.environ.setdefault("TORCHINDUCTOR_COMPILE_THREADS", "1")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _shutdown_torch_inductor_compile_workers() -> Iterator[None]:
+    """Belt-and-suspenders: explicitly stop any Inductor compile workers.
+
+    Guards against the pool still being started (e.g. by code that overrides
+    `TORCHINDUCTOR_COMPILE_THREADS`), which would otherwise hang the test
+    process at exit waiting on non-daemon worker threads/subprocesses.
+    """
+    yield
+    try:
+        from torch._inductor.async_compile import shutdown_compile_workers
+    except ImportError:
+        return
+    shutdown_compile_workers()
 
 
 @pytest.fixture(scope="session")

--- a/application/backend/tests/integration/test_e2e_dataset_to_export.py
+++ b/application/backend/tests/integration/test_e2e_dataset_to_export.py
@@ -1,0 +1,323 @@
+"""End-to-end integration test: upload a dataset, train ACT, export, and infer.
+
+Drives the real FastAPI app, real services, and a real (isolated) SQLite
+database - no dependency-injection stubs - through the same lifecycle a user
+exercises through the UI:
+
+    upload dataset -> import job -> train job (ACT) -> auto-export -> download
+    -> load exported model -> infer
+
+Background workers normally run as separate `multiprocessing.Process`es
+(`core.scheduler.Scheduler`). Spawning real processes per test is slow and
+hard to synchronize, so this test instantiates `TrainingWorker` /
+`DatasetImportWorker` directly and drives their per-job methods in-process -
+the same production code path, just called synchronously instead of polled
+from an infinite loop. See `docs/development/e2e-integration-testing-plan.md`.
+"""
+
+from __future__ import annotations
+
+import io
+import multiprocessing as mp
+import zipfile
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.dependencies import get_scheduler
+from main import app
+from schemas.base_job import JobStatus
+from schemas.job import TrainJobPayload
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+_ONNX_BACKEND = "onnx"
+
+
+def _run_dataset_import_job_step() -> None:
+    """Claim and process exactly one pending dataset-import job, in-process."""
+    import asyncio
+
+    from schemas.job import DatasetImportJob
+    from services.dataset_import.service import DatasetImportService
+    from workers.dataset_import_worker import DatasetImportWorker
+
+    async def _drain() -> None:
+        job = await DatasetImportService.claim_pending_dataset_import_job()
+        assert isinstance(job, DatasetImportJob), "Expected a pending dataset import job"
+        worker = DatasetImportWorker(stop_event=mp.Event(), event_queue=mp.Queue())
+        await worker._process_job(job)
+
+    asyncio.run(_drain())
+
+
+def _run_training_job_step() -> None:
+    """Claim and run exactly one pending training job to completion, in-process.
+
+    Mirrors the body of `TrainingWorker.run_loop` for a single iteration
+    instead of running the (otherwise infinite) polling loop.
+    """
+    import asyncio
+
+    from schemas import Model
+    from services import DatasetService
+    from services.job_service import JobService
+    from services.snapshot_service import SnapshotService
+    from settings import get_settings
+    from workers.training_worker import TrainingWorker
+
+    async def _drain() -> None:
+        job = await JobService.get_pending_train_job()
+        assert job is not None, "Expected a pending training job"
+        payload = TrainJobPayload.model_validate(job.payload)
+
+        settings = get_settings()
+        model_id = uuid4()
+        model_dir = settings.models_dir / str(model_id)
+
+        dataset = await DatasetService.get_dataset_by_id(payload.dataset_id)
+        snapshot_dir = settings.snapshot_dir / SnapshotService.generate_snapshot_folder_name()
+        snapshot = await SnapshotService.create_snapshot_for_dataset(dataset, destination=snapshot_dir)
+        payload.snapshot_id = snapshot.id
+
+        model = Model(
+            id=model_id,
+            project_id=payload.project_id,
+            dataset_id=payload.dataset_id,
+            path=str(model_dir),
+            name=payload.model_name,
+            snapshot_id=snapshot.id,
+            policy=payload.policy,
+            properties={},
+            train_job_id=job.id,
+            parent_model_id=payload.base_model_id,
+            version=1,
+            created_at=None,
+        )
+
+        worker = TrainingWorker(stop_event=mp.Event(), interrupt_event=mp.Event(), event_queue=mp.Queue())
+        worker.interrupt_event.clear()
+        await worker._train_model(job, model, snapshot, payload)
+
+    asyncio.run(_drain())
+    # `_train_model` persists the model under `model_id` on success; the caller
+    # already knows that id (it's generated before training starts), so no
+    # extra lookup is needed here.
+
+
+def test_dataset_upload_train_export_infer_e2e(
+    migrated_db: None,
+    synthetic_dataset_archive_bytes: bytes,
+) -> None:
+    """Full happy path: upload -> import -> train ACT -> export -> download -> infer."""
+    client = TestClient(app)
+
+    # --- 1. Project + environment -------------------------------------------------
+    project_id = uuid4()
+    response = client.post("/api/projects", json={"id": str(project_id), "name": "E2E Project"})
+    assert response.status_code == 201, response.text
+
+    environment_id = uuid4()
+    response = client.post(
+        f"/api/projects/{project_id}/environments",
+        json={"id": str(environment_id), "name": "E2E Environment", "robots": [], "cameras": []},
+    )
+    assert response.status_code == 201, response.text
+
+    # --- 2. Dataset import: prepare -> upload -> detect -> finalize -> commit -----
+    response = client.post(
+        f"/api/projects/{project_id}/imports/datasets:prepare",
+        data={"format_hint": "auto", "dataset_name": "E2E Dataset"},
+    )
+    assert response.status_code == 202, response.text
+    import_job_id = response.json()["id"]
+
+    response = client.put(
+        f"/api/projects/{project_id}/imports/datasets/{import_job_id}:upload",
+        files={"archive": ("dataset.zip", synthetic_dataset_archive_bytes, "application/zip")},
+    )
+    assert response.status_code == 202, response.text
+
+    _run_dataset_import_job_step()  # detect + build draft manifest
+
+    response = client.get(f"/api/jobs/{import_job_id}")
+    assert response.status_code == 200, response.text
+    import_job = response.json()
+    assert import_job["payload"]["step"] == "awaiting_user_review", import_job
+
+    response = client.post(
+        f"/api/projects/{project_id}/imports/datasets/{import_job_id}:finalize",
+        json={"environment_id": str(environment_id), "default_task": "do the thing"},
+    )
+    assert response.status_code == 202, response.text
+
+    _run_dataset_import_job_step()  # pre-commit validation + commit
+
+    response = client.get(f"/api/jobs/{import_job_id}")
+    assert response.status_code == 200, response.text
+    import_job = response.json()
+    assert import_job["status"] == JobStatus.COMPLETED, import_job
+    dataset_id = import_job["payload"]["result_dataset_id"]
+    assert dataset_id is not None
+
+    # --- 3. Submit an ACT training job ---------------------------------------------
+    response = client.post(
+        "/api/jobs:train",
+        json={
+            "project_id": str(project_id),
+            "dataset_id": dataset_id,
+            "policy": "act",
+            "model_name": "E2E ACT Model",
+            "max_steps": 100,  # TrainJobPayload.max_steps has a ge=100 floor
+            "batch_size": 2,
+            "num_workers": 0,
+            "val_split": 0.5,
+            "device": {"type": "cpu"},
+            "precision": "32-true",  # bf16-mixed (the default) is unreliable on CPU
+        },
+    )
+    assert response.status_code == 200, response.text
+    train_job = response.json()
+    train_job_id = train_job["id"]
+
+    _run_training_job_step()
+
+    response = client.get(f"/api/jobs/{train_job_id}")
+    assert response.status_code == 200, response.text
+    train_job = response.json()
+    assert train_job["status"] == JobStatus.COMPLETED, train_job
+    assert train_job["progress"] == 100
+
+    # The model id is deterministic from `_run_training_job_step`'s job draining;
+    # look it up the same way the UI would: via the project's model list.
+    response = client.get(f"/api/projects/{project_id}/models")
+    assert response.status_code == 200, response.text
+    models = response.json()
+    assert len(models) == 1, models
+    model = models[0]
+    model_id = model["id"]
+    assert model["policy"] == "act"
+    assert set(model["available_backends"]) >= {_ONNX_BACKEND}
+
+    # --- 4. Model detail + metrics --------------------------------------------------
+    response = client.get(f"/api/models/{model_id}")
+    assert response.status_code == 200, response.text
+    detail = response.json()
+    assert any(export["type"] == _ONNX_BACKEND for export in detail["exports"])
+    assert detail["training_summary"]["max_steps"] == 100
+
+    # --- 5. Download the onnx export and confirm it is a valid archive -------------
+    response = client.get(f"/api/models/{model_id}/exports/{_ONNX_BACKEND}/download")
+    assert response.status_code == 200, response.text
+    archive = zipfile.ZipFile(io.BytesIO(response.content))
+    assert "manifest.json" in archive.namelist()
+
+    # --- 6. Load the exported model and run inference on a real observation -------
+    _assert_exported_model_runs_inference(Path(model["path"]) / "exports" / _ONNX_BACKEND, dataset_id)
+
+    # --- 7. Cleanup: deleting the model removes the DB row and files --------------
+    response = client.delete(f"/api/models/{model_id}")
+    assert response.status_code == 200, response.text
+    assert not Path(model["path"]).exists()
+
+
+def _assert_exported_model_runs_inference(export_dir: Path, dataset_id: str) -> None:
+    """Load the exported ONNX model and run one `select_action` call.
+
+    This is the "deploying for inference" checkpoint: Studio's job is to
+    produce an artifact Runtime's `InferenceModel(...)` can load and run - see
+    `AGENTS.md` Cross-Repo Rules.
+    """
+    from physicalai.data import LeRobotDataModule
+    from physicalai.data.lerobot import FormatConverter
+    from physicalai.inference import InferenceModel
+
+    from settings import get_settings
+
+    # Read from the dataset the model was trained on (the training worker
+    # copies it into a snapshot before training, but the source dataset is
+    # untouched and equivalent for this check).
+    dataset_root = get_settings().datasets_dir / dataset_id
+    datamodule = LeRobotDataModule(repo_id="snapshot", root=dataset_root, train_batch_size=1, num_workers=0)
+    batch = next(iter(datamodule.train_dataloader()))
+    observation = FormatConverter.to_observation(batch)[0:1].to_numpy().to_dict(flatten=False)
+
+    images = observation["images"]
+    if isinstance(images, dict):
+        # A single camera collapses to one array; the exported model's input
+        # signature is named "images" (see manifest.json input_features).
+        observation["images"] = next(iter(images.values()))
+
+    inference_model = InferenceModel(export_dir)
+    assert inference_model.backend == "onnx"
+
+    action = inference_model.select_action(observation)
+    assert action.shape[-1] == 2
+
+
+def test_submit_training_job_for_missing_project_returns_404() -> None:
+    """Submitting against a project that doesn't exist is a clean 404, not a crash."""
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/jobs:train",
+        json={
+            "project_id": str(uuid4()),
+            "dataset_id": str(uuid4()),
+            "policy": "act",
+            "model_name": "Orphan Job",
+            "max_steps": 100,
+        },
+    )
+    assert response.status_code == 404, response.text
+
+
+def test_interrupt_job_marks_job_canceled(migrated_db: None) -> None:
+    """POST /api/jobs/{id}:interrupt flips a running job to CANCELED.
+
+    Overrides `get_scheduler` with a minimal stand-in instead of running the
+    real `Scheduler` (which needs the FastAPI lifespan to populate
+    `app.state.scheduler`, and spins up real background worker processes).
+    """
+    import asyncio
+    from types import SimpleNamespace
+
+    # submit_train_job requires a real project row (FK constraint), so create
+    # one directly rather than pointing the job at a fake project id.
+    client = TestClient(app)
+    project_id = uuid4()
+    response = client.post("/api/projects", json={"id": str(project_id), "name": "Interrupt Project"})
+    assert response.status_code == 201, response.text
+
+    async def _submit_and_run(project_id: UUID) -> str:
+        from services.job_service import JobService
+
+        job = await JobService.submit_train_job(
+            TrainJobPayload(
+                project_id=project_id,
+                dataset_id=uuid4(),
+                policy="act",
+                model_name="Interrupt Me",
+                max_steps=100,
+            )
+        )
+        await JobService.update_job_status(job.id, status=JobStatus.RUNNING, message="Training started")
+        return str(job.id)
+
+    job_id = asyncio.run(_submit_and_run(project_id))
+
+    fake_scheduler = SimpleNamespace(training_interrupt_event=mp.Event())
+    app.dependency_overrides[get_scheduler] = lambda: fake_scheduler
+    try:
+        response = client.post(f"/api/jobs/{job_id}:interrupt")
+        assert response.status_code == 200, response.text
+    finally:
+        app.dependency_overrides.clear()
+
+    assert fake_scheduler.training_interrupt_event.is_set()
+
+    response = client.get(f"/api/jobs/{job_id}")
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == JobStatus.CANCELED


### PR DESCRIPTION
## Description

This pull request introduces a new end-to-end (E2E) integration test suite for the backend, ensuring that the real FastAPI app, services, and database work together as expected. 

**Integration testing and test isolation:**

* Added a comprehensive E2E integration test (`test_e2e_dataset_to_export.py`) that exercises the full user workflow: dataset upload, import, training, export, model download, inference, and cleanup, using the real app and database. This ensures the backend behaves correctly in real-world scenarios.
* Introduced shared fixtures and hooks for integration tests (`tests/integration/conftest.py`), including database migration setup, synthetic dataset generation, and a workaround to ensure pytest terminates cleanly despite native threads from dependencies.
* Ensured all tests run in an isolated temporary storage directory by setting the `STORAGE_DIR` environment variable at test session startup, preventing accidental modification of developer data.

**Continuous integration workflow:**

* Updated the GitHub Actions backend workflow to add a new `integration-tests` job that runs the new E2E tests (marked as "slow") and includes it as a required check for backend PRs.

**Code quality and bug fixes:**

* Fixed a type casting issue in the repository base class's `update` method to ensure the updated item is correctly validated and typed.
