### PR TITLE
fix(gyms): fix LiberoGym image rotation and init-state index

### DIFF
--- a/library/src/physicalai/gyms/libero.py
+++ b/library/src/physicalai/gyms/libero.py
@@ -55,7 +55,9 @@ Example:
 
 Note:
     - Requires optional dependencies: `uv pip install hf-libero`
-    - Images are automatically rotated 180° to match LeRobot conventions
+    - Images fed to policies are in raw robosuite orientation (no rotation), matching
+      the LeRobot training convention. The 180° flip is applied only in render()
+      for human-viewable output.
     - State space: 8-dim (3 pos + 3 orientation + 2 gripper)
     - Action space: 7-dim
     - See TASK_SUITE_MAX_STEPS for episode limits per suite
@@ -365,9 +367,11 @@ class LiberoGym(Gym):
 
         raw_obs = self.env.reset()
 
-        # Apply init state if available
+        # Apply init state if available, then advance the index so successive
+        # episodes use distinct starting configurations.
         if self.init_states and self._init_states is not None:
-            raw_obs = self.env.set_init_state(self._init_states[self._init_state_id])
+            raw_obs = self.env.set_init_state(self._init_states[self._init_state_id % len(self._init_states)])
+            self._init_state_id += 1
 
         # After reset, objects may be unstable (slightly floating, intersecting, etc.).
         # Step the simulator with a no-op action for a few frames so everything settles.
@@ -438,12 +442,13 @@ class LiberoGym(Gym):
         Returns:
             Formatted observation dict with 'pixels' and optionally 'agent_pos'
         """
-        # Process images (rotate 180° to match LeRobot convention)
+        # Pass raw images to the policy without rotation — pretrained checkpoints
+        # (e.g. HuggingFaceVLA/smolvla_libero, lerobot/pi05_libero_finetuned_v044)
+        # are trained on raw robosuite orientation via LeRobot's LiberoEnv, which
+        # does NOT rotate images in its observation path.
         images = {}
         for camera_name in self.camera_names:
             image = raw_obs[camera_name]
-            # Rotate 180 degrees (copy to avoid negative strides)
-            image = image[::-1, ::-1].copy()
             images[self.CAMERA_NAME_MAPPING[camera_name]] = image
 
         # For pixels-only mode, skip state processing
@@ -479,7 +484,9 @@ class LiberoGym(Gym):
         # OffScreenRenderEnv wraps a robosuite environment (double nesting)
         # Using _get_observations() is the standard LIBERO pattern - no public alternative
         raw_obs = self.env.env._get_observations()  # noqa: SLF001
-        return self._format_raw_obs(raw_obs)["pixels"]["image"]
+        image = self._format_raw_obs(raw_obs)["pixels"]["image"]
+        # Rotate 180° for human-viewable output only, matching LeRobot's LiberoEnv.render().
+        return image[::-1, ::-1].copy()
 
     def close(self) -> None:
         """Close the environment and release resources.


### PR DESCRIPTION
## Summary

Two bugs remained in `LiberoGym` after #826 fixed the reset order.

### Bug 1 — `_init_state_id` never advanced between episodes

Every episode in a multi-episode run replayed the same init state (`0`). This eliminated diversity across episodes and made aggregate success rates unreliable.

**Fix:** increment `_init_state_id` after each reset with mod wrapping against `len(self._init_states)`.

### Bug 2 — 180° image flip applied to policy observations

`_format_raw_obs()` rotated every camera image 180° before passing it to the policy. Pretrained checkpoints (`HuggingFaceVLA/smolvla_libero`, `lerobot/pi05_libero_finetuned_v044`) are trained via LeRobot's `LiberoEnv`, which does **not** rotate images in its observation path — the flip exists only in `render()` for human-viewable display.

Feeding the policy upside-down images causes near-zero success rates even with the correct scene layout.

**Fix:** remove the flip from `_format_raw_obs()`; apply it only in `render()`, matching `lerobot/envs/libero.py`.

## Files changed

- `library/src/physicalai/gyms/libero.py`