### PR TITLE
fix: Fix cleanup old app images scheduled dry run

### DIFF
--- a/.github/workflows/cleanup-old-app-images.yml
+++ b/.github/workflows/cleanup-old-app-images.yml
@@ -16,7 +16,7 @@ name: Cleanup Old Application Container Images
 #   most recent `min_versions_to_keep` are kept; older ones are deleted.
 #
 # Supports a dry-run mode (default) that previews deletions without removing
-# anything.
+# anything for dispatched runs.
 
 on:
   workflow_dispatch:
@@ -37,6 +37,11 @@ on:
 
 permissions: {} # No permissions by default
 
+# Ensure only one cleanup runs at a time; cancel any in-progress run when a new one starts.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   cleanup-old-images:
     name: Delete old GHCR application images
@@ -56,5 +61,5 @@ jobs:
             physical-ai-studio-cpu
             physical-ai-studio-xpu
             physical-ai-studio-cuda
-          min-versions-to-keep: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.min_versions_to_keep || 10 }}
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' && 'false' || 'true' }}
+          min-versions-to-keep: ${{ github.event_name == 'workflow_dispatch' && inputs.min_versions_to_keep || 10 }}
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}

--- a/.github/workflows/cleanup-old-app-images.yml
+++ b/.github/workflows/cleanup-old-app-images.yml
@@ -37,10 +37,10 @@ on:
 
 permissions: {} # No permissions by default
 
-# Ensure only one cleanup runs at a time; cancel any in-progress run when a new one starts.
+# Ensure only one cleanup runs at a time.
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   cleanup-old-images:


### PR DESCRIPTION
## Description

Fixing cleanup old app images workflow when scheduled execution is always done in dry run mode, and add group to ensure that it does not run in parallel.

## Related Issues

Fixes #852
