### PR TITLE
feat: bimanual so101 via external plugin

### DIFF
--- a/application/ui/src/features/robots/robot-form/catalog/bimanual-so101.test.ts
+++ b/application/ui/src/features/robots/robot-form/catalog/bimanual-so101.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildBimanualSO101Body } from './bimanual-so101';
+
+const formData = {
+    name: 'Dual arm',
+    payload: {
+        left_serial_number: 'left-arm',
+        right_serial_number: 'right-arm',
+        left_calibration: {
+            shoulder_pan: { id: 1, drive_mode: 0, homing_offset: 0, range_min: 0, range_max: 4095 },
+        },
+        right_calibration: {
+            shoulder_pan: { id: 1, drive_mode: 0, homing_offset: 0, range_min: 0, range_max: 4095 },
+        },
+        baudrate: 1000000,
+        role: 'follower' as const,
+        disable_torque_on_disconnect: true,
+    },
+};
+
+describe('buildBimanualSO101Body', () => {
+    it('builds a follower payload from two selected SO101 robots', () => {
+        expect(
+            buildBimanualSO101Body(formData, 'BimanualSO101_Follower', '00000000-0000-0000-0000-000000000001')
+        ).toMatchObject({
+            type: 'BimanualSO101_Follower',
+            payload: {
+                left_serial_number: formData.payload.left_serial_number,
+                right_serial_number: formData.payload.right_serial_number,
+                left_calibration: formData.payload.left_calibration,
+                right_calibration: formData.payload.right_calibration,
+                role: 'follower',
+            },
+        });
+    });
+
+    it('requires selections for both arms', () => {
+        expect(
+            buildBimanualSO101Body(
+                { ...formData, payload: { ...formData.payload, right_calibration: null } },
+                'BimanualSO101_Follower',
+                '00000000-0000-0000-0000-000000000001'
+            )
+        ).toBeNull();
+    });
+});

--- a/application/ui/src/features/robots/robot-form/catalog/bimanual-so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/bimanual-so101.tsx
@@ -1,18 +1,33 @@
 import { Flex, Item, Picker, Text } from '@geti-ui/ui';
 
 import { $api } from '../../../../api/client';
-import type { SchemaBimanualSo101Payload } from '../../../../api/openapi-spec';
+import type { SchemaSo101JointCalibration } from '../../../../api/openapi-spec';
 import { useProjectId } from '../../../projects/use-project';
-import type { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
+import type { ConfigurableRobotType, SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
 import { useRobotFormFields } from '../provider';
+
+// Bimanual SO101 is a plugin robot type; the backend does not return it in the OpenAPI catalog, so its payload schema
+// is defined here.
+type BimanualSO101Payload = {
+    left_serial_number: string;
+    right_serial_number: string;
+    left_calibration: Record<string, SchemaSo101JointCalibration> | null;
+    right_calibration: Record<string, SchemaSo101JointCalibration> | null;
+    baudrate: number;
+    role: 'follower' | 'leader';
+    disable_torque_on_disconnect: boolean;
+};
 
 export interface BimanualSO101FormData {
     name: string;
-    payload: SchemaBimanualSo101Payload;
+    payload: BimanualSO101Payload;
 }
 
 type SO101SourceRobot = Extract<SchemaRobot, { type: 'SO101_Follower' | 'SO101_Leader' }>;
-type BimanualSO101Robot = Extract<SchemaRobot, { type: 'BimanualSO101_Follower' | 'BimanualSO101_Leader' }>;
+type BimanualSO101Robot = SchemaRobot & {
+    type: 'BimanualSO101_Follower' | 'BimanualSO101_Leader';
+    payload: BimanualSO101Payload;
+};
 
 const isBimanualSO101Robot = (robot: SchemaRobot): robot is BimanualSO101Robot =>
     robot.type === 'BimanualSO101_Follower' || robot.type === 'BimanualSO101_Leader';
@@ -55,7 +70,7 @@ export const buildBimanualSO101Body = (
             ...formData.payload,
             role: schemaType === 'BimanualSO101_Leader' ? 'leader' : 'follower',
         },
-    } as SchemaRobotInput;
+    } as unknown as SchemaRobotInput;
 };
 
 const isEligibleSource = (robot: SchemaRobot, type: SO101SourceRobot['type']): robot is SO101SourceRobot =>
@@ -85,7 +100,8 @@ export const BimanualSO101FormFields = () => {
     const robotsQuery = $api.useSuspenseQuery('get', '/api/projects/{project_id}/robots', {
         params: { path: { project_id } },
     });
-    const sourceType = activeType === 'BimanualSO101_Leader' ? 'SO101_Leader' : 'SO101_Follower';
+    const sourceType =
+        activeType === ('BimanualSO101_Leader' as ConfigurableRobotType) ? 'SO101_Leader' : 'SO101_Follower';
     const eligibleRobots = robotsQuery.data.filter((robot) => isEligibleSource(robot, sourceType));
     const leftRobots = eligibleRobots.filter(
         (robot) => robot.payload.serial_number !== formData.payload.right_serial_number

--- a/application/ui/src/features/robots/robot-form/catalog/bimanual-so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/bimanual-so101.tsx
@@ -1,0 +1,132 @@
+import { Flex, Item, Picker, Text } from '@geti-ui/ui';
+
+import { $api } from '../../../../api/client';
+import type { SchemaBimanualSo101Payload } from '../../../../api/openapi-spec';
+import { useProjectId } from '../../../projects/use-project';
+import type { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
+import { useRobotFormFields } from '../provider';
+
+export interface BimanualSO101FormData {
+    name: string;
+    payload: SchemaBimanualSo101Payload;
+}
+
+type SO101SourceRobot = Extract<SchemaRobot, { type: 'SO101_Follower' | 'SO101_Leader' }>;
+type BimanualSO101Robot = Extract<SchemaRobot, { type: 'BimanualSO101_Follower' | 'BimanualSO101_Leader' }>;
+
+const isBimanualSO101Robot = (robot: SchemaRobot): robot is BimanualSO101Robot =>
+    robot.type === 'BimanualSO101_Follower' || robot.type === 'BimanualSO101_Leader';
+
+export const getInitialBimanualSO101FormData = (robot?: SchemaRobot): BimanualSO101FormData => ({
+    name: robot?.name ?? '',
+    payload:
+        robot && isBimanualSO101Robot(robot)
+            ? robot.payload
+            : {
+                  left_serial_number: '',
+                  right_serial_number: '',
+                  left_calibration: null,
+                  right_calibration: null,
+                  baudrate: 1000000,
+                  role: 'follower',
+                  disable_torque_on_disconnect: true,
+              },
+});
+
+export const buildBimanualSO101Body = (
+    formData: BimanualSO101FormData,
+    schemaType: SchemaRobotType,
+    robot_id: string
+): SchemaRobotInput | null => {
+    if (
+        !formData.payload.left_serial_number ||
+        !formData.payload.right_serial_number ||
+        !formData.payload.left_calibration ||
+        !formData.payload.right_calibration
+    ) {
+        return null;
+    }
+
+    return {
+        id: robot_id,
+        name: formData.name,
+        type: schemaType,
+        payload: {
+            ...formData.payload,
+            role: schemaType === 'BimanualSO101_Leader' ? 'leader' : 'follower',
+        },
+    } as SchemaRobotInput;
+};
+
+const isEligibleSource = (robot: SchemaRobot, type: SO101SourceRobot['type']): robot is SO101SourceRobot =>
+    robot.type === type && robot.payload.serial_number !== '' && robot.payload.calibration != null;
+
+export const BimanualSO101FormFields = () => {
+    const { project_id } = useProjectId();
+    const { formData, updateField, activeType } = useRobotFormFields<BimanualSO101FormData>();
+    const robotsQuery = $api.useSuspenseQuery('get', '/api/projects/{project_id}/robots', {
+        params: { path: { project_id } },
+    });
+    const sourceType = activeType === 'BimanualSO101_Leader' ? 'SO101_Leader' : 'SO101_Follower';
+    const eligibleRobots = robotsQuery.data.filter((robot) => isEligibleSource(robot, sourceType));
+    const leftRobots = eligibleRobots.filter(
+        (robot) => robot.payload.serial_number !== formData.payload.right_serial_number
+    );
+    const rightRobots = eligibleRobots.filter(
+        (robot) => robot.payload.serial_number !== formData.payload.left_serial_number
+    );
+
+    const selectArm = (arm: 'left' | 'right', robotId: string | number | null) => {
+        const robot = eligibleRobots.find(({ id }) => id === robotId);
+        if (robot === undefined || robot.payload.calibration == null) {
+            return;
+        }
+
+        if (arm === 'left') {
+            updateField('payload', {
+                ...formData.payload,
+                left_serial_number: robot.payload.serial_number,
+                left_calibration: robot.payload.calibration,
+            });
+            return;
+        }
+
+        updateField('payload', {
+            ...formData.payload,
+            right_serial_number: robot.payload.serial_number,
+            right_calibration: robot.payload.calibration,
+        });
+    };
+
+    const selectedRobotId = (arm: 'left' | 'right') => {
+        const serial_number =
+            arm === 'left' ? formData.payload.left_serial_number : formData.payload.right_serial_number;
+        return eligibleRobots.find((robot) => robot.payload.serial_number === serial_number)?.id ?? null;
+    };
+
+    const armPicker = (arm: 'left' | 'right', robots: SO101SourceRobot[]) => (
+        <Picker
+            isRequired
+            label={`Select ${arm} arm`}
+            width='100%'
+            selectedKey={selectedRobotId(arm)}
+            onSelectionChange={(robotId) => {
+                selectArm(arm, robotId);
+            }}
+        >
+            {robots.map((robot) => (
+                <Item key={robot.id} textValue={robot.name}>
+                    <Text>{robot.name}</Text>
+                    <Text slot='description'>{robot.payload.serial_number}</Text>
+                </Item>
+            ))}
+        </Picker>
+    );
+
+    return (
+        <Flex direction='column' gap='size-100' width='100%'>
+            {armPicker('left', leftRobots)}
+            {armPicker('right', rightRobots)}
+        </Flex>
+    );
+};

--- a/application/ui/src/features/robots/robot-form/catalog/bimanual-so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/bimanual-so101.tsx
@@ -61,6 +61,24 @@ export const buildBimanualSO101Body = (
 const isEligibleSource = (robot: SchemaRobot, type: SO101SourceRobot['type']): robot is SO101SourceRobot =>
     robot.type === type && robot.payload.serial_number !== '' && robot.payload.calibration != null;
 
+interface SO101ArmPickerProps {
+    arm: 'left' | 'right';
+    robots: SO101SourceRobot[];
+    selectedKey: string | number | null;
+    onSelect: (robotId: string | number | null) => void;
+}
+
+const SO101ArmPicker = ({ arm, robots, selectedKey, onSelect }: SO101ArmPickerProps) => (
+    <Picker isRequired label={`Select ${arm} arm`} width='100%' selectedKey={selectedKey} onSelectionChange={onSelect}>
+        {robots.map((robot) => (
+            <Item key={robot.id} textValue={robot.name}>
+                <Text>{robot.name}</Text>
+                <Text slot='description'>{robot.payload.serial_number}</Text>
+            </Item>
+        ))}
+    </Picker>
+);
+
 export const BimanualSO101FormFields = () => {
     const { project_id } = useProjectId();
     const { formData, updateField, activeType } = useRobotFormFields<BimanualSO101FormData>();
@@ -104,29 +122,20 @@ export const BimanualSO101FormFields = () => {
         return eligibleRobots.find((robot) => robot.payload.serial_number === serial_number)?.id ?? null;
     };
 
-    const armPicker = (arm: 'left' | 'right', robots: SO101SourceRobot[]) => (
-        <Picker
-            isRequired
-            label={`Select ${arm} arm`}
-            width='100%'
-            selectedKey={selectedRobotId(arm)}
-            onSelectionChange={(robotId) => {
-                selectArm(arm, robotId);
-            }}
-        >
-            {robots.map((robot) => (
-                <Item key={robot.id} textValue={robot.name}>
-                    <Text>{robot.name}</Text>
-                    <Text slot='description'>{robot.payload.serial_number}</Text>
-                </Item>
-            ))}
-        </Picker>
-    );
-
     return (
         <Flex direction='column' gap='size-100' width='100%'>
-            {armPicker('left', leftRobots)}
-            {armPicker('right', rightRobots)}
+            <SO101ArmPicker
+                arm='left'
+                robots={leftRobots}
+                selectedKey={selectedRobotId('left')}
+                onSelect={(robotId) => selectArm('left', robotId)}
+            />
+            <SO101ArmPicker
+                arm='right'
+                robots={rightRobots}
+                selectedKey={selectedRobotId('right')}
+                onSelect={(robotId) => selectArm('right', robotId)}
+            />
         </Flex>
     );
 };

--- a/application/ui/src/features/robots/robot-form/form-data.ts
+++ b/application/ui/src/features/robots/robot-form/form-data.ts
@@ -1,9 +1,10 @@
 import { SchemaRobotInput, SchemaRobotType } from '../robot-types';
+import { buildBimanualSO101Body, type BimanualSO101FormData } from './catalog/bimanual-so101';
 import { buildSO101Body, type SO101FormData } from './catalog/so101';
 import { buildWidowxBody, type WidowxFormData } from './catalog/widowxai';
 import { buildBimanualBody, type BimanualFormData } from './catalog/widowxai-bimanual';
 
-export type AnyRobotFormData = SO101FormData | WidowxFormData | BimanualFormData;
+export type AnyRobotFormData = SO101FormData | WidowxFormData | BimanualFormData | BimanualSO101FormData;
 
 export type FormDataForSchema = {
     SO101_Follower: SO101FormData;
@@ -12,6 +13,8 @@ export type FormDataForSchema = {
     Trossen_WidowXAI_Leader: WidowxFormData;
     Trossen_Bimanual_WidowXAI_Follower: BimanualFormData;
     Trossen_Bimanual_WidowXAI_Leader: BimanualFormData;
+    BimanualSO101_Follower: BimanualSO101FormData;
+    BimanualSO101_Leader: BimanualSO101FormData;
 };
 
 export const buildRobotBody = (
@@ -29,6 +32,9 @@ export const buildRobotBody = (
         case 'Trossen_Bimanual_WidowXAI_Follower':
         case 'Trossen_Bimanual_WidowXAI_Leader':
             return buildBimanualBody(formData as BimanualFormData, schemaType, robot_id);
+        case 'BimanualSO101_Follower':
+        case 'BimanualSO101_Leader':
+            return buildBimanualSO101Body(formData as BimanualSO101FormData, schemaType, robot_id);
         default:
             return null;
     }

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -5,6 +5,7 @@ import { useProjectId } from '../../../features/projects/use-project';
 import { paths } from '../../../router';
 import { useRobotCatalogQuery } from '../robot-catalog.hooks';
 import { ConfigurableRobotType } from '../robot-types';
+import { BimanualSO101FormFields } from './catalog/bimanual-so101';
 import { SO101FormFields } from './catalog/so101';
 import { WidowxAIFormFields } from './catalog/widowxai';
 import { BiManualWidowxAIFormFields } from './catalog/widowxai-bimanual';
@@ -50,6 +51,10 @@ export const FormFields = () => {
         case 'Trossen_Bimanual_WidowXAI_Leader':
         case 'Trossen_Bimanual_WidowXAI_Follower':
             formFields = <BiManualWidowxAIFormFields />;
+            break;
+        case 'BimanualSO101_Follower':
+        case 'BimanualSO101_Leader':
+            formFields = <BimanualSO101FormFields />;
             break;
     }
 

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -52,8 +52,9 @@ export const FormFields = () => {
         case 'Trossen_Bimanual_WidowXAI_Follower':
             formFields = <BiManualWidowxAIFormFields />;
             break;
-        case 'BimanualSO101_Follower':
-        case 'BimanualSO101_Leader':
+        // Bimanual SO101 is a plugin robot type not present in the backend catalog; kept for persisted robots.
+        case 'BimanualSO101_Follower' as ConfigurableRobotType:
+        case 'BimanualSO101_Leader' as ConfigurableRobotType:
             formFields = <BimanualSO101FormFields />;
             break;
     }

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -31,7 +31,7 @@ type SetRobotFormContextType = {
 
 const SetRobotFormContext = createContext<SetRobotFormContextType | null>(null);
 
-const FORM_DATA_FAMILY: Record<ConfigurableRobotType, string> = {
+const FORM_DATA_FAMILY: Record<ConfigurableRobotType | 'BimanualSO101_Follower' | 'BimanualSO101_Leader', string> = {
     SO101_Follower: 'so101',
     SO101_Leader: 'so101',
     Trossen_WidowXAI_Follower: 'widowx',
@@ -45,9 +45,11 @@ const FORM_DATA_FAMILY: Record<ConfigurableRobotType, string> = {
 const getInitialState = (robot?: AvailableSchemaRobot): RobotFormState => ({
     activeType: robot?.type ?? 'SO101_Follower',
     BimanualSO101_Follower: getInitialBimanualSO101FormData(
-        robot?.type === 'BimanualSO101_Follower' ? robot : undefined
+        robot?.type === ('BimanualSO101_Follower' as ConfigurableRobotType) ? robot : undefined
     ),
-    BimanualSO101_Leader: getInitialBimanualSO101FormData(robot?.type === 'BimanualSO101_Leader' ? robot : undefined),
+    BimanualSO101_Leader: getInitialBimanualSO101FormData(
+        robot?.type === ('BimanualSO101_Leader' as ConfigurableRobotType) ? robot : undefined
+    ),
     SO101_Follower: getInitialSO101FormData(robot?.type === 'SO101_Follower' ? robot : undefined),
     SO101_Leader: getInitialSO101FormData(robot?.type === 'SO101_Leader' ? robot : undefined),
     Trossen_WidowXAI_Follower: getInitialWidowxFormData(

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -1,6 +1,7 @@
 import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 
 import { AvailableSchemaRobot, ConfigurableRobotType, SchemaRobotInput } from '../robot-types';
+import { getInitialBimanualSO101FormData } from './catalog/bimanual-so101';
 import { getInitialSO101FormData } from './catalog/so101';
 import { getInitialWidowxFormData } from './catalog/widowxai';
 import { getInitialBimanualFormData } from './catalog/widowxai-bimanual';
@@ -14,6 +15,8 @@ type RobotFormState = {
     Trossen_WidowXAI_Leader: FormDataForSchema['Trossen_WidowXAI_Leader'];
     Trossen_Bimanual_WidowXAI_Follower: FormDataForSchema['Trossen_Bimanual_WidowXAI_Follower'];
     Trossen_Bimanual_WidowXAI_Leader: FormDataForSchema['Trossen_Bimanual_WidowXAI_Leader'];
+    BimanualSO101_Follower: FormDataForSchema['BimanualSO101_Follower'];
+    BimanualSO101_Leader: FormDataForSchema['BimanualSO101_Leader'];
 };
 
 const RobotFormContext = createContext<RobotFormState | null>(null);
@@ -35,10 +38,16 @@ const FORM_DATA_FAMILY: Record<ConfigurableRobotType, string> = {
     Trossen_WidowXAI_Leader: 'widowx',
     Trossen_Bimanual_WidowXAI_Follower: 'bimanual',
     Trossen_Bimanual_WidowXAI_Leader: 'bimanual',
+    BimanualSO101_Follower: 'bimanual_so101',
+    BimanualSO101_Leader: 'bimanual_so101',
 };
 
 const getInitialState = (robot?: AvailableSchemaRobot): RobotFormState => ({
     activeType: robot?.type ?? 'SO101_Follower',
+    BimanualSO101_Follower: getInitialBimanualSO101FormData(
+        robot?.type === 'BimanualSO101_Follower' ? robot : undefined
+    ),
+    BimanualSO101_Leader: getInitialBimanualSO101FormData(robot?.type === 'BimanualSO101_Leader' ? robot : undefined),
     SO101_Follower: getInitialSO101FormData(robot?.type === 'SO101_Follower' ? robot : undefined),
     SO101_Leader: getInitialSO101FormData(robot?.type === 'SO101_Leader' ? robot : undefined),
     Trossen_WidowXAI_Follower: getInitialWidowxFormData(


### PR DESCRIPTION
## Description

This PR adds a new `physicalai-bimanual-so101-plugin` plugin and enables UI configuration.
Like with the bimanual widowx arms we add bimanual so101 by creating a "CompositeRobot" that joints the state of two SO101 robots. The package exposes its own urdf that gets synced with the composite robot.

On the dataset side the feature names are prefixed with either `left_` or `right_`.

To create a SO101 robot the user first needs to create a singular follower/leader for both left and right arms. After this they can create a bimnaual arm that references the existing ones. This way we can reuse the same calibration configuration as the already existing arms.

| Preview  | Edit  |
|---|---|
| <img width="1898" height="1080" alt="image" src="https://github.com/user-attachments/assets/b057ec50-de56-4d80-9723-943e7d01bd44" />   | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4023cabd-8cb1-439d-8324-cf9358b65b59" />
  |


## Related Issues

#762
