### PR TITLE
fix: additional code review suggestions from #835

### DIFF
--- a/application/backend/src/alembic/versions/d4e5f6a7b8c9_normalize_robot_types_and_trim_widowx_payload.py
+++ b/application/backend/src/alembic/versions/d4e5f6a7b8c9_normalize_robot_types_and_trim_widowx_payload.py
@@ -1,0 +1,120 @@
+"""normalize robot types and remove widowx serial_number
+
+Revision ID: d4e5f6a7b8c9
+Revises: c9d8e7f6a5b4
+Create Date: 2026-07-27 00:00:00.000000
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: str | Sequence[str] | None = "c9d8e7f6a5b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_TYPE_NORMALIZATION = {
+    "SO101_FOLLOWER": "SO101_Follower",
+    "SO101_LEADER": "SO101_Leader",
+    "TROSSEN_WIDOWXAI_FOLLOWER": "Trossen_WidowXAI_Follower",
+    "TROSSEN_WIDOWXAI_LEADER": "Trossen_WidowXAI_Leader",
+    "TROSSEN_BIMANUAL_WIDOWXAI_FOLLOWER": "Trossen_Bimanual_WidowXAI_Follower",
+    "TROSSEN_BIMANUAL_WIDOWXAI_LEADER": "Trossen_Bimanual_WidowXAI_Leader",
+}
+
+_TYPE_DENORMALIZATION = {new: old for old, new in _TYPE_NORMALIZATION.items()}
+
+_WIDOWX_TYPES = (
+    "Trossen_WidowXAI_Follower",
+    "Trossen_WidowXAI_Leader",
+    "Trossen_Bimanual_WidowXAI_Follower",
+    "Trossen_Bimanual_WidowXAI_Leader",
+)
+
+
+def _parse_payload(payload_raw: object) -> dict | None:
+    if isinstance(payload_raw, dict):
+        return payload_raw
+    if isinstance(payload_raw, str):
+        try:
+            parsed = json.loads(payload_raw)
+        except ValueError:
+            return None
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _normalize_robot_types(conn: sa.Connection) -> None:
+    for legacy_type, canonical_type in _TYPE_NORMALIZATION.items():
+        conn.execute(
+            sa.text("UPDATE project_robots SET type = :canonical WHERE type = :legacy"),
+            {"canonical": canonical_type, "legacy": legacy_type},
+        )
+
+
+def _denormalize_robot_types(conn: sa.Connection) -> None:
+    for canonical_type, legacy_type in _TYPE_DENORMALIZATION.items():
+        conn.execute(
+            sa.text("UPDATE project_robots SET type = :legacy WHERE type = :canonical"),
+            {"legacy": legacy_type, "canonical": canonical_type},
+        )
+
+
+def _remove_widowx_serial_number(conn: sa.Connection) -> None:
+    rows = conn.execute(
+        sa.text("SELECT id, payload FROM project_robots WHERE type IN :types").bindparams(
+            sa.bindparam("types", expanding=True)
+        ),
+        {"types": _WIDOWX_TYPES},
+    ).fetchall()
+
+    for robot_id, payload_raw in rows:
+        payload = _parse_payload(payload_raw)
+        if payload is None or "serial_number" not in payload:
+            continue
+
+        payload.pop("serial_number", None)
+        conn.execute(
+            sa.text("UPDATE project_robots SET payload = :payload WHERE id = :id"),
+            {"payload": json.dumps(payload), "id": robot_id},
+        )
+
+
+def _add_widowx_serial_number(conn: sa.Connection) -> None:
+    rows = conn.execute(
+        sa.text("SELECT id, payload FROM project_robots WHERE type IN :types").bindparams(
+            sa.bindparam("types", expanding=True)
+        ),
+        {"types": _WIDOWX_TYPES},
+    ).fetchall()
+
+    for robot_id, payload_raw in rows:
+        payload = _parse_payload(payload_raw)
+        if payload is None or "serial_number" in payload:
+            continue
+
+        payload["serial_number"] = ""
+        conn.execute(
+            sa.text("UPDATE project_robots SET payload = :payload WHERE id = :id"),
+            {"payload": json.dumps(payload), "id": robot_id},
+        )
+
+
+def upgrade() -> None:
+    """Normalize legacy robot types and remove widowx serial_number from payload."""
+    conn = op.get_bind()
+    _normalize_robot_types(conn)
+    _remove_widowx_serial_number(conn)
+
+
+def downgrade() -> None:
+    """Re-add widowx serial_number and restore legacy uppercase type values."""
+    conn = op.get_bind()
+    _add_widowx_serial_number(conn)
+    _denormalize_robot_types(conn)

--- a/application/backend/src/repositories/mappers/project_robot_mapper.py
+++ b/application/backend/src/repositories/mappers/project_robot_mapper.py
@@ -2,21 +2,6 @@ from db.schema import ProjectRobotDB
 from repositories.mappers.base_mapper_interface import IBaseMapper
 from schemas.robot import Robot, RobotAdapter
 
-# Our database initially stored types using all uppercase due to them
-# being stored as StrEnum
-_TYPE_NORMALIZATION: dict[str, str] = {
-    "SO101_FOLLOWER": "SO101_Follower",
-    "SO101_LEADER": "SO101_Leader",
-    "TROSSEN_WIDOWXAI_FOLLOWER": "Trossen_WidowXAI_Follower",
-    "TROSSEN_WIDOWXAI_LEADER": "Trossen_WidowXAI_Leader",
-    "TROSSEN_BIMANUAL_WIDOWXAI_FOLLOWER": "Trossen_Bimanual_WidowXAI_Follower",
-    "TROSSEN_BIMANUAL_WIDOWXAI_LEADER": "Trossen_Bimanual_WidowXAI_Leader",
-}
-
-
-def _convert_databasee_type(raw: str) -> str:
-    return _TYPE_NORMALIZATION.get(raw, raw)
-
 
 class ProjectRobotMapper(IBaseMapper):
     """Mapper for Robot schema entity <-> DB entity conversions."""
@@ -27,7 +12,7 @@ class ProjectRobotMapper(IBaseMapper):
         return ProjectRobotDB(
             id=str(db_schema.id),
             name=db_schema.name,
-            type=_convert_databasee_type(db_schema.type),
+            type=db_schema.type,
             payload=db_schema.payload.model_dump(),
         )
 
@@ -38,7 +23,7 @@ class ProjectRobotMapper(IBaseMapper):
             {
                 "id": model.id,
                 "name": model.name,
-                "type": _convert_databasee_type(model.type),
+                "type": model.type,
                 "payload": model.payload,
                 "created_at": model.created_at,
                 "updated_at": model.updated_at,

--- a/application/backend/src/robots/catalog/registry.py
+++ b/application/backend/src/robots/catalog/registry.py
@@ -5,6 +5,7 @@ from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
+from loguru import logger
 from physicalai_studio_plugin import RobotAsset, RobotCatalogDefinition
 from physicalai_studio_plugin import RobotCatalogRegistry as RobotCatalogRegistryProtocol
 from pydantic import BaseModel, Field, TypeAdapter, create_model
@@ -120,18 +121,42 @@ class RobotCatalogRegistry(RobotCatalogRegistryProtocol):
         return Annotated[_build_union(models), Field(discriminator="type")]
 
     def _load_external_plugins(self) -> None:
-        discovered_entry_points = list(entry_points(group=CATALOG_PLUGIN_ENTRYPOINT_GROUP))
+        try:
+            discovered_entry_points = list(entry_points(group=CATALOG_PLUGIN_ENTRYPOINT_GROUP))
+        except Exception:
+            logger.exception(
+                "Failed to discover robot catalog plugins from entry point group '{}'",
+                CATALOG_PLUGIN_ENTRYPOINT_GROUP,
+            )
+            return
 
         for discovered_entry_point in discovered_entry_points:
-            register_plugin = discovered_entry_point.load()
-            if not callable(register_plugin):
-                raise ValueError(
-                    f"Catalog plugin entry point '{discovered_entry_point.name}' must load a callable "
-                    "register_physicalai_studio_plugin(registry)"
+            try:
+                register_plugin = discovered_entry_point.load()
+            except Exception:
+                logger.exception(
+                    "Failed to load robot catalog plugin entry point '{}' ({})",
+                    discovered_entry_point.name,
+                    discovered_entry_point.value,
                 )
+                continue
+
+            if not callable(register_plugin):
+                logger.error(
+                    "Catalog plugin entry point '{}' loaded non-callable object ({})",
+                    discovered_entry_point.name,
+                    type(register_plugin).__name__,
+                )
+                continue
 
             plugin_callable: RegisterPluginCallable = cast("RegisterPluginCallable", register_plugin)
-            plugin_callable(self)
+            try:
+                plugin_callable(self)
+            except Exception:
+                logger.exception(
+                    "Catalog plugin entry point '{}' failed during registration",
+                    discovered_entry_point.name,
+                )
 
     def get_robot_adapter(self) -> TypeAdapter:
         if self._robot_adapter is None:

--- a/application/backend/src/robots/catalog/widowxai.py
+++ b/application/backend/src/robots/catalog/widowxai.py
@@ -24,13 +24,11 @@ class TrossenSingleArmPayload(BaseModel):
     """Connection configuration for Trossen single-arm robots."""
 
     connection_string: str = Field(..., description="IP address of the robot")
-    serial_number: str = Field(default="", description="Serial number (unused for IP robots)")
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "connection_string": "192.168.1.100",
-                "serial_number": "",
             },
         },
     )
@@ -41,14 +39,12 @@ class TrossenBimanualPayload(BaseModel):
 
     connection_string_left: str = Field(..., description="IP address of the left arm")
     connection_string_right: str = Field(..., description="IP address of the right arm")
-    serial_number: str = Field(default="", description="Serial number (unused for IP robots)")
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "connection_string_left": "192.168.1.100",
                 "connection_string_right": "192.168.1.101",
-                "serial_number": "",
             },
         },
     )

--- a/application/backend/tests/api/test_hardware.py
+++ b/application/backend/tests/api/test_hardware.py
@@ -159,7 +159,7 @@ class TestHardwareApi:
             with patch("robots.catalog.widowxai.identify_trossen_robot_visually", new_callable=AsyncMock) as identify:
                 response = client.post(
                     "/api/robots/catalog/Trossen_WidowXAI_Follower/identify",
-                    json={"connection_string": "192.168.1.100", "serial_number": ""},
+                    json={"connection_string": "192.168.1.100"},
                 )
         finally:
             app.dependency_overrides.clear()

--- a/application/backend/tests/repositories/mappers/test_project_robot_mapper_bimanual.py
+++ b/application/backend/tests/repositories/mappers/test_project_robot_mapper_bimanual.py
@@ -21,7 +21,6 @@ def _make_bimanual_db_model(robot_type: str):
     model.payload = {
         "connection_string_left": "10.0.0.1",
         "connection_string_right": "10.0.0.2",
-        "serial_number": "",
     }
     model.created_at = datetime(2026, 1, 1)
     model.updated_at = datetime(2026, 1, 1)
@@ -61,7 +60,6 @@ class TestProjectRobotMapperBimanual:
             payload=TrossenBimanualPayload(
                 connection_string_left="192.168.10.1",
                 connection_string_right="192.168.10.2",
-                serial_number="SN-BIMAN-001",
             ),
         )
 
@@ -79,4 +77,3 @@ class TestProjectRobotMapperBimanual:
 
         assert restored.payload.connection_string_left == "192.168.10.1"
         assert restored.payload.connection_string_right == "192.168.10.2"
-        assert restored.payload.serial_number == "SN-BIMAN-001"

--- a/application/backend/tests/robots/test_catalog_registry.py
+++ b/application/backend/tests/robots/test_catalog_registry.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from robots.catalog.registry import RobotCatalogRegistry
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, value: str, loader):
+        self.name = name
+        self.value = value
+        self._loader = loader
+
+    def load(self):
+        return self._loader()
+
+
+def test_registry_continues_when_plugin_discovery_fails() -> None:
+    with patch("robots.catalog.registry.entry_points", side_effect=RuntimeError("boom")):
+        registry = RobotCatalogRegistry()
+
+    definitions = registry.list_definitions()
+    assert definitions
+    assert any(definition.type == "SO101_Follower" for definition in definitions)
+
+
+def test_registry_skips_bad_plugins_and_continues_loading_remaining_plugins() -> None:
+    called: list[str] = []
+
+    def _raises_on_load():
+        raise RuntimeError("cannot import")
+
+    def _returns_non_callable():
+        return 123
+
+    def _raises_on_register():
+        def _plugin(_registry):
+            raise RuntimeError("register failed")
+
+        return _plugin
+
+    def _good_plugin():
+        def _plugin(_registry):
+            called.append("ok")
+
+        return _plugin
+
+    entry_points = [
+        _FakeEntryPoint("broken-load", "plugin.module:bad_load", _raises_on_load),
+        _FakeEntryPoint("non-callable", "plugin.module:not_callable", _returns_non_callable),
+        _FakeEntryPoint("broken-register", "plugin.module:broken_register", _raises_on_register),
+        _FakeEntryPoint("good", "plugin.module:register", _good_plugin),
+    ]
+
+    with patch("robots.catalog.registry.entry_points", return_value=entry_points):
+        registry = RobotCatalogRegistry()
+
+    assert called == ["ok"]
+    definitions = registry.list_definitions()
+    assert definitions
+    assert any(definition.type == "SO101_Follower" for definition in definitions)

--- a/application/ui/src/features/robots/robot-form/catalog/actions.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/actions.tsx
@@ -2,7 +2,7 @@ import { ActionButton, Icon } from '@geti-ui/ui';
 import { Refresh } from '@geti-ui/ui/icons';
 
 import { useCatalogIdentifyMutation, useDiscoverRobotsQuery } from '../../robot-catalog.hooks';
-import type { SchemaRobot } from '../../robot-types';
+import type { SchemaRobot, SchemaRobotType } from '../../robot-types';
 import { useRobotFormFields } from '../provider';
 
 import classes from '../form.module.css';
@@ -29,11 +29,13 @@ export const RefreshRobotsButton = () => {
 export const IdentifyRobot = ({
     identifyMutation,
     payload: override,
+    robotType,
 }: {
     identifyMutation: ReturnType<typeof useCatalogIdentifyMutation>;
     payload?: SchemaRobot['payload'] | null;
+    robotType?: SchemaRobotType;
 }) => {
-    const { formData, activeType: robotType } = useRobotFormFields();
+    const { formData, activeType } = useRobotFormFields();
     const payload = override ?? formData.payload;
     const isDisabled = payload === null || identifyMutation.isPending;
 
@@ -43,7 +45,7 @@ export const IdentifyRobot = ({
         }
 
         identifyMutation.mutate({
-            params: { path: { robot_type: robotType } },
+            params: { path: { robot_type: robotType ?? activeType } },
             body: payload,
         });
     };

--- a/application/ui/src/features/robots/robot-form/catalog/so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.tsx
@@ -15,7 +15,9 @@ export interface SO101FormData {
 export const getInitialSO101FormData = (robot?: SchemaRobot): SO101FormData => ({
     name: robot?.name ?? '',
     payload:
-        robot && 'connection_string' in robot.payload ? robot.payload : { connection_string: '', serial_number: '' },
+        robot && (robot.type === 'SO101_Follower' || robot.type === 'SO101_Leader')
+            ? robot.payload
+            : { connection_string: '', serial_number: '' },
 });
 
 export const buildSO101Body = (

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
@@ -18,7 +18,7 @@ export const getInitialBimanualFormData = (robot?: SchemaRobot): BimanualFormDat
     payload:
         robot && 'connection_string_left' in robot.payload
             ? robot.payload
-            : { connection_string_left: '', connection_string_right: '', serial_number: '' },
+            : { connection_string_left: '', connection_string_right: '' },
 });
 
 export const buildBimanualBody = (
@@ -45,7 +45,7 @@ export const BiManualWidowxAIFormFields = () => {
     const leftIdentifyRobot = buildWidowxBody(
         {
             name: formData.name,
-            payload: { connection_string: formData.payload.connection_string_left, serial_number: '' },
+            payload: { connection_string: formData.payload.connection_string_left },
         },
         'Trossen_WidowXAI_Follower',
         uuidv4()
@@ -53,7 +53,7 @@ export const BiManualWidowxAIFormFields = () => {
     const rightIdentifyRobot = buildWidowxBody(
         {
             name: formData.name,
-            payload: { connection_string: formData.payload.connection_string_right, serial_number: '' },
+            payload: { connection_string: formData.payload.connection_string_right },
         },
         'Trossen_WidowXAI_Follower',
         uuidv4()
@@ -72,7 +72,6 @@ export const BiManualWidowxAIFormFields = () => {
                             updateField('payload', {
                                 ...formData.payload,
                                 connection_string_left,
-                                serial_number: '',
                             });
                         }}
                         placeholder='192.168.1.2'
@@ -97,7 +96,6 @@ export const BiManualWidowxAIFormFields = () => {
                         updateField('payload', {
                             ...formData.payload,
                             connection_string_right,
-                            serial_number: '',
                         });
                     }}
                     placeholder='192.168.1.3'

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
@@ -78,7 +78,11 @@ export const BiManualWidowxAIFormFields = () => {
                         placeholder='192.168.1.2'
                     />
                     <View>
-                        <IdentifyRobot identifyMutation={identifyMutation} payload={leftIdentifyRobot?.payload} />
+                        <IdentifyRobot
+                            identifyMutation={identifyMutation}
+                            payload={leftIdentifyRobot?.payload}
+                            robotType={'Trossen_WidowXAI_Follower'}
+                        />
                     </View>
                 </Flex>
             </Flex>
@@ -99,7 +103,11 @@ export const BiManualWidowxAIFormFields = () => {
                     placeholder='192.168.1.3'
                 />
                 <View>
-                    <IdentifyRobot identifyMutation={identifyMutation} payload={rightIdentifyRobot?.payload} />
+                    <IdentifyRobot
+                        identifyMutation={identifyMutation}
+                        payload={rightIdentifyRobot?.payload}
+                        robotType={'Trossen_WidowXAI_Follower'}
+                    />
                 </View>
             </Flex>
         </>

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
@@ -13,8 +13,7 @@ export interface WidowxFormData {
 
 export const getInitialWidowxFormData = (robot?: SchemaRobot): WidowxFormData => ({
     name: robot?.name ?? '',
-    payload:
-        robot && 'connection_string' in robot.payload ? robot.payload : { connection_string: '', serial_number: '' },
+    payload: robot && 'connection_string' in robot.payload ? robot.payload : { connection_string: '' },
 });
 
 export const buildWidowxBody = (
@@ -46,7 +45,7 @@ export const WidowxAIFormFields = () => {
                 width='100%'
                 value={formData.payload.connection_string}
                 onChange={(connection_string) => {
-                    updateField('payload', { ...formData.payload, connection_string, serial_number: '' });
+                    updateField('payload', { ...formData.payload, connection_string });
                 }}
                 placeholder='192.168.1.2'
             />

--- a/application/ui/src/features/robots/robot-form/form-data.test.ts
+++ b/application/ui/src/features/robots/robot-form/form-data.test.ts
@@ -36,7 +36,6 @@ describe('buildRobotBody', () => {
                 payload: {
                     connection_string_left: '192.168.1.2',
                     connection_string_right: '192.168.1.3',
-                    serial_number: '',
                 },
             },
             'Trossen_Bimanual_WidowXAI_Follower',
@@ -47,7 +46,6 @@ describe('buildRobotBody', () => {
         expect(body?.payload).toEqual({
             connection_string_left: '192.168.1.2',
             connection_string_right: '192.168.1.3',
-            serial_number: '',
         });
     });
 });

--- a/application/ui/src/features/robots/robots-list.test.tsx
+++ b/application/ui/src/features/robots/robots-list.test.tsx
@@ -52,7 +52,7 @@ describe('RobotsList', () => {
                         id: 'widowx-id',
                         name: 'Test WidowX',
                         type: 'Trossen_WidowXAI_Follower',
-                        payload: { connection_string: '', serial_number: 'widowx-001' },
+                        payload: { connection_string: '' },
                     },
                 ])
             ),

--- a/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/verification-step.tsx
@@ -6,6 +6,7 @@ import { degToRad } from 'three/src/math/MathUtils.js';
 import { v4 as uuidv4 } from 'uuid';
 
 import { $api } from '../../../../api/client';
+import type { SchemaSo101RobotPayload } from '../../../../api/openapi-spec';
 import { paths } from '../../../../router';
 import { useProjectId } from '../../../projects/use-project';
 import { buildRobotBody } from '../../robot-form/form-data';
@@ -71,9 +72,12 @@ export const VerificationStep = () => {
     const { wsState } = useSetupState();
     const { activeType, robotForm } = useRobotForm();
 
-    const payload = 'connection_string' in robotForm.payload ? robotForm.payload : null;
-    const serialNumber = payload?.serial_number ?? '';
-    const connectionString = payload?.connection_string ?? '';
+    const so101Payload: SchemaSo101RobotPayload | null =
+        activeType === 'SO101_Follower' || activeType === 'SO101_Leader'
+            ? (robotForm.payload as SchemaSo101RobotPayload)
+            : null;
+    const serialNumber = so101Payload?.serial_number ?? '';
+    const connectionString = so101Payload?.connection_string ?? '';
     const robotType = activeType;
 
     const [robotId] = useState(() => uuidv4());

--- a/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
+++ b/application/ui/src/features/robots/setup-wizard/so101/wizard-provider.tsx
@@ -1,5 +1,6 @@
 import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 
+import type { SchemaSo101RobotPayload } from '../../../../api/openapi-spec';
 import { useProjectId } from '../../../projects/use-project';
 import { useRobotForm } from '../../robot-form/provider';
 import { MotorProbeResult, SetupWebSocketState, useSetupWebSocket } from './use-setup-websocket';
@@ -158,10 +159,13 @@ export const SetupWizardProvider = ({ children }: { children: ReactNode }) => {
     // -----------------------------------------------------------------------
     // WebSocket hook
     // -----------------------------------------------------------------------
-    const payload = 'connection_string' in robotForm.payload ? robotForm.payload : null;
-    const serialNumber = payload?.serial_number ?? '';
+    const so101Payload: SchemaSo101RobotPayload | null =
+        activeType === 'SO101_Follower' || activeType === 'SO101_Leader'
+            ? (robotForm.payload as SchemaSo101RobotPayload)
+            : null;
+    const serialNumber = so101Payload?.serial_number ?? '';
     const robotType = activeType;
-    const connectionString = payload?.connection_string ?? '';
+    const connectionString = so101Payload?.connection_string ?? '';
 
     const wsEnabled = (!!serialNumber || !!connectionString) && robotType.startsWith('SO101');
 


### PR DESCRIPTION
- Migrate robot types in database from all uppercase to the exact string used in our code
- harden robot registry calls, adding try catch around `register_robot`
- remove `serial_number` from widowx payload
- fix `IdentifyRobot` for bimanual widowx arms (before it was sending a `POST /api/robots/catalog/{robot_type}/identify` request with `robot_type` equal to `TROSSEN_BIMANUAL_WIDOWXAI_FOLLOWER`, but with a payload intended for a single arm)