### PR TITLE
fix: add pkg-containers.githubusercontent.com to allowed hosts

### DIFF
--- a/.github/workflows/trainer-images.yml
+++ b/.github/workflows/trainer-images.yml
@@ -163,6 +163,7 @@ jobs:
             ghcr1production.blob.core.windows.net:443
             github.com:443
             keyserver.ubuntu.com:443
+            pkg-containers.githubusercontent.com:443
             ppa.launchpadcontent.net:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `trainer-images.yml` GitHub Actions workflow by allowing network access to `pkg-containers.githubusercontent.com:443` required for container operations.

Fixes failure in https://github.com/open-edge-platform/physical-ai-studio/actions/runs/30353138628