### PR TITLE
fix(backend): validate current alembic revision against full history

### DIFF
--- a/application/backend/src/db/migration.py
+++ b/application/backend/src/db/migration.py
@@ -86,11 +86,21 @@ class MigrationManager:
                 context = migration.MigrationContext.configure(conn)
                 current_rev = context.get_current_revision()
 
-            # Check if current_rev is in Alembic's tracked revisions
-            if current_rev and current_rev not in script.get_heads() + script.get_bases():
-                raise RevisionNotFoundError(
-                    f"Current revision '{current_rev}' not found in Alembic history. Please, recreate the database."
-                )
+            # Check if current_rev exists anywhere in Alembic's revision map.
+            # A valid database can sit on an intermediate revision, not only
+            # on a base or the current head.
+            if current_rev:
+                try:
+                    resolved_revision = script.get_revision(current_rev)
+                except ResolutionError as e:
+                    raise RevisionNotFoundError(
+                        f"Current revision '{current_rev}' not found in Alembic history. Please, recreate the database."
+                    ) from e
+
+                if resolved_revision is None:
+                    raise RevisionNotFoundError(
+                        f"Current revision '{current_rev}' not found in Alembic history. Please, recreate the database."
+                    )
 
             needs_migration = current_rev != current_head
             status = f"Current: {current_rev or 'None'}, Head: {current_head or 'None'}"

--- a/application/backend/tests/cli/test_serve.py
+++ b/application/backend/tests/cli/test_serve.py
@@ -1,9 +1,25 @@
 import importlib
+import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 serve_module = importlib.import_module("cli.serve")
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache() -> Iterator[None]:
+    settings_module = importlib.import_module("settings")
+    os.environ.pop("ALEMBIC_CONFIG_PATH", None)
+    os.environ.pop("ALEMBIC_SCRIPT_LOCATION", None)
+    os.environ.pop("STATIC_FILES_DIR", None)
+    settings_module.get_settings.cache_clear()
+    yield
+    os.environ.pop("ALEMBIC_CONFIG_PATH", None)
+    os.environ.pop("ALEMBIC_SCRIPT_LOCATION", None)
+    os.environ.pop("STATIC_FILES_DIR", None)
+    settings_module.get_settings.cache_clear()
 
 
 def test_sync_missing_robot_assets_skips_when_available(monkeypatch) -> None:

--- a/application/backend/tests/integration/test_e2e_dataset_to_export.py
+++ b/application/backend/tests/integration/test_e2e_dataset_to_export.py
@@ -262,7 +262,7 @@ def _assert_exported_model_runs_inference(export_dir: Path, dataset_id: str) -> 
     assert action.shape[-1] == 2
 
 
-def test_submit_training_job_for_missing_project_returns_404() -> None:
+def test_submit_training_job_for_missing_project_returns_404(migrated_db: None) -> None:
     """Submitting against a project that doesn't exist is a clean 404, not a crash."""
     client = TestClient(app)
 

--- a/application/backend/tests/test_migration_manager.py
+++ b/application/backend/tests/test_migration_manager.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+from typing import Literal
+
+import pytest
+
+import db.migration as migration_module
+from alembic.script.revision import ResolutionError
+from db.migration import MigrationManager, RevisionNotFoundError
+from settings import Settings
+
+
+class _DummyConnectionContext:
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, exc_type, exc, tb) -> Literal[False]:
+        return False
+
+
+class _DummyEngine:
+    def connect(self) -> _DummyConnectionContext:
+        return _DummyConnectionContext()
+
+
+def test_check_migration_status_accepts_intermediate_revision(monkeypatch, tmp_path) -> None:
+    settings = Settings(STORAGE_DIR=tmp_path)
+    manager = MigrationManager(settings)
+
+    current_rev = "d4e5f6a7b8c9"
+    head_rev = "e4b2f1c8a907"
+
+    script = SimpleNamespace(
+        get_current_head=lambda: head_rev,
+        get_revision=lambda revision: object() if revision == current_rev else None,
+    )
+
+    context = SimpleNamespace(get_current_revision=lambda: current_rev)
+
+    monkeypatch.setattr(migration_module, "sync_engine", _DummyEngine())
+    monkeypatch.setattr(migration_module.ScriptDirectory, "from_config", lambda _: script)
+    monkeypatch.setattr(migration_module.migration.MigrationContext, "configure", lambda _: context)
+
+    needs_migration, status = manager.check_migration_status()
+
+    assert needs_migration is True
+    assert status == f"Current: {current_rev}, Head: {head_rev}"
+
+
+def test_check_migration_status_raises_for_unknown_revision(monkeypatch, tmp_path) -> None:
+    settings = Settings(STORAGE_DIR=tmp_path)
+    manager = MigrationManager(settings)
+
+    missing_rev = "deadbeefdead"
+
+    def _raise_missing_revision(_: str) -> None:
+        raise ResolutionError("missing", missing_rev)
+
+    script = SimpleNamespace(
+        get_current_head=lambda: "e4b2f1c8a907",
+        get_revision=_raise_missing_revision,
+    )
+
+    context = SimpleNamespace(get_current_revision=lambda: missing_rev)
+
+    monkeypatch.setattr(migration_module, "sync_engine", _DummyEngine())
+    monkeypatch.setattr(migration_module.ScriptDirectory, "from_config", lambda _: script)
+    monkeypatch.setattr(migration_module.migration.MigrationContext, "configure", lambda _: context)
+
+    with pytest.raises(RevisionNotFoundError, match=missing_rev):
+        manager.check_migration_status()


### PR DESCRIPTION
The previous migration status check treated a database revision as valid only if it was one of: (a) a base revision or (b) a head revision. It did this by checking current_rev against `script.get_heads()` + `script.get_bases()`.

That logic is incorrect for normal Alembic workflows because a healthy database is often on an intermediate node before startup upgrades it to head.

Example (linear chain): A -> B -> C(head)

- DB at B is valid and should be migrated to C
- old check rejects B as 'not found' because B is neither base nor head
- startup fails with a false 'recreate the database' error

Another real example from this repo: d4e5f6a7b8c9 is valid and present in versions/, but it can still be rejected when e4b2f1c8a907 is the newer head.

This change fixes the validation by resolving current_rev through Alembic's full revision map via script.get_revision(current_rev).

- if Alembic can resolve it, the revision is valid (including intermediate revisions)
- if Alembic raises ResolutionError or returns None, we keep failing with RevisionNotFoundError for truly unknown revisions

Also adds regression tests for both cases:

- accepts an intermediate revision and reports migration-needed status
- raises RevisionNotFoundError for a genuinely unknown revision
