### PR TITLE
fix: show camera name in environment tabs

### DIFF
--- a/application/ui/src/features/robots/environment-form/preview.tsx
+++ b/application/ui/src/features/robots/environment-form/preview.tsx
@@ -1,10 +1,12 @@
-import { Suspense, useEffect, useRef } from 'react';
+import { Suspense, useEffect, useMemo, useRef } from 'react';
 
 import { Content, Flex, Heading, IllustratedMessage, Loading, Text, View } from '@geti-ui/ui';
 import { DockviewApi, IDockviewPanelProps } from 'dockview';
 import { DockviewReact, DockviewReadyEvent, IDockviewReactProps } from 'dockview-react';
 
+import { $api } from '../../../api/client';
 import { physicalAiTheme } from '../../dockview';
+import { useProjectId } from '../../projects/use-project';
 import { ReactComponent as RobotIllustration } from './../../../assets/illustrations/INTEL_08_NO-TESTS.svg';
 import { CameraCell } from './cells/camera-cell';
 import { RobotCell } from './cells/robot-cell';
@@ -40,23 +42,26 @@ const components = {
     },
 } satisfies IDockviewReactProps['components'];
 
-// Builds up all panels that we should add to Dockview
-// also removes any panels that are no longer part of the environment
-const buildDockviewPanels = (api: DockviewReadyEvent['api'], environment: EnvironmentFormState) => {
+const buildDockviewPanels = (
+    api: DockviewReadyEvent['api'],
+    environment: EnvironmentFormState,
+    cameraNameMap: Record<string, string>
+) => {
     if (environment === null) {
         return api;
     }
 
     const panels = new Set<string>();
 
-    environment.cameras.forEach(({ camera_id }, idx) => {
+    environment.cameras.forEach(({ camera_id }) => {
         panels.add(camera_id);
         if (!api.panels.some((panel) => panel.id === camera_id)) {
             api.addPanel({
                 id: camera_id,
+                title: cameraNameMap[camera_id] ?? camera_id,
                 component: 'camera',
                 params: {
-                    title: `Camera ${idx}`,
+                    title: cameraNameMap[camera_id] ?? camera_id,
                     camera_id,
                 },
                 position: {
@@ -101,10 +106,26 @@ const buildDockviewPanels = (api: DockviewReadyEvent['api'], environment: Enviro
 
 const ActualPreview = () => {
     const environment = useEnvironmentForm();
+    const { project_id } = useProjectId();
     const api = useRef<DockviewApi>(null);
 
+    const camerasQuery = $api.useSuspenseQuery('get', '/api/projects/{project_id}/cameras', {
+        params: { path: { project_id } },
+    });
+
+    const cameraNameMap: Record<string, string> = useMemo(() => {
+        const map: Record<string, string> = {};
+        for (const camera of camerasQuery.data) {
+            if (camera.id == undefined) {
+                continue;
+            }
+            map[camera.id] = camera.name;
+        }
+        return map;
+    }, [camerasQuery.data]);
+
     const onReady = (event: DockviewReadyEvent): void => {
-        api.current = buildDockviewPanels(event.api, environment);
+        api.current = buildDockviewPanels(event.api, environment, cameraNameMap);
     };
 
     useEffect(() => {
@@ -112,8 +133,8 @@ const ActualPreview = () => {
             return;
         }
 
-        buildDockviewPanels(api.current, environment);
-    }, [environment]);
+        buildDockviewPanels(api.current, environment, cameraNameMap);
+    }, [environment, cameraNameMap]);
 
     return <DockviewReact onReady={onReady} components={components} theme={physicalAiTheme} />;
 };


### PR DESCRIPTION
This PR fixes the environment view so that we show a camera name instead of its id in the environment view.

| **Before** | **After** |
|------------|-----------|
|  <img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/bfc6bc7a-ddd1-4184-9570-eedf58cd574a" />   |  <img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/e954f459-31b1-497c-971e-1889b8a722ac" />  |