### PR TITLE
refactor: improve 3d visualization

### DIFF
--- a/application/ui/src/features/robots/controller/robot-viewer.module.css
+++ b/application/ui/src/features/robots/controller/robot-viewer.module.css
@@ -15,6 +15,7 @@
     display: grid;
     place-items: center;
     padding: 16px;
+    background-color: rgb(36 37 40 / 65%);
     background-color: color-mix(in srgb, var(--spectrum-global-color-gray-100, #242528), transparent 35%);
     font-size: 13px;
 }

--- a/application/ui/src/features/robots/controller/robot-viewer.module.css
+++ b/application/ui/src/features/robots/controller/robot-viewer.module.css
@@ -1,0 +1,47 @@
+.viewer {
+    width: 100%;
+    height: 100%;
+}
+
+.canvas {
+    position: relative;
+    overflow: hidden;
+}
+
+.loadingOverlay,
+.errorOverlay {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: 16px;
+    background-color: color-mix(in srgb, var(--spectrum-global-color-gray-100, #242528), transparent 35%);
+    font-size: 13px;
+}
+
+.loadingOverlay::before {
+    width: 16px;
+    height: 16px;
+    margin-right: 8px;
+    border: 2px solid var(--spectrum-accent-color-500, #1473e6);
+    border-top-color: transparent;
+    border-radius: 50%;
+    content: '';
+    animation: spin 0.8s linear infinite;
+}
+
+.loadingOverlay {
+    grid-template-columns: auto auto;
+    justify-content: center;
+}
+
+.errorOverlay {
+    color: var(--spectrum-semantic-negative-color-default, #e34850);
+    text-align: center;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/application/ui/src/features/robots/controller/robot-viewer.tsx
+++ b/application/ui/src/features/robots/controller/robot-viewer.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/no-unknown-property */
 
-import { Suspense, useEffect, useMemo, useRef } from 'react';
+import { Suspense, useEffect, useRef } from 'react';
 
-import { ContactShadows, Grid, OrbitControls, PerspectiveCamera } from '@react-three/drei';
+import { OrbitControls, PerspectiveCamera } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
 import * as THREE from 'three';
 import { degToRad } from 'three/src/math/MathUtils.js';
@@ -12,26 +12,12 @@ import { useContainerSize } from '../../../components/zoom/use-container-size';
 import { useRobotCatalogDefinitionQuery } from '../robot-catalog.hooks';
 import { SchemaRobot } from '../robot-types';
 import { mapJointToURDFJoint, useLoadModelQuery } from './../robot-models-context';
+import { RobotViewerScene, SCENE_COLORS, useConfigureModelShadows } from './../robot-viewer-scene';
 
 import classes from './robot-viewer.module.css';
 
 /** Material name used by the dark parts in the Trossen URDF. */
 const TROSSEN_DARK_MATERIAL = 'trossen_black';
-
-const SCENE_COLORS = {
-    background: '#242528',
-    ambientLight: '#c8d6eb',
-    primaryLight: '#e8f0ff',
-    fillLight: '#88aadd',
-    gridCell: '#3a3d4f',
-    gridSection: '#545870',
-    checkerboardEven: '#282a30',
-    checkerboardOdd: '#2c2e34',
-    trossenReplacement: new THREE.Color('#585858'),
-};
-
-const FLOOR_SIZE = 21;
-const CHECKERBOARD_TILE_SIZE = 0.5;
 
 /**
  * Find the shared `trossen_black` material on the model and replace its dark
@@ -94,59 +80,6 @@ const useBrightenDarkMaterials = (model: URDFRobot | undefined, enabled: boolean
     }, [model, enabled]);
 };
 
-const useConfigureModelShadows = (model: URDFRobot) => {
-    useEffect(() => {
-        model.traverse((node) => {
-            if ((node as THREE.Mesh).isMesh) {
-                (node as THREE.Mesh).castShadow = true;
-            }
-        });
-    }, [model]);
-};
-
-const CheckerboardFloor = () => {
-    const texture = useMemo(() => {
-        const canvas = document.createElement('canvas');
-        canvas.width = 512;
-        canvas.height = 512;
-
-        const context = canvas.getContext('2d');
-        if (!context) {
-            return null;
-        }
-
-        const tiles = 24;
-        const tileSize = canvas.width / tiles;
-        for (let x = 0; x < tiles; x += 1) {
-            for (let y = 0; y < tiles; y += 1) {
-                context.fillStyle = (x + y) % 2 === 0 ? SCENE_COLORS.checkerboardEven : SCENE_COLORS.checkerboardOdd;
-                context.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
-            }
-        }
-
-        const checkerboardTexture = new THREE.CanvasTexture(canvas);
-        checkerboardTexture.wrapS = THREE.RepeatWrapping;
-        checkerboardTexture.wrapT = THREE.RepeatWrapping;
-        checkerboardTexture.repeat.set(
-            FLOOR_SIZE / (tiles * CHECKERBOARD_TILE_SIZE),
-            FLOOR_SIZE / (tiles * CHECKERBOARD_TILE_SIZE)
-        );
-
-        return checkerboardTexture;
-    }, []);
-
-    useEffect(() => {
-        return () => texture?.dispose();
-    }, [texture]);
-
-    return (
-        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.005, 0]} receiveShadow>
-            <planeGeometry args={[FLOOR_SIZE, FLOOR_SIZE]} />
-            <meshStandardMaterial map={texture} roughness={0.8} metalness={0} />
-        </mesh>
-    );
-};
-
 // This is a wrapper component for the loaded URDF model
 const ActualURDFModel = ({ model, isTrossen }: { model: URDFRobot; isTrossen: boolean }) => {
     // Rotate -90 degrees around X-axis (π/2 radians)
@@ -198,43 +131,9 @@ export const RobotViewer = ({ robot = { type: 'SO101_Follower' }, featureValues,
         <div ref={ref} className={classes.viewer}>
             <div className={classes.canvas} style={{ height: `${size.height}px`, width: `${size.width}px` }}>
                 <Canvas>
-                    <color attach='background' args={[SCENE_COLORS.background]} />
-                    <ambientLight intensity={0.7} color={SCENE_COLORS.ambientLight} />
-                    <directionalLight
-                        position={[-1.5, 3.5, 2]}
-                        intensity={1.5}
-                        color={SCENE_COLORS.primaryLight}
-                        castShadow
-                        shadow-mapSize-width={2048}
-                        shadow-mapSize-height={2048}
-                        shadow-camera-left={-3 * 2}
-                        shadow-camera-right={3 * 2}
-                        shadow-camera-top={3 * 2}
-                        shadow-camera-bottom={-3 * 2}
-                        shadow-camera-near={0.1 * 2}
-                        shadow-camera-far={20 * 2}
-                        shadow-bias={-0.0001}
-                    />
-                    <directionalLight position={[2, 2, -3]} intensity={0.4} color={SCENE_COLORS.fillLight} />
+                    <RobotViewerScene />
                     <PerspectiveCamera makeDefault position={[2.0, 1, 1]} />
                     <OrbitControls enableDamping={false} />
-                    <CheckerboardFloor />
-                    <Grid
-                        infiniteGrid
-                        cellSize={0.25}
-                        cellColor={SCENE_COLORS.gridCell}
-                        sectionSize={0.5}
-                        sectionColor={SCENE_COLORS.gridSection}
-                        fadeDistance={FLOOR_SIZE - 1}
-                    />
-                    <ContactShadows
-                        position={[0, 0, 0]}
-                        opacity={0.2}
-                        scale={2.5}
-                        blur={2.5}
-                        far={1}
-                        resolution={512}
-                    />
                     {model && (
                         <group key={model.uuid} position={[0, 0, 0]} rotation={[0, angle, 0]}>
                             <Suspense fallback={null}>

--- a/application/ui/src/features/robots/controller/robot-viewer.tsx
+++ b/application/ui/src/features/robots/controller/robot-viewer.tsx
@@ -130,7 +130,7 @@ export const RobotViewer = ({ robot = { type: 'SO101_Follower' }, featureValues,
     return (
         <div ref={ref} className={classes.viewer}>
             <div className={classes.canvas} style={{ height: `${size.height}px`, width: `${size.width}px` }}>
-                <Canvas>
+                <Canvas shadows>
                     <RobotViewerScene />
                     <PerspectiveCamera makeDefault position={[2.0, 1, 1]} />
                     <OrbitControls enableDamping={false} />

--- a/application/ui/src/features/robots/controller/robot-viewer.tsx
+++ b/application/ui/src/features/robots/controller/robot-viewer.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/no-unknown-property */
 
-import { Suspense, useEffect, useRef } from 'react';
+import { Suspense, useEffect, useMemo, useRef } from 'react';
 
-import { Grid, OrbitControls, PerspectiveCamera } from '@react-three/drei';
+import { ContactShadows, Grid, OrbitControls, PerspectiveCamera } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
 import * as THREE from 'three';
 import { degToRad } from 'three/src/math/MathUtils.js';
@@ -13,11 +13,25 @@ import { useRobotCatalogDefinitionQuery } from '../robot-catalog.hooks';
 import { SchemaRobot } from '../robot-types';
 import { mapJointToURDFJoint, useLoadModelQuery } from './../robot-models-context';
 
+import classes from './robot-viewer.module.css';
+
 /** Material name used by the dark parts in the Trossen URDF. */
 const TROSSEN_DARK_MATERIAL = 'trossen_black';
 
-/** Replacement color for dark Trossen materials. */
-const TROSSEN_REPLACEMENT_COLOR = new THREE.Color('#585858');
+const SCENE_COLORS = {
+    background: '#242528',
+    ambientLight: '#c8d6eb',
+    primaryLight: '#e8f0ff',
+    fillLight: '#88aadd',
+    gridCell: '#3a3d4f',
+    gridSection: '#545870',
+    checkerboardEven: '#282a30',
+    checkerboardOdd: '#2c2e34',
+    trossenReplacement: new THREE.Color('#585858'),
+};
+
+const FLOOR_SIZE = 21;
+const CHECKERBOARD_TILE_SIZE = 0.5;
 
 /**
  * Find the shared `trossen_black` material on the model and replace its dark
@@ -65,7 +79,7 @@ const useBrightenDarkMaterials = (model: URDFRobot | undefined, enabled: boolean
                 saved.push({ mat: phong, map: phong.map, color: phong.color.clone() });
 
                 phong.map = null;
-                phong.color.copy(TROSSEN_REPLACEMENT_COLOR);
+                phong.color.copy(SCENE_COLORS.trossenReplacement);
                 phong.needsUpdate = true;
             }
         });
@@ -80,6 +94,59 @@ const useBrightenDarkMaterials = (model: URDFRobot | undefined, enabled: boolean
     }, [model, enabled]);
 };
 
+const useConfigureModelShadows = (model: URDFRobot) => {
+    useEffect(() => {
+        model.traverse((node) => {
+            if ((node as THREE.Mesh).isMesh) {
+                (node as THREE.Mesh).castShadow = true;
+            }
+        });
+    }, [model]);
+};
+
+const CheckerboardFloor = () => {
+    const texture = useMemo(() => {
+        const canvas = document.createElement('canvas');
+        canvas.width = 512;
+        canvas.height = 512;
+
+        const context = canvas.getContext('2d');
+        if (!context) {
+            return null;
+        }
+
+        const tiles = 24;
+        const tileSize = canvas.width / tiles;
+        for (let x = 0; x < tiles; x += 1) {
+            for (let y = 0; y < tiles; y += 1) {
+                context.fillStyle = (x + y) % 2 === 0 ? SCENE_COLORS.checkerboardEven : SCENE_COLORS.checkerboardOdd;
+                context.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+            }
+        }
+
+        const checkerboardTexture = new THREE.CanvasTexture(canvas);
+        checkerboardTexture.wrapS = THREE.RepeatWrapping;
+        checkerboardTexture.wrapT = THREE.RepeatWrapping;
+        checkerboardTexture.repeat.set(
+            FLOOR_SIZE / (tiles * CHECKERBOARD_TILE_SIZE),
+            FLOOR_SIZE / (tiles * CHECKERBOARD_TILE_SIZE)
+        );
+
+        return checkerboardTexture;
+    }, []);
+
+    useEffect(() => {
+        return () => texture?.dispose();
+    }, [texture]);
+
+    return (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.005, 0]} receiveShadow>
+            <planeGeometry args={[FLOOR_SIZE, FLOOR_SIZE]} />
+            <meshStandardMaterial map={texture} roughness={0.8} metalness={0} />
+        </mesh>
+    );
+};
+
 // This is a wrapper component for the loaded URDF model
 const ActualURDFModel = ({ model, isTrossen }: { model: URDFRobot; isTrossen: boolean }) => {
     // Rotate -90 degrees around X-axis (π/2 radians)
@@ -87,6 +154,7 @@ const ActualURDFModel = ({ model, isTrossen }: { model: URDFRobot; isTrossen: bo
     const scale = [3, 3, 3] as const;
 
     useBrightenDarkMaterials(model, isTrossen);
+    useConfigureModelShadows(model);
 
     return (
         <group rotation={rotation} scale={scale}>
@@ -107,7 +175,7 @@ export const RobotViewer = ({ robot = { type: 'SO101_Follower' }, featureValues,
     const { data: definition } = useRobotCatalogDefinitionQuery(robot.type);
     const jointMap = definition.joint_map;
 
-    const { data: model } = useLoadModelQuery(robot.type);
+    const { data: model, error, isPending } = useLoadModelQuery(robot.type);
     const ref = useRef<HTMLDivElement>(null);
     const size = useContainerSize(ref);
 
@@ -127,23 +195,46 @@ export const RobotViewer = ({ robot = { type: 'SO101_Follower' }, featureValues,
     }, [featureValues, featureNames, model, jointMap]);
 
     return (
-        <div ref={ref} style={{ width: '100%', height: '100%' }}>
-            <div className='canvas-container' style={{ height: `${size.height}px`, width: `${size.width}px` }}>
-                <Canvas shadows>
-                    <color attach='background' args={['#242528']} />
-                    <ambientLight intensity={0.4} />
+        <div ref={ref} className={classes.viewer}>
+            <div className={classes.canvas} style={{ height: `${size.height}px`, width: `${size.width}px` }}>
+                <Canvas>
+                    <color attach='background' args={[SCENE_COLORS.background]} />
+                    <ambientLight intensity={0.7} color={SCENE_COLORS.ambientLight} />
                     <directionalLight
-                        position={[10, 10, 5]}
-                        intensity={1}
+                        position={[-1.5, 3.5, 2]}
+                        intensity={1.5}
+                        color={SCENE_COLORS.primaryLight}
                         castShadow
-                        shadow-mapSize-width={1024}
-                        shadow-mapSize-height={1024}
+                        shadow-mapSize-width={2048}
+                        shadow-mapSize-height={2048}
+                        shadow-camera-left={-3 * 2}
+                        shadow-camera-right={3 * 2}
+                        shadow-camera-top={3 * 2}
+                        shadow-camera-bottom={-3 * 2}
+                        shadow-camera-near={0.1 * 2}
+                        shadow-camera-far={20 * 2}
+                        shadow-bias={-0.0001}
                     />
-                    <directionalLight position={[-5, 5, -5]} intensity={0.3} />
-                    <directionalLight position={[0, -3, 5]} intensity={0.2} />
+                    <directionalLight position={[2, 2, -3]} intensity={0.4} color={SCENE_COLORS.fillLight} />
                     <PerspectiveCamera makeDefault position={[2.0, 1, 1]} />
                     <OrbitControls enableDamping={false} />
-                    <Grid infiniteGrid cellSize={0.25} sectionColor={'rgb(0, 199, 253)'} fadeDistance={10} />
+                    <CheckerboardFloor />
+                    <Grid
+                        infiniteGrid
+                        cellSize={0.25}
+                        cellColor={SCENE_COLORS.gridCell}
+                        sectionSize={0.5}
+                        sectionColor={SCENE_COLORS.gridSection}
+                        fadeDistance={FLOOR_SIZE - 1}
+                    />
+                    <ContactShadows
+                        position={[0, 0, 0]}
+                        opacity={0.2}
+                        scale={2.5}
+                        blur={2.5}
+                        far={1}
+                        resolution={512}
+                    />
                     {model && (
                         <group key={model.uuid} position={[0, 0, 0]} rotation={[0, angle, 0]}>
                             <Suspense fallback={null}>
@@ -152,6 +243,12 @@ export const RobotViewer = ({ robot = { type: 'SO101_Follower' }, featureValues,
                         </group>
                     )}
                 </Canvas>
+                {isPending && <div className={classes.loadingOverlay}>Loading robot model...</div>}
+                {error && (
+                    <div className={classes.errorOverlay} role='alert'>
+                        Failed to load robot model: {error instanceof Error ? error.message : String(error)}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/application/ui/src/features/robots/robot-viewer-scene.tsx
+++ b/application/ui/src/features/robots/robot-viewer-scene.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable react/no-unknown-property */
+
+import { useEffect, useMemo } from 'react';
+
+import { ContactShadows, Grid } from '@react-three/drei';
+import * as THREE from 'three';
+import { URDFRobot } from 'urdf-loader';
+
+export const SCENE_COLORS = {
+    background: '#242528',
+    ambientLight: '#c8d6eb',
+    primaryLight: '#e8f0ff',
+    fillLight: '#88aadd',
+    gridCell: '#3a3d4f',
+    gridSection: '#545870',
+    checkerboardEven: '#282a30',
+    checkerboardOdd: '#2c2e34',
+    trossenReplacement: new THREE.Color('#585858'),
+};
+
+const FLOOR_SIZE = 21;
+const CHECKERBOARD_TILE_SIZE = 0.5;
+
+export const useConfigureModelShadows = (model: URDFRobot) => {
+    useEffect(() => {
+        model.traverse((node) => {
+            if ((node as THREE.Mesh).isMesh) {
+                (node as THREE.Mesh).castShadow = true;
+            }
+        });
+    }, [model]);
+};
+
+const CheckerboardFloor = () => {
+    const texture = useMemo(() => {
+        const canvas = document.createElement('canvas');
+        canvas.width = 512;
+        canvas.height = 512;
+
+        const context = canvas.getContext('2d');
+        if (!context) {
+            return null;
+        }
+
+        const tiles = 24;
+        const tileSize = canvas.width / tiles;
+        for (let x = 0; x < tiles; x += 1) {
+            for (let y = 0; y < tiles; y += 1) {
+                context.fillStyle = (x + y) % 2 === 0 ? SCENE_COLORS.checkerboardEven : SCENE_COLORS.checkerboardOdd;
+                context.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+            }
+        }
+
+        const checkerboardTexture = new THREE.CanvasTexture(canvas);
+        checkerboardTexture.wrapS = THREE.RepeatWrapping;
+        checkerboardTexture.wrapT = THREE.RepeatWrapping;
+        checkerboardTexture.repeat.set(
+            FLOOR_SIZE / (tiles * CHECKERBOARD_TILE_SIZE),
+            FLOOR_SIZE / (tiles * CHECKERBOARD_TILE_SIZE)
+        );
+
+        return checkerboardTexture;
+    }, []);
+
+    useEffect(() => () => texture?.dispose(), [texture]);
+
+    return (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.005, 0]} receiveShadow>
+            <planeGeometry args={[FLOOR_SIZE, FLOOR_SIZE]} />
+            <meshStandardMaterial map={texture} roughness={0.8} metalness={0} />
+        </mesh>
+    );
+};
+
+export const RobotViewerScene = () => {
+    return (
+        <>
+            <color attach='background' args={[SCENE_COLORS.background]} />
+            <ambientLight intensity={0.7} color={SCENE_COLORS.ambientLight} />
+            <directionalLight
+                position={[-1.5, 3.5, 2]}
+                intensity={1.5}
+                color={SCENE_COLORS.primaryLight}
+                castShadow
+                shadow-mapSize-width={2048}
+                shadow-mapSize-height={2048}
+                shadow-camera-left={-6}
+                shadow-camera-right={6}
+                shadow-camera-top={6}
+                shadow-camera-bottom={-6}
+                shadow-camera-near={0.2}
+                shadow-camera-far={40}
+                shadow-bias={-0.0001}
+            />
+            <directionalLight position={[2, 2, -3]} intensity={0.4} color={SCENE_COLORS.fillLight} />
+            <CheckerboardFloor />
+            <Grid
+                infiniteGrid
+                cellSize={0.25}
+                cellColor={SCENE_COLORS.gridCell}
+                sectionSize={0.5}
+                sectionColor={SCENE_COLORS.gridSection}
+                fadeDistance={FLOOR_SIZE - 1}
+            />
+            <ContactShadows position={[0, 0, 0]} opacity={0.2} scale={2.5} blur={2.5} far={1} resolution={512} />
+        </>
+    );
+};

--- a/application/ui/src/features/robots/robot-viewer-scene.tsx
+++ b/application/ui/src/features/robots/robot-viewer-scene.tsx
@@ -78,7 +78,7 @@ export const RobotViewerScene = () => {
             <color attach='background' args={[SCENE_COLORS.background]} />
             <ambientLight intensity={0.7} color={SCENE_COLORS.ambientLight} />
             <directionalLight
-                position={[-1.5, 3.5, 2]}
+                position={[1.5, 3.5, 2]}
                 intensity={1.5}
                 color={SCENE_COLORS.primaryLight}
                 castShadow

--- a/application/ui/src/features/robots/robot-viewer-scene.tsx
+++ b/application/ui/src/features/robots/robot-viewer-scene.tsx
@@ -11,8 +11,8 @@ export const SCENE_COLORS = {
     fillLight: '#88aadd',
     gridCell: '#3a3d4f',
     gridSection: '#545870',
-    checkerboardEven: '#282a30',
-    checkerboardOdd: '#2c2e34',
+    checkerboardEven: '#2d2f35',
+    checkerboardOdd: '#313339',
     trossenReplacement: new THREE.Color('#585858'),
 };
 

--- a/application/ui/src/features/robots/robot-viewer-scene.tsx
+++ b/application/ui/src/features/robots/robot-viewer-scene.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-unknown-property */
-
 import { useEffect, useMemo } from 'react';
 
 import { ContactShadows, Grid } from '@react-three/drei';
@@ -26,11 +24,13 @@ export const useConfigureModelShadows = (model: URDFRobot) => {
         model.traverse((node) => {
             if ((node as THREE.Mesh).isMesh) {
                 (node as THREE.Mesh).castShadow = true;
+                (node as THREE.Mesh).receiveShadow = true;
             }
         });
     }, [model]);
 };
 
+/* eslint-disable react/no-unknown-property */
 const CheckerboardFloor = () => {
     const texture = useMemo(() => {
         const canvas = document.createElement('canvas');
@@ -106,3 +106,4 @@ export const RobotViewerScene = () => {
         </>
     );
 };
+/* eslint-enable react/no-unknown-property */

--- a/application/ui/src/features/robots/setup-wizard/shared/setup-robot-viewer.tsx
+++ b/application/ui/src/features/robots/setup-wizard/shared/setup-robot-viewer.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useMemo, useRef } from 'react';
 
-import { Grid, OrbitControls, PerspectiveCamera } from '@react-three/drei';
+import { OrbitControls, PerspectiveCamera } from '@react-three/drei';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
@@ -12,6 +12,7 @@ import { URDFRobot } from 'urdf-loader';
 import { useContainerSize } from '../../../../components/zoom/use-container-size';
 import { useLoadModelQuery } from '../../robot-models-context';
 import { SchemaRobotType } from '../../robot-types';
+import { RobotViewerScene, useConfigureModelShadows } from '../../robot-viewer-scene';
 import { JointHighlight, useJointHighlight } from './use-joint-highlight';
 
 // ---------------------------------------------------------------------------
@@ -23,6 +24,7 @@ const ActualURDFModel = ({ model, highlights }: { model: URDFRobot; highlights: 
     const scale = [3, 3, 3] as const;
 
     useJointHighlight(model, highlights);
+    useConfigureModelShadows(model);
 
     return (
         <group rotation={rotation} scale={scale}>
@@ -149,20 +151,11 @@ export const SetupRobotViewer = ({ robotType, highlights = [] }: SetupRobotViewe
     return (
         <div ref={ref} style={{ width: '100%', height: '100%' }}>
             <div className='canvas-container' style={{ height: `${size.height}px`, width: `${size.width}px` }}>
-                <Canvas shadows>
-                    <color attach='background' args={['#242528']} />
-                    <ambientLight intensity={0.5} />
-                    <directionalLight
-                        position={[10, 10, 5]}
-                        intensity={1}
-                        castShadow
-                        shadow-mapSize-width={1024}
-                        shadow-mapSize-height={1024}
-                    />
+                <Canvas>
+                    <RobotViewerScene />
                     <PerspectiveCamera makeDefault position={[2.0, 1, 1]} />
                     <OrbitControls ref={controlsRef} enableDamping={false} />
                     <CameraController controlsRef={controlsRef} model={model} highlights={highlights} />
-                    <Grid infiniteGrid cellSize={0.25} sectionColor={'rgb(0, 199, 253)'} fadeDistance={10} />
                     {model && (
                         <group key={model.uuid} position={[0, 0, 0]} rotation={[0, angle, 0]}>
                             <Suspense fallback={null}>

--- a/application/ui/src/features/robots/setup-wizard/shared/setup-robot-viewer.tsx
+++ b/application/ui/src/features/robots/setup-wizard/shared/setup-robot-viewer.tsx
@@ -151,7 +151,7 @@ export const SetupRobotViewer = ({ robotType, highlights = [] }: SetupRobotViewe
     return (
         <div ref={ref} style={{ width: '100%', height: '100%' }}>
             <div className='canvas-container' style={{ height: `${size.height}px`, width: `${size.width}px` }}>
-                <Canvas>
+                <Canvas shadows>
                     <RobotViewerScene />
                     <PerspectiveCamera makeDefault position={[2.0, 1, 1]} />
                     <OrbitControls ref={controlsRef} enableDamping={false} />


### PR DESCRIPTION
Tweak the background and lighting setup for the 3D visualization of robot models. In particular this makes it a bit easier to see contours of arms that don't have any colored textures (like the black trossen, or other models that haven't been optimized yet)

## Related Issues

| **Before** | **After** |
|------------|-----------|
|  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f686da27-79d8-4e6d-be93-548cf9a67d42" />          |    <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f9aa8fd6-ca04-4eaa-9ee3-6922907c8559" />        |
|  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a87a07e4-30d4-4a09-98ef-11a240e88cc0" />  | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cb39411b-ed25-45e8-903e-75e9326ec0fb" /> |
|  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cd34a3bf-123d-470c-b185-3ec10021e88e" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5294a06c-09db-4c5a-8795-bac9e55ab32a" /> |
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/389da98e-8601-406c-a7b5-a216180c5afd" /> |  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/297ef119-c0a2-4a05-9765-c41e0b521e31" /> |




