### PR TITLE
fix: reduce verbose export logs

### DIFF
--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -4,6 +4,7 @@
 """Mixin classes for exporting Policies."""
 
 import inspect
+import logging
 import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -38,6 +39,35 @@ from physicalai.export.backends import (
 CONFIG_KEY = "model_config"
 POLICY_NAME_KEY = "policy_name"
 DATASET_STATS_KEY = "dataset_stats"
+
+# The ONNX exporter's optimizer and IR passes log one INFO record per graph node
+# (constant folding, slice collapsing, initializer dedup, ...). For a VLA policy
+# that is tens of thousands of lines per export, which drowns out the job log.
+# Their warnings and errors still matter, so only INFO and below is suppressed.
+_VERBOSE_ONNX_EXPORT_LOGGERS = ("onnxscript", "onnx_ir")
+
+
+@contextmanager
+def _quiet_onnx_export_logs() -> Generator[None, None, None]:
+    """Raise the ONNX exporter loggers to WARNING for the duration of the block.
+
+    Usable as either a context manager or a decorator. Loggers that already sit
+    at WARNING or above (for example because the caller configured them
+    explicitly) are left untouched, and every level is restored on exit even if
+    the export raises.
+    """
+    restore: list[tuple[logging.Logger, int]] = []
+    for name in _VERBOSE_ONNX_EXPORT_LOGGERS:
+        onnx_logger = logging.getLogger(name)
+        if onnx_logger.getEffectiveLevel() >= logging.WARNING:
+            continue
+        restore.append((onnx_logger, onnx_logger.level))
+        onnx_logger.setLevel(logging.WARNING)
+    try:
+        yield
+    finally:
+        for onnx_logger, level in restore:
+            onnx_logger.setLevel(level)
 
 
 class ExportablePolicyMixin:
@@ -661,6 +691,7 @@ class ExportablePolicyMixin:
             msg = f"Unsupported export backend: {backend}"
             raise ValueError(msg)
 
+    @_quiet_onnx_export_logs()
     def _onnx_core_export_step(
         self,
         model_path: Path,

--- a/library/tests/unit/export/test_mixin_export.py
+++ b/library/tests/unit/export/test_mixin_export.py
@@ -3,6 +3,7 @@
 
 """Unit tests for mixin_export module."""
 
+import logging
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
@@ -16,7 +17,11 @@ from physicalai.export.backends import (
     OpenVINOExportParameters,
     TorchExportParameters,
 )
-from physicalai.export.mixin_policy import ExportablePolicyMixin, ExportBackend
+from physicalai.export.mixin_policy import (
+    ExportablePolicyMixin,
+    ExportBackend,
+    _quiet_onnx_export_logs,  # noqa: PLC2701
+)
 from physicalai.inference.data import (
     InferenceFeature,
     InferenceFeatureDtype,
@@ -297,6 +302,50 @@ class TestToOnnx:
         # Verify the ONNX model can be loaded
         onnx_model = onnx.load(str(output_path))
         onnx.checker.check_model(onnx_model)
+
+    def test_to_onnx_suppresses_per_node_exporter_logs(self, tmp_path, caplog):
+        """Test that the exporter's per-node INFO chatter is not propagated."""
+        model = ModelWithSampleInput(input_dim=10, output_dim=5)
+        wrapper = ExportWrapper(model)
+
+        with caplog.at_level(logging.INFO):
+            wrapper.to_onnx(tmp_path / "model.onnx")
+
+        noisy = [
+            record
+            for record in caplog.records
+            if record.levelno <= logging.INFO and record.name.split(".")[0] in {"onnxscript", "onnx_ir"}
+        ]
+        assert noisy == []
+
+
+class TestQuietOnnxExportLogs:
+    """Tests for the _quiet_onnx_export_logs context manager."""
+
+    def test_levels_restored_on_exception(self):
+        """Test that original levels are restored even when the block raises."""
+        onnxscript_logger = logging.getLogger("onnxscript")
+        onnxscript_logger.setLevel(logging.DEBUG)
+
+        try:
+            with pytest.raises(ValueError, match="boom"), _quiet_onnx_export_logs():
+                assert onnxscript_logger.level == logging.WARNING
+                raise ValueError("boom")
+
+            assert onnxscript_logger.level == logging.DEBUG
+        finally:
+            onnxscript_logger.setLevel(logging.NOTSET)
+
+    def test_explicitly_quieter_logger_left_untouched(self):
+        """Test that a logger already above WARNING keeps its configured level."""
+        onnxscript_logger = logging.getLogger("onnxscript")
+        onnxscript_logger.setLevel(logging.ERROR)
+
+        try:
+            with _quiet_onnx_export_logs():
+                assert onnxscript_logger.level == logging.ERROR
+        finally:
+            onnxscript_logger.setLevel(logging.NOTSET)
 
 
 class TestToOpenVINO:


### PR DESCRIPTION
## Description

Model export logs thousands of lines like:

`Replaced initializer 'val_8604' with existing initializer 'val_1106'`
`Replaced initializer 'scalar_tensor_default_399' with existing initializer 'scalar_tensor_default_19'`

Which make the train job logs hard to read. This PR temporarily raises the log level to warning during export to suppress these messages. 