### PR TITLE
feat: use max epochs instead of max steps #846

### DIFF
--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -67,13 +67,47 @@ class TrainingDevice(BaseModel):
         return self
 
 
+_DEFAULT_MAX_EPOCHS = 10
+
+
 class TrainJobPayload(BaseModel):
     project_id: UUID
     dataset_id: UUID
     policy: str
     model_name: str
-    max_steps: int = Field(default=100, ge=100, le=100_000, description="Number of training steps")
+    max_epochs: int | None = Field(
+        default=None,
+        ge=1,
+        le=10_000,
+        description="Number of training epochs (preferred over max_steps when both are provided)",
+    )
+    max_steps: int | None = Field(
+        default=None,
+        ge=1,
+        le=100_000,
+        description="Number of training steps (legacy; ignored when max_epochs is provided)",
+    )
     batch_size: int = Field(default=8, ge=1, le=256, description="Training batch size")
+
+    @model_validator(mode="after")
+    def resolve_training_limit(self) -> "TrainJobPayload":
+        """Resolve training-limit fields, applying precedence and defaults.
+
+        Rules (in order of priority):
+        1. If ``max_epochs`` is set, use it (``max_steps`` is ignored).
+        2. If ``max_epochs`` is not set (including legacy ``max_steps``-only payloads),
+           default to ``_DEFAULT_MAX_EPOCHS`` epochs.
+
+        ``max_steps`` is retained only for backward-compatible payload parsing.
+        """
+        if self.max_epochs is not None:
+            # max_epochs wins; clear max_steps to avoid ambiguity downstream
+            self.max_steps = None
+        else:
+            # No epoch value provided (including legacy max_steps-only payloads)
+            self.max_epochs = _DEFAULT_MAX_EPOCHS
+        return self
+
     num_workers: int | Literal["auto"] = Field(default="auto", description="DataLoader workers ('auto' or 0-16)")
     auto_scale_batch_size: bool = Field(
         default=False,

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -67,7 +67,7 @@ class TrainingDevice(BaseModel):
         return self
 
 
-_DEFAULT_MAX_EPOCHS = 10
+_DEFAULT_MAX_EPOCHS = 5
 
 
 class TrainJobPayload(BaseModel):

--- a/application/backend/src/schemas/model.py
+++ b/application/backend/src/schemas/model.py
@@ -172,6 +172,7 @@ class BackendExportDetail(BaseModel):
 
 
 class TrainingSummary(BaseModel):
+    max_epochs: int | None = None
     max_steps: int | None = None
     batch_size: int | None = None
     auto_scale_batch_size: bool | None = None

--- a/application/backend/src/services/model_service.py
+++ b/application/backend/src/services/model_service.py
@@ -86,6 +86,7 @@ class ModelService:
         device_type = str(payload.device.type) if payload.device is not None else None
 
         return TrainingSummary(
+            max_epochs=payload.max_epochs,
             max_steps=payload.max_steps,
             batch_size=payload.batch_size,
             precision=str(payload.precision),

--- a/application/backend/src/services/training_backends/local.py
+++ b/application/backend/src/services/training_backends/local.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
     from training import TrainingJobSpec
 
 
+_DEFAULT_MAX_EPOCHS = 10
+
+
 class LocalTrainingBackend:
     """Train in the worker process with Lightning."""
 
@@ -88,7 +91,7 @@ def build_spec(context: TrainingContext) -> TrainingJobSpec:
     return TrainingJobSpec(
         # A resumed run's architecture is dictated by the base model's checkpoint.
         policy=(context.base_model or context.model).policy,
-        max_steps=payload.max_steps,
+        max_epochs=payload.max_epochs,
         batch_size=payload.batch_size,
         num_workers=payload.num_workers,
         val_split=payload.val_split,

--- a/application/backend/src/services/training_backends/local.py
+++ b/application/backend/src/services/training_backends/local.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from training import TrainingJobSpec
 
 
-_DEFAULT_MAX_EPOCHS = 10
+_DEFAULT_MAX_EPOCHS = 5
 
 
 class LocalTrainingBackend:

--- a/application/backend/src/services/training_backends/local.py
+++ b/application/backend/src/services/training_backends/local.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from schemas.job import _DEFAULT_MAX_EPOCHS
 from services.training_backends._log_format import render_progress_log
 
 if TYPE_CHECKING:
@@ -27,9 +28,6 @@ if TYPE_CHECKING:
 
     from services.training_backends.base import TrainingContext
     from training import TrainingJobSpec
-
-
-_DEFAULT_MAX_EPOCHS = 5
 
 
 class LocalTrainingBackend:
@@ -91,7 +89,7 @@ def build_spec(context: TrainingContext) -> TrainingJobSpec:
     return TrainingJobSpec(
         # A resumed run's architecture is dictated by the base model's checkpoint.
         policy=(context.base_model or context.model).policy,
-        max_epochs=payload.max_epochs if payload.max_epochs is not None else 5,
+        max_epochs=payload.max_epochs if payload.max_epochs is not None else _DEFAULT_MAX_EPOCHS,
         batch_size=payload.batch_size,
         num_workers=payload.num_workers,
         val_split=payload.val_split,

--- a/application/backend/src/services/training_backends/local.py
+++ b/application/backend/src/services/training_backends/local.py
@@ -91,7 +91,7 @@ def build_spec(context: TrainingContext) -> TrainingJobSpec:
     return TrainingJobSpec(
         # A resumed run's architecture is dictated by the base model's checkpoint.
         policy=(context.base_model or context.model).policy,
-        max_epochs=payload.max_epochs,
+        max_epochs=payload.max_epochs if payload.max_epochs is not None else 5,
         batch_size=payload.batch_size,
         num_workers=payload.num_workers,
         val_split=payload.val_split,

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -4,7 +4,7 @@
 """One training run, described by a spec and executed by one function.
 
 :class:`TrainingJobSpec` is the complete configuration of a training run —
-policy, step budget, batch size, precision, device — and nothing else. It holds
+ policy, epoch budget, batch size, precision, device — and nothing else. It holds
 no paths, no job identity, and no transport details, so the same spec can be
 built in-process or sent over HTTP to a remote trainer and mean the same thing
 in both places.
@@ -16,7 +16,7 @@ result goes, how progress is reported, and how cancellation is signalled are all
 arguments — the runner owns none of that policy.
 
 Example:
-    >>> spec = TrainingJobSpec(policy="act", max_steps=1000, batch_size=8)
+    >>> spec = TrainingJobSpec(policy="act", max_epochs=5, batch_size=8)
     >>> run_training_job(  # doctest: +SKIP
     ...     spec,
     ...     dataset_root="/data/snapshot",
@@ -74,7 +74,7 @@ class TrainingJobSpec(BaseModel):
     arguments to :func:`run_training_job`.
 
     Example:
-        >>> spec = TrainingJobSpec(policy="act", max_steps=2000)
+        >>> spec = TrainingJobSpec(policy="act", max_epochs=5)
         >>> spec.precision
         'bf16-mixed'
     """
@@ -86,7 +86,7 @@ class TrainingJobSpec(BaseModel):
         default="physicalai",
         description="Which implementation of the policy to train.",
     )
-    max_steps: int = Field(default=100, ge=1, description="Optimizer step budget.")
+    max_epochs: int = Field(default=5, ge=1, description="Training epoch budget.")
     batch_size: int = Field(default=8, ge=1, description="Training batch size.")
     num_workers: int | Literal["auto"] = Field(default="auto", description="Dataloader worker count.")
     val_split: float = Field(default=0.1, ge=0.0, lt=1.0, description="Fraction of episodes held out for validation.")
@@ -192,7 +192,7 @@ def run_training_job(
         accelerator=resolve_accelerator(spec.device_type),
         strategy=resolve_strategy(spec.device_type),
         devices=resolve_devices(spec.device_index),
-        max_steps=spec.max_steps,
+        max_epochs=spec.max_epochs,
         auto_scale_batch_size=spec.auto_scale_batch_size,
         precision=spec.precision,
         check_val_every_n_epoch=1,

--- a/application/backend/tests/integration/test_e2e_dataset_to_export.py
+++ b/application/backend/tests/integration/test_e2e_dataset_to_export.py
@@ -273,7 +273,7 @@ def test_submit_training_job_for_missing_project_returns_404(migrated_db: None) 
             "dataset_id": str(uuid4()),
             "policy": "act",
             "model_name": "Orphan Job",
-            "max_steps": 100,
+            "max_epochs": 1,
         },
     )
     assert response.status_code == 404, response.text
@@ -308,7 +308,7 @@ def test_interrupt_job_marks_job_canceled(migrated_db: None) -> None:
                     dataset_id=uuid4(),
                     policy="act",
                     model_name="Interrupt Me",
-                    max_steps=100,
+                    max_epochs=1,
                 )
             )
             await job_service.update_job_status(job.id, status=JobStatus.RUNNING, message="Training started")

--- a/application/backend/tests/integration/test_e2e_dataset_to_export.py
+++ b/application/backend/tests/integration/test_e2e_dataset_to_export.py
@@ -175,7 +175,7 @@ def test_dataset_upload_train_export_infer_e2e(
             "dataset_id": dataset_id,
             "policy": "act",
             "model_name": "E2E ACT Model",
-            "max_steps": 100,  # TrainJobPayload.max_steps has a ge=100 floor
+            "max_epochs": 1,
             "batch_size": 2,
             "num_workers": 0,
             "val_split": 0.5,
@@ -211,7 +211,7 @@ def test_dataset_upload_train_export_infer_e2e(
     assert response.status_code == 200, response.text
     detail = response.json()
     assert any(export["type"] == _ONNX_BACKEND for export in detail["exports"])
-    assert detail["training_summary"]["max_steps"] == 100
+    assert detail["training_summary"]["max_epochs"] == 1
 
     # --- 5. Download the onnx export and confirm it is a valid archive -------------
     response = client.get(f"/api/models/{model_id}/exports/{_ONNX_BACKEND}/download")

--- a/application/backend/tests/models/test_utils.py
+++ b/application/backend/tests/models/test_utils.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
-from models.utils import _find_checkpoint, load_inference_model
+from models.utils import load_inference_model
 from schemas import InferenceBackend, InferenceDevice
 
 
@@ -33,25 +31,3 @@ def test_load_inference_model_uses_selected_openvino_device(test_model) -> None:
         backend="openvino",
         device="GPU",
     )
-
-
-def test_find_checkpoint_prefers_model_ckpt(tmp_path) -> None:
-    (tmp_path / "model.ckpt").touch()
-    (tmp_path / "last.ckpt").touch()
-
-    result = _find_checkpoint(tmp_path)
-
-    assert result == tmp_path / "model.ckpt"
-
-
-def test_find_checkpoint_falls_back_to_last_ckpt(tmp_path) -> None:
-    (tmp_path / "last.ckpt").touch()
-
-    result = _find_checkpoint(tmp_path)
-
-    assert result == tmp_path / "last.ckpt"
-
-
-def test_find_checkpoint_raises_when_no_checkpoint(tmp_path) -> None:
-    with pytest.raises(FileNotFoundError, match="No checkpoint found"):
-        _find_checkpoint(tmp_path)

--- a/application/backend/tests/models/test_utils.py
+++ b/application/backend/tests/models/test_utils.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from models.utils import load_inference_model
+import pytest
+
+from models.utils import _find_checkpoint, load_inference_model
 from schemas import InferenceBackend, InferenceDevice
 
 
@@ -31,3 +33,25 @@ def test_load_inference_model_uses_selected_openvino_device(test_model) -> None:
         backend="openvino",
         device="GPU",
     )
+
+
+def test_find_checkpoint_prefers_model_ckpt(tmp_path) -> None:
+    (tmp_path / "model.ckpt").touch()
+    (tmp_path / "last.ckpt").touch()
+
+    result = _find_checkpoint(tmp_path)
+
+    assert result == tmp_path / "model.ckpt"
+
+
+def test_find_checkpoint_falls_back_to_last_ckpt(tmp_path) -> None:
+    (tmp_path / "last.ckpt").touch()
+
+    result = _find_checkpoint(tmp_path)
+
+    assert result == tmp_path / "last.ckpt"
+
+
+def test_find_checkpoint_raises_when_no_checkpoint(tmp_path) -> None:
+    with pytest.raises(FileNotFoundError, match="No checkpoint found"):
+        _find_checkpoint(tmp_path)

--- a/application/backend/tests/services/test_local_training_backend.py
+++ b/application/backend/tests/services/test_local_training_backend.py
@@ -93,7 +93,7 @@ class TestBuildSpec:
 
         assert spec == TrainingJobSpec(
             policy="act",
-            max_steps=500,
+            max_epochs=10,
             batch_size=16,
             num_workers="auto",
             val_split=0.2,

--- a/application/backend/tests/services/test_local_training_backend.py
+++ b/application/backend/tests/services/test_local_training_backend.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 import pytest
 
 from schemas.dataset import Snapshot
-from schemas.job import TrainingDevice, TrainingPrecision, TrainJobPayload
+from schemas.job import _DEFAULT_MAX_EPOCHS, TrainingDevice, TrainingPrecision, TrainJobPayload
 from schemas.model import Model
 from services.training_backends.base import TrainingContext
 from services.training_backends.local import LocalTrainingBackend, build_spec
@@ -93,7 +93,7 @@ class TestBuildSpec:
 
         assert spec == TrainingJobSpec(
             policy="act",
-            max_epochs=10,
+            max_epochs=_DEFAULT_MAX_EPOCHS,
             batch_size=16,
             num_workers="auto",
             val_split=0.2,

--- a/application/backend/tests/services/test_remote_training_backend.py
+++ b/application/backend/tests/services/test_remote_training_backend.py
@@ -644,7 +644,7 @@ class TestHttpDatasetTransfer:
         """The remote job trains from the same spec a local run would execute."""
         settings = _settings()
         context = _context(tmp_path)
-        context.payload = context.payload.model_copy(update={"max_steps": 500, "batch_size": 16})
+        context.payload = context.payload.model_copy(update={"max_epochs": 5, "batch_size": 16})
 
         body = await _submitted_body(settings, context)
 
@@ -652,7 +652,7 @@ class TestHttpDatasetTransfer:
             "device_type": None,
             "device_index": None,
         }
-        assert (body["spec"]["policy"], body["spec"]["max_steps"], body["spec"]["batch_size"]) == ("act", 500, 16)
+        assert (body["spec"]["policy"], body["spec"]["max_epochs"], body["spec"]["batch_size"]) == ("act", 5, 16)
 
     @pytest.mark.anyio
     async def test_submit_body_omits_the_studios_device_selection(self, tmp_path):

--- a/application/backend/tests/trainer/conftest.py
+++ b/application/backend/tests/trainer/conftest.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 def sample_request() -> SubmitJobRequest:
     """A valid http-transfer job submission request."""
     return SubmitJobRequest(
-        spec=TrainingJobSpec(policy="act", max_steps=100, batch_size=8, precision="bf16-mixed"),
+        spec=TrainingJobSpec(policy="act", max_epochs=5, batch_size=8, precision="bf16-mixed"),
     )
 
 

--- a/application/backend/tests/training/test_job.py
+++ b/application/backend/tests/training/test_job.py
@@ -34,7 +34,7 @@ class TestTrainingJobSpec:
     def test_only_the_policy_is_required(self) -> None:
         spec = TrainingJobSpec(policy="act")
 
-        assert (spec.policy_source, spec.max_steps, spec.batch_size) == ("physicalai", 100, 8)
+        assert (spec.policy_source, spec.max_epochs, spec.batch_size) == ("physicalai", 5, 8)
         assert (spec.num_workers, spec.val_split, spec.precision) == ("auto", 0.1, "bf16-mixed")
         assert (spec.compile_model, spec.auto_scale_batch_size) == (False, False)
         assert (spec.device_type, spec.device_index) == (None, None)
@@ -47,7 +47,7 @@ class TestTrainingJobSpec:
     @pytest.mark.parametrize(
         "invalid",
         [
-            {"max_steps": 0},
+            {"max_epochs": 0},
             {"batch_size": 0},
             {"val_split": 1.0},
             {"val_split": -0.1},
@@ -61,7 +61,7 @@ class TestTrainingJobSpec:
 
     def test_spec_round_trips_through_json(self) -> None:
         """Remote submission sends the spec as JSON; it must survive the trip."""
-        spec = TrainingJobSpec(policy="pi0", max_steps=500, num_workers=4, device_type="xpu", device_index=1)
+        spec = TrainingJobSpec(policy="pi0", max_epochs=5, num_workers=4, device_type="xpu", device_index=1)
 
         assert TrainingJobSpec.model_validate_json(spec.model_dump_json()) == spec
 
@@ -168,7 +168,7 @@ class TestRunTrainingJob:
     def test_trainer_is_configured_from_the_spec(self, tmp_path: Path) -> None:
         spec = TrainingJobSpec(
             policy="act",
-            max_steps=500,
+            max_epochs=5,
             precision="32-true",
             auto_scale_batch_size=True,
             device_type="cpu",
@@ -178,7 +178,7 @@ class TestRunTrainingJob:
         trainer_class = _run(spec, tmp_path)
 
         kwargs = trainer_class.call_args.kwargs
-        assert kwargs["max_steps"] == 500
+        assert kwargs["max_epochs"] == 5
         assert kwargs["precision"] == "32-true"
         assert kwargs["auto_scale_batch_size"] is True
         assert (kwargs["accelerator"], kwargs["strategy"], kwargs["devices"]) == ("cpu", "auto", [1])

--- a/application/backend/tests/workers/test_training_worker.py
+++ b/application/backend/tests/workers/test_training_worker.py
@@ -40,7 +40,7 @@ def _make_payload(
         dataset_id=uuid4(),
         policy="act",
         model_name="test-model",
-        max_steps=100,
+        max_epochs=5,
         batch_size=8,
         num_workers=0,
         auto_scale_batch_size=False,

--- a/application/ui/src/features/models/details/model-details.tsx
+++ b/application/ui/src/features/models/details/model-details.tsx
@@ -156,7 +156,11 @@ const TrainingParameters = ({ summary }: { summary: SchemaModelDetailResponse['t
         <View>
             <Heading>Training parameters</Heading>
             <Flex direction='column' gap='size-75'>
-                <DetailRow name='Max steps' value={summary.max_steps} />
+                {summary.max_epochs !== null && summary.max_epochs !== undefined ? (
+                    <DetailRow name='Max epochs' value={summary.max_epochs} />
+                ) : (
+                    <DetailRow name='Max steps' value={summary.max_steps} />
+                )}
                 <DetailRow name='Batch size' value={summary.auto_scale_batch_size ? 'Auto' : summary.batch_size} />
                 <DetailRow name='Workers' value={summary.num_workers ?? '—'} />
                 {summary.precision && <DetailRow name='Precision' value={summary.precision} />}

--- a/application/ui/src/routes/models/train-model-dialog.tsx
+++ b/application/ui/src/routes/models/train-model-dialog.tsx
@@ -82,7 +82,7 @@ export const MODELS: ReadonlyArray<{
 interface TrainModelDialogProps {
     baseModel?: SchemaModel;
     close: (job: SchemaJob | undefined) => void;
-    defaultMaxSteps?: number;
+    defaultMaxEpochs?: number;
 }
 
 type TrainingTargetOption = {
@@ -238,8 +238,8 @@ const PRECISION_LABELS: Record<string, string> = {
 };
 
 interface TrainingParametersProps {
-    maxSteps: number;
-    onMaxStepsChange: (value: number) => void;
+    maxEpochs: number;
+    onMaxEpochsChange: (value: number) => void;
     batchSize: number;
     onBatchSizeChange: (value: number) => void;
     numWorkers: Key | null;
@@ -255,8 +255,8 @@ interface TrainingParametersProps {
 }
 
 const TrainingParameters = ({
-    maxSteps,
-    onMaxStepsChange,
+    maxEpochs,
+    onMaxEpochsChange,
     batchSize,
     onBatchSizeChange,
     numWorkers,
@@ -304,20 +304,20 @@ const TrainingParameters = ({
                 </Flex>
             </Flex>
             <NumberField
-                label='Max Steps'
-                value={maxSteps}
-                onChange={onMaxStepsChange}
-                minValue={100}
-                maxValue={100000}
-                step={100}
+                label='Max Epochs'
+                value={maxEpochs}
+                onChange={onMaxEpochsChange}
+                minValue={1}
+                maxValue={1000}
+                step={1}
                 width='100%'
                 contextualHelp={
                     <ContextualHelp variant='info'>
-                        <Heading>Max steps</Heading>
+                        <Heading>Max epochs</Heading>
                         <Content>
                             <Text>
-                                Total number of gradient update steps. Training will stop after this many steps
-                                regardless of epochs.
+                                Total number of training epochs. Training will stop after this many full passes through
+                                the dataset.
                             </Text>
                         </Content>
                     </ContextualHelp>
@@ -399,7 +399,7 @@ const TrainingParameters = ({
     </Flex>
 );
 
-export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: TrainModelDialogProps) => {
+export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 10 }: TrainModelDialogProps) => {
     const bestDevice = useBestTrainingDevice();
     const { data: remoteTrainers = [] } = $api.useQuery('get', '/api/remote-trainers');
     // Continuing an existing model needs its checkpoint, which only this machine
@@ -423,7 +423,7 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: 
     const { datasets, id: projectId } = useProject();
 
     const [selectedDataset, setSelectedDataset] = useState<Key | null>(defaultDatasetId);
-    const [maxSteps, setMaxSteps] = useState<number>(defaultMaxSteps);
+    const [maxEpochs, setMaxEpochs] = useState<number>(defaultMaxEpochs);
     const [batchSize, setBatchSize] = useState<number>(8);
     const [numWorkers, setNumWorkers] = useState<Key | null>('auto');
     const [autoScaleBatchSize, setAutoScaleBatchSize] = useState<boolean>(bestDevice?.type === 'cuda');
@@ -484,7 +484,7 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: 
             project_id: projectId,
             model_name: name,
             policy: selectedPolicy,
-            max_steps: maxSteps,
+            max_epochs: maxEpochs,
             batch_size: batchSize,
             num_workers: numWorkers === 'auto' ? 'auto' : Number(numWorkers),
             auto_scale_batch_size: autoScaleBatchSize,
@@ -562,8 +562,8 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxSteps = 10000 }: 
                         </DisclosureTitle>
                         <DisclosurePanel UNSAFE_style={{ padding: 0 }}>
                             <TrainingParameters
-                                maxSteps={maxSteps}
-                                onMaxStepsChange={setMaxSteps}
+                                maxEpochs={maxEpochs}
+                                onMaxEpochsChange={setMaxEpochs}
                                 batchSize={batchSize}
                                 onBatchSizeChange={setBatchSize}
                                 numWorkers={numWorkers}

--- a/application/ui/src/routes/models/train-model-dialog.tsx
+++ b/application/ui/src/routes/models/train-model-dialog.tsx
@@ -317,7 +317,7 @@ const TrainingParameters = ({
                         <Content>
                             <Text>
                                 Total number of training epochs. Training will stop after this many full passes through
-                                the dataset.
+                                the dataset. We recommend training for 5 to 10 epochs
                             </Text>
                         </Content>
                     </ContextualHelp>
@@ -399,7 +399,7 @@ const TrainingParameters = ({
     </Flex>
 );
 
-export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 10 }: TrainModelDialogProps) => {
+export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: TrainModelDialogProps) => {
     const bestDevice = useBestTrainingDevice();
     const { data: remoteTrainers = [] } = $api.useQuery('get', '/api/remote-trainers');
     // Continuing an existing model needs its checkpoint, which only this machine

--- a/library/src/physicalai/train/callbacks.py
+++ b/library/src/physicalai/train/callbacks.py
@@ -54,7 +54,7 @@ class ProgressReportingCallback(Callback):
         super().__init__()
         self._report = report
         self._should_stop = should_stop
-        # Logging cadence in steps; resolved from the step budget on fit start.
+        # Logging cadence in steps; resolved once Lightning knows the dataloader size.
         self._every_n_steps = 1
         self._val_start_t: float | None = None
 
@@ -92,14 +92,16 @@ class ProgressReportingCallback(Callback):
         return float(value)  # type: ignore[arg-type]
 
     @staticmethod
-    def _max_steps(trainer: L.Trainer) -> int | None:
-        """Return the configured step budget, or None when unset/disabled.
+    def _total_steps(trainer: L.Trainer) -> int | None:
+        """Return the effective step budget, or None when it cannot be determined.
 
-        Lightning uses -1 (or any non-positive value) to signal an unbounded step
-        budget. Surface that as None so consumers do not misread it as a real
-        limit, keeping the value consistent with ``_progress`` returning 0.
+        ``estimated_stepping_batches`` accounts for a configured ``max_epochs``
+        and becomes available after Lightning attaches the dataloader.
         """
-        return trainer.max_steps if trainer.max_steps > 0 else None
+        if trainer.max_steps > 0:
+            return trainer.max_steps
+        estimated_steps = trainer.estimated_stepping_batches
+        return estimated_steps if estimated_steps > 0 else None
 
     @staticmethod
     def _extract_loss(outputs: object) -> float | None:
@@ -119,23 +121,22 @@ class ProgressReportingCallback(Callback):
 
     @staticmethod
     def _progress(trainer: L.Trainer) -> int:
-        """Compute step-based completion.
+        """Compute completion from the effective step budget.
 
         Args:
             trainer: The active Lightning trainer.
 
         Returns:
-            Completion percentage clamped to 0-100. Returns 0 when ``max_steps``
-            is unset (-1) or otherwise non-positive. Emits 100 only once
-            ``global_step >= max_steps`` so partial steps never round up to
-            completion.
+            Completion percentage clamped to 0-100. Returns 0 when the effective
+            step budget is unavailable. Emits 100 only once all estimated steps
+            complete so partial steps never round up to completion.
         """
-        max_steps = trainer.max_steps
-        if max_steps <= 0:
+        total_steps = ProgressReportingCallback._total_steps(trainer)
+        if total_steps is None:
             return 0
-        if trainer.global_step >= max_steps:
+        if trainer.global_step >= total_steps:
             return 100
-        return min(99, int(trainer.global_step / max_steps * 100))
+        return min(99, int(trainer.global_step / total_steps * 100))
 
     def _check_stop(self, trainer: L.Trainer) -> None:
         """Stop the trainer cooperatively when cancellation was requested."""
@@ -144,7 +145,7 @@ class ProgressReportingCallback(Callback):
 
     def on_fit_start(self, trainer: L.Trainer, _pl_module: L.LightningModule) -> None:
         """Resolve the logging cadence and honor a cancel requested before training."""
-        self._every_n_steps = self._auto_every_n_steps(trainer.max_steps)
+        self._every_n_steps = self._auto_every_n_steps(self._total_steps(trainer) or 0)
         self._check_stop(trainer)
 
     def on_train_batch_end(
@@ -161,7 +162,7 @@ class ProgressReportingCallback(Callback):
         # Attach the detailed cadence fields so consumers can throttle logs.
         if global_step <= 1 or global_step % self._every_n_steps == 0:
             extra["global_step"] = global_step
-            extra["max_steps"] = self._max_steps(trainer)
+            extra["max_steps"] = self._total_steps(trainer)
             extra["epoch"] = trainer.current_epoch
         self._report(self._progress(trainer), None, extra)
         self._check_stop(trainer)
@@ -172,7 +173,7 @@ class ProgressReportingCallback(Callback):
         self._report(
             self._progress(trainer),
             None,
-            {"val_event": "start", "global_step": trainer.global_step, "max_steps": self._max_steps(trainer)},
+            {"val_event": "start", "global_step": trainer.global_step, "max_steps": self._total_steps(trainer)},
         )
         self._check_stop(trainer)
 

--- a/library/src/physicalai/train/callbacks.py
+++ b/library/src/physicalai/train/callbacks.py
@@ -101,7 +101,7 @@ class ProgressReportingCallback(Callback):
         if trainer.max_steps > 0:
             return trainer.max_steps
         estimated_steps = trainer.estimated_stepping_batches
-        return estimated_steps if estimated_steps > 0 else None
+        return int(estimated_steps) if estimated_steps > 0 else None
 
     @staticmethod
     def _extract_loss(outputs: object) -> float | None:

--- a/library/tests/unit/train/test_callbacks.py
+++ b/library/tests/unit/train/test_callbacks.py
@@ -17,10 +17,13 @@ def _loss(value: float) -> MagicMock:
     return tensor
 
 
-def _trainer(*, global_step: int, max_steps: int, epoch: int = 0) -> MagicMock:
+def _trainer(
+    *, global_step: int, max_steps: int, estimated_steps: int | None = None, epoch: int = 0
+) -> MagicMock:
     trainer = MagicMock(spec=L.Trainer)
     trainer.global_step = global_step
     trainer.max_steps = max_steps
+    trainer.estimated_stepping_batches = max_steps if estimated_steps is None else estimated_steps
     trainer.current_epoch = epoch
     trainer.should_stop = False
     trainer.callback_metrics = {}
@@ -127,10 +130,22 @@ class TestProgressReportingCallback:
         progress = report.call_args[0][0]
         assert progress == 100
 
+    def test_max_epochs_uses_estimated_step_budget(self) -> None:
+        cb, report = self._callback()
+        trainer = _trainer(global_step=1000, max_steps=-1, estimated_steps=2000)
+        cb.on_fit_start(trainer, MagicMock())
+
+        cb.on_train_batch_end(trainer, MagicMock(), {"loss": _loss(0.1)}, None, 0)
+
+        assert cb._every_n_steps == 2
+        progress, _, extra = report.call_args[0]
+        assert progress == 50
+        assert extra["max_steps"] == 2000
+
     def test_unset_max_steps_emits_none_sentinel(self) -> None:
         # Lightning uses -1 for an unbounded step budget; surface it as None.
         cb, report = self._callback()
-        trainer = _trainer(global_step=1, max_steps=-1)
+        trainer = _trainer(global_step=1, max_steps=-1, estimated_steps=-1)
         cb.on_fit_start(trainer, MagicMock())
 
         cb.on_train_batch_end(trainer, MagicMock(), {"loss": _loss(0.5)}, None, 0)


### PR DESCRIPTION
Change the UI and backend so that we now use `max_epochs` instead of `max_steps`. The goal here is that we will get more consistent training runs as epochs is not depending on the batch size and makes sure the model is trained on all the users's data.


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a3ca0614-668e-4e53-bb3c-d606e586a1b7" />