### PR TITLE
fix: show per-step training loss in the model metrics chart #871

### DIFF
--- a/application/ui/src/routes/models/metrics.tsx
+++ b/application/ui/src/routes/models/metrics.tsx
@@ -9,16 +9,19 @@ import { MetricGraph } from './metrics-graph.component';
 interface MetricsEntry {
     epoch: number;
     step: number;
-    train_loss: number | null;
-    train_loss_step: number | null;
+    train_loss: number | null | undefined;
+    train_loss_step: number | null | undefined;
 }
 
 const filterLossStepMetrics = (data?: MetricsEntry[]) => {
     if (!data) return [];
-    const stepRows = data.filter((entry): entry is MetricsEntry => {
-        return entry.train_loss !== null;
+    return data.flatMap((entry) => {
+        // Prefer the per-step train/loss. Fall back to train/loss_step, which ACT
+        // logged per-step historically, so jobs still streaming from older runs
+        // keep charting.
+        const y = entry.train_loss ?? entry.train_loss_step;
+        return y == null ? [] : [{ x: entry.step, y }];
     });
-    return stepRows.map((row) => ({ x: row.step, y: row.train_loss! }));
 };
 
 export const JobMetricsContent = ({ jobId }: { jobId: string }) => {

--- a/library/src/physicalai/policies/act/policy.py
+++ b/library/src/physicalai/policies/act/policy.py
@@ -523,16 +523,7 @@ class ACT(ExportablePolicyMixin, Policy):
             msg = "ACT model is not initialized."
             raise RuntimeError(msg)
         loss, loss_dict = self.forward(batch)  # noqa: RUF059
-        self.log("train/loss_step", loss, on_step=True, on_epoch=False, prog_bar=True, logger=True)
-        self.log(
-            "train/loss",
-            loss,
-            on_step=False,
-            on_epoch=True,
-            prog_bar=False,
-            logger=True,
-            sync_dist=True,
-        )
+        self.log("train/loss", loss, prog_bar=True)
         return {"loss": loss}
 
     def configure_optimizers(self) -> dict[str, Any]:


### PR DESCRIPTION
ACT logged per-step loss as train/loss_step and epoch loss as train/loss, so the metrics chart (which read train_loss) only had a handful of epoch points for ACT -- and nothing at all when the CSV lacked a train/loss column. Make ACT log train/loss per step like the other policies,

The UI shows `train_loss`, but uses `train_loss_step` as a fallback for models trained before this fix.

Fixes #871