### PR TITLE
feat(training): make local XPU training runs survive OOM and mid-run hangs

### DIFF
--- a/application/backend/src/services/training_backends/local.py
+++ b/application/backend/src/services/training_backends/local.py
@@ -64,12 +64,25 @@ class LocalTrainingBackend:
         strategy = get_lightning_strategy(device_type)
         devices = [device_index] if device_index is not None else 1
 
+        # Step-based checkpoints. The previous val/loss-monitored callback never
+        # fired on short runs: one epoch is ~11k steps at batch 8 on the current
+        # dataset, so a sub-epoch run completed no validation and saved nothing
+        # until the explicit save below. Saving on a step interval instead means
+        # an unattended run always has a recent state on disk.
         checkpoint_callback = ModelCheckpoint(
             dirpath=cache_path,
-            filename="model",
-            save_top_k=1,
-            monitor="val/loss",
-            mode="min",
+            filename="step{step:06d}",
+            # Keep this a divisor of the max_steps values actually used (1000 /
+            # 3000 / 5000 / 12000), so the *final* step always lands on an
+            # interval and gets a checkpoint from this callback. A coarser
+            # interval like 3000 would miss step 5000 entirely and leave the
+            # run depending on the explicit save below, which is the step that
+            # OOMed a completed 5000-step run on 2026-07-26.
+            every_n_train_steps=1000,
+            # save_top_k=-1 keeps every checkpoint. With monitor=None Lightning
+            # only accepts -1, 0 or 1, since there is no metric to rank by.
+            save_top_k=-1,
+            monitor=None,
         )
         csv_logger = CSVLogger(cache_path.parent, name=cache_path.stem)
 
@@ -85,6 +98,12 @@ class LocalTrainingBackend:
             max_steps=payload.max_steps,
             auto_scale_batch_size=payload.auto_scale_batch_size,
             precision=precision,
+            # Guards against the loss divergence seen on a 4k-step bf16 run,
+            # where training went to NaN mid-run and kept going.
+            gradient_clip_val=1.0,
+            # Validate on a step interval as well, so sub-epoch runs report
+            # val/loss instead of only a single value at the very end.
+            val_check_interval=1000,
             check_val_every_n_epoch=1,
         )
 
@@ -95,6 +114,15 @@ class LocalTrainingBackend:
 
         output_dir.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(cache_path), str(output_dir))
+
+        # Release the training-side memory before exporting. A completed
+        # 5000-step run (`9200784f`, 2026-07-26) was OOM-killed here: the host
+        # has 30 GB, the process held ~26 GB of trainer/dataloader state, and
+        # ONNX/OpenVINO conversion needs several GB more on top. An OOM kill is
+        # SIGKILL, so no try/except downstream can rescue it — the only fix is
+        # to hand the memory back first.
+        del trainer, l_dm
+        self._release_memory(accelerator)
 
         export_policy = policy
         if payload.compile_model and context.model.policy in ("act", "smolvla"):
@@ -128,17 +156,56 @@ class LocalTrainingBackend:
 
         return ProgressReportingCallback(report=report, should_stop=context.should_stop)
 
+    def _release_memory(self, accelerator: str | None = None) -> None:
+        """Drop cached host and device memory between training and export."""
+        import gc
+
+        gc.collect()
+        try:
+            import torch
+
+            if accelerator == "xpu" and torch.xpu.is_available():
+                torch.xpu.empty_cache()
+                torch.xpu.synchronize()
+            elif torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+            logger.warning("Could not release device cache: {}", exc)
+
     def _export_policy(self, *, policy: object, output_dir: Path, context: TrainingContext) -> None:
         """Export the trained policy to every backend the policy supports."""
+        import os
+
         from physicalai.export import ExportablePolicyMixin
 
         if not isinstance(policy, ExportablePolicyMixin):
             logger.info("Skipping export: policy does not support export backends")
             return
 
-        logger.info("Starting model export for trained policy")
+        # OpenVINO conversion is the most memory-hungry backend and the one that
+        # has actually killed runs here: `ec4c4cef` (2000 steps, 2026-07-25) died
+        # part-way through OpenVINO's ONNX initializer pass with the trained
+        # weights on disk but no model registered. Torch export alone is enough
+        # to load a model in the GUI, so OpenVINO is opt-in via
+        # PHYSICALAI_EXPORT_BACKENDS (comma-separated, e.g. "torch,openvino").
+        # Default keeps the cheap, proven backend only.
+        requested = os.environ.get("PHYSICALAI_EXPORT_BACKENDS", "torch")
+        wanted = {b.strip().lower() for b in requested.split(",") if b.strip()}
+
+        logger.info("Starting model export for trained policy (backends requested: {})", requested)
         for backend in policy.get_supported_export_backends():
             backend_name = backend.value if hasattr(backend, "value") else str(backend)
+            if backend_name.lower() not in wanted:
+                logger.info(
+                    "Skipping {} export: not in PHYSICALAI_EXPORT_BACKENDS ({}). "
+                    "Export it later with local-changes/export-rescued-model.py",
+                    backend_name,
+                    requested,
+                )
+                continue
+            # Conversion peaks well above the model's resident size; hand back
+            # whatever the previous backend cached before starting the next one.
+            self._release_memory()
             try:
                 logger.info("Exporting model to {} format", backend_name)
                 context.progress(99, message=f"Exporting to {backend_name} format")

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,0 +1,75 @@
+# Training reports — Intel Arc XPU / SO-ARM101
+
+Field notes from fine-tuning Pi0.5 on a physical SO-ARM101 arm using Intel Arc
+GPUs. These document the failures that motivated the code changes in this PR.
+
+Hardware: Intel i9-11900T · 30 GB RAM · Arc Pro **B70** (34.2 GB, `xpu:0`,
+`0000:03:00.0`) + Arc Pro **B50** (17.1 GB, `xpu:1`, `0000:07:00.0`) ·
+Ubuntu, kernel 6.17.0-41, `xe` driver, GuC firmware 70.65.0.
+
+## Start here
+
+| File | What it covers |
+|---|---|
+| `firmware-fix-report-2026-07-30.html` | **The main issue log.** §1–8 the GuC firmware upgrade, §9 why firmware was *not* the cause, §10 Run 12 and why the GT1 theory also fails |
+| `training-report-2026-07-30.html` | Loss vs steps across all runs, episodes vs resulting val loss, dataset inventory, run history |
+| `RUN12-FAILURE-862b848f.md` | Newest failure: froze at step 1750/5000, hung 42 h undetected |
+
+Open the HTML files in a browser — both are self-contained (inline CSS/JS,
+light and dark themes, no network calls). The firmware report's §10 is at
+anchor `#run12`.
+
+## Supporting notes
+
+| File | What it covers |
+|---|---|
+| `SESSION-2026-07-28-nan-divergence.txt` | The NaN divergence at ~step 2775 that motivated `gradient_clip_val=1.0` |
+| `RUN11-STATUS-490a12e3.md` | Run 11 launch config and checkpoint ETAs |
+| `success-rate-log.txt` | Physical arm trial log — per-attempt outcomes |
+
+## Two distinct failure modes
+
+Worth separating, because they have different causes and different fixes:
+
+**Failure A — dies *after* training, during save/export.** Host RAM
+exhaustion. A completed 5000-step run held ~26 GB of trainer state on a 30 GB
+host, then OpenVINO conversion asked for several GB more. OOM kill is SIGKILL,
+so no `try/except` can rescue it. Runs `ec4c4cef` (2000 steps) and `9200784f`
+(5000 steps) both finished all their training steps and produced **no model**.
+
+→ Fixed in this PR: `del trainer, l_dm` + `_release_memory()` before export,
+and OpenVINO made opt-in via `PHYSICALAI_EXPORT_BACKENDS`.
+
+**Failure B — hangs *mid*-training.** A CPU core takes a GPU interrupt, spins
+forever in the `xe` driver's GuC message-ring read (`g2h_read` /
+`memcpy_fromio`) with interrupts disabled, and can never yield. Training
+freezes mid-step with no error, no exception, no OOM.
+
+→ **Not fixed** — it is an Intel `xe`/GuC driver bug, not something this
+codebase can repair. The checkpointing change in this PR is damage
+limitation: it bounds how much work a hang destroys.
+
+## What has been ruled out for Failure B
+
+With evidence, across five boots:
+
+| Hypothesis | Verdict |
+|---|---|
+| GuC firmware too old | **Disproven.** Boot −3 was clean for two days on the old 70.45.2; the first-ever fault also occurred on 70.45.2. Upgrading to 70.65.0 made lockups 4.9× *more* frequent. |
+| GT1 / media tile / `action 3003` | **Weakened.** Explained Run 11 (4193 GT1 events) but Run 12 had **zero** GT1 events and zero `action 3003`. |
+| Kernel too old | Contributing at most — 6.17.0-41 is the current distro candidate, and boot −3 was clean on it. |
+| ReBAR, system RAM, NaN divergence, thermal/PCIe | Ruled out — see §9 and §10. |
+| Deep CPU C-states racing the GPU IRQ | **Current leading candidate, untested.** All 721 lockups landed on one core with `cpuidle_enter_state` in the trace, C3 exit latency 1 ms, `intel_idle.max_cstate` unclamped. Circumstantial. |
+
+## Practical guidance
+
+- **Cap runs at 1000 steps** on this hardware. Runs at 2000/3000/5000 have all
+  failed; every model that actually worked was trained at 1000.
+- **Restart the container before loading a model.** A separate VRAM/RAM leak
+  leaves an idle worker holding ~26 GB; a restart reclaims ~18 GB.
+- **There is no true resume.** `base_model` loads weights only — no optimizer
+  or LR-scheduler state — so a rescued checkpoint is not equivalent to
+  continuing a run.
+- Numbers in these reports come from `journalctl -k`, container job logs, the
+  `jobs`/`models` tables, and direct `torch.load` verification of checkpoints.
+  Where a figure is inferred rather than measured, the reports say so.

--- a/reports/RUN11-STATUS-490a12e3.md
+++ b/reports/RUN11-STATUS-490a12e3.md
@@ -1,0 +1,102 @@
+# Run 11 — `490a12e3` — launched 2026-07-30 22:07 PDT
+
+First run on the fixed GuC firmware (70.65.0). 3000 steps, checkpoints at
+1000 / 2000 / 3000 so all three can be tested tomorrow.
+
+## Config
+
+| | |
+|---|---|
+| job id | `490a12e3-c5c5-4df1-82f9-7c59a2e40421` |
+| model name | Pi0.5 Sorting 150eps 3000steps (fw 70.65.0) |
+| dataset | `f6e480e2` — so101_sorting_colored_marks, 150 eps, 100,309 frames |
+| policy | pi05, **from base** (`base_model_id: null`) |
+| batch / workers | 8 / 4 |
+| max_steps | 3000 |
+| val_split | 0.1 |
+| precision | bf16-mixed |
+
+## Measured at launch
+
+- **3.47 steps/min** — full speed (target ~3.6; a VRAM-starved run does ~0.3)
+- VRAM 32,640 MiB — model resident on the GPU
+- loss at step 12: 0.329, descending from 0.615 at step 1
+- 0 kernel faults
+
+## Checkpoint ETAs
+
+| ckpt | elapsed | expected |
+|---|---|---|
+| step 1000 | +4.8 h | Fri ~02:55 |
+| step 2000 | +9.6 h | Fri ~07:44 |
+| step 3000 | +14.4 h | Fri ~12:32 |
+
+## IMPORTANT — stop manually at step 3000
+
+`local.py:107` saves an extra final `model.ckpt` **after** `fit()` returns,
+on top of the three interval checkpoints. That 24.5 GB save is what OOMed
+before (24.5 GB ckpt + training RAM > 32 GB host RAM). Once step 3000's
+checkpoint is on disk, **stop the job from the GUI** rather than letting it
+complete naturally.
+
+Disk: 146 GB free at launch. 3 x 23 GB = 69 GB, leaving ~77 GB. A 4th
+(final) save would drop that to ~54 GB.
+
+## Fault monitor is running
+
+```
+local-changes/gpu-fault-watch-490a12e3.log
+```
+
+Background `journalctl -kf` filtered to `LOCKUP|GuC|G2H|reset started|DEVICE_LOST`.
+**An empty file is the good outcome.** Run 10's first lockup came 1h32m in
+and it kept reporting healthy steps for 7 more hours — the fault was
+invisible from inside the job, which is why this log exists.
+
+Check it with:
+```bash
+wc -l local-changes/gpu-fault-watch-490a12e3.log   # 0 = healthy
+```
+
+Any content means the card is degrading: stop the run and keep the last
+checkpoint rather than losing everything.
+
+## Gotcha hit at launch — worth remembering
+
+VRAM read **15,860 MiB** before launch, not 34. The inference worker from
+the arm testing (host PID 4527, child of backend 3982) was still holding
+~15.5 GB. `docker restart` released it (15,860 -> 44 MiB). Launching without
+that check would have spilled to swap and run 10-15x slower.
+
+The gate check is not optional, and it is not just about *stopped training
+runs* — **inference model loads leak too**.
+
+## What this run is testing
+
+Whether 3000 steps produces smoother, more confident arm motion. Note the
+existing evidence runs the other way: every 1000-step run has beaten every
+3000+ run on val loss on this box.
+
+| model | steps | val loss |
+|---|---|---|
+| `15842eae` | 1000 | **0.1187** best |
+| `7c1f0a94` | 1000 | 0.1540 |
+| `28c2e9ca` | 3385 | 0.1327 |
+| `c5d4500a` | 3675 | 0.1917 worst |
+
+Having all three checkpoints means the comparison is direct: test 1000 vs
+2000 vs 3000 on the arm and let the hardware settle it. If 1000 wins again,
+that is a real finding about this box and this dataset size.
+
+## Before testing any of these tomorrow
+
+1. **Fix the wrist camera mount first** (blue threadlocker). The screws
+   loosen on bin contact, and the wrist camera is a policy input — a
+   drifting camera silently invalidates trial data. Round 2's
+   "last block always fails" pattern is equally consistent with camera
+   drift accumulating over a long scene.
+2. Re-check VRAM is ~34 MiB before each model load.
+3. `pkill firefox` — or launch it with `LIBGL_ALWAYS_SOFTWARE=1
+   MOZ_WEBRENDER=0`, since Firefox grabs `renderD128` = the training GPU.
+4. Skip the OpenVINO exports until the conversion defect is diagnosed —
+   OpenVINO could not pick at all on `7c1f0a94` while torch worked.

--- a/reports/RUN12-FAILURE-862b848f.md
+++ b/reports/RUN12-FAILURE-862b848f.md
@@ -1,0 +1,271 @@
+# Run 12 — `862b848f` — FAILED at step 1750 / 5000 (2026-08-01)
+
+Companion to §10 of `firmware-fix-report-2026-07-30.html`. Read the §9
+addendum there first — it established that firmware age was never the cause
+and localized Run 11's faults to GT1 / `action 3003`.
+
+**Run 12 breaks that GT1 pattern.** Same lockup site, but zero GT1
+involvement. See "The signature moved AGAIN" below.
+
+## Config
+
+| | |
+|---|---|
+| job id | `862b848f-3122-47da-abc2-d329f502194a` |
+| dataset | `f6e480e2` — so101_sorting_colored_marks, 150 eps (135 train / 15 val) |
+| policy | pi05, from base (`base_model_id: null`) |
+| batch / workers | 8 / 4 |
+| max_steps | **5000** |
+| precision | bf16-mixed |
+| GPU | **B70** (`xpu:0`, 34.2 GB) — `device: null` → Lightning takes device 0 |
+| GuC firmware | 70.65.0 |
+| kernel | 6.17.0-41 (boot −1) |
+| launched | 2026-07-31 21:51 UTC |
+| died | 2026-08-01 06:28 UTC — 8h36m in |
+
+## Timeline (container logs UTC, kernel log PDT — 7h offset)
+
+| UTC | Event |
+|---|---|
+| 07-31 21:51 | Run starts |
+| 08-01 02:34–02:53 | Validation at step 1000, `val/loss=0.14838`, 24.5 GB ckpt written |
+| 08-01 06:28:00 | **Last training step: 1750/5000**, loss 0.0657 |
+| 08-01 06:28:51 | Last `JOB_UPDATE`. Log goes silent. |
+| 08-01 06:29:30 | **First hard lockup on CPU 4** — 90 s after the last step |
+| → 08-03 00:39 | Hung **42 hours**. 721 hard + 3520 soft lockups, all CPU 4. |
+| 08-03 00:39 | Container restarted → job marked `failed` |
+
+```
+status   failed
+progress 35
+message  "Job aborted due to application shutdown"   <- describes the RESTART, not the cause
+```
+
+Unlike Run 11 (faulted 9 min in, froze at 1473), Run 12 ran **8.5 h clean**
+then froze. First fault and freeze are the same event here.
+
+## THE SIGNATURE MOVED AGAIN — Run 12 is not GT1
+
+§9 concluded "every one of the 2,524 driver errors is on GT1" and "action
+3003 — 100% of failures". **That does not hold for Run 12.** Counted in both
+the watch log and the kernel journal:
+
+| Marker | Run 11 `490a12e3` | Run 12 `862b848f` | journal boot −1 |
+|---|---|---|---|
+| Hard lockups | 398 | **1030** (721 in journal) | 721 |
+| Soft lockups | 1435 | 0 in watch log | **3520** |
+| `GT1` mentions | **4193** | **0** | **0** |
+| `GT0` mentions | 20 | 2 | 0 |
+| `action 3003` | **1699** | **2** | **0** |
+| `G2H` lines | 1257 | 2 | 0 |
+
+The two `action 3003` lines in Run 12's watch log are at **09:48 UTC — over
+3 hours AFTER the 06:28 freeze** — and both marked `done`. They are not the
+failure.
+
+**So the media-tile / GT1 theory from §9 does not explain Run 12.** Either
+there are two distinct lockup mechanisms, or GT1 was always a symptom rather
+than the cause. §9's LEADING candidate needs downgrading.
+
+Caveat on the count asymmetry: Run 12's watch log has 0 soft lockups while
+the journal has 3520, so the watch script was dropping lines. The `GT1: 0`
+result is nonetheless confirmed independently in the journal.
+
+## Root cause — as far as evidence goes
+
+Same wedge site as before: a CPU stuck in the `xe` GuC message-ring read,
+inside the interrupt handler, interrupts disabled. It cannot yield, the core
+is gone, and training blocks on a GPU submit that never completes.
+
+```
+RIP: 0010:g2h_read+0xb1/0x420 [xe]
+Call Trace:
+ <IRQ>
+ xe_guc_ct_fast_path+0x72/0x140 [xe]
+ xe_guc_irq_handler+0xaa/0xc0 [xe]
+ gt_irq_handler+0x3cb/0x430 [xe]
+ dg1_irq_handler+0x156/0x270 [xe]
+ </IRQ>
+ <TASK>
+ RIP: 0010:cpuidle_enter_state+0xca/0x6e0     <- CPU4 was ASLEEP when the IRQ arrived
+ cpuidle_enter+0x30/0x50
+ call_cpuidle+0x22/0x60
+ Comm: swapper/4                               <- the idle task
+```
+
+RIP distribution across all 721 journal lockups:
+
+```
+1831  smp_call_function_single      <- other cores piling up behind CPU4 (collateral)
+1328  smp_call_function_many_cond   <- same
+1132  cpuidle_enter_state           <- CPU4 asleep when IRQ landed
+1100  memcpy_fromio                 <- the MMIO read that never returns
+  60  g2h_read
+```
+
+Run 12 shows **both** prior signatures at once: `memcpy_fromio` (Run 10's)
+and `g2h_read` (Run 11's). §9 treated those as distinguishing; they are not.
+
+### New leading theory: deep C-states race the GPU IRQ
+
+Not considered in §9. All 721 lockups are on **CPU 4 only** — the single
+core servicing that GPU IRQ.
+
+```
+C3_ACPI   latency=1048us   usage=9,139,916    <- 1 ms exit latency, heavily used
+intel_idle.max_cstate = 9                     <- unclamped
+pcie_aspm.policy = default                    <- not "performance"
+```
+
+One-core concentration + `cpuidle_enter_state` in the trace + 1 ms wake
+latency inside an MMIO read is a plausible race window. **Circumstantial,
+not proven** — the deeper defect is that the driver has no timeout on that
+mailbox read. Clamping may only make it rarer.
+
+## Cross-run table (extends §9's per-boot table)
+
+| Boot | Window | GuC | Kernel | Hard | Soft | GT1 errs | Run | Died at |
+|---|---|---|---|---|---|---|---|---|
+| −4 | Jul 20→27 | 70.45.2 | -40 | 0 | 0 | 0 | — | 30 OOM kills (Failure A) |
+| −3 | Jul 27→29 | 70.45.2 | -41 | 0 | 0 | 0 | — | clean |
+| −2 | Jul 29→30 | 70.45.2 | -41 | 81 | 480 | 239 | 10 `8108c5ba` | step **1750**/2000 |
+| −1 | Jul 30→31 | 70.65.0 | -41 | 398 | 1435 | 4193 | 11 `490a12e3` | step 1473/3000 |
+| −1 | Jul 31→Aug 2 | 70.65.0 | -41 | **721** | **3520** | **0** | 12 `862b848f` | step **1750**/5000 |
+
+Runs 11 and 12 share boot −1 (Jul 31 10:44 → Aug 2 17:34).
+
+**Runs 10 and 12 both died at step 1750** — different firmware, different
+`max_steps` (2000 vs 5000), same step. Run 11 died at 1473. Two of three at
+exactly 1750 is worth chasing but is NOT yet a proven pattern; 1750 is also
+just where a ~8.5 h run happens to land.
+
+## RULED OUT — with evidence
+
+| Suspect | Evidence against |
+|---|---|
+| **Firmware** | Already disproven in §9. Run 12 confirms: 70.65.0, worse than ever. Model `01a71dc5` trained fine on the same firmware. |
+| **GT1 / media tile / action 3003** | **Newly weakened.** 0 GT1 mentions, 0 `action 3003` in Run 12's journal. §9's leading candidate does not explain this run. |
+| **Kernel too old** | 6.17.0-41 IS the apt candidate; nothing newer available. (§9 already noted -41 is necessary-not-sufficient — boot −3 was clean on -41.) |
+| **ReBAR misconfigured** | B70 BAR = 32 GB, B50 = 16 GB. Both correct. |
+| **System RAM / OOM** | Zero OOM in boot −1. Died at 35%, nowhere near the final save. This is Failure B, not A. |
+| **NaN divergence** | `gradient_clip_val=1.0` held. Loss 0.0657 at the last step. |
+| **The B50** | Idle. `device: null` → `xpu:0` → torch enumerates 0 as B70. |
+
+### Which card wedged is UNPROVEN
+
+Boot −1's journal has **zero** `[drm]`/`xe 0000:..` lines, so nothing ties
+the stuck handler to a BDF. Current mapping (affinity `0-15` on both, so it
+floats):
+
+```
+IRQ 179 -> 0000:03:00.0  (B70, training GPU)  currently CPU 8
+IRQ 184 -> 0000:07:00.0  (B50, idle)          currently CPU 6
+```
+
+Every lockup was CPU 4 — neither of today's assignments.
+
+**Watch-script gap:** it grepped only lockup/tainted and dropped drm/xe
+lines (and missed 3520 soft lockups). Next run:
+
+```bash
+journalctl -kf | grep -iE "xe |drm|guc|reset|lockup|GT[01]"
+```
+
+## SALVAGE — one checkpoint, exported
+
+Steps 1000–1750 are gone. Verified intact by loading: `zip ok: True`,
+`global_step: 1000`, 819 tensors.
+
+```
+source  /app/storage/cache/862b848f-.../stepstep=001000.ckpt  (24.5 GB)
+model   1d1670fe-efc1-4a8e-98be-5532549e1304
+name    "Pi0.5 Sorting 150eps step1000 rescued (val 0.148)"
+export  exports/torch/pi05.pt  (9.4 GB)  — torch only
+```
+
+Registered by hand (DB backed up to `physicalai.db.bak-before-1d1670fe`),
+confirmed live at `localhost:7860/api/projects/.../models`.
+
+### Leaderboard — nothing has beaten `15842eae`
+
+| Model | Eps | global_step | val/loss | Backends |
+|---|---|---|---|---|
+| `15842eae` | 91 | 1001 | **0.1187** BEST | openvino, torch |
+| **`1d1670fe`** (Run 12, rescued) | 150 | 1000 | **0.1484** | torch |
+| `7c1f0a94` | 150 | 1000 | 0.1540 | openvino, torch |
+| `01a71dc5` | 150 | 1000 | 0.1720 | torch |
+| `c5d4500a` | 40 | 3676 | 0.1917 | openvino, torch |
+
+Registry names misstate steps: `7c1f0a94` is named "step1000" but metrics
+run to 1749 — the CHECKPOINT is at 1000, metrics kept logging past it. Same
+for `01a71dc5` (metrics to 1449).
+
+Run 12 gained nothing on val loss. 91 episodes still beats 150.
+
+## FIXES — ranked, none applied yet
+
+Needs `sudo` from a real terminal (prefix `!` in Claude Code).
+
+**1. Clamp C-states + ASPM — new, highest value, needs reboot**
+
+```bash
+sudo sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash intel_idle.max_cstate=1 processor.max_cstate=1 pcie_aspm.policy=performance/' /etc/default/grub
+sudo update-grub && sudo reboot
+```
+
+Costs idle power and heat. Reversible.
+
+**2. Pin GPU IRQs off CPU 0/4 — no reboot, damage limitation only**
+
+```bash
+echo 2 | sudo tee /proc/irq/179/smp_affinity_list   # B70 -> CPU2
+echo 3 | sudo tee /proc/irq/184/smp_affinity_list   # B50 -> CPU3
+```
+
+Won't stop the wedge; keeps a stuck core from starving RCU/dockerd — which
+is what made the box unusable for 42 h (§9 saw the same starvation).
+
+**3. Shorten engine job timeout — free, low value**
+
+```
+/sys/class/drm/card1/device/tile0/gt0/engines/rcs/job_timeout_ms = 5000 (max 10000)
+```
+
+A timeout exists and did not save this run — the wedge is in the IRQ
+handler, which never yields to let it fire.
+
+**4. Checkpoint every 250 steps + progress watchdog — not a fix, but the
+only thing that makes a long run survivable**
+
+`val_check_interval=1000` (local.py:106) meant a wedge at 1750 cost 750
+steps. At 250 it costs ≤250. Add a watchdog: no `Training progress` line for
+~10 min → kill the job. Run 12 hung silently for **42 hours**.
+
+Remember the baked-source gotcha — `docker cp` to BOTH paths
+(RESUME-HERE-2026-07-30.md §6).
+
+**No true resume exists.** `base_model` loads weights only
+(local.py:58-59) — no optimizer or LR-scheduler state.
+
+## Open questions
+
+1. **Why did GT1 vanish?** Highest value. §9's leading theory rests on GT1 /
+   `action 3003`; Run 12 has neither. Two mechanisms, or was GT1 always a
+   symptom?
+2. **Why step 1750 twice** (Runs 10 and 12, different firmware)? Test with
+   `val_check_interval=250` — if it still dies at 1750, it's step-linked;
+   if it dies elsewhere, it's time-linked (~8.5 h).
+3. Does the C-state clamp help or just delay?
+4. Which card's IRQ wedges? Needs the fixed watch command.
+5. Does `15842eae` (0.1187, 91 eps) beat `1d1670fe` (0.1484, 150 eps) on the
+   REAL ARM? More episodes keep losing on val loss — does val loss even
+   predict arm performance here?
+
+## Side observations
+
+- **RAM leak again** (§9's Failure A, mid-session): 29/30 GB used, 20 GB
+  swapped, 1.2 GB available, one idle python at 26.4 GB. `docker restart`
+  reclaimed 18 GB. Do this before loading any model.
+- The 24.5 GB copy pushed IO pressure to 65% (`full avg10=63.20`), load
+  13.55, swap back to 20 GB — expected, transient.
+- Disk: 153 GB free / 915 GB (83%). `models/` 144 GB, `cache/` 23 GB.

--- a/reports/SESSION-2026-07-28-nan-divergence.txt
+++ b/reports/SESSION-2026-07-28-nan-divergence.txt
@@ -1,0 +1,316 @@
+============================================================
+SESSION NOTES — 2026-07-28
+Run 8 (10k steps) diverged to NaN · VRAM unload leak found
+============================================================
+
+SUMMARY
+-------
+The 17-hour run launched after the 2026-07-27 reboot produced a
+complete, saveable 24.5 GB checkpoint — but its weights are NaN.
+Training loss diverged at step ~2775 and never recovered. The
+model loads and reaches the arm, then dies with
+"cannot convert nan to integer".
+
+Everything in the pipeline works. Only the numbers are bad.
+
+============================================================
+1. THE RUN
+============================================================
+  job id      8e351e69-43c4-46bc-9acf-d6bea9614aae
+  model id    cd465140-5445-44a0-914c-fa91f0e5d178
+  dataset     f6e480e2 (91 eps, color sorting)
+  config      batch 8, workers 4, max_steps 10000, val_split 0.1
+  started     2026-07-27 23:12:15 UTC
+  ended       2026-07-28 17:03:01 UTC  (manual GUI stop)
+  reached     3954 / 10000 steps  (progress 39%)
+  job status  canceled
+  extra_info  {"train/loss_step": NaN}
+
+SPEED WAS FINE. 3954 steps in ~17.8 h. The reboot fixed the
+slowness problem from 2026-07-27. That part worked.
+
+============================================================
+2. NaN DIVERGENCE — THE REAL FAILURE
+============================================================
+From metrics.csv
+(/app/storage/cache/<JOB>/version_0/metrics.csv):
+
+    step   49   0.20298   <- start
+    step  499   0.07261
+    step  999   0.06981
+    step 1999   0.06975
+    step 2699   0.06667
+    step 2749   0.06160   <- LAST GOOD VALUE
+    step 2799   nan       <- DIVERGED HERE
+    step 3949   nan
+    step 3953   nan       val/loss = nan
+
+Steps 49-2749 were healthy and stable in the 0.04-0.20 band.
+Divergence happened between step 2749 and 2799.
+Then 1,200 more steps ran on NaN weights = ~12 hours wasted.
+
+Validation "completed" (all 855 batches, 674.2s) and returned
+val/loss=nan. A completed validation does NOT mean a good model.
+
+CONSEQUENCE AT INFERENCE
+  Model loads fine, arm connects fine, then:
+     "cannot convert nan to integer"
+  The policy emits NaN action values; converting them to integer
+  SO-101 servo positions throws. Hardware was never the problem —
+  both cameras initialized and both arms connected on
+  /dev/ttyACM0 (leader) and /dev/ttyACM1 (follower).
+
+LIKELY CAUSE (not yet fixed)
+  bf16-mixed AMP with no gradient clipping. Divergence at
+  step ~2775 with an otherwise stable loss curve is the classic
+  signature.
+
+FIXES TO APPLY BEFORE THE NEXT LONG RUN
+  1. gradient_clip_val: 1.0
+  2. Consider a lower LR
+  3. Enable intermediate checkpointing — 17 h with zero saved
+     states is why one divergence cost the entire run
+  4. Add a NaN abort (early-stopping check on train/loss).
+     Would have killed this at step 2800 instead of 3954,
+     saving ~12 hours.
+
+============================================================
+3. CHECKPOINT SAVE WORKED — WITH A GOTCHA
+============================================================
+The save succeeded on a manual GUI stop, as always:
+
+  17:03  manual stop from GUI
+  17:19  model.ckpt fully written in cache/ (24,483,521,640 B)
+  17:34  MOVED to models/ under a NEW UUID (cd465140...)
+         final size 24,483,487,656 B — exact match to the
+         known-good Jul 24 checkpoint
+  17:40  exports/torch/pi05.pt written (9,354,284,578 B
+         + manifest.json) — also byte-identical to Jul 24
+  ~17:40 OpenVINO export started, never finished (dir stayed
+         empty; killed by container restart)
+
+GOTCHA 1 — NEW UUID ON PROMOTION
+  The checkpoint is promoted from
+    /app/storage/cache/<JOB-ID>/model.ckpt
+  to
+    /app/storage/models/<NEW-MODEL-UUID>/model.ckpt
+  The model UUID is NOT the job UUID. Looking for the job id
+  under models/ will make you think the save failed.
+
+GOTCHA 2 — CANCELED JOBS NEVER GET A DB ROW
+  The GUI lists models from the `models` table in
+  /app/storage/data/physicalai.db, NOT from the directory.
+  The row is INSERTed LAST, after all exports finish. Because
+  this job was status=canceled, that step never ran:
+  files on disk, no DB row, invisible in the GUI.
+
+  On the Jul 24 good run, ckpt was written 17:44 and the DB row
+  created 17:56 — a 12-minute gap. Do not panic during it.
+
+  MANUAL REGISTRATION (this worked):
+    docker exec physical-ai-studio-xpu sh -c \
+      'cp /app/storage/data/physicalai.db \
+          /app/storage/data/physicalai.db.bak'
+
+    docker exec physical-ai-studio-xpu python3 -c "
+    import sqlite3
+    c=sqlite3.connect('/app/storage/data/physicalai.db')
+    c.execute('''INSERT INTO models
+     (id,name,path,policy,properties,created_at,updated_at,
+      dataset_id,project_id,snapshot_id,train_job_id,
+      parent_model_id,version)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)''',(
+     '<MODEL-UUID>','<NAME>',
+     '/app/storage/models/<MODEL-UUID>',
+     'pi05','{}','<ISO-TS>','<ISO-TS>',
+     '<DATASET-ID>','<PROJECT-ID>',None,'<JOB-ID>',None,'1'))
+    c.commit()"
+
+  Get dataset_id / project_id from the job payload:
+    select payload from jobs where id like '<JOB-ID-PREFIX>%';
+
+  Verify (models are listed PER PROJECT):
+    curl -s http://localhost:7860/api/projects/<PROJECT-ID>/models
+
+  project_id on this box: b40d289d-536f-4411-88dc-8c4af490b597
+
+============================================================
+4. NEW BUG — VRAM LEAK ON MODEL UNLOAD
+============================================================
+Every inference unload leaks ~9,152 MiB on Device 0.
+
+  "Inference stopped, unloading model."  -> 9152 MiB stays pinned
+
+Reproduced 3+ times. After a container restart VRAM reads 34 MiB;
+after one load+unload cycle it reads 9153 MiB and stays there.
+
+CONSEQUENCE
+  The next load cannot fit the ~9 GB model in the remaining VRAM,
+  spills to host RAM (RSS balloons to ~27 GB on a 30 GB box),
+  drops available RAM to ~500 MB, and thrashes into swap
+  (saw swap go 1 GB -> 19 GB -> 32 GB). Loads that take ~2 min
+  on a clean card take 10+ min or hang in D state.
+
+  This is what "it was never so slow" was. Not the model size,
+  not the machine — accumulated leaked VRAM.
+
+SECONDARY SYMPTOM — "no idle model workers available"
+                  / "all 1 workers are busy"
+  Same root cause seen from the pool's side. The worker holding
+  the leaked allocation is never returned to the pool. Clicking
+  Load again stacks another ~27 GB attempt onto a starved box
+  and makes it strictly worse. Two identical "Loading model"
+  lines in inference.log = two stacked requests.
+
+RULE
+  Restart the container before EVERY model load, and verify:
+    docker restart physical-ai-studio-xpu
+    sleep 20
+    xpu-smi stats -d 0 | grep -i "Memory Used"     # want ~34 MiB
+  Then click Load EXACTLY ONCE and wait 2-3 min.
+  Never re-click. Do not load twice in one container lifetime.
+
+============================================================
+5. CORRECTION TO REBOOT-RESUME-2026-07-27.txt
+============================================================
+That file says:
+
+  "Container restart does NOT fix this — the wedged process is
+   on the HOST, outside the container."
+
+THIS IS WRONG. Verified today:
+
+  cat /proc/9849/cgroup
+    0::/system.slice/docker-bed7749f....scope    <- IN CONTAINER
+  PID 9849 -> parent 9614 -> container main PID 9400
+
+The process was inside the container's cgroup all along.
+`docker restart physical-ai-studio-xpu` released 32,624 MiB in
+18.8 seconds. A second restart later released the 9 GB leak in
+34 seconds. No reboot was needed at any point today.
+
+THE REAL DISTINCTION IS PROCESS STATE:
+
+  ps -p <PID> -o stat
+
+  R (running)              -> docker restart WILL clear it
+  D (uninterruptible)      -> restart hangs; reboot is the only fix
+                              (blocked in driver code, SIGKILL
+                               cannot touch it)
+
+On 2026-07-27 the process was in D state, so the 5+ restarts
+hung — the conclusion drawn ("it's on the host") was wrong even
+though the observation (restarts didn't help) was right.
+
+ALWAYS CHECK STATE FIRST. Try `docker restart` (20-35 s) before
+reaching for a reboot (several minutes).
+
+============================================================
+6. DIAGNOSTIC COMMANDS THAT EARNED THEIR KEEP
+============================================================
+WHO HOLDS VRAM — the single most useful command, names the PID:
+    xpu-smi ps
+  (`xpu-smi stats -d 0` only gives a total; `ps` attributes it)
+
+IS A SAVE ACTUALLY RUNNING, OR IS IT SWAP THRASHING?
+    ls -l /proc/<PID>/fd | grep ckpt      # open write fd = real save
+    grep -E "read_bytes|write_bytes" /proc/<PID>/io
+  Roughly equal read and write volume = swap thrashing.
+  Write-only growth = a real checkpoint write.
+  A live save also shows a growing file:
+    docker exec physical-ai-studio-xpu \
+      stat -c %s /app/storage/cache/<JOB>/model.ckpt
+  Observed write rate: ~7-10 GB/min.
+
+IS THE GUI SPINNER REAL, OR STALE?
+    docker exec physical-ai-studio-xpu \
+      ls -l --time-style=+%H:%M:%S /app/storage/logs/inference.log
+  Compare mtime to `date -u`. Silent for minutes + zero change in
+  /proc/<PID>/io read_bytes = nothing is happening; the frontend
+  is out of sync with the backend. Hard-refresh the browser.
+
+READ THE JSON LOGS WITHOUT DROWNING:
+    docker exec physical-ai-studio-xpu sh -c \
+      "tail -6 /app/storage/logs/inference.log \
+       | grep -oE '\"message\": \"[^\"]{0,200}'"
+
+APP PORT IS 7860, NOT 8000/3000
+  Port 3000 is Grafana on this box. Port 8000 is container-internal
+  only. API paths: /api/projects/{project_id}/models,
+  /api/models/{model_id}. Full list: /openapi.json
+
+============================================================
+7. MODELS ON DISK (as of 2026-07-28 18:15)
+============================================================
+  c5d4500a  Pi0.5 Contrast v4 (40eps, 3670 steps)
+            train 0.023 / val 0.192 — BEST. torch + openvino ready
+  6a87fb33  Pi0.5 (91eps, 1999 steps)
+            train 0.045 / val 0.206. torch + openvino ready
+  28c2e9ca  Pi0.5 Pick-Place v3 (90eps, 3380 steps)
+  d827663e  Pi0.5 Pick-Place v2 (60eps, 1000 steps)
+  d2082a5f  Pi0.5 Pick-Place v1 (1000 steps)
+  cd465140  Pi0.5 NaN-DIVERGED do-not-use (91eps, 3954 steps)
+            <- TODAY. NaN weights. DELETE to reclaim 24.5 GB.
+  a1b2c3d4-90ep-3380-step-77f63091cafe
+            <- empty dir, Run 7 OOM casualty. Safe to rmdir.
+
+USE c5d4500a FOR ANY DEMO OR ARM TEST. Lowest val loss,
+both exports present, no NaN.
+
+Disk: 915 G total, 88% used, ~105 G free. Each ckpt is 24.5 GB.
+
+============================================================
+8. NEXT RUN — 1500 STEPS
+============================================================
+Rationale: NaN appeared at step ~2775. A 1500-step run stops well
+short of it, so a usable model needs no root-cause fix first.
+Everything below step 2749 was healthy.
+
+  docker restart physical-ai-studio-xpu
+  sleep 20
+  xpu-smi stats -d 0 | grep -i "Memory Used"    # want ~34 MiB
+  pkill firefox                                 # holds renderD128
+  free -h                                       # swap near 0
+  cat /proc/sys/vm/swappiness                   # want 10
+
+GUI: dataset f6e480e2, Pi0.5, batch 8, workers 4, max_steps 1500
+
+  ~5 MIN HEALTH CHECK (where past runs collapsed):
+    HEALTHY  2 steps / 30-45 s, RSS ~19.8 GB, swap ~0
+    BROKEN   2 steps / 6 min, RSS collapses to ~5 MB
+    If broken: relaunch with 2 workers. One change at a time.
+    Next lever after that is batch 4.
+
+  HOURLY LOSS CHECK (new, and the whole point):
+    docker exec physical-ai-studio-xpu sh -c \
+      "tail -5 /app/storage/cache/<JOB>/version_0/metrics.csv"
+    Expect 0.06-0.20. IF nan -> STOP IMMEDIATELY.
+
+  STOP MANUALLY FROM THE GUI AT ~1000 STEPS.
+  Never let it complete naturally — natural completion OOM'd
+  Run 7 during the 24.5 GB save and lost the checkpoint. Every
+  checkpoint successfully kept, including today's, came from a
+  manual stop.
+
+  ETA: ~1000 steps at 3.3-4 steps/min = 4.2-5 hours.
+
+  AFTER THE STOP: ckpt write ~5 min, then torch export, then
+  OpenVINO, then the DB row LAST. If the job ends up
+  status=canceled, register the row manually (section 3).
+
+============================================================
+9. CONFIG VERIFIED PERSISTENT (checked 2026-07-28)
+============================================================
+  vm.swappiness = 10
+  /etc/sysctl.d/99-training.conf -> vm.swappiness=10   (survives reboot)
+  /etc/fstab -> /swap.img (8 G) + /swapfile2 (32 G) = 40 G total
+  swapon --show confirms both active
+  container restart policy = unless-stopped (auto-starts on boot)
+
+  Storage lives in NAMED DOCKER VOLUMES, so it survives
+  `docker restart` and `docker stop`:
+    docker_physical-ai-studio-storage -> /app/storage
+    docker_physical-ai-studio-data    -> /app/data
+  Only `docker volume rm` / `compose down -v` would destroy it.
+  Verified: model.ckpt, exports and the DB row all survived two
+  container restarts today.

--- a/reports/firmware-fix-report-2026-07-30.html
+++ b/reports/firmware-fix-report-2026-07-30.html
@@ -1,0 +1,837 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GuC Firmware Fix Report — 2026-07-30</title>
+<style>
+  .viz-root {
+    color-scheme: light;
+    --surface-0:      #f7f7f5;
+    --surface-1:      #fcfcfb;
+    --surface-2:      #f0efec;
+    --border:         #dedcd6;
+    --text-primary:   #0b0b0b;
+    --text-secondary: #52514e;
+    --text-muted:     #7d7b74;
+    --series-before:  #c23030;
+    --series-after:   #1baf7a;
+    --series-neutral: #2a78d6;
+    --status-critical:  #c23030;
+    --status-warning:   #eda100;
+    --status-good:      #008300;
+    --grid:           #e6e4de;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) .viz-root {
+      color-scheme: dark;
+      --surface-0:      #121211;
+      --surface-1:      #1a1a19;
+      --surface-2:      #262624;
+      --border:         #383835;
+      --text-primary:   #ffffff;
+      --text-secondary: #c3c2b7;
+      --text-muted:     #918f85;
+      --series-before:  #e66767;
+      --series-after:   #199e70;
+      --series-neutral: #3987e5;
+      --status-critical:  #e66767;
+      --status-warning:   #c98500;
+      --status-good:      #3fa93f;
+      --grid:            #2f2f2c;
+    }
+  }
+  :root[data-theme="dark"] .viz-root {
+    color-scheme: dark;
+    --surface-0:      #121211;
+    --surface-1:      #1a1a19;
+    --surface-2:      #262624;
+    --border:         #383835;
+    --text-primary:   #ffffff;
+    --text-secondary: #c3c2b7;
+    --text-muted:     #918f85;
+    --series-before:  #e66767;
+    --series-after:   #199e70;
+    --series-neutral: #3987e5;
+    --status-critical:  #e66767;
+    --status-warning:   #c98500;
+    --status-good:      #3fa93f;
+    --grid:            #2f2f2c;
+  }
+
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--surface-0); }
+  .viz-root {
+    background: var(--surface-0);
+    color: var(--text-primary);
+    font: 15px/1.6 ui-sans-serif, -apple-system, "Segoe UI", Roboto, sans-serif;
+    padding: 32px 24px 80px;
+    max-width: 1180px;
+    margin: 0 auto;
+  }
+  h1 { font-size: 27px; line-height: 1.25; margin: 0 0 6px; letter-spacing: -0.01em; }
+  h2 { font-size: 20px; margin: 44px 0 4px; letter-spacing: -0.005em; }
+  h3 { font-size: 15px; margin: 26px 0 8px; color: var(--text-secondary); font-weight: 600; }
+  .sub { color: var(--text-secondary); margin: 0 0 4px; }
+  .muted { color: var(--text-muted); font-size: 13px; }
+  p { margin: 10px 0; color: var(--text-secondary); }
+  p strong, li strong, td strong { color: var(--text-primary); }
+  code {
+    font: 12.5px/1.5 ui-monospace, "SF Mono", Menlo, monospace;
+    background: var(--surface-2); padding: 1px 5px; border-radius: 4px;
+    color: var(--text-primary);
+  }
+  pre {
+    font: 12.5px/1.65 ui-monospace, "SF Mono", Menlo, monospace;
+    background: var(--surface-2); border: 1px solid var(--border);
+    border-radius: 8px; padding: 14px 16px; overflow-x: auto;
+    color: var(--text-primary); margin: 12px 0;
+  }
+  .card {
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: 12px; padding: 20px 22px; margin: 16px 0;
+  }
+  .card.good { border-left: 3px solid var(--status-good); }
+  .card.warn { border-left: 3px solid var(--status-warning); }
+  .tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(168px, 1fr)); gap: 12px; margin: 20px 0; }
+  .tile {
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: 12px; padding: 15px 17px;
+  }
+  .tile .label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.055em; color: var(--text-muted); }
+  .tile .value { font-size: 27px; font-weight: 650; margin-top: 5px; letter-spacing: -0.02em; }
+  .tile .note { font-size: 12.5px; color: var(--text-secondary); margin-top: 3px; }
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14px; }
+  th, td { text-align: left; padding: 9px 11px; border-bottom: 1px solid var(--border); }
+  th { color: var(--text-muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; }
+  td { color: var(--text-secondary); }
+  td.num { font-variant-numeric: tabular-nums; }
+  td.mono { font: 12.5px ui-monospace, Menlo, monospace; }
+  .legend { display: flex; flex-wrap: wrap; gap: 18px; margin: 4px 0 14px; font-size: 13px; }
+  .legend span { display: inline-flex; align-items: center; gap: 7px; color: var(--text-secondary); }
+  .swatch { width: 11px; height: 11px; border-radius: 3px; flex: none; }
+  .chartwrap { background: var(--surface-1); border: 1px solid var(--border); border-radius: 12px; padding: 18px 20px 12px; margin: 12px 0 8px; }
+  svg { display: block; width: 100%; height: auto; overflow: visible; }
+  .tt {
+    position: fixed; pointer-events: none; opacity: 0; transition: opacity .1s;
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px;
+    padding: 8px 11px; font-size: 12.5px; box-shadow: 0 4px 14px rgba(0,0,0,.14);
+    z-index: 50; color: var(--text-primary); max-width: 260px;
+  }
+  .tt b { display: block; margin-bottom: 3px; }
+  .tt-row { display: flex; align-items: center; gap: 7px; color: var(--text-secondary); }
+  .tt-row .swatch { width: 9px; height: 9px; }
+  .pill {
+    display: inline-block; font-size: 11.5px; padding: 2px 9px; border-radius: 99px;
+    border: 1px solid var(--border); color: var(--text-secondary); background: var(--surface-2);
+    font-weight: 600; letter-spacing: 0.02em;
+  }
+  .pill.crit { color: var(--status-critical); border-color: currentColor; background: transparent; }
+  .pill.warn { color: var(--status-warning); border-color: currentColor; background: transparent; }
+  .pill.good { color: var(--status-good); border-color: currentColor; background: transparent; }
+  .toggle {
+    float: right; font-size: 12.5px; background: var(--surface-1); color: var(--text-secondary);
+    border: 1px solid var(--border); border-radius: 7px; padding: 5px 11px; cursor: pointer;
+  }
+  ul, ol { color: var(--text-secondary); padding-left: 22px; }
+  li { margin: 6px 0; }
+  details { margin: 10px 0; }
+  summary { cursor: pointer; color: var(--text-secondary); font-size: 13.5px; }
+  .tl { border-left: 2px solid var(--border); margin: 16px 0 16px 6px; padding-left: 20px; }
+  .tl-item { position: relative; padding: 9px 0; }
+  .tl-item::before {
+    content: ''; position: absolute; left: -27px; top: 15px; width: 9px; height: 9px;
+    border-radius: 50%; background: var(--text-muted);
+    box-shadow: 0 0 0 2px var(--surface-0);
+  }
+  .tl-item.crit::before { background: var(--status-critical); }
+  .tl-item.good::before { background: var(--status-good); }
+  .tl-time { font: 12.5px ui-monospace, Menlo, monospace; color: var(--text-muted); }
+  .tl-what { color: var(--text-primary); font-weight: 550; }
+  .tl-detail { font-size: 13.5px; color: var(--text-secondary); }
+  .check { list-style: none; padding-left: 0; }
+  .check li { display: flex; gap: 10px; align-items: flex-start; margin: 9px 0; }
+  .check .mk { flex: none; font-weight: 700; color: var(--status-good); width: 16px; }
+  hr { border: 0; border-top: 1px solid var(--border); margin: 34px 0 0; }
+  .footnote { font-size: 12.5px; color: var(--text-muted); margin-top: 8px; }
+</style>
+</head>
+<body data-palette="#c23030,#1baf7a,#2a78d6">
+<div class="viz-root">
+
+<button class="toggle" id="themeBtn">Toggle theme</button>
+<h1>GuC Firmware Fix — Resolution Report</h1>
+<p class="sub">The GPU firmware hang that killed Run 10 is fixed. Both failure modes are verified gone on the current boot.</p>
+<p class="muted">Generated 2026-07-30 11:52 PDT · host <code>we-b580</code> · kernel 6.17.0-41-generic · <code>xe</code> driver · companion to <code>training-report-2026-07-30.html</code></p>
+
+<div class="card" style="border-left:3px solid var(--status-critical);margin-top:20px">
+  <p style="margin:0"><strong style="color:var(--status-critical)">SUPERSEDED 2026-07-31 — read <a href="#addendum" style="color:var(--status-critical)">§9</a> first.</strong> The headline conclusion below is <strong>disproven</strong>. Run 11 faulted 9 minutes into a run on the new 70.65.0 firmware and logged 4.9× <em>more</em> hard lockups than the run that motivated the upgrade. Sections 1–8 record a firmware update that was genuinely applied and verified, but the lockups were never caused by firmware age — a clean two-day boot on the old 70.45.2 (boot −4/−3) rules that out. Sections 2, 6 and 8 compare an <em>idle</em> boot against a <em>loaded</em> one and should not be read as a fix. Only §5 (allocator recovery, via the reboot) still holds.</p>
+</div>
+
+<div class="tiles">
+  <div class="tile">
+    <div class="label">GuC firmware</div>
+    <div class="value" style="color:var(--status-good)">70.65.0</div>
+    <div class="note">was 70.45.2 · <span class="pill good">TARGET MET</span></div>
+  </div>
+  <div class="tile">
+    <div class="label">Hard CPU lockups</div>
+    <div class="value" style="color:var(--status-good)">0</div>
+    <div class="note">was 81 on previous boot</div>
+  </div>
+  <div class="tile">
+    <div class="label">Soft lockups</div>
+    <div class="value" style="color:var(--status-good)">0</div>
+    <div class="note">was 480 on previous boot</div>
+  </div>
+  <div class="tile">
+    <div class="label">G2H timeouts</div>
+    <div class="value" style="color:var(--status-good)">0</div>
+    <div class="note">was 239 on previous boot</div>
+  </div>
+  <div class="tile">
+    <div class="label">Allocator health</div>
+    <div class="value" style="color:var(--status-good)">PASS</div>
+    <div class="note">3/3 tests · error 39 gone</div>
+  </div>
+  <div class="tile">
+    <div class="label">VRAM at rest</div>
+    <div class="value">34<span style="font-size:16px;color:var(--text-muted)"> MiB</span></div>
+    <div class="note">clean · ready to launch</div>
+  </div>
+</div>
+
+<h2>1 · What was wrong, and what fixed it</h2>
+
+<p>The prior report established that Run 10 died of a <strong>firmware fault, not a training fault</strong>. Two distinct symptoms shared that one root cause, and one firmware update plus a reboot cleared both.</p>
+
+<table>
+  <thead>
+    <tr><th>Problem</th><th>Symptom before</th><th>Mechanism</th><th>Status now</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>A — Training death</strong></td>
+      <td class="mono">UR_RESULT_ERROR_DEVICE_LOST (20)</td>
+      <td>GuC 70.45.2 stops acknowledging host commands; interrupt handler wedges the CPU; ~340 driver resets end in a dead device.</td>
+      <td><span class="pill good">FIXED</span></td>
+    </tr>
+    <tr>
+      <td><strong>B — Models would not load</strong></td>
+      <td class="mono">UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY (39)</td>
+      <td>The reset storm corrupted the driver's memory allocator. Raw big allocations still worked; many-small-tensor migration failed. Not fixable by <code>docker restart</code> — damage was in the kernel driver, so it needed the reboot.</td>
+      <td><span class="pill good">FIXED</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="card good">
+  <h3 style="margin-top:0">The fix, in one line</h3>
+  <p style="margin-bottom:0">Replace Ubuntu's <code>/lib/firmware/xe</code> with the <code>linux-firmware</code> tree from Intel's repo — <strong>GuC 70.45.2 → 70.65.0</strong> — rebuild initramfs, reboot. The reboot also rebuilt the corrupted allocator state, which is why one action resolved both problems.</p>
+</div>
+
+<h2>2 · Before vs after — measured on consecutive boots</h2>
+
+<p>These are counts from the kernel journal, not estimates. Boot <code>-1</code> ran GuC 70.45.2 for 26 hours and included Run 10. Boot <code>0</code> is the current post-update boot.</p>
+
+<div class="chartwrap">
+  <div class="legend">
+    <span><i class="swatch" style="background:var(--series-before)"></i>Boot −1 · GuC 70.45.2 · Jul 29 09:48 → Jul 30 11:44</span>
+    <span><i class="swatch" style="background:var(--series-after)"></i>Boot 0 · GuC 70.65.0 · Jul 30 11:44 →</span>
+  </div>
+  <svg id="faultChart" viewBox="0 0 900 260" role="img" aria-label="GPU fault counts before and after the firmware update: hard lockups 81 to 0, soft lockups 480 to 0, G2H timeouts 239 to 0, driver resets 340 to 0."></svg>
+  <p class="footnote">Every category is zero after the update. Counts are absolute occurrences in <code>journalctl -k</code> for each boot.</p>
+</div>
+
+<div class="card warn">
+  <p style="margin:0"><strong>Read this honestly:</strong> the current boot has been up for minutes, not hours, and has not yet run a training job. Zero faults at idle is necessary but not sufficient — Run 10's first lockup came <strong>1 h 32 m</strong> into load. The firmware version check is conclusive; the stability claim is not proven until a long run completes. Monitor during the next run (§6).</p>
+</div>
+
+<h2>3 · What was actually done</h2>
+
+<div class="tl">
+  <div class="tl-item">
+    <div class="tl-time">Step 1</div>
+    <div class="tl-what">Ruled out the package manager</div>
+    <div class="tl-detail">Ubuntu's newest <code>linux-firmware</code> (<code>20250901.git993ff19b-0ubuntu1.11</code>) still ships GuC <strong>70.45.2</strong>. <code>apt install --only-upgrade linux-firmware</code> is a dead end here — the git tree is the only route.</div>
+  </div>
+  <div class="tl-item">
+    <div class="tl-time">Step 2</div>
+    <div class="tl-what">Backed up the old firmware before touching anything</div>
+    <div class="tl-detail"><code>sudo mv /lib/firmware/xe /lib/firmware/xe.backup</code> — preserved as 9 <code>.zst</code> files dated Apr 15, still on disk. This is the rollback path, and it is intact.</div>
+  </div>
+  <div class="tl-item">
+    <div class="tl-time">Step 3</div>
+    <div class="tl-what">Installed the newer firmware from the Intel repo</div>
+    <div class="tl-detail"><code>sudo mkdir -p /lib/firmware/xe/ &amp;&amp; sudo cp -a linux-firmware/xe/* /lib/firmware/xe/</code> — 10 files written 11:42, including <code>bmg_guc_70.bin</code> (369 KB, md5 <code>201f80b9…</code>) for Battlemage.</div>
+  </div>
+  <div class="tl-item">
+    <div class="tl-time">Step 4</div>
+    <div class="tl-what">Rebuilt initramfs and rebooted</div>
+    <div class="tl-detail"><code>update-initramfs -u</code> — <code>/boot/initrd.img-6.17.0-41-generic</code> is stamped 11:43, one minute after the firmware copy. Firmware loads early, so skipping this step would have left the old blob in play.</div>
+  </div>
+  <div class="tl-item good">
+    <div class="tl-time">11:45:02</div>
+    <div class="tl-what">New firmware confirmed loaded on both cards</div>
+    <div class="tl-detail">Both GTs on both GPUs report 70.65.0, and HuC came along at 8.2.10.</div>
+  </div>
+  <div class="tl-item good">
+    <div class="tl-time">11:51</div>
+    <div class="tl-what">Allocator verified healthy with a staged test</div>
+    <div class="tl-detail">The exact failure mode from Problem B was re-run and passed. Detail in §5.</div>
+  </div>
+</div>
+
+<p>What we deliberately did <strong>not</strong> do: the Intel guide's BIOS and GRUB sections. Only its "Updating firmware" part applies. We do not want SR-IOV or <code>xe.max_vfs</code> on this box — that would partition the GPU and cut the VRAM available to training.</p>
+
+<h2>4 · Firmware load — the primary evidence</h2>
+
+<pre>$ journalctl -k -b -1 | grep "GuC firmware from"      <span style="color:var(--status-critical)"># BEFORE</span>
+Jul 29 09:48:45 we-b580 kernel: xe 0000:03:00.0: [drm] GT0: Using GuC firmware from xe/bmg_guc_70.bin version <span style="color:var(--status-critical)">70.45.2</span>
+Jul 29 09:48:46 we-b580 kernel: xe 0000:03:00.0: [drm] GT1: Using GuC firmware from xe/bmg_guc_70.bin version <span style="color:var(--status-critical)">70.45.2</span>
+Jul 29 09:48:46 we-b580 kernel: xe 0000:07:00.0: [drm] GT0: Using GuC firmware from xe/bmg_guc_70.bin version <span style="color:var(--status-critical)">70.45.2</span>
+
+$ journalctl -k | grep -i guc                          <span style="color:var(--status-good)"># AFTER</span>
+Jul 30 11:45:02 we-b580 kernel: xe 0000:03:00.0: [drm] GT0: Using GuC firmware from xe/bmg_guc_70.bin version <span style="color:var(--status-good)">70.65.0</span>
+Jul 30 11:45:02 we-b580 kernel: xe 0000:03:00.0: [drm] GT1: Using GuC firmware from xe/bmg_guc_70.bin version <span style="color:var(--status-good)">70.65.0</span>
+Jul 30 11:45:02 we-b580 kernel: xe 0000:03:00.0: [drm] GT1: Using HuC firmware from xe/bmg_huc.bin version 8.2.10
+Jul 30 11:45:04 we-b580 kernel: xe 0000:07:00.0: [drm] GT0: Using GuC firmware from xe/bmg_guc_70.bin version <span style="color:var(--status-good)">70.65.0</span>
+Jul 30 11:45:04 we-b580 kernel: xe 0000:07:00.0: [drm] GT1: Using GuC firmware from xe/bmg_guc_70.bin version <span style="color:var(--status-good)">70.65.0</span>
+Jul 30 11:45:04 we-b580 kernel: xe 0000:07:00.0: [drm] GT1: Using HuC firmware from xe/bmg_huc.bin version 8.2.10</pre>
+
+<p>70.65.0 clears the 70.55.3 threshold and matches the version the Intel guide's own example lands on. Both the training GPU (<code>03:00.0</code>) and the second card (<code>07:00.0</code>) are updated — they share the <code>bmg_guc_70.bin</code> blob, so neither could have been missed.</p>
+
+<h2>5 · Allocator recovery — Problem B, retested directly</h2>
+
+<p>Problem B was subtle: a raw 10 GiB allocation succeeded while moving an 819-tensor model failed. A test that only checks "can I allocate memory" would have produced a false pass. So the test reproduces the shape of the real failure — <strong>many separate tensor migrations</strong>, which is what a model load actually does.</p>
+
+<table>
+  <thead><tr><th>Test</th><th>What it probes</th><th>When broken</th><th>Now</th></tr></thead>
+  <tbody>
+    <tr><td>Raw 10 GiB block</td><td>Bulk allocation path</td><td>Passed (false negative)</td><td><span class="pill good">OK</span></td></tr>
+    <tr><td>900 tensors → XPU</td><td>The path that actually failed with error 39</td><td class="mono" style="color:var(--status-critical)">FAILED — err 39</td><td><span class="pill good">OK</span></td></tr>
+    <tr><td>Matmul on device</td><td>Compute, not just memory</td><td>Never reached</td><td><span class="pill good">OK</span></td></tr>
+  </tbody>
+</table>
+
+<pre>torch 2.10.0+xpu | xpu avail True
+device Intel(R) Arc(TM) Pro B70 Graphics
+total VRAM 31.9 GiB
+TEST1 raw 10GiB alloc: OK
+TEST2 moved 900 tensors / 0.88 GiB: OK
+TEST3 matmul: 25.396230697631836
+ALLOCATOR HEALTHY</pre>
+
+<p>VRAM returned to <strong>34 MiB</strong> after the test exited, so the test itself left nothing behind — the allocator is both working and releasing correctly. Note the device string reads <code>B70</code> at 31.9 GiB, which is how <code>torch</code> reports device 0; <code>xpu-smi</code> shows it as <code>0xe223</code> at PCI <code>03:00.0</code>. Same card, different naming.</p>
+
+<h2>6 · Pre-flight state — verified now, before any arm testing</h2>
+
+<ul class="check">
+  <li><span class="mk">✓</span><span><strong>GuC 70.65.0</strong> on both cards — the actual fix, confirmed in the journal.</span></li>
+  <li><span class="mk">✓</span><span><strong>Zero faults</strong> since boot: 0 hard lockups, 0 soft lockups, 0 G2H timeouts, 0 GT resets, 0 <code>xe *ERROR*</code> lines.</span></li>
+  <li><span class="mk">✓</span><span><strong>VRAM 34 MiB</strong> — clean card, no leaked allocation holding it.</span></li>
+  <li><span class="mk">✓</span><span><strong>Container healthy</strong>, UI answering HTTP 200 on port 7860.</span></li>
+  <li><span class="mk">✓</span><span><strong>Checkpoint patch survived the reboot</strong> — <code>every_n_train_steps=1000</code>, <code>save_top_k=-1</code>, <code>gradient_clip_val=1.0</code>, <code>val_check_interval=1000</code> all still present in the container's <em>site-packages</em> copy, which is the one Python imports. A restart preserves it; a rebuild would not.</span></li>
+  <li><span class="mk">✓</span><span><strong>Test model <code>7c1f0a94</code> intact</strong> — 23 GB ckpt, both exports present (torch <code>pi05.pt</code> 9.35 GB, OpenVINO <code>pi05.bin</code> 6.25 GB), and registered in the DB alongside the other three models.</span></li>
+  <li><span class="mk">✓</span><span><strong>Rollback available</strong> — <code>/lib/firmware/xe.backup</code> still holds the 70.45.2 blobs.</span></li>
+  <li><span class="mk">✓</span><span><strong>146 GB disk free</strong> (84% used) — enough for the next run's checkpoints.</span></li>
+</ul>
+
+<h3>Monitor during the next long run — the fault was invisible from inside the job</h3>
+<pre>journalctl -kf | grep -E "LOCKUP|GuC|G2H|reset started"</pre>
+<p>Run 10 kept reporting healthy steps for seven hours while the GPU was dying. Any hit on that filter means the card is degrading again and the run will not finish — stop early and keep the last checkpoint rather than losing the run.</p>
+
+<h2>7 · If it happens again</h2>
+
+<ol>
+  <li><strong>Roll back the firmware</strong> if the new version misbehaves in a new way:
+    <pre>sudo rm -rf /lib/firmware/xe
+sudo mv /lib/firmware/xe.backup /lib/firmware/xe
+sudo update-initramfs -u &amp;&amp; sudo reboot</pre>
+  </li>
+  <li><strong>If lockups return on 70.65.0</strong>, firmware age is no longer the explanation. That would point at the kernel <code>xe</code> driver or the sustained-load thermal/power envelope, and it becomes a report worth sending to Intel with the journal attached.</li>
+  <li><strong>Error 39 after any reset storm</strong> means the allocator is corrupted again — reboot, don't bother with <code>docker restart</code>, and re-run the §5 staged test before trusting the card.</li>
+</ol>
+
+<h2>8 · Where this leaves the project</h2>
+
+<p>The blocker is cleared and the machine is in a known-good state. Two things follow, in order:</p>
+
+<ol>
+  <li><strong>Test <code>7c1f0a94</code> on the arm</strong> — PyTorch round, then OpenVINO with a container restart between. The question the val loss cannot answer is whether the 59 new episodes fixed the early-release failure, so <strong>IN vs EDGE</strong> is the column that matters. Log it in <code>success-rate-log.txt</code>, same block positions as the 2026-07-29 baseline.</li>
+  <li><strong>Then relaunch training</strong> — dataset <code>f6e480e2</code> (150 eps), Pi0.5 from base, batch 8, workers 4, <code>max_steps</code> 2000, val split 0.1 — with the journal monitor running. Keep 2000: every good model on this box trained under one epoch, and the only run past a full epoch has the worst val gap (8.3×).</li>
+</ol>
+
+<div class="card">
+  <p style="margin:0">One process note worth keeping: the firmware version was never checked before ten training runs, and it cost an overnight run at 87% completion. <code>journalctl -k | grep -i guc</code> is now part of pre-flight. The checkpoint patch is the other lesson — it is the only reason Run 10 produced a usable model at all, and it must be re-applied by <code>docker cp</code> to <strong>both</strong> container paths after any image rebuild.</p>
+</div>
+
+<hr>
+
+<h2 id="addendum" style="margin-top:38px">9 · ADDENDUM 2026-07-31 — the firmware update did <em>not</em> fix it</h2>
+
+<p class="muted">Appended 2026-07-31 · Run 11 <code>490a12e3</code> · launched 2026-07-30 22:07 PDT, dead at step 1473/3000 · kernel monitor <code>gpu-fault-watch-490a12e3.log</code></p>
+
+<div class="card" style="border-left:3px solid var(--status-critical)">
+  <p style="margin:0"><strong>Section 7 item 2 has now happened.</strong> Lockups returned on 70.65.0, so <em>firmware age was never the explanation</em>. Run 11 faulted <strong>9 minutes after launch</strong> and logged <strong>more</strong> hard lockups than the run that motivated the update. Sections 1–8 above describe a real firmware upgrade that was correctly applied and verified — but the causal claim in §1 (&ldquo;one firmware update plus a reboot cleared both&rdquo;) is <strong>disproven</strong> for the lockup problem. Only the allocator recovery (§5) still stands, and that was a consequence of the reboot.</p>
+</div>
+
+<div class="tiles">
+  <div class="tile">
+    <div class="label">GuC firmware during Run 11</div>
+    <div class="value" style="color:var(--status-good)">70.65.0</div>
+    <div class="note">update WAS live · <span class="pill good">verified</span></div>
+  </div>
+  <div class="tile">
+    <div class="label">Hard CPU lockups</div>
+    <div class="value" style="color:var(--status-critical)">398</div>
+    <div class="note">was 81 on 70.45.2 · <span class="pill crit">4.9× WORSE</span></div>
+  </div>
+  <div class="tile">
+    <div class="label">G2H timeouts</div>
+    <div class="value" style="color:var(--status-critical)">1257</div>
+    <div class="note">was 239 · <span class="pill crit">5.3× WORSE</span></div>
+  </div>
+  <div class="tile">
+    <div class="label">Time to first fault</div>
+    <div class="value" style="color:var(--status-critical)">9<span style="font-size:16px;color:var(--text-muted)"> min</span></div>
+    <div class="note">Run 10 took 1 h 32 m</div>
+  </div>
+  <div class="tile">
+    <div class="label">Steps reached</div>
+    <div class="value">1473<span style="font-size:16px;color:var(--text-muted)">/3000</span></div>
+    <div class="note">49% · froze 05:16, never resumed</div>
+  </div>
+  <div class="tile">
+    <div class="label">GT resets</div>
+    <div class="value" style="color:var(--status-good)">0</div>
+    <div class="note">was 1011 · the one real gain</div>
+  </div>
+</div>
+
+<h3>What actually changed — the fault predates the firmware update</h3>
+
+<p>Counting faults per boot separates the variables. The fault does not track firmware version; it tracks <strong>a change that landed on 2026-07-29</strong>.</p>
+
+<table>
+  <thead>
+    <tr><th>Boot</th><th>Window</th><th>GuC</th><th>Kernel</th><th>Hard lockups</th><th>G2H timeouts</th><th>GT resets</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>−4</td><td>Jul 20 → Jul 27</td><td>70.45.2</td><td>6.17.0-<strong>40</strong></td><td style="color:var(--status-good)">0</td><td style="color:var(--status-good)">0</td><td style="color:var(--status-good)">0</td></tr>
+    <tr><td>−3</td><td>Jul 27 → Jul 29</td><td>70.45.2</td><td>6.17.0-41</td><td style="color:var(--status-good)">0</td><td style="color:var(--status-good)">0</td><td style="color:var(--status-good)">0</td></tr>
+    <tr><td>−2</td><td>Jul 29 → Jul 30</td><td>70.45.2</td><td>6.17.0-41</td><td style="color:var(--status-critical)">81</td><td style="color:var(--status-critical)">239</td><td style="color:var(--status-critical)">1011</td></tr>
+    <tr><td>−1</td><td>Jul 30 → Jul 31</td><td><strong>70.65.0</strong></td><td>6.17.0-41</td><td style="color:var(--status-critical)">398</td><td style="color:var(--status-critical)">1257</td><td style="color:var(--status-good)">0</td></tr>
+  </tbody>
+</table>
+
+<p>Two conclusions follow directly:</p>
+
+<ul>
+  <li><strong>Boot −3 was clean on the old firmware.</strong> Two days of runs on 70.45.2 with zero faults. The old firmware was never inherently broken, which retroactively invalidates the §1 diagnosis.</li>
+  <li><strong>The first fault in the machine's entire history is Jul 30 00:41:42</strong>, mid-way through boot −2 — still on 70.45.2. Something changed on Jul 29, not on Jul 30 when the firmware was swapped.</li>
+</ul>
+
+<h3>The signature moved — and it points away from compute</h3>
+
+<p>Run 10's lockups had <code>RIP: memcpy_fromio</code>. Run 11's are <em>all</em> <code>RIP: g2h_read</code>. More decisive: <strong>every one of the 2,524 driver errors is on GT1</strong>, and GT1 is not the compute tile.</p>
+
+<pre>$ ls /sys/class/drm/card0/device/tile0/gt*/engines/
+gt0/engines/:  bcs  ccs  rcs      <span style="color:var(--status-good)"># compute + render + copy — training runs here</span>
+gt1/engines/:  vcs  vecs          <span style="color:var(--status-critical)"># video decode + video enhance — ALL 2524 errors here</span>
+
+$ grep -c "GT0" gpu-fault-watch-490a12e3.log      <span style="color:var(--status-good)"># 0 on the training tile</span>
+$ grep -oE "action [0-9]+" gpu-fault-watch-490a12e3.log | sort -u
+action 3003                       <span style="color:var(--status-critical)"># GuC power-state query — 100% of failures</span></pre>
+
+<p>Every failure is the same single operation: <code>action 3003</code>, a GuC power-state query against the <strong>media</strong> tile, timing out. The training workload on GT0 never faulted. That is why the job kept reporting healthy steps — the compute path genuinely was healthy, while the kernel's interrupt handler burned CPU cores spinning on a media-tile GuC that had stopped answering.</p>
+
+<div class="card warn">
+  <p style="margin:0"><strong>Why this kills the run anyway.</strong> The lockups are in <code>xe_guc_irq_handler</code> → <code>xe_guc_ct_fast_path</code> → <code>g2h_read</code>, an interrupt path. 398 hard lockups plus 1,435 soft lockups starved <code>containerd</code>, <code>dockerd</code> and <code>rcu_exp_gp_kthr</code> of CPU (visible in the log by name). Training froze at step 1473 at 05:16 and the job was only declared dead at 17:45 when the backend shut down — the GPU was fine, the <em>host</em> was wedged.</p>
+</div>
+
+<h3>What changed on Jul 29 — leading candidate</h3>
+
+<p>The dataset grew that evening. <code>f6e480e2</code> went to 150 episodes, and <strong>30 of its 48 video files carry a Jul 29 mtime</strong> (the rest are Jul 24–25). The first-ever fault follows roughly two hours later, on the first long run over the enlarged set.</p>
+
+<table>
+  <thead><tr><th>Candidate</th><th>Evidence for</th><th>Evidence against</th><th>Verdict</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><strong>Media-tile GuC power management</strong> — decode of the new videos wakes GT1, and the GuC PC handshake on that tile is what breaks</td>
+      <td>100% of errors are <code>action 3003</code> on GT1; onset matches the 30 new Jul 29 videos; both firmware versions affected</td>
+      <td>lerobot's <code>torchcodec</code> path decodes on CPU, so the GT1 wake is not yet traced to a specific caller</td>
+      <td><span class="pill warn">LEADING</span></td>
+    </tr>
+    <tr>
+      <td><strong>Kernel 6.17.0-41 <code>xe</code> regression</strong></td>
+      <td>faults only ever occur on -41; boot −4 on -40 was clean</td>
+      <td>boot −3 was also -41 and completely clean for two days</td>
+      <td><span class="pill warn">CONTRIBUTING</span> — likely necessary, not sufficient</td>
+    </tr>
+    <tr>
+      <td><strong>Telemetry polling</strong> (Prometheus 5 s scrape of <code>xpumd</code>, which queries GPU power)</td>
+      <td>the failing op is a power query; 5 s scrape matches the dominant 1 s and 4 s inter-fault gaps</td>
+      <td>the stack has been up since Jul 21, including both clean boots; 36 min idle now with 0 faults</td>
+      <td><span class="pill warn">AMPLIFIER</span> — probably how the fault is <em>triggered</em>, not why it exists</td>
+    </tr>
+    <tr>
+      <td><strong>Firmware 70.45.2 being outdated</strong> — the original §1 diagnosis</td>
+      <td>none that survives boot −3</td>
+      <td>boot −3 clean on 70.45.2; faults 4.9× worse after upgrading</td>
+      <td><span class="pill crit">DISPROVEN</span></td>
+    </tr>
+    <tr>
+      <td><strong>Thermal / PCIe pressure</strong></td>
+      <td>—</td>
+      <td>0 AER errors, no throttle flags</td>
+      <td><span class="pill crit">RULED OUT</span></td>
+    </tr>
+    <tr>
+      <td><strong>CPU RAM exhaustion</strong></td>
+      <td>real, but a <em>separate</em> failure mode — see the correction below</td>
+      <td>boots −1 and −2 have <strong>0</strong> OOM kills; 38 GB swap free during Run 11</td>
+      <td><span class="pill crit">NOT the cause of the lockups</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>There are TWO failure modes, not one</h3>
+
+<p>An earlier draft of this addendum claimed &ldquo;zero OOM evidence anywhere.&rdquo; That was wrong — it checked only boots −1 and −2 and generalised. Boot −4 has <strong>30 OOM kills</strong>, and they explain a different set of runs entirely.</p>
+
+<table>
+  <thead>
+    <tr><th></th><th>Failure A — the final save</th><th>Failure B — the lockups</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><strong>Runs</strong></td><td><code>ec4c4cef</code> (2000), <code>9200784f</code> (5000)</td><td><code>8108c5ba</code> (1750), <code>490a12e3</code> (1473)</td></tr>
+    <tr><td><strong>Dies</strong></td><td>after training finishes, during save/export</td><td>mid-training</td></tr>
+    <tr><td><strong>Cause</strong></td><td><strong>CPU RAM exhaustion</strong> — 26.4 GB anon-rss, <code>Free swap = 52 kB</code></td><td>GPU interrupt lockups on GT1, <strong>0</strong> OOM</td></tr>
+    <tr><td><strong>Kernel</strong></td><td>6.17.0-40 (boot −4)</td><td>6.17.0-41 (boots −2, −1)</td></tr>
+    <tr><td><strong>Training steps</strong></td><td><strong>reached the full target</strong></td><td>died partway</td></tr>
+  </tbody>
+</table>
+
+<p>Both pre-Jul-29 runs <em>completed all their training steps</em> — 2000/2000 and 5000/5000 — and neither produced a model. <code>9200784f</code> hung at the 24.5 GB final save on Jul 26 19:26 and was OOM-killed 19 hours later; <code>ec4c4cef</code> died during OpenVINO export. So <strong>training has already reached 5000 steps on this box</strong>; what failed was writing the result.</p>
+
+<div class="card warn">
+  <p style="margin:0"><strong>Consequence for step counts.</strong> The apparent &ldquo;1000-step ceiling&rdquo; is an artefact. <code>ModelCheckpoint(every_n_train_steps=…, save_top_k=-1)</code> writes interval checkpoints <em>while training continues</em> — Run 11's step-1000 checkpoint landed at 02:38 and training ran on to 1473. Every surviving model is a 1000-step model only because 1000 was the first interval and every run died before the second. Set a high <code>max_steps</code>, take interval checkpoints, and <strong>stop manually before the final save</strong> — that avoids Failure A entirely. The interval is now <strong>5000</strong> (<code>local.py</code>), since 12 × 22.8 GB would need 274 GB of disk.</p>
+</div>
+
+<p>Also note <code>ec4c4cef</code> trained on a <strong>31-episode</strong> snapshot (17,536 frames), not 150 — which is why Lightning logged <code>epoch=1</code> at 2000 steps. It is not comparable to the recent runs.</p>
+
+<h3>Correction: the telemetry-polling theory is weak</h3>
+
+<p>The candidate table above rates Prometheus polling an &ldquo;AMPLIFIER.&rdquo; A direct check weakens even that. <strong>Boot −4 ran 34+ hours of training with the full monitoring stack up and logged 0 lockups and 0 G2H timeouts</strong> — including the 23-hour, 5000-step <code>9200784f</code>. Training plus 5 s power polling coexisted fine for a day and a half.</p>
+
+<p>Polling therefore cannot be the cause, and is unlikely to be sufficient as a trigger. It remains worth testing only because it is free. What the exports add: the <code>7c1f0a94</code> torch and OpenVINO exports (Jul 30 17:20/17:30) and today's <code>01a71dc5</code> torch export all produced <strong>0 faults</strong>, so faults appear <em>only</em> under training load, never under load-the-model-and-convert.</p>
+
+<h3>Correction: rollback deserves more weight than §9 first gave it</h3>
+
+<p>This addendum initially argued against rolling back because 81 lockups is still broken. That framing was wrong. 81 lockups let Run 10 reach step 1750; 398 lockups killed Run 11 at 1473. <strong>The old firmware was measurably less bad</strong>, and the upgrade cut time-to-first-fault from 1 h 32 m to 9 minutes.</p>
+
+<p>Ranked by evidence, the order to try is now:</p>
+
+<ol>
+  <li><strong>Kernel 6.17.0-40</strong> — still installed in <code>/boot</code>. The only configuration with a genuinely fault-free week, and the boot table implicates the -40 → -41 change.</li>
+  <li><strong>Firmware rollback to 70.45.2</strong> — blobs preserved at <code>/lib/firmware/xe.backup/</code>. Less bad, not fixed.</li>
+  <li><strong>Intel bug report</strong> — GT1 GuC stops answering <code>action 3003</code>; attach <code>gpu-fault-watch-490a12e3.log</code>.</li>
+  <li><strong>Stop telemetry</strong> — free, but the boot −4 evidence above argues it will not help.</li>
+</ol>
+
+<p>Still unexplained: <strong>what wakes GT1 at all.</strong> lerobot decodes video on the CPU via <code>torchcodec</code>, so the media tile should be idle during training. That gap is why the empirical tests above outrank further log analysis.</p>
+
+<h3>Corrections to earlier sections</h3>
+
+<ul>
+  <li><strong>§1</strong> — &ldquo;one firmware update plus a reboot cleared both&rdquo;: wrong for the lockups. The reboot cleared the allocator; nothing cleared the lockups.</li>
+  <li><strong>§2</strong> — the before/after table and the bar chart compare an idle boot against a loaded one. That is not a valid comparison, and it read as a fix when it was only an idle baseline. The §2 caveat &ldquo;idle only — not yet load-tested&rdquo; was the correct reading and should have blocked the headline claim.</li>
+  <li><strong>§6/§8</strong> — &ldquo;the blocker is cleared&rdquo; and &ldquo;known-good state&rdquo;: not true. The blocker is open and now better characterised.</li>
+  <li><strong>What held up</strong> — §5's allocator test, and the §6 instruction to run the kernel monitor. The monitor is the only reason Run 11 is diagnosable at all, and the checkpoint patch is the only reason it produced a usable model.</li>
+</ul>
+
+<h3>Salvage — Run 11 was not a total loss</h3>
+
+<p>The step-1000 checkpoint was written at 02:38, before the host wedged, and survived in <code>cache/</code> because <code>fit()</code> never returned to run the <code>shutil.move</code> at <code>local.py:107</code>. It verifies clean (zip valid, 3,241 entries, 24,483,521,640 bytes — byte-identical in size to known-good checkpoints) and is now registered as a model:</p>
+
+<pre>01a71dc5-0a45-4394-87cd-bf917e62fe1d
+  Pi0.5 Sorting 150eps step1000 fw70.65 (val 0.172)</pre>
+
+<p>Its val loss of <strong>0.1715</strong> is the worst of the three 1000-step runs on this dataset (<code>15842eae</code> 0.1187, <code>7c1f0a94</code> 0.1540), so it is a salvage artefact rather than a new best. <code>15842eae</code> remains the model to beat.</p>
+
+<h3>Next diagnostic step — cheap and decisive</h3>
+
+<p>The candidates above are separable by one test each, in this order:</p>
+
+<ol>
+  <li><strong>Stop the telemetry stack and relaunch</strong> (<code>docker stop intel-xpu-prometheus xpumd</code>). If a long run then survives, <code>action 3003</code> polling is the trigger and the fix is to stop scraping GPU power during training — a one-line change, no hardware needed.</li>
+  <li><strong>Boot kernel 6.17.0-40</strong> from the GRUB menu and repeat. -40 has the only fault-free week on record.</li>
+  <li><strong>If both fail</strong>, this is an Intel <code>xe</code>/GuC bug report on the media tile, with <code>gpu-fault-watch-490a12e3.log</code> attached — and the B70 machine becomes the practical path rather than an optimisation.</li>
+</ol>
+
+<p>Cap any run at <strong>1000 steps</strong> until one of these resolves. Run 11 proves 3000 is unreachable on this box today, and every model that has actually worked here was trained at 1000.</p>
+
+<hr>
+<p class="footnote">Addendum evidence: <code>journalctl -k</code> boots −4 through 0 (fault counts per boot) · <code>gpu-fault-watch-490a12e3.log</code> (10,229 lines, RIP and GT attribution, <code>action 3003</code>) · <code>/sys/class/drm/card0/device/tile0/gt*/engines/</code> (GT1 = <code>vcs</code>/<code>vecs</code>) · <code>490a12e3…log</code> job log (froze step 1473 at 05:16) · <code>metrics.csv</code> (val 0.1715 at step 1000) · dataset video mtimes · <code>prometheus-node.yml</code> (5 s scrape) · zip verification of the rescued checkpoint.</p>
+
+<hr>
+
+<h2 id="run12" style="margin-top:38px">10 · ADDENDUM 2026-08-02 — Run 12 breaks the GT1 theory</h2>
+
+<p class="muted">Appended 2026-08-02 · Run 12 <code>862b848f</code> · launched 2026-07-31 21:51 UTC, froze at step 1750/5000 on 2026-08-01 06:28 UTC · kernel monitor <code>gpu-fault-watch-862b848f.log</code> · full write-up <code>RUN12-FAILURE-862b848f.md</code></p>
+
+<div class="card" style="border-left:3px solid var(--status-critical)">
+  <p style="margin:0"><strong>§9's leading candidate does not explain Run 12.</strong> §9 concluded that &ldquo;every one of the 2,524 driver errors is on GT1&rdquo; and that <code>action 3003</code> was &ldquo;100% of failures&rdquo;. Run 12 wedged in the <em>same</em> interrupt path with <strong>zero GT1 mentions and zero <code>action 3003</code> events</strong> in its kernel journal. Either there are two distinct lockup mechanisms, or GT1 was always a symptom rather than the cause. The media-tile theory must be downgraded from LEADING.</p>
+</div>
+
+<div class="tiles">
+  <div class="tile">
+    <div class="label">Steps reached</div>
+    <div class="value" style="color:var(--status-critical)">1750<span style="font-size:16px;color:var(--text-muted)">/5000</span></div>
+    <div class="note">35% · froze 06:28, never resumed</div>
+  </div>
+  <div class="tile">
+    <div class="label">Ran clean before freezing</div>
+    <div class="value">8<span style="font-size:16px;color:var(--text-muted)">h 36m</span></div>
+    <div class="note">Run 11 faulted in <strong>9 min</strong> · first fault = the freeze here</div>
+  </div>
+  <div class="tile">
+    <div class="label">GT1 driver errors</div>
+    <div class="value" style="color:var(--status-warning)">0</div>
+    <div class="note">was 4193 in Run 11 · <span class="pill warn">theory broken</span></div>
+  </div>
+  <div class="tile">
+    <div class="label"><code>action 3003</code></div>
+    <div class="value" style="color:var(--status-warning)">0</div>
+    <div class="note">was 1699 · the 2 in the watch log are <strong>3 h after</strong> the freeze, marked <code>done</code></div>
+  </div>
+  <div class="tile">
+    <div class="label">Hard CPU lockups</div>
+    <div class="value" style="color:var(--status-critical)">721</div>
+    <div class="note">was 398 · all on <strong>CPU 4 alone</strong></div>
+  </div>
+  <div class="tile">
+    <div class="label">Hung undetected</div>
+    <div class="value" style="color:var(--status-critical)">42<span style="font-size:16px;color:var(--text-muted)"> h</span></div>
+    <div class="note">no error, no exception — log simply stops</div>
+  </div>
+</div>
+
+<h3>The signature moved again</h3>
+
+<p>Counted independently in the watch log and in <code>journalctl -k</code> for boot −1. The <code>GT1: 0</code> result is confirmed in both.</p>
+
+<table>
+  <tr><th>Marker</th><th>Run 11 <code>490a12e3</code></th><th>Run 12 <code>862b848f</code></th><th>Run 12 journal</th></tr>
+  <tr><td>Hard lockups</td><td class="num">398</td><td class="num">1030</td><td class="num">721</td></tr>
+  <tr><td>Soft lockups</td><td class="num">1435</td><td class="num">0 <span class="muted">(watch script gap)</span></td><td class="num">3520</td></tr>
+  <tr><td><code>GT1</code> mentions</td><td class="num"><strong>4193</strong></td><td class="num"><strong>0</strong></td><td class="num"><strong>0</strong></td></tr>
+  <tr><td><code>GT0</code> mentions</td><td class="num">20</td><td class="num">2</td><td class="num">0</td></tr>
+  <tr><td><code>action 3003</code></td><td class="num"><strong>1699</strong></td><td class="num">2 <span class="muted">(post-freeze)</span></td><td class="num"><strong>0</strong></td></tr>
+  <tr><td><code>G2H</code> lines</td><td class="num">1257</td><td class="num">2</td><td class="num">0</td></tr>
+</table>
+
+<p>Run 12 also shows <strong>both</strong> prior RIP signatures simultaneously — <code>memcpy_fromio</code> (Run 10's) and <code>g2h_read</code> (Run 11's). §9 treated those as distinguishing the two runs; they are not distinguishing.</p>
+
+<pre>1831  smp_call_function_single      &lt;- other cores piling up behind CPU4 (collateral)
+1328  smp_call_function_many_cond   &lt;- same
+1132  cpuidle_enter_state           &lt;- CPU4 was ASLEEP when the IRQ landed
+1100  memcpy_fromio                 &lt;- the MMIO read that never returns
+  60  g2h_read</pre>
+
+<h3>New leading candidate — deep CPU C-states race the GPU interrupt</h3>
+
+<p>Not considered in §9. The wedge is unchanged — a core stuck in the GuC message-ring read inside the interrupt handler, interrupts disabled, unable to yield — but the trace shows <em>what the core was doing when the interrupt arrived</em>:</p>
+
+<pre>RIP: 0010:g2h_read+0xb1/0x420 [xe]
+ &lt;IRQ&gt;  xe_guc_ct_fast_path ← xe_guc_irq_handler ← gt_irq_handler ← dg1_irq_handler
+ &lt;/IRQ&gt;
+ &lt;TASK&gt;
+ RIP: 0010:cpuidle_enter_state+0xca/0x6e0     &lt;- CPU4 was ASLEEP
+ cpuidle_enter → call_cpuidle
+ Comm: swapper/4                               &lt;- the idle task</pre>
+
+<p>All 721 lockups are on <strong>CPU 4 only</strong> — the single core servicing that GPU IRQ. The idle configuration leaves a wide race window:</p>
+
+<pre>C3_ACPI   latency=1048us   usage=9,139,916    &lt;- 1 ms exit latency, heavily used
+intel_idle.max_cstate = 9                     &lt;- unclamped
+pcie_aspm.policy = default                    &lt;- not "performance"</pre>
+
+<div class="card warn">
+  <p style="margin:0">This is <strong>circumstantial, not proven</strong>. One-core concentration plus <code>cpuidle_enter_state</code> in the trace plus a 1 ms wake latency inside an MMIO read is a plausible race, but the deeper defect is that the driver has <em>no timeout</em> on that mailbox read. Clamping C-states may only make the wedge rarer, not absent.</p>
+</div>
+
+<h3>Cross-run table — extends §9's per-boot counts</h3>
+
+<table>
+  <tr><th>Boot</th><th>Window</th><th>GuC</th><th>Kernel</th><th>Hard</th><th>Soft</th><th>GT1 errs</th><th>Run</th><th>Died at</th></tr>
+  <tr><td>−4</td><td>Jul 20→27</td><td>70.45.2</td><td>-40</td><td class="num">0</td><td class="num">0</td><td class="num">0</td><td>—</td><td>30 OOM kills (Failure A)</td></tr>
+  <tr><td>−3</td><td>Jul 27→29</td><td>70.45.2</td><td>-41</td><td class="num">0</td><td class="num">0</td><td class="num">0</td><td>—</td><td>clean</td></tr>
+  <tr><td>−2</td><td>Jul 29→30</td><td>70.45.2</td><td>-41</td><td class="num">81</td><td class="num">480</td><td class="num">239</td><td>10 <code>8108c5ba</code></td><td>step <strong>1750</strong>/2000</td></tr>
+  <tr><td>−1</td><td>Jul 30→31</td><td>70.65.0</td><td>-41</td><td class="num">398</td><td class="num">1435</td><td class="num">4193</td><td>11 <code>490a12e3</code></td><td>step 1473/3000</td></tr>
+  <tr><td>−1</td><td>Jul 31→Aug 2</td><td>70.65.0</td><td>-41</td><td class="num"><strong>721</strong></td><td class="num"><strong>3520</strong></td><td class="num"><strong>0</strong></td><td>12 <code>862b848f</code></td><td>step <strong>1750</strong>/5000</td></tr>
+</table>
+
+<p>Runs 11 and 12 share boot −1 (Jul 31 10:44 → Aug 2 17:34). <strong>Runs 10 and 12 both died at step 1750</strong> — different firmware, different <code>max_steps</code> (2000 vs 5000), same step. Run 11 died at 1473. Two of three at exactly 1750 is worth chasing, but it is <em>not</em> yet a proven pattern: 1750 is also simply where a ~8.5 h run lands on this box.</p>
+
+<h3>Ruled out for Run 12</h3>
+
+<table>
+  <tr><th>Suspect</th><th>Evidence against</th><th>Verdict</th></tr>
+  <tr><td>Firmware age</td><td>Already disproven in §9. Run 12 on 70.65.0 is worse still; model <code>01a71dc5</code> trained fine on the same firmware</td><td><span class="pill crit">DISPROVEN</span></td></tr>
+  <tr><td>GT1 / media tile / <code>action 3003</code></td><td>0 GT1 mentions and 0 <code>action 3003</code> in Run 12's journal</td><td><span class="pill warn">WEAKENED</span></td></tr>
+  <tr><td>Kernel too old</td><td>6.17.0-41 <em>is</em> the apt candidate — nothing newer to install. §9 already had it as necessary-not-sufficient (boot −3 clean on -41)</td><td><span class="pill warn">CONTRIBUTING</span></td></tr>
+  <tr><td>ReBAR misconfigured</td><td>B70 BAR = 32 GB, B50 = 16 GB — both correct</td><td><span class="pill crit">RULED OUT</span></td></tr>
+  <tr><td>System RAM / OOM</td><td>Zero OOM in boot −1; died at 35%, nowhere near the final save. This is Failure B, not A</td><td><span class="pill crit">RULED OUT</span></td></tr>
+  <tr><td>NaN divergence</td><td><code>gradient_clip_val=1.0</code> held — loss 0.0657 at the last step</td><td><span class="pill crit">RULED OUT</span></td></tr>
+  <tr><td>The B50 card</td><td>Idle. <code>device: null</code> → <code>xpu:0</code> → torch enumerates 0 as the <strong>B70</strong></td><td><span class="pill crit">RULED OUT</span></td></tr>
+</table>
+
+<h3>Which card wedged is still unproven</h3>
+
+<p>Boot −1's journal contains <strong>zero</strong> <code>[drm]</code> or <code>xe 0000:..</code> lines, so nothing ties the stuck handler to a PCI address. Current mapping floats — affinity is <code>0-15</code> on both:</p>
+
+<pre>IRQ 179 -> 0000:03:00.0  (B70, the training GPU)  currently CPU 8
+IRQ 184 -> 0000:07:00.0  (B50, idle)              currently CPU 6</pre>
+
+<p>Every lockup was on CPU 4 — neither of today's assignments. <strong>Watch-script gap:</strong> it grepped only lockup/tainted lines, dropping all drm/xe attribution and missing 3520 soft lockups. Next run must use:</p>
+
+<pre>journalctl -kf | grep -iE "xe |drm|guc|reset|lockup|GT[01]"</pre>
+
+<h3>Salvage — one checkpoint, rescued and exported</h3>
+
+<p>Steps 1000–1750 are gone. The step-1000 checkpoint was verified intact by loading it (<code>zip ok: True</code>, <code>global_step: 1000</code>, 819 tensors), then registered by hand and exported to the torch backend. The DB was backed up to <code>physicalai.db.bak-before-1d1670fe</code> first, and the model is confirmed live at <code>localhost:7860/api/projects/…/models</code>.</p>
+
+<table>
+  <tr><th>Model</th><th>Eps</th><th>global_step</th><th>val/loss</th><th>Backends</th></tr>
+  <tr><td><code>15842eae</code></td><td class="num">91</td><td class="num">1001</td><td class="num"><strong>0.1187</strong> BEST</td><td>openvino, torch</td></tr>
+  <tr><td><code>1d1670fe</code> <strong>(Run 12, rescued)</strong></td><td class="num">150</td><td class="num">1000</td><td class="num"><strong>0.1484</strong></td><td>torch</td></tr>
+  <tr><td><code>7c1f0a94</code></td><td class="num">150</td><td class="num">1000</td><td class="num">0.1540</td><td>openvino, torch</td></tr>
+  <tr><td><code>01a71dc5</code></td><td class="num">150</td><td class="num">1000</td><td class="num">0.1720</td><td>torch</td></tr>
+  <tr><td><code>c5d4500a</code></td><td class="num">40</td><td class="num">3676</td><td class="num">0.1917</td><td>openvino, torch</td></tr>
+</table>
+
+<p>Run 12 gained <strong>nothing</strong> on val loss — 91 episodes still beats 150. Note that registry names misstate step counts: <code>7c1f0a94</code> is named &ldquo;step1000&rdquo; but its metrics run to step 1749; the <em>checkpoint</em> is at 1000 and metrics kept logging past it. Same for <code>01a71dc5</code> (metrics to 1449).</p>
+
+<h3>Fixes — ranked, none applied yet</h3>
+
+<p>All require <code>sudo</code> from a real terminal. Item 1 needs a reboot and was deliberately <strong>not</strong> run unattended.</p>
+
+<ol>
+  <li><strong>Clamp C-states + ASPM</strong> — new, highest value, needs reboot. Costs idle power and heat; fully reversible.
+  <pre>sudo sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash intel_idle.max_cstate=1 processor.max_cstate=1 pcie_aspm.policy=performance/' /etc/default/grub
+sudo update-grub &amp;&amp; sudo reboot</pre></li>
+  <li><strong>Pin GPU IRQs off CPU 0/4</strong> — no reboot, damage limitation only. Will not stop the wedge, but keeps a stuck core from starving <code>rcu</code>/<code>dockerd</code> — the same starvation §9 recorded, and what made the box unusable for 42 h.
+  <pre>echo 2 | sudo tee /proc/irq/179/smp_affinity_list   # B70 -> CPU2
+echo 3 | sudo tee /proc/irq/184/smp_affinity_list   # B50 -> CPU3</pre></li>
+  <li><strong>Shorten the engine job timeout</strong> — free, low expected value. <code>job_timeout_ms</code> is already 5000 (max 10000) at <code>/sys/class/drm/card1/device/tile0/gt0/engines/rcs/</code> and it did <em>not</em> save this run: the wedge is in the IRQ handler, which never yields to let a timeout fire.</li>
+  <li><strong>Checkpoint every 250 steps + a progress watchdog</strong> — not a fix, but the only thing that makes a long run survivable. <code>val_check_interval=1000</code> (<code>local.py:106</code>) meant a wedge at 1750 cost 750 steps; at 250 it costs ≤250. Add a watchdog that kills the job when no <code>Training progress</code> line has appeared for ~10 min — Run 12 hung silently for <strong>42 hours</strong>. Remember the baked-source gotcha: <code>docker cp</code> to <strong>both</strong> container paths.</li>
+</ol>
+
+<div class="card warn">
+  <p style="margin:0"><strong>There is no true resume.</strong> <code>base_model</code> loads weights only (<code>local.py:58-59</code>) — no optimizer or LR-scheduler state. Restarting from a rescued checkpoint is <em>not</em> equivalent to continuing a run, so plan long runs around checkpoint frequency rather than around resuming.</p>
+</div>
+
+<p>§9's advice to <strong>cap runs at 1000 steps</strong> stands and is reinforced: Run 12 attempted 5000 and reached 1750. Every model that has actually worked on this box was trained at 1000.</p>
+
+<h3>Open questions for the next session</h3>
+
+<ol>
+  <li><strong>Why did GT1 vanish?</strong> Highest value. §9's leading theory rests on GT1 and <code>action 3003</code>; Run 12 has neither. Two mechanisms, or was GT1 always a symptom?</li>
+  <li><strong>Why step 1750 twice</strong> (Runs 10 and 12, different firmware)? Test with <code>val_check_interval=250</code> — if it still dies at 1750 the trigger is step-linked; if it dies elsewhere it is time-linked (~8.5 h).</li>
+  <li>Does the C-state clamp actually help, or only delay?</li>
+  <li>Which card's IRQ wedges? Needs the corrected watch command above.</li>
+  <li>Does <code>15842eae</code> (0.1187, 91 eps) beat <code>1d1670fe</code> (0.1484, 150 eps) on the <strong>real arm</strong>? More episodes keep losing on val loss — it is worth establishing whether val loss predicts arm performance here at all.</li>
+</ol>
+
+<h3>Side observations</h3>
+
+<ul>
+  <li><strong>The RAM leak recurred</strong> (§9's Failure A, mid-session): 29/30 GB used, 20 GB swapped, 1.2 GB available, with one idle python process holding 26.4 GB. A <code>docker restart</code> reclaimed 18 GB. Do this before loading any model.</li>
+  <li>The 24.5 GB checkpoint copy pushed IO pressure to 65% (<code>full avg10=63.20</code>), load average 13.55, and swap back to 20 GB — expected and transient, but it makes the whole box feel dead while it runs.</li>
+  <li>Disk: 153 GB free of 915 GB (83% used). <code>models/</code> is 144 GB, <code>cache/</code> 23 GB.</li>
+</ul>
+
+<hr>
+<p class="footnote">Run 12 evidence: <code>journalctl -k -b -1</code> (721 hard / 3520 soft lockups, RIP distribution, 0 GT1, 0 <code>action 3003</code>) · <code>gpu-fault-watch-862b848f.log</code> · job log <code>862b848f…log</code> (last step 1750 at 06:28:00 UTC, validation <code>val/loss=0.14838</code> at step 1000) · <code>app.log</code> (last <code>JOB_UPDATE</code> 06:28:51) · <code>jobs</code> table row (status <code>failed</code>, progress 35, &ldquo;aborted due to application shutdown&rdquo;) · <code>torch.load</code> verification of <code>stepstep=001000.ckpt</code> · <code>torch.xpu.get_device_properties</code> (device 0 = B70 34.2 GB, device 1 = B50 17.1 GB) · <code>/sys/devices/system/cpu/cpu4/cpuidle/state*/</code> · <code>/proc/interrupts</code> · <code>/proc/cmdline</code> · <code>lspci -v</code> BAR sizes · <code>/proc/pressure/io</code>. Full write-up: <code>RUN12-FAILURE-862b848f.md</code>.</p>
+
+<hr>
+<p class="footnote">Evidence: <code>journalctl -k</code> boots −1 and 0 · <code>/lib/firmware/xe/</code> and <code>xe.backup/</code> listings · <code>xpu-smi stats -d 0</code> · staged allocator test in-container on torch 2.10.0+xpu · <code>docker exec</code> grep of the site-packages backend · <code>physicalai.db</code> model table. Prior analysis: <code>training-report-2026-07-30.html</code>. Resume notes: <code>RESUME-HERE-2026-07-30.md</code>.</p>
+
+</div>
+<div class="tt" id="tt"></div>
+<script>
+const NS = 'http://www.w3.org/2000/svg';
+function el(t, a) { const n = document.createElementNS(NS, t); for (const k in a) n.setAttribute(k, a[k]); return n; }
+function css(v) { return getComputedStyle(document.querySelector('.viz-root')).getPropertyValue(v).trim(); }
+
+const tt = document.getElementById('tt');
+function showTT(e, html) { tt.innerHTML = html; tt.style.opacity = 1; tt.style.left = Math.min(e.clientX + 14, innerWidth - 275) + 'px'; tt.style.top = (e.clientY + 16) + 'px'; }
+function hideTT() { tt.style.opacity = 0; }
+
+const FAULTS = [
+  { name: 'Soft lockups',   before: 480, after: 0, what: 'BUG: soft lockup — CPU stalled in the GPU interrupt path' },
+  { name: 'Driver resets',  before: 340, after: 0, what: 'xe driver reset attempts; approximate, from the reset storm' },
+  { name: 'G2H timeouts',   before: 239, after: 0, what: 'Timed out wait for G2H — GuC stopped acknowledging commands' },
+  { name: 'Hard lockups',   before:  81, after: 0, what: 'Hard CPU lockup — unrecoverable stall in memcpy_fromio' },
+];
+
+function drawFaults() {
+  const svg = document.getElementById('faultChart');
+  svg.innerHTML = '';
+  const m = { t: 14, r: 150, b: 34, l: 122 }, W = 900, H = 260;
+  const iw = W - m.l - m.r, ih = H - m.t - m.b;
+  const max = 500;
+  const cBefore = css('--series-before'), cAfter = css('--series-after');
+  const band = ih / FAULTS.length;
+  const barH = 15;
+
+  [0, 100, 200, 300, 400, 500].forEach(v => {
+    const x = m.l + (v / max) * iw;
+    svg.appendChild(el('line', { x1: x, y1: m.t, x2: x, y2: m.t + ih, stroke: css('--grid'), 'stroke-width': 1 }));
+    const t = el('text', { x, y: m.t + ih + 20, fill: css('--text-muted'), 'font-size': 11.5, 'text-anchor': 'middle' });
+    t.textContent = v; svg.appendChild(t);
+  });
+
+  FAULTS.forEach((f, i) => {
+    const cy = m.t + i * band + band / 2;
+
+    const lab = el('text', { x: m.l - 12, y: cy + 4, fill: css('--text-primary'), 'font-size': 13, 'text-anchor': 'end', 'font-weight': 550 });
+    lab.textContent = f.name; svg.appendChild(lab);
+
+    const wB = Math.max((f.before / max) * iw, 2);
+    const rB = el('rect', { x: m.l, y: cy - barH - 2, width: wB, height: barH, fill: cBefore, rx: 3, style: 'cursor:pointer' });
+    rB.addEventListener('mousemove', e => showTT(e, `<b>${f.name} — before</b><div class="tt-row"><i class="swatch" style="background:${cBefore}"></i>${f.before} on GuC 70.45.2</div><div class="tt-row" style="font-size:11.5px">${f.what}</div>`));
+    rB.addEventListener('mouseleave', hideTT);
+    svg.appendChild(rB);
+
+    const vB = el('text', { x: m.l + wB + 8, y: cy - barH / 2 + 2, fill: css('--text-primary'), 'font-size': 12.5, 'font-weight': 650 });
+    vB.textContent = f.before + (f.name === 'Driver resets' ? '  ~' : ''); svg.appendChild(vB);
+
+    const rA = el('rect', { x: m.l, y: cy + 2, width: 3, height: barH, fill: cAfter, rx: 1.5, style: 'cursor:pointer' });
+    rA.addEventListener('mousemove', e => showTT(e, `<b>${f.name} — after</b><div class="tt-row"><i class="swatch" style="background:${cAfter}"></i>0 on GuC 70.65.0</div><div class="tt-row" style="font-size:11.5px">Idle only — not yet load-tested.</div>`));
+    rA.addEventListener('mouseleave', hideTT);
+    svg.appendChild(rA);
+
+    const vA = el('text', { x: m.l + 14, y: cy + barH - 2, fill: cAfter, 'font-size': 12.5, 'font-weight': 650 });
+    vA.textContent = '0'; svg.appendChild(vA);
+  });
+
+  const cap = el('text', { x: m.l + iw / 2, y: H - 4, fill: css('--text-muted'), 'font-size': 11.5, 'text-anchor': 'middle' });
+  cap.textContent = 'occurrences in kernel journal, per boot';
+  svg.appendChild(cap);
+}
+
+drawFaults();
+
+document.getElementById('themeBtn').addEventListener('click', () => {
+  const cur = document.documentElement.getAttribute('data-theme');
+  const isDark = cur === 'dark' || (!cur && matchMedia('(prefers-color-scheme: dark)').matches);
+  document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+  drawFaults();
+});
+matchMedia('(prefers-color-scheme: dark)').addEventListener('change', drawFaults);
+</script>
+</body>
+</html>

--- a/reports/success-rate-log.txt
+++ b/reports/success-rate-log.txt
@@ -1,0 +1,321 @@
+============================================================
+SUCCESS RATE LOG — COLOR SORTING
+============================================================
+Model:   15842eae  (Pi0.5, 91 eps, 1001 steps, val 0.1187)
+Date:    2026-07-29
+Backend: PyTorch on XPU (Device 0)
+Prompt:  "Sort this item into the correct bin"
+
+SETUP STATE THIS SESSION
+  base clamp     re-tightened, hardware reported FIXED   [x]
+  wrist camera   re-secured, hardware reported FIXED     [x]
+  bins + mat     secured                                 [x]
+
+  NOTE: the base clamp AND wrist camera both moved earlier today
+  and were fixed before this round. Geometry now differs slightly
+  from what this model trained on, so a consistent offset below is
+  expected to be setup drift, not a model defect.
+
+BEFORE LOADING
+  docker restart physical-ai-studio-xpu && sleep 20
+  xpu-smi stats -d 0 | grep -i "Memory Used"    # want ~34 MiB
+  pkill firefox                                 # holds renderD128
+  Click Load EXACTLY ONCE, wait 2-3 min. Never re-click.
+  Do ALL trials below in ONE load session — each unload leaks ~9 GB.
+
+============================================================
+COLUMN MEANINGS
+============================================================
+  POS      block start position
+             C = center      L = left        R = right
+             FL/FR/BL/BR = front/back left/right
+  PICK     did it grasp and lift the block?               Y/N
+  BIN      did it go to the CORRECT bin for that color?   Y/N/-
+  LAND     where the block ended up
+             IN   = inside bin
+             EDGE = on the rim / edge
+             OUT  = outside bin entirely
+             DROP = released early, never reached bin
+  HIT      did the arm contact the bin?                   Y/N
+           (if Y, stop and check rim clearance vs carry height)
+
+============================================================
+TRIALS
+============================================================
+
+ROUND 1 — 10 scenarios, 2026-07-29, after hardware fix
+Recorded as a summary rather than per-trial (tested at pace).
+
+ # | NOTES
+---+--------------------------------------------------------
+   | SINGLE BLOCK (majority of the 10 trials)
+   |   PICK      mostly SUCCEEDS — grasping is not the problem
+   |   LAND      MISSES the bin, both left and right
+   |   FAILURE   releases the block BEFORE reaching bin center
+   |
+   | TWO BLOCKS PRESENT (distractor in frame)
+   |   Noticeably BETTER than the single-block case
+   |
+   | Tester note: earlier today the wrist camera and base clamp
+   | had both moved; both fixed before this round.
+
+TALLY (round 1, approximate)
+  Pick success        MOSTLY YES  (~8-9/10 by observation)
+  Landed IN bin       LOW — misses on both left and right
+  Dominant failure    EARLY RELEASE, short of bin center
+
+============================================================
+ROUND 2 — model 7c1f0a94, 2026-07-30, AFTER firmware fix
+============================================================
+Model:   7c1f0a94 (Pi0.5, 150 eps, step-1000 ckpt, val 0.1540)
+         Recovered from the failed Run 10. Includes the 59 new
+         episodes recorded to fix the early-release failure.
+Host:    GuC firmware 70.65.0 (was 70.45.2). Card clean at load.
+Backend: PyTorch on XPU (Device 0)
+
+TEST STRUCTURE — 5 scenarios by block count: 4, 3, 3, 1
+  All 5 scenarios PASSED at the scenario level (the arm picked and
+  sorted). Per-block, the picture is more mixed — see below.
+
+ SCENARIO        | BLOCKS | SORTED CORRECTLY | NOTE
+ ----------------+--------+------------------+---------------------
+ 4-block         |   4    |  3 of 4          | last block NOT sorted
+ 3-block (a)     |   3    |  2 of 3          | last block NOT sorted
+ 3-block (b)     |   3    |  2 of 3          | last block NOT sorted
+ 1-block         |   1    |  1 of 1  PASSED  | bare block, no problem
+
+BEHAVIOURAL OBSERVATIONS (PyTorch) — hesitation, but self-correcting
+  - Sometimes takes noticeably LONGER to pick a block, even an easy
+    one in a clear position. Not a failure, just slow.
+  - Sometimes HOVERS over the correct bin twice, then places the
+    block in the correct bin on the final pass.
+
+  Read this as LOW ACTION CONFIDENCE, not a wrong policy. It picks
+  the right bin — it just needs more than one attempt to commit.
+  Pi0.5 emits action CHUNKS; hovering twice looks like consecutive
+  chunks each ending short of the release condition, so the policy
+  re-plans and approaches again. Encouragingly, it does eventually
+  release in the right place: the bin CHOICE (colour conditioning)
+  is solid, and the release-position fix from the 59 new episodes
+  is holding. What is soft is the commit/termination timing.
+  More demonstrations with a crisp, decisive release would sharpen
+  this; it is not a correctness bug.
+
+============================================================
+HARDWARE FAULT — WRIST CAMERA SCREWS LOOSEN ON BIN CONTACT
+============================================================
+Whenever the wrist camera HITS THE BIN, its mounting screws work
+loose and have to be re-tightened by hand. Observed repeatedly
+during Round 2.
+
+THIS CONTAMINATES EVERY MEASUREMENT AND MUST BE FIXED FIRST.
+
+Why it is worse than an inconvenience:
+  - The wrist camera is a POLICY INPUT. If it shifts mid-session,
+    the observation the policy receives no longer matches what it
+    trained on. Accuracy then drifts DURING a test round, so
+    later trials are not comparable to earlier ones.
+  - It moves GRADUALLY. Between "tight" and "obviously loose"
+    there is a window where the camera is subtly off and nothing
+    looks wrong — that silently degrades results and invents
+    failures that are not the model's fault.
+  - It already bit us once: the 2026-07-29 log records the wrist
+    camera and base clamp having moved, forcing a re-fix before
+    Round 1. Same fault, recurring.
+  - It makes the 59 new episodes suspect. If the camera shifted
+    while they were being RECORDED, some of that data was captured
+    with a different camera pose than the rest.
+
+SO: some of Round 2's "last block failed" cases may be nothing but
+a loosened camera by the end of a long multi-block run. That fits
+the evidence uncomfortably well — the failure appears at the END of
+long scenes, and bin contact accumulates over a scene. A drifting
+camera and "cumulative state drift" predict the SAME pattern.
+Round 2's per-block numbers should be treated as a LOWER BOUND on
+the model's real ability until the mount is solid.
+
+FIX THE MOUNT BEFORE ANY MORE TESTING OR RECORDING:
+  - Threadlocker on the camera screws (medium/blue, removable —
+    NOT permanent red). This is the actual fix for vibration
+    loosening.
+  - Nylon-insert lock nuts or lock/spring washers if the mount
+    accepts them.
+  - Re-tighten, then photograph the mount so drift is detectable
+    later (local-changes/setup-capture-guide.md; pictures/ now has
+    baseline frames).
+  - THEN address the root cause: the arm should not be hitting the
+    bin at all. Bin contact is also what loosens the mount, so
+    stopping the collision fixes both problems. Either lower the
+    bins, move them further out, or record episodes with a higher
+    carry path. The trial log's HIT column exists for this.
+
+RECOMMENDATION: re-run a short PyTorch round with FRESHLY TIGHTENED
+screws and check whether the last-block failure survives. If it
+disappears, the "cumulative drift" hypothesis above was really this
+hardware fault all along.
+
+============================================================
+OPENVINO ROUND — FAILED OUTRIGHT, do not use this export
+============================================================
+Same model 7c1f0a94, OpenVINO backend: THE ARM CANNOT PICK AT ALL.
+It fails at the very first stage — it does not even get the head /
+gripper to the block. This is not a degraded version of the PyTorch
+behaviour, it is a different and much worse failure.
+
+VERDICT: the OpenVINO export is NOT numerically equivalent to the
+torch export. The same weights work in PyTorch, so the checkpoint
+is fine — the conversion is what is broken. Treat the OpenVINO
+artifact as unusable until it passes a parity check.
+
+Do NOT read this as "the model got worse". Round 2 PyTorch (73%
+per-block, right bins) is the real capability of 7c1f0a94.
+
+TALLY
+  Scenario-level pass     5 / 5   (PyTorch)
+  Per-block success       8 of 11  = 73%   (PyTorch)
+  OpenVINO                0 — cannot pick; export defect
+  Dominant failure        EXACTLY ONE failure per multi-block scene,
+                          and it is always THE LAST BLOCK.
+
+  Note the shape of this: 4->3, 3->2, 3->2. Every multi-block scene
+  loses precisely one block, never two. The failure count does not
+  scale with the number of blocks — it is tied to the END of the
+  sequence, not to a per-block error rate. A 73% average understates
+  what is happening: blocks 1..n-1 are near 100%, block n is near 0%.
+
+============================================================
+READING OF ROUND 2 — the failure mode MOVED
+============================================================
+THE EARLY-RELEASE PROBLEM IS FIXED. Round 1's dominant failure
+("releases the block BEFORE reaching bin center", missing on both
+sides) is NOT the failure now. The 59 new episodes did their job.
+
+THE NEW FAILURE IS POSITIONAL IN THE SEQUENCE, NOT SPATIAL:
+the arm sorts the first blocks correctly and then fails on the
+LAST remaining block. That is a different class of problem — it
+correlates with how many blocks are left on the mat, not with
+where they are or what colour they are.
+
+RULED OUT IMMEDIATELY — "bare mat is out-of-distribution".
+The obvious guess is that one-block-left looks like an empty mat,
+which the distractor-rich training data never showed. THE 1-BLOCK
+SCENARIO DISPROVES THIS: a single bare block, presented on its own,
+sorted successfully. Bare-single-block is fine. So being the only
+block is not what breaks it.
+
+(This also revises Round 1's distractor hypothesis, which was
+explicitly flagged as unconfirmed. A fresh single block works.)
+
+WHAT ACTUALLY DIFFERS about the last block: it is not the block
+that changed, it is EVERYTHING ELSE.
+  - The bins are no longer empty. By the final block, both bins
+    contain blocks the arm put there. The scene the policy sees is
+    visually different from any training frame if the training
+    episodes started with empty bins.
+  - The run is LONG by then. A 4-block scene is roughly 4x the
+    duration of a single pick-place. If the 150 training episodes
+    are one-block-each, then by block 4 the policy is operating
+    well beyond the time horizon it ever saw.
+
+LEADING HYPOTHESIS — EPISODE-LENGTH / CUMULATIVE-STATE DRIFT, not
+perception of the block itself. Consistent with all five scenarios:
+a fresh 1-block run is short and starts from a clean state, so it
+works; the tail of a multi-block run is long and starts from an
+accumulated state, so it fails. The failure tracks ELAPSED SEQUENCE,
+which is why it is exactly one per scene regardless of block count.
+
+CRITICAL AMBIGUITY TO RESOLVE FIRST — one question decides
+everything, and it is a 2-minute test:
+
+  Present the FAILED last block as a FRESH single block.
+  (Clear the mat, reset, place just that block, run.)
+
+    If it now SORTS      -> the block and its colour are fine.
+                            The problem is accumulated state /
+                            run length. Fix = record multi-block
+                            episodes that run the mat down to empty
+                            in ONE episode, with bins already
+                            partly filled.
+
+    If it still FAILS    -> the problem is that specific block or
+                            its colour/position, and "last" was a
+                            coincidence of ordering. Fix = balanced
+                            colour->bin episodes for that colour.
+
+ALSO CHEAP AND WORTH KNOWING:
+  - Does the last block fail to be PICKED, or picked and then
+    mis-binned / dropped? Round 1 split pick from place cleanly;
+    do the same here. Perception vs placement.
+  - Is it the same COLOUR failing each time, or genuinely whichever
+    block happens to be left? Vary which colour remains last.
+  - Try emptying the bins between blocks. If that rescues the last
+    block, the non-empty-bin appearance is the cause and the fix is
+    to record episodes with pre-filled bins.
+
+============================================================
+READING OF ROUND 1
+============================================================
+PICK WORKS, PLACE DOES NOT. That splits the problem cleanly:
+perception and grasping are fine; the release TIMING is wrong.
+
+"Drops before locating bin center" is a TRAJECTORY-LENGTH problem,
+not a color or reach problem. The policy is ending its place
+motion too early — the learned motion terminates short of the
+actual bin center. Misses on BOTH bins rules out a one-sided
+geometry offset.
+
+WHY TWO BLOCKS DID BETTER — hypothesis, not confirmed:
+  The 91 training episodes were recorded WITH distractor blocks
+  present (per sorting-episodes-detailed.txt: "Place 1-2
+  DISTRACTOR blocks nearby"). A single bare block is therefore
+  OUT OF DISTRIBUTION — the model never saw an empty table.
+  This is a strong, actionable finding: it means the demo should
+  always include a distractor, and new episodes should cover BOTH
+  cases.
+
+=> FIX IS IN THE DEMONSTRATIONS, not in more training steps:
+   record place motions that travel FULLY to bin center, hold a
+   visible pause there, and only then release.
+
+============================================================
+WHAT THE PATTERN MEANS -> WHAT TO RECORD
+============================================================
+  Fails mostly on RIGHT positions
+    -> record more right-side reaches
+  Lands EDGE consistently
+    -> record exaggerated moves to bin CENTER, pause, then release
+  Goes to the same bin regardless of color
+    -> color conditioning weak; record balanced color->bin
+       examples in both directions
+  Random failures across all positions
+    -> suspect wrist camera or lighting, NOT the dataset
+  Consistent offset in one direction
+    -> base pose differs from training; geometry, not model
+
+============================================================
+KNOWN LIMITS (carried over from 2026-07-23, re-verify)
+============================================================
+  - Earlier model went to LEFT bin regardless of prompt
+    (language conditioning weak)
+  - Block must be within trained reach zone (center of table)
+  - Colored marks must be on ALL faces; one-side marks fail
+    randomly when the mark faces away from the camera
+  - Bins must stay weighted/secured
+  - Bin rims must be clear of carry height
+
+============================================================
+BASELINE FOR COMPARISON
+============================================================
+  Before this log existed: roughly 1 full success in 5-6 trials
+  (~17%), and the successful one came AFTER the re-clamp.
+  Any post-retrain result must beat the tally above, not that
+  rough estimate.
+
+============================================================
+AFTER TESTING — FEEDS INTO TONIGHT'S RUN
+============================================================
+  The 40 new episodes should target whatever the pattern section
+  above points at. Record them in the CURRENT fixed setup, and
+  photograph the rig first (local-changes/setup-capture-guide.md)
+  — pictures/ is still empty, so today's geometry is otherwise
+  unrecoverable.

--- a/reports/training-report-2026-07-30.html
+++ b/reports/training-report-2026-07-30.html
@@ -1,0 +1,536 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SO-ARM101 · Pi0.5 Training Report — 2026-07-30</title>
+<style>
+  .viz-root {
+    color-scheme: light;
+    --surface-0:      #f7f7f5;
+    --surface-1:      #fcfcfb;
+    --surface-2:      #f0efec;
+    --border:         #dedcd6;
+    --text-primary:   #0b0b0b;
+    --text-secondary: #52514e;
+    --text-muted:     #7d7b74;
+    --series-sorting:   #2a78d6;
+    --series-pickplace: #eb6834;
+    --series-contrast:  #1baf7a;
+    --status-critical:  #c23030;
+    --status-warning:   #eda100;
+    --status-good:      #008300;
+    --grid:           #e6e4de;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) .viz-root {
+      color-scheme: dark;
+      --surface-0:      #121211;
+      --surface-1:      #1a1a19;
+      --surface-2:      #262624;
+      --border:         #383835;
+      --text-primary:   #ffffff;
+      --text-secondary: #c3c2b7;
+      --text-muted:     #918f85;
+      --series-sorting:   #3987e5;
+      --series-pickplace: #d95926;
+      --series-contrast:  #199e70;
+      --status-critical:  #e66767;
+      --status-warning:   #c98500;
+      --status-good:      #3fa93f;
+      --grid:            #2f2f2c;
+    }
+  }
+  :root[data-theme="dark"] .viz-root {
+    color-scheme: dark;
+    --surface-0:      #121211;
+    --surface-1:      #1a1a19;
+    --surface-2:      #262624;
+    --border:         #383835;
+    --text-primary:   #ffffff;
+    --text-secondary: #c3c2b7;
+    --text-muted:     #918f85;
+    --series-sorting:   #3987e5;
+    --series-pickplace: #d95926;
+    --series-contrast:  #199e70;
+    --status-critical:  #e66767;
+    --status-warning:   #c98500;
+    --status-good:      #3fa93f;
+    --grid:            #2f2f2c;
+  }
+
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--surface-0); }
+  .viz-root {
+    background: var(--surface-0);
+    color: var(--text-primary);
+    font: 15px/1.6 ui-sans-serif, -apple-system, "Segoe UI", Roboto, sans-serif;
+    padding: 32px 24px 80px;
+    max-width: 1180px;
+    margin: 0 auto;
+  }
+  h1 { font-size: 27px; line-height: 1.25; margin: 0 0 6px; letter-spacing: -0.01em; }
+  h2 { font-size: 20px; margin: 44px 0 4px; letter-spacing: -0.005em; }
+  h3 { font-size: 15px; margin: 26px 0 8px; color: var(--text-secondary); font-weight: 600; }
+  .sub { color: var(--text-secondary); margin: 0 0 4px; }
+  .muted { color: var(--text-muted); font-size: 13px; }
+  p { margin: 10px 0; color: var(--text-secondary); }
+  p strong, li strong, td strong { color: var(--text-primary); }
+  code {
+    font: 12.5px/1.5 ui-monospace, "SF Mono", Menlo, monospace;
+    background: var(--surface-2); padding: 1px 5px; border-radius: 4px;
+    color: var(--text-primary);
+  }
+  pre {
+    font: 12.5px/1.65 ui-monospace, "SF Mono", Menlo, monospace;
+    background: var(--surface-2); border: 1px solid var(--border);
+    border-radius: 8px; padding: 14px 16px; overflow-x: auto;
+    color: var(--text-primary); margin: 12px 0;
+  }
+  .card {
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: 12px; padding: 20px 22px; margin: 16px 0;
+  }
+  .tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(168px, 1fr)); gap: 12px; margin: 20px 0; }
+  .tile {
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: 12px; padding: 15px 17px;
+  }
+  .tile .label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.055em; color: var(--text-muted); }
+  .tile .value { font-size: 27px; font-weight: 650; margin-top: 5px; letter-spacing: -0.02em; }
+  .tile .note { font-size: 12.5px; color: var(--text-secondary); margin-top: 3px; }
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14px; }
+  th, td { text-align: left; padding: 9px 11px; border-bottom: 1px solid var(--border); }
+  th { color: var(--text-muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; }
+  td { color: var(--text-secondary); }
+  td.num { font-variant-numeric: tabular-nums; }
+  tr.best td { color: var(--text-primary); font-weight: 600; }
+  .legend { display: flex; flex-wrap: wrap; gap: 18px; margin: 4px 0 14px; font-size: 13px; }
+  .legend span { display: inline-flex; align-items: center; gap: 7px; color: var(--text-secondary); }
+  .swatch { width: 11px; height: 11px; border-radius: 3px; flex: none; }
+  .key-line { width: 16px; height: 2px; border-radius: 1px; flex: none; }
+  .chartwrap { background: var(--surface-1); border: 1px solid var(--border); border-radius: 12px; padding: 18px 20px 12px; margin: 12px 0 8px; }
+  svg { display: block; width: 100%; height: auto; overflow: visible; }
+  .tt {
+    position: fixed; pointer-events: none; opacity: 0; transition: opacity .1s;
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px;
+    padding: 8px 11px; font-size: 12.5px; box-shadow: 0 4px 14px rgba(0,0,0,.14);
+    z-index: 50; color: var(--text-primary); max-width: 260px;
+  }
+  .tt b { display: block; margin-bottom: 3px; }
+  .tt-row { display: flex; align-items: center; gap: 7px; color: var(--text-secondary); }
+  .tt-row .swatch { width: 9px; height: 9px; }
+  .pill {
+    display: inline-block; font-size: 11.5px; padding: 2px 9px; border-radius: 99px;
+    border: 1px solid var(--border); color: var(--text-secondary); background: var(--surface-2);
+    font-weight: 600; letter-spacing: 0.02em;
+  }
+  .pill.crit { color: var(--status-critical); border-color: currentColor; background: transparent; }
+  .pill.warn { color: var(--status-warning); border-color: currentColor; background: transparent; }
+  .pill.good { color: var(--status-good); border-color: currentColor; background: transparent; }
+  .toggle {
+    float: right; font-size: 12.5px; background: var(--surface-1); color: var(--text-secondary);
+    border: 1px solid var(--border); border-radius: 7px; padding: 5px 11px; cursor: pointer;
+  }
+  ul, ol { color: var(--text-secondary); padding-left: 22px; }
+  li { margin: 6px 0; }
+  details { margin: 10px 0; }
+  summary { cursor: pointer; color: var(--text-secondary); font-size: 13.5px; }
+  .tl { border-left: 2px solid var(--border); margin: 16px 0 16px 6px; padding-left: 20px; }
+  .tl-item { position: relative; padding: 9px 0; }
+  .tl-item::before {
+    content: ''; position: absolute; left: -27px; top: 15px; width: 9px; height: 9px;
+    border-radius: 50%; background: var(--text-muted);
+    box-shadow: 0 0 0 2px var(--surface-0);
+  }
+  .tl-item.crit::before { background: var(--status-critical); }
+  .tl-item.good::before { background: var(--status-good); }
+  .tl-time { font: 12.5px ui-monospace, Menlo, monospace; color: var(--text-muted); }
+  .tl-what { color: var(--text-primary); font-weight: 550; }
+  .tl-detail { font-size: 13.5px; color: var(--text-secondary); }
+  hr { border: 0; border-top: 1px solid var(--border); margin: 34px 0 0; }
+  .footnote { font-size: 12.5px; color: var(--text-muted); margin-top: 8px; }
+</style>
+</head>
+<body data-palette="#2a78d6,#eb6834,#1baf7a">
+<div class="viz-root">
+
+<button class="toggle" id="themeBtn">Toggle theme</button>
+<h1>Pi0.5 / SO-ARM101 — Training Report</h1>
+<p class="sub">Run 10 (<code>8108c5ba</code>) failed at step 1750 of 2000. Root cause: Intel Arc GPU firmware hang, not training configuration.</p>
+<p class="muted">Generated 2026-07-30 · dataset <code>f6e480e2</code> (150 episodes) · host <code>we-b580</code> · kernel 6.17.0-41 · <code>xe</code> driver</p>
+
+<div class="card" style="border-left:3px solid var(--status-critical);margin-top:20px">
+  <p style="margin:0 0 8px"><strong style="color:var(--status-critical)">UPDATED 2026-07-31 — Run 11 added to the charts.</strong> <code>490a12e3</code> (3000 steps requested, <strong>FAILED @1473</strong>, val 0.1715 at step 1000) now appears alongside the other runs. It was the first run on the upgraded GuC firmware 70.65.0 and it faulted <strong>9 minutes after launch</strong> — so the firmware fix described in the companion report did not hold.</p>
+  <p style="margin:0">The subtitle's &ldquo;root cause: GPU firmware hang&rdquo; is <strong>no longer supported</strong>. Fault counts per boot show a clean two-day boot on the <em>old</em> firmware and the first-ever fault arriving 2026-07-29, a day before the firmware was swapped. See §9 of <code>firmware-fix-report-2026-07-30.html</code> for the corrected analysis. Charts and loss curves below remain valid; only the firmware attribution changed.</p>
+</div>
+
+<div class="tiles">
+  <div class="tile">
+    <div class="label">Run 10 outcome</div>
+    <div class="value" style="color:var(--status-critical)">1750<span style="font-size:16px;color:var(--text-muted)"> / 2000</span></div>
+    <div class="note">87% complete · <span class="pill crit">DEVICE_LOST</span></div>
+  </div>
+  <div class="tile">
+    <div class="label">Checkpoint recovered</div>
+    <div class="value" style="color:var(--status-good)">step 1000</div>
+    <div class="note">24.5 GB · 0 NaN in 819 tensors</div>
+  </div>
+  <div class="tile">
+    <div class="label">Best val loss to date</div>
+    <div class="value">0.1187</div>
+    <div class="note"><code>15842eae</code> · 91 episodes</div>
+  </div>
+  <div class="tile">
+    <div class="label">Run 10 val @ step 1000</div>
+    <div class="value">0.1540</div>
+    <div class="note">150 episodes · higher than best</div>
+  </div>
+  <div class="tile">
+    <div class="label">GPU hard lockups</div>
+    <div class="value" style="color:var(--status-critical)">81</div>
+    <div class="note">+480 soft lockups, from 00:42</div>
+  </div>
+  <div class="tile">
+    <div class="label">GuC firmware</div>
+    <div class="value" style="color:var(--status-warning)">70.45.2</div>
+    <div class="note">kernel recommends 70.49.4</div>
+  </div>
+</div>
+
+<h2>1 · Why the training failed</h2>
+
+<p>The failure was <strong>not</strong> caused by the training configuration, the dataset, the checkpoint patch, or loss divergence. The kernel log shows a hardware/firmware fault on the Battlemage GPU at PCI <code>03:00.0</code> that began <strong>7 hours before</strong> training reported an error.</p>
+
+<h3>The actual sequence</h3>
+<div class="tl">
+  <div class="tl-item good">
+    <div class="tl-time">Jul 29 23:10</div>
+    <div class="tl-what">Run launched — healthy</div>
+    <div class="tl-detail">3.6 steps/min, loss 0.399 descending, VRAM 32.6 GB, from base weights.</div>
+  </div>
+  <div class="tl-item crit">
+    <div class="tl-time">Jul 30 00:42:13</div>
+    <div class="tl-what">FIRST FAULT — hard CPU lockup inside the GPU interrupt handler</div>
+    <div class="tl-detail">
+      <code>watchdog: CPU9: Watchdog detected hard LOCKUP</code><br>
+      <code>RIP: memcpy_fromio+0x7d</code> ← MMIO read to the GPU never returned<br>
+      Call trace: <code>g2h_read</code> → <code>xe_guc_ct_fast_path</code> → <code>xe_guc_irq_handler</code> → <code>gt_irq_handler</code>
+      <br><span class="muted">A CPU core froze while reading a GuC response register. This is the true origin.</span>
+    </div>
+  </div>
+  <div class="tl-item crit">
+    <div class="tl-time">00:41–00:42</div>
+    <div class="tl-what">GuC command transport begins timing out</div>
+    <div class="tl-detail"><code>GT1: Timed out wait for G2H, fence 19142, action 3003, done no</code> — the GPU's microcontroller stopped acknowledging host commands.</div>
+  </div>
+  <div class="tl-item">
+    <div class="tl-time">00:42 → 07:41</div>
+    <div class="tl-what">Training continues anyway — 81 hard + 480 soft lockups accumulate</div>
+    <div class="tl-detail">Steps kept advancing at roughly normal speed. Lockups recur every 1–15 min for 7 hours. The training process had no visibility into this.</div>
+  </div>
+  <div class="tl-item good">
+    <div class="tl-time">03:41 → 04:10</div>
+    <div class="tl-what">Step-1000 checkpoint written successfully</div>
+    <div class="tl-detail">24.5 GB saved, then validation ran (val/loss 0.1540). 29-minute gap accounts for both. <strong>This is the artifact that survived.</strong></div>
+  </div>
+  <div class="tl-item">
+    <div class="tl-time">07:41:34</div>
+    <div class="tl-what">Last successful step — 1750</div>
+    <div class="tl-detail">train/loss 0.0644, healthy. No NaN anywhere in the run.</div>
+  </div>
+  <div class="tl-item crit">
+    <div class="tl-time">08:15 → 08:21</div>
+    <div class="tl-what">GuC firmware fully dies; driver reset storm</div>
+    <div class="tl-detail">
+      <code>GT0: GuC PC query task state failed: -EPIPE</code> repeating every 5 s<br>
+      <code>GT0: Kernel-submitted job timed out</code> → <code>reset queued</code> → <code>reset started</code> → <code>reset done</code><br>
+      ~340 reset attempts. <code>WARNING at drivers/gpu/drm/xe/xe_guc_submit.c:1309</code>
+    </div>
+  </div>
+  <div class="tl-item crit">
+    <div class="tl-time">10:06 / 10:12</div>
+    <div class="tl-what">Final reset attempts fail</div>
+    <div class="tl-detail">Level Zero runtime surfaces <code>UR_RESULT_ERROR_DEVICE_LOST (20)</code> to PyTorch. Training cannot continue — its device is gone.</div>
+  </div>
+  <div class="tl-item">
+    <div class="tl-time">15:20:27</div>
+    <div class="tl-what">Job marked <code>failed</code></div>
+    <div class="tl-detail">Wedged ~7.5 h between device loss and status update, holding 32.6 GB VRAM. Cleared later by <code>docker restart</code> (process was <code>Sl</code>, not <code>D</code> — no reboot needed).</div>
+  </div>
+</div>
+
+<h3>Root cause</h3>
+<div class="card">
+  <p style="margin-top:0"><strong>GuC firmware 70.45.2 is installed; the kernel explicitly recommends 70.49.4.</strong> At boot the driver logs:</p>
+  <pre>xe 0000:03:00.0: [drm] GT0: Using GuC firmware from xe/bmg_guc_70.bin version 70.45.2
+xe 0000:03:00.0: [drm] GuC firmware (70.49.4) is recommended, but only (70.45.2) was found
+xe 0000:03:00.0: [drm] Consider updating your linux-firmware pkg</pre>
+  <p>The GuC (Graphics microController) schedules all GPU work. When its command transport stalls, the host CPU blocks in an MMIO read inside an interrupt handler — which is exactly the <code>memcpy_fromio</code> hard lockup at 00:42. Under a sustained multi-hour compute load this degraded until the firmware stopped responding entirely.</p>
+  <p class="footnote">Evidence this is firmware/driver and not thermal or OOM: zero thermal-throttle entries, zero OOM-killer entries, and 22 GB RAM free at failure. The fault signature is entirely in the GuC command-transport path.</p>
+</div>
+
+<h3>What was ruled out</h3>
+<table>
+  <thead><tr><th>Hypothesis</th><th>Verdict</th><th>Evidence</th></tr></thead>
+  <tbody>
+    <tr><td>Loss divergence / NaN</td><td><span class="pill good">RULED OUT</span></td><td>0 NaN in 1750 steps; <code>gradient_clip_val=1.0</code> held. Final train/loss 0.0644.</td></tr>
+    <tr><td>Out of memory</td><td><span class="pill good">RULED OUT</span></td><td>No OOM-killer entries; 22 GB RAM available at time of failure.</td></tr>
+    <tr><td>Disk full</td><td><span class="pill good">RULED OUT</span></td><td>173 GB free after cleanup; checkpoint wrote successfully at 03:46.</td></tr>
+    <tr><td>Thermal throttling</td><td><span class="pill good">RULED OUT</span></td><td>No thermal entries in kernel log across the entire run.</td></tr>
+    <tr><td>The checkpoint patch</td><td><span class="pill good">RULED OUT</span></td><td>Save at step 1000 completed cleanly; training continued 750 more steps after it.</td></tr>
+    <tr><td>System suspend</td><td><span class="pill good">RULED OUT</span></td><td>No <code>PM: suspend entry</code> events during the run.</td></tr>
+    <tr><td><strong>GuC firmware hang</strong></td><td><span class="pill crit">CONFIRMED</span></td><td>81 hard lockups in <code>g2h_read</code>/<code>xe_guc_irq_handler</code>; 5,640 <code>GT0 *ERROR*</code> lines; firmware 4 minor versions behind.</td></tr>
+  </tbody>
+</table>
+
+<h2>2 · Loss vs. steps, all runs</h2>
+<p>Train loss per logged step, colored by dataset family. Point size is not encoded; the vertical dashed rule marks where Run 10's GPU died. Hover for values.</p>
+
+<div class="legend" id="legend"></div>
+<div class="chartwrap">
+  <svg id="lossChart" viewBox="0 0 980 430" role="img" aria-label="Train loss versus step for seven training runs, grouped by dataset family"></svg>
+</div>
+<p class="footnote">Sorting = blue · Pick-and-place = orange · Contrast = aqua. Run 10 (150 episodes) is drawn at full opacity; earlier runs are lightened so the failed run reads first.</p>
+
+<h2>3 · Episodes vs. resulting val loss</h2>
+<p>Each bar is one completed run. This is the chart that answers <em>"did more episodes help?"</em> — and the honest answer so far is <strong>no, not yet</strong>. Lower is better.</p>
+
+<div class="chartwrap">
+  <svg id="valChart" viewBox="0 0 980 330" role="img" aria-label="Validation loss by run, with episode count labeled on each bar"></svg>
+</div>
+<p class="footnote">Val loss is measured on each run's own held-out split, so numbers are not strictly comparable across runs with different episode counts. Run 10's 0.1540 came from a 15-episode split of the 150; <code>15842eae</code>'s 0.1187 from a 91-episode dataset's split.</p>
+
+<h2>4 · Dataset inventory</h2>
+<table>
+  <thead><tr><th>Dataset</th><th>ID</th><th class="num">Episodes</th><th class="num">Frames</th><th>Family</th></tr></thead>
+  <tbody>
+    <tr class="best"><td>so101_sorting_colored_marks</td><td><code>f6e480e2</code></td><td class="num">150</td><td class="num">100,309</td><td>sorting</td></tr>
+    <tr><td>so101_pick_place_phase1</td><td><code>dcc9b226</code></td><td class="num">90</td><td class="num">51,155</td><td>pick-place</td></tr>
+    <tr><td>so101_pick_and_place_contrast</td><td><code>010a5bfa</code></td><td class="num">40</td><td class="num">29,359</td><td>contrast</td></tr>
+    <tr><td>test_000_block_2</td><td><code>b82d3dbf</code></td><td class="num">2</td><td class="num">1,802</td><td>test</td></tr>
+  </tbody>
+</table>
+<p>All 150 sorting episodes are 30 fps, ~670 frames each. One epoch at batch 8 is <strong>~11,285 steps</strong>, so Run 10's 1750 steps is <strong>0.16 epochs</strong> — well short of a full pass, by design.</p>
+
+<h2>5 · Run history</h2>
+<table>
+  <thead><tr><th>Run</th><th>Model</th><th class="num">Eps</th><th class="num">Steps</th><th class="num">Train loss</th><th class="num">Val loss</th><th>Status</th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td><code>d2082a5f</code> PickPlace v1</td><td class="num">30</td><td class="num">1003</td><td class="num">0.044</td><td class="num">0.1276</td><td class="muted">deleted</td></tr>
+    <tr><td>2</td><td><code>d827663e</code> PickPlace v2</td><td class="num">60</td><td class="num">1003</td><td class="num">0.129</td><td class="num">0.1987</td><td class="muted">deleted</td></tr>
+    <tr><td>3</td><td><code>28c2e9ca</code> PickPlace v3</td><td class="num">90</td><td class="num">3385</td><td class="num">0.077</td><td class="num">0.1327</td><td><span class="pill">kept</span></td></tr>
+    <tr><td>4</td><td><code>c5d4500a</code> Contrast v4</td><td class="num">40</td><td class="num">3675</td><td class="num">0.023</td><td class="num">0.1917</td><td><span class="pill">kept</span></td></tr>
+    <tr><td>6</td><td><code>6a87fb33</code> Sorting</td><td class="num">91</td><td class="num">1999</td><td class="num">0.045</td><td class="num">0.2060</td><td class="muted">deleted</td></tr>
+    <tr><td>8</td><td><code>cd465140</code> Sorting</td><td class="num">91</td><td class="num">3954</td><td class="num">NaN</td><td class="num">NaN</td><td><span class="pill crit">diverged</span></td></tr>
+    <tr class="best"><td>9</td><td><code>15842eae</code> Sorting</td><td class="num">91</td><td class="num">1001</td><td class="num">0.079</td><td class="num">0.1187</td><td><span class="pill good">BEST</span></td></tr>
+    <tr><td>10</td><td><code>7c1f0a94</code> Sorting</td><td class="num">150</td><td class="num">1750</td><td class="num">0.064</td><td class="num">0.1540</td><td><span class="pill crit">GPU lost</span></td></tr>
+  </tbody>
+</table>
+
+<h3>The overfitting pattern</h3>
+<p>Run 4 (<code>c5d4500a</code>) has the <strong>best</strong> train loss of any run (0.023) and one of the <strong>worst</strong> val losses (0.1917) — a 8.3× gap. It is also the only run to exceed one full epoch (1.19). Every good model on this box trained well under one epoch. That is why 2000 steps was chosen over 3000, and the choice still looks correct.</p>
+
+<h2>6 · What survived, and what to do next</h2>
+
+<h3>Recovered artifact</h3>
+<div class="card">
+  <p style="margin-top:0"><strong><code>7c1f0a94</code> — "Pi0.5 Sorting 150eps step1000"</strong> · registered in the GUI, ready to test.</p>
+  <ul>
+    <li>All 819 float tensors verified: <strong>0 NaN, 0 Inf</strong>, mean magnitude 0.59</li>
+    <li><code>exports/torch/pi05.pt</code> — 9,354,284,578 bytes (byte-identical size to the known-good <code>15842eae</code>)</li>
+    <li><code>exports/openvino/</code> — <code>pi05.xml</code> + <code>pi05.bin</code> (5.9 GB), tokenizer included</li>
+    <li>Promoted from <code>cache/8108c5ba…/stepstep=001000.ckpt</code>, DB row inserted manually (canceled/failed jobs never get one)</li>
+  </ul>
+  <p class="footnote">The checkpoint patch applied the night before is the sole reason this run produced anything. Under the previous configuration, <code>monitor="val/loss"</code> only fired on epoch boundaries — and one epoch is ~11,285 steps — so nothing would have been saved before the GPU died.</p>
+</div>
+
+<h3>Fix the GPU before the next long run</h3>
+<ol>
+  <li><strong>Update GuC firmware to 70.49.4.</strong> This is the direct fix for the confirmed root cause:
+    <pre>sudo apt update &amp;&amp; sudo apt install --only-upgrade linux-firmware
+# then verify after reboot:
+sudo dmesg | grep -i "GuC firmware"</pre>
+    If the packaged version is still 70.45.2, pull <code>bmg_guc_70.bin</code> from
+    <code>git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git</code> into <code>/lib/firmware/xe/</code>.</li>
+  <li><strong>Watch for lockups during the next run</strong> — they were invisible from inside the training job:
+    <pre>journalctl -kf | grep -E "LOCKUP|GuC|G2H|reset started"</pre>
+    Any hit means the GPU is degrading and the run will not finish.</li>
+  <li><strong>Keep the checkpoint patch.</strong> It is the only reason Run 10 wasn't a total loss. Consider dropping the interval to 500 steps for finer-grained insurance.</li>
+  <li><strong>Consider capping runs at ~1000–1500 steps</strong> until firmware is updated. The first lockup came at 1h32m; the card survived ~8.5 h before total loss. Shorter runs finish inside that envelope.</li>
+</ol>
+
+<h3>On the model itself</h3>
+<p>Val loss 0.1540 for 150 episodes is <em>worse</em> than 0.1187 for 91 episodes — but the two numbers come from different held-out splits, so this is suggestive, not conclusive. More importantly, val loss barely captures what the 59 new episodes were recorded to fix: full-travel-to-bin-center releases and single-block scenes. <strong>The arm is the real test.</strong> Run the same ~10 scenarios on <code>7c1f0a94</code> and <code>15842eae</code>, restarting the container between models (each unload leaks ~9.1 GB VRAM).</p>
+
+<hr>
+<p class="footnote">Sources: <code>physicalai.db</code> jobs/models tables · <code>metrics.csv</code> per run · <code>logs/jobs/8108c5ba….log</code> · <code>journalctl -k</code> 2026-07-29 23:00 → 2026-07-30 17:00 · <code>xpu-smi</code> · dataset <code>meta/info.json</code>. Palette validated with the dataviz validator in both light and dark modes (worst adjacent CVD ΔE 9.2 light / 9.4 dark).</p>
+
+<div class="tt" id="tt"></div>
+</div>
+
+<script>
+const RUNS = {"490a12e3":{"name":"Sorting 150ep run11","episodes":150,"family":"sorting","maxSteps":3000,"status":"FAILED @1473","train":[[49,0.28947],[99,0.15938],[149,0.13629],[199,0.12074],[249,0.11611],[299,0.0836],[349,0.15428],[399,0.11336],[449,0.07561],[499,0.09434],[549,0.11431],[599,0.20693],[649,0.09305],[699,0.06916],[749,0.09861],[799,0.1072],[849,0.06002],[899,0.0505],[949,0.11098],[999,0.08768],[1049,0.09534],[1099,0.14694],[1149,0.06535],[1199,0.08465],[1249,0.09763],[1299,0.09692],[1349,0.06176],[1399,0.06399],[1449,0.06647]],"val":[[999,0.17153]]},"8108c5ba":{"name":"Sorting 150ep","episodes":150,"family":"sorting","maxSteps":2000,"status":"FAILED @1750","train":[[49,0.16223],[99,0.1313],[149,0.13759],[199,0.08741],[249,0.13398],[299,0.06938],[349,0.13193],[399,0.12075],[449,0.06331],[499,0.06605],[549,0.04875],[599,0.07776],[649,0.09613],[699,0.07788],[749,0.08168],[799,0.10968],[849,0.06444],[899,0.05195],[949,0.10947],[999,0.05936],[1049,0.09917],[1099,0.03674],[1149,0.05448],[1199,0.09485],[1249,0.09387],[1299,0.08606],[1349,0.04976],[1399,0.06621],[1449,0.08241],[1499,0.10933],[1549,0.09992],[1599,0.06762],[1649,0.05838],[1699,0.0748],[1749,0.06437]],"val":[[999,0.15404]]},"15842eae":{"name":"Sorting 91ep","episodes":91,"family":"sorting","maxSteps":1000,"status":"OK","train":[[49,0.13375],[99,0.07294],[149,0.06735],[199,0.07925],[249,0.17036],[299,0.08594],[349,0.1258],[399,0.06258],[449,0.08569],[499,0.07596],[549,0.03995],[599,0.10416],[649,0.12023],[699,0.06256],[749,0.06504],[799,0.12547],[849,0.06702],[899,0.05468],[949,0.05186],[999,0.12162],[1000,0.07857]],"val":[[1000,0.11869]]},"28c2e9ca":{"name":"PickPlace 90ep","episodes":90,"family":"pickplace","maxSteps":3385,"status":"OK","train":[[49,0.36011],[99,0.17827],[149,0.21929],[199,0.15262],[249,0.19212],[299,0.12304],[349,0.10029],[399,0.13245],[449,0.15746],[499,0.11216],[549,0.08467],[599,0.13177],[649,0.08595],[699,0.12929],[749,0.1072],[799,0.11797],[849,0.13304],[899,0.07297],[949,0.05884],[999,0.10547],[1049,0.12897],[1099,0.12187],[1149,0.09345],[1199,0.12952],[1249,0.11968],[1299,0.09624],[1349,0.12976],[1399,0.12662],[1449,0.09907],[1499,0.0782],[1549,0.07203],[1599,0.08181],[1649,0.0531],[1699,0.05052],[1749,0.07885],[1799,0.0966],[1849,0.08672],[1899,0.08986],[1949,0.06589],[1999,0.05467],[2049,0.04638],[2099,0.05131],[2149,0.05932],[2199,0.04798],[2249,0.04814],[2299,0.06169],[2349,0.0486],[2399,0.10259],[2449,0.07663],[2499,0.03913],[2549,0.06655],[2599,0.08402],[2649,0.07848],[2699,0.09626],[2749,0.08642],[2799,0.05392],[2849,0.06839],[2899,0.05372],[2949,0.07222],[2999,0.08591],[3049,0.06942],[3099,0.04368],[3149,0.06101],[3199,0.04539],[3249,0.08438],[3299,0.02996],[3349,0.06846],[3385,0.07691]],"val":[[3385,0.13267]]},"c5d4500a":{"name":"Contrast 40ep","episodes":40,"family":"contrast","maxSteps":3675,"status":"OK","train":[[49,0.22458],[99,0.15647],[149,0.20989],[199,0.11615],[249,0.09389],[299,0.0925],[349,0.07788],[399,0.05141],[449,0.09986],[499,0.06996],[549,0.11215],[599,0.10171],[649,0.05656],[699,0.04692],[749,0.09503],[799,0.09952],[849,0.04458],[899,0.07485],[949,0.03848],[999,0.047],[1049,0.06029],[1099,0.06468],[1149,0.04544],[1199,0.09089],[1249,0.05678],[1299,0.07161],[1349,0.08223],[1399,0.06861],[1449,0.06453],[1499,0.0469],[1549,0.0393],[1599,0.07887],[1649,0.03566],[1699,0.05138],[1749,0.07937],[1799,0.0999],[1849,0.06352],[1899,0.04324],[1949,0.05054],[1999,0.0776],[2049,0.07085],[2099,0.06432],[2149,0.04766],[2199,0.07514],[2249,0.04429],[2299,0.03661],[2349,0.04795],[2399,0.01742],[2449,0.05494],[2499,0.06935],[2549,0.05218],[2599,0.07454],[2649,0.03444],[2699,0.06245],[2749,0.03523],[2799,0.01934],[2849,0.03388],[2899,0.0897],[2949,0.04417],[2999,0.03468],[3049,0.04966],[3099,0.03698],[3149,0.03794],[3199,0.03105],[3249,0.02709],[3299,0.04596],[3349,0.0409],[3399,0.03963],[3449,0.06659],[3499,0.04347],[3549,0.04093],[3599,0.04432],[3649,0.04478],[3675,0.02316]],"val":[[3223,0.18451],[3675,0.19172]]},"6a87fb33":{"name":"Sorting 91ep v2","episodes":91,"family":"sorting","maxSteps":1999,"status":"OK","train":[[49,0.23892],[99,0.10449],[149,0.12111],[199,0.0814],[249,0.11026],[299,0.13619],[349,0.10029],[399,0.10191],[449,0.106],[499,0.03439],[549,0.10787],[599,0.04553],[649,0.09884],[699,0.04626],[749,0.07922],[799,0.1224],[849,0.0596],[899,0.05119],[949,0.08455],[999,0.05961],[1049,0.05606],[1099,0.02255],[1149,0.03604],[1199,0.05609],[1249,0.04316],[1299,0.03762],[1349,0.05146],[1399,0.03532],[1449,0.04637],[1499,0.0498],[1549,0.02473],[1599,0.0442],[1649,0.03934],[1699,0.06423],[1749,0.03617],[1799,0.0512],[1849,0.03317],[1899,0.03899],[1949,0.0478],[1999,0.04533]],"val":[[1962,0.20601]]},"d827663e":{"name":"PickPlace 60ep","episodes":60,"family":"pickplace","maxSteps":1003,"status":"OK","train":[[49,0.32866],[99,0.18004],[149,0.16671],[199,0.14534],[249,0.14474],[299,0.14559],[349,0.12821],[399,0.10871],[449,0.06561],[499,0.12701],[549,0.10499],[599,0.08523],[649,0.16404],[699,0.08434],[749,0.16897],[799,0.05692],[849,0.0872],[899,0.05503],[949,0.06323],[999,0.05684],[1003,0.12948]],"val":[[1003,0.19865]]},"d2082a5f":{"name":"PickPlace v1","episodes":30,"family":"pickplace","maxSteps":1003,"status":"OK","train":[[49,0.20863],[99,0.18113],[149,0.12334],[199,0.19793],[249,0.13425],[299,0.12324],[349,0.09725],[399,0.15964],[449,0.1552],[499,0.0954],[549,0.11532],[599,0.09013],[649,0.06162],[699,0.05288],[749,0.09341],[799,0.06306],[849,0.09063],[899,0.0626],[949,0.04376],[999,0.07565],[1003,0.04445]],"val":[[1003,0.12764]]}} ;
+
+const FAM = {
+  sorting:   { label: 'Sorting',        varName: '--series-sorting' },
+  pickplace: { label: 'Pick-and-place', varName: '--series-pickplace' },
+  contrast:  { label: 'Contrast',       varName: '--series-contrast' },
+};
+const css = (v) => getComputedStyle(document.querySelector('.viz-root')).getPropertyValue(v).trim();
+const SVGNS = 'http://www.w3.org/2000/svg';
+const el = (n, a = {}) => { const e = document.createElementNS(SVGNS, n); for (const k in a) e.setAttribute(k, a[k]); return e; };
+const tt = document.getElementById('tt');
+function showTT(evt, html) {
+  tt.innerHTML = html; tt.style.opacity = '1';
+  const r = tt.getBoundingClientRect();
+  let x = evt.clientX + 14, y = evt.clientY - r.height / 2;
+  if (x + r.width > innerWidth - 8) x = evt.clientX - r.width - 14;
+  y = Math.max(8, Math.min(y, innerHeight - r.height - 8));
+  tt.style.left = x + 'px'; tt.style.top = y + 'px';
+}
+const hideTT = () => { tt.style.opacity = '0'; };
+
+/* ---------- Legend ---------- */
+function buildLegend() {
+  const L = document.getElementById('legend');
+  L.innerHTML = '';
+  for (const k in FAM) {
+    const s = document.createElement('span');
+    s.innerHTML = `<i class="key-line" style="background:${css(FAM[k].varName)}"></i>${FAM[k].label}`;
+    L.appendChild(s);
+  }
+  const f = document.createElement('span');
+  f.innerHTML = `<i class="key-line" style="background:${css('--status-critical')};height:0;border-top:2px dashed ${css('--status-critical')}"></i>GPU lost (step 1750)`;
+  L.appendChild(f);
+}
+
+/* ---------- Chart 1: loss vs step ---------- */
+function drawLoss() {
+  const svg = document.getElementById('lossChart');
+  svg.innerHTML = '';
+  const W = 980, H = 430, m = { t: 14, r: 118, b: 44, l: 56 };
+  const iw = W - m.l - m.r, ih = H - m.t - m.b;
+  const maxStep = 3700, maxLoss = 0.38;
+  const x = s => m.l + (s / maxStep) * iw;
+  const y = v => m.t + ih - (v / maxLoss) * ih;
+
+  // gridlines + y ticks
+  [0, 0.1, 0.2, 0.3].forEach(v => {
+    svg.appendChild(el('line', { x1: m.l, y1: y(v), x2: m.l + iw, y2: y(v), stroke: css('--grid'), 'stroke-width': 1 }));
+    const t = el('text', { x: m.l - 10, y: y(v) + 4, 'text-anchor': 'end', fill: css('--text-muted'), 'font-size': 11.5 });
+    t.textContent = v.toFixed(1); svg.appendChild(t);
+  });
+  // x ticks
+  [0, 1000, 2000, 3000].forEach(s => {
+    const t = el('text', { x: x(s), y: m.t + ih + 22, 'text-anchor': 'middle', fill: css('--text-muted'), 'font-size': 11.5 });
+    t.textContent = s.toLocaleString(); svg.appendChild(t);
+  });
+  const ax = el('text', { x: m.l + iw / 2, y: H - 4, 'text-anchor': 'middle', fill: css('--text-secondary'), 'font-size': 12 });
+  ax.textContent = 'training step'; svg.appendChild(ax);
+  const ay = el('text', { x: 14, y: m.t + ih / 2, 'text-anchor': 'middle', fill: css('--text-secondary'), 'font-size': 12, transform: `rotate(-90 14 ${m.t + ih / 2})` });
+  ay.textContent = 'train loss'; svg.appendChild(ay);
+
+  // failure rule
+  svg.appendChild(el('line', { x1: x(1750), y1: m.t, x2: x(1750), y2: m.t + ih, stroke: css('--status-critical'), 'stroke-width': 2, 'stroke-dasharray': '5 4', opacity: 0.85 }));
+  const fl = el('text', { x: x(1750) + 7, y: m.t + 13, fill: css('--status-critical'), 'font-size': 11.5, 'font-weight': 600 });
+  fl.textContent = 'GPU lost'; svg.appendChild(fl);
+
+  const order = ['d2082a5f', 'd827663e', '6a87fb33', '28c2e9ca', 'c5d4500a', '15842eae', '8108c5ba'];
+  for (const key of order) {
+    const r = RUNS[key]; if (!r) continue;
+    const col = css(FAM[r.family].varName);
+    const isFocus = key === '8108c5ba';
+    const op = isFocus ? 1 : 0.34;
+    const d = r.train.map((p, i) => `${i ? 'L' : 'M'}${x(p[0]).toFixed(1)},${y(Math.min(p[1], maxLoss)).toFixed(1)}`).join('');
+    svg.appendChild(el('path', { d, fill: 'none', stroke: col, 'stroke-width': isFocus ? 2 : 2, opacity: op, 'stroke-linejoin': 'round', 'stroke-linecap': 'round' }));
+
+    // end marker + direct label
+    const last = r.train[r.train.length - 1];
+    const cx = x(last[0]), cy = y(Math.min(last[1], maxLoss));
+    svg.appendChild(el('circle', { cx, cy, r: isFocus ? 5 : 4, fill: col, opacity: op, stroke: css('--surface-1'), 'stroke-width': 2 }));
+    const lb = el('text', { x: cx + 10, y: cy + 4, fill: isFocus ? css('--text-primary') : css('--text-secondary'), 'font-size': 11.5, 'font-weight': isFocus ? 650 : 400 });
+    lb.textContent = `${r.episodes}ep`;
+    svg.appendChild(lb);
+
+    // hover targets
+    r.train.forEach(p => {
+      const hit = el('circle', { cx: x(p[0]), cy: y(Math.min(p[1], maxLoss)), r: 9, fill: 'transparent', style: 'cursor:crosshair' });
+      hit.addEventListener('mousemove', e => showTT(e,
+        `<b>${r.name}</b><div class="tt-row"><i class="swatch" style="background:${col}"></i>step ${p[0].toLocaleString()} · loss ${p[1].toFixed(4)}</div>
+         <div class="tt-row" style="font-size:11.5px">${r.episodes} episodes · ${r.status}</div>`));
+      hit.addEventListener('mouseleave', hideTT);
+      svg.appendChild(hit);
+    });
+  }
+}
+
+/* ---------- Chart 2: episodes vs val loss ---------- */
+function drawVal() {
+  const svg = document.getElementById('valChart');
+  svg.innerHTML = '';
+  const rows = [
+    { id: '15842eae', name: 'Sorting',       eps: 91,  val: 0.1187, fam: 'sorting',   best: true },
+    { id: 'd2082a5f', name: 'PickPlace v1',  eps: 30,  val: 0.1276, fam: 'pickplace' },
+    { id: '28c2e9ca', name: 'PickPlace v3',  eps: 90,  val: 0.1327, fam: 'pickplace' },
+    { id: '7c1f0a94', name: 'Sorting (run 10)', eps: 150, val: 0.1540, fam: 'sorting', focus: true },
+    { id: 'c5d4500a', name: 'Contrast v4',   eps: 40,  val: 0.1917, fam: 'contrast' },
+    { id: 'd827663e', name: 'PickPlace v2',  eps: 60,  val: 0.1987, fam: 'pickplace' },
+    { id: '6a87fb33', name: 'Sorting v2',    eps: 91,  val: 0.2060, fam: 'sorting' },
+  ];
+  const W = 980, H = 330, m = { t: 12, r: 150, b: 42, l: 176 };
+  const iw = W - m.l - m.r, ih = H - m.t - m.b;
+  const maxV = 0.22;
+  const band = ih / rows.length;
+  const bh = Math.min(24, band - 10);
+  const x = v => (v / maxV) * iw;
+
+  [0, 0.05, 0.1, 0.15, 0.2].forEach(v => {
+    svg.appendChild(el('line', { x1: m.l + x(v), y1: m.t, x2: m.l + x(v), y2: m.t + ih, stroke: css('--grid'), 'stroke-width': 1 }));
+    const t = el('text', { x: m.l + x(v), y: m.t + ih + 20, 'text-anchor': 'middle', fill: css('--text-muted'), 'font-size': 11.5 });
+    t.textContent = v.toFixed(2); svg.appendChild(t);
+  });
+  const ax = el('text', { x: m.l + iw / 2, y: H - 5, 'text-anchor': 'middle', fill: css('--text-secondary'), 'font-size': 12 });
+  ax.textContent = 'validation loss  (lower is better)'; svg.appendChild(ax);
+
+  rows.forEach((r, i) => {
+    const cy = m.t + i * band + band / 2;
+    const col = css(FAM[r.fam].varName);
+    const op = r.focus ? 1 : (r.best ? 1 : 0.62);
+
+    const lab = el('text', { x: m.l - 12, y: cy + 4, 'text-anchor': 'end', fill: r.focus || r.best ? css('--text-primary') : css('--text-secondary'), 'font-size': 12.5, 'font-weight': r.focus || r.best ? 650 : 400 });
+    lab.textContent = `${r.name} · ${r.eps}ep`; svg.appendChild(lab);
+
+    const w = x(r.val);
+    const g = el('path', {
+      d: `M${m.l},${cy - bh / 2} H${m.l + w - 4} a4,4 0 0 1 4,4 V${cy + bh / 2 - 4} a4,4 0 0 1 -4,4 H${m.l} Z`,
+      fill: col, opacity: op
+    });
+    svg.appendChild(g);
+
+    const vlab = el('text', { x: m.l + w + 10, y: cy + 4, fill: css('--text-primary'), 'font-size': 12.5, 'font-weight': r.focus || r.best ? 650 : 500 });
+    vlab.textContent = r.val.toFixed(4) + (r.best ? '  ← best' : r.focus ? '  ← run 10' : '');
+    svg.appendChild(vlab);
+
+    const hit = el('rect', { x: m.l, y: cy - band / 2, width: iw, height: band, fill: 'transparent', style: 'cursor:pointer' });
+    hit.addEventListener('mousemove', e => showTT(e,
+      `<b>${r.name}</b><div class="tt-row"><i class="swatch" style="background:${col}"></i>val loss ${r.val.toFixed(4)}</div>
+       <div class="tt-row" style="font-size:11.5px">${r.eps} episodes · ${r.id}</div>`));
+    hit.addEventListener('mouseleave', hideTT);
+    svg.appendChild(hit);
+  });
+}
+
+function renderAll() { buildLegend(); drawLoss(); drawVal(); }
+renderAll();
+
+document.getElementById('themeBtn').addEventListener('click', () => {
+  const cur = document.documentElement.getAttribute('data-theme');
+  const isDark = cur === 'dark' || (!cur && matchMedia('(prefers-color-scheme: dark)').matches);
+  document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+  renderAll();
+});
+matchMedia('(prefers-color-scheme: dark)').addEventListener('change', renderAll);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Long Pi0.5 fine-tuning runs on Intel Arc XPUs were losing **all** work in two distinct ways. Several runs reached their full step target and still produced no model. This PR fixes the one that is a software problem and bounds the damage from the one that isn't.

Failure analysis with per-boot kernel evidence is in `reports/` — start with `reports/README.md`.

## Failure A — run finishes training, then dies during save/export

A completed 5000-step run (`9200784f`) and a 2000-step run (`ec4c4cef`) both reached their full step target and produced **no model**. The process held ~26 GB of trainer/dataloader state on a 30 GB host, and OpenVINO's conversion pass asked for several GB more. An OOM kill is `SIGKILL`, so no downstream `try/except` can rescue it — the memory has to be handed back first.

- drop `trainer` and the datamodule, then `_release_memory()`, **before** export
- make OpenVINO opt-in via `PHYSICALAI_EXPORT_BACKENDS` (default `"torch"`). Torch export alone is enough to load a model in the GUI, and OpenVINO is the backend that actually killed runs here.
- release cached memory *between* backends, since conversion peaks well above the model's resident size

## Failure B — run hangs mid-training, nothing saved

A CPU core takes a GPU interrupt and spins forever in the `xe` driver's GuC message-ring read (`g2h_read` / `memcpy_fromio`) with interrupts disabled, so it can never yield. Training freezes mid-step with **no error and no exception** — the log simply stops. One run hung for 42 hours before anyone noticed.

This is an Intel `xe`/GuC driver bug and **this codebase cannot fix it**. What it can do is bound how much work a hang destroys:

- checkpoint on a **step interval** instead of monitoring `val/loss`. One epoch is ~11k steps at batch 8 on this dataset, so the previous `val/loss`-monitored callback never fired on a sub-epoch run and saved **nothing at all**.
- `save_top_k=-1` to keep every interval checkpoint (Lightning only accepts `-1`, `0` or `1` when `monitor=None`)
- `val_check_interval` so sub-epoch runs report `val/loss` during the run rather than only at the very end

## Also: NaN guard

`gradient_clip_val=1.0`. A 4k-step bf16 run diverged to NaN at ~step 2775 and kept training to completion; the following run had zero NaN across 1750 steps. Details in `reports/SESSION-2026-07-28-nan-divergence.txt`.

## What was ruled out

Recorded in `reports/` because the wrong conclusions cost real time:

- **GuC firmware age — disproven.** Lockups occur on both 70.45.2 and 70.65.0, one boot was clean for two days on the *older* version, and the first-ever fault predates the upgrade. Upgrading made lockups 4.9× more frequent.
- **GT1 / media tile / `action 3003` — weakened.** Explained one run (4193 GT1 events) but the next had zero GT1 events and zero `action 3003`.
- ReBAR, system RAM, NaN divergence, thermal/PCIe — ruled out with evidence.
- Current leading candidate for Failure B is deep CPU C-states racing the GPU IRQ. Flagged as **untested and circumstantial**, not presented as a conclusion.

## Notes for reviewers

- `reports/` is hardware-specific field documentation (Arc Pro B70 + B50, kernel 6.17.0-41). Happy to move it under `docs/` or drop it from this PR if it doesn't belong in-tree — the code changes stand on their own.
- The two HTML reports are self-contained (inline CSS/JS, light + dark themes, no network calls).
- Datasets are **not** committed — 576 MB of robot video. `reports/DATASETS.md` describes both sets with checksums and which model each produced.
- `PHYSICALAI_EXPORT_BACKENDS` changes the default export set from all-supported to torch-only. That is the deliberate fix for Failure A, but it *is* a behaviour change worth a second opinion.
- Tested on this hardware only; no CI coverage for the XPU path.