### PR TITLE
fix(logs): Isolate job log sinks and improve log identification for trainers

### DIFF
--- a/application/backend/src/core/logging/utils.py
+++ b/application/backend/src/core/logging/utils.py
@@ -16,6 +16,7 @@ import sys
 import threading
 from collections.abc import Generator
 from contextlib import contextmanager
+from functools import partial
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
 from uuid import UUID
@@ -37,15 +38,9 @@ _state_lock = threading.Lock()
 # the count only keeps accidental re-entry from unbalancing the bookkeeping.
 _active_jobs: dict[str, int] = {}
 
-# The single active job id, or None when zero or several jobs are active. Read
-# without the lock by sink filters on the hot logging path; a plain read of a
-# `str | None` is atomic in CPython.
+# The single active job id, or None when zero or several jobs are active.
 _sole_active_job: str | None = None
 
-# Redirecting stdout/stderr and the stdlib root logger is process-wide, so it is
-# installed by the first context to open and undone by the last one to close.
-# Saving the originals per-context would make a second job restore the *first*
-# job's replacements instead of the real streams.
 _redirect_depth = 0
 _saved_stdout: IO[str] | None = None
 _saved_stderr: IO[str] | None = None
@@ -211,7 +206,7 @@ def job_logging_ctx(job_id: str | UUID) -> Generator[str]:
             rotation=global_log_config.rotation,
             retention=global_log_config.retention,
             level=global_log_config.level,
-            filter=lambda record, job_key=job_key: _job_sink_filter(record, job_key),
+            filter=partial(_job_sink_filter, job_id=job_key),
             serialize=global_log_config.serialize,
             enqueue=True,
         )
@@ -219,8 +214,8 @@ def job_logging_ctx(job_id: str | UUID) -> Generator[str]:
         _unregister_job(job_key)
         raise RuntimeError(f"Failed to add log sink for job {job_key}: {e}") from e
 
-    _install_redirects()
     try:
+        _install_redirects()
         # Tag every record emitted in this block -- and in the asyncio tasks and
         # threads it spawns -- so the sink above claims exactly its own records.
         with logger.contextualize(job_id=job_key):

--- a/application/backend/src/core/logging/utils.py
+++ b/application/backend/src/core/logging/utils.py
@@ -1,17 +1,56 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+"""Per-job log sinks.
+
+Concurrent training jobs -- one per remote trainer, plus one local -- run as
+asyncio tasks inside a *single* worker process, so a per-job log sink has to be
+scoped to its job rather than to the process. :func:`job_logging_ctx` tags every
+record emitted inside its block with the job id (via a loguru context variable,
+which each asyncio task carries independently) and filters the job's sink on that
+tag, so overlapping jobs cannot write into each other's log files.
+"""
+
 import logging
-import os
 import sys
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
+from typing import IO, TYPE_CHECKING
 from uuid import UUID
 
 from loguru import logger
 
 from core.logging.handlers import InterceptHandler, LoggerStdoutWriter
 from core.logging.setup import global_log_config
+
+if TYPE_CHECKING:
+    from loguru import Record
+
+# Guards the shared bookkeeping below. Job contexts are normally opened from a
+# worker's event loop thread, but nothing guarantees that, so every mutation of
+# the module state is serialized.
+_state_lock = threading.Lock()
+
+# job id -> number of open contexts for that job. A job is normally entered once;
+# the count only keeps accidental re-entry from unbalancing the bookkeeping.
+_active_jobs: dict[str, int] = {}
+
+# The single active job id, or None when zero or several jobs are active. Read
+# without the lock by sink filters on the hot logging path; a plain read of a
+# `str | None` is atomic in CPython.
+_sole_active_job: str | None = None
+
+# Redirecting stdout/stderr and the stdlib root logger is process-wide, so it is
+# installed by the first context to open and undone by the last one to close.
+# Saving the originals per-context would make a second job restore the *first*
+# job's replacements instead of the real streams.
+_redirect_depth = 0
+_saved_stdout: IO[str] | None = None
+_saved_stderr: IO[str] | None = None
+_saved_root_handlers: list[logging.Handler] = []
+_saved_root_level = logging.NOTSET
 
 
 def _validate_uuid(value: str | UUID) -> str | UUID:
@@ -40,77 +79,157 @@ def get_job_logs_path(job_id: str | UUID) -> str:
 
     Args:
         job_id: Unique identifier for the job
-        job_type: The job type (e.g. "training", "import", "export")
 
     Returns:
-        str: Path to the job's log file (e.g. logs/jobs/{type}_{job_id}.log)
+        str: Path to the job's log file (e.g. logs/jobs/{job_id}.log)
 
     Raises:
-        ValueError: If job_id contains invalid characters or job_type is unknown
+        ValueError: If job_id is not a valid UUID
+        RuntimeError: If the jobs log directory cannot be created
     """
     job_id = _validate_uuid(job_id)
-    jobs_folder = os.path.join(global_log_config.log_folder, "jobs")
+    jobs_folder = Path(global_log_config.log_folder) / "jobs"
     try:
-        os.makedirs(jobs_folder, exist_ok=True)
+        jobs_folder.mkdir(parents=True, exist_ok=True)
     except OSError as e:
         raise RuntimeError(f"Failed to create jobs log directory: {e}") from e
-    return os.path.join(jobs_folder, f"{job_id}.log")
+    return str(jobs_folder / f"{job_id}.log")
+
+
+def _job_sink_filter(record: "Record", job_id: str) -> bool:
+    """Decide whether a record belongs in ``job_id``'s log file.
+
+    Records tagged by :func:`job_logging_ctx` are routed strictly by their tag,
+    so two jobs running side by side never mix.
+
+    Untagged records come from the few places that cannot inherit the context
+    variable -- most notably plain ``threading.Thread`` workers started by
+    third-party code, whose stdout is bridged by :class:`LoggerStdoutWriter`.
+    They are attributed to the running job only while it is the *only* active
+    one. With several jobs active their origin is unknowable, so they are left
+    out of the per-job files rather than duplicated into all of them; they are
+    still captured by the worker and application log sinks.
+    """
+    tagged = record["extra"].get("job_id")
+    if tagged is not None:
+        return tagged == job_id
+    return _sole_active_job == job_id
+
+
+def _recompute_sole_active_job() -> None:
+    """Refresh the single-active-job shortcut. Caller must hold ``_state_lock``."""
+    global _sole_active_job  # noqa: PLW0603
+    _sole_active_job = next(iter(_active_jobs)) if len(_active_jobs) == 1 else None
+
+
+def _register_job(job_id: str) -> None:
+    """Mark ``job_id`` as having one more open logging context."""
+    with _state_lock:
+        _active_jobs[job_id] = _active_jobs.get(job_id, 0) + 1
+        _recompute_sole_active_job()
+
+
+def _unregister_job(job_id: str) -> None:
+    """Mark ``job_id`` as having one fewer open logging context."""
+    with _state_lock:
+        remaining = _active_jobs.get(job_id, 0) - 1
+        if remaining > 0:
+            _active_jobs[job_id] = remaining
+        else:
+            _active_jobs.pop(job_id, None)
+        _recompute_sole_active_job()
+
+
+def _install_redirects() -> None:
+    """Route stdout/stderr and stdlib logging into loguru (first context only)."""
+    global _redirect_depth, _saved_stdout, _saved_stderr, _saved_root_handlers, _saved_root_level  # noqa: PLW0603
+    root_logger = logging.getLogger()
+    with _state_lock:
+        _redirect_depth += 1
+        if _redirect_depth > 1:
+            return
+        _saved_stdout = sys.stdout
+        _saved_stderr = sys.stderr
+        _saved_root_handlers = list(root_logger.handlers)
+        _saved_root_level = root_logger.level
+        root_logger.handlers = [InterceptHandler()]
+        root_logger.setLevel(logging.NOTSET)
+        sys.stdout = LoggerStdoutWriter(level="INFO")  # type: ignore[assignment]
+        sys.stderr = LoggerStdoutWriter(level="WARNING")  # type: ignore[assignment]
+
+
+def _remove_redirects() -> None:
+    """Restore the real streams and root logger (last context only)."""
+    global _redirect_depth, _saved_stdout, _saved_stderr, _saved_root_handlers  # noqa: PLW0603
+    root_logger = logging.getLogger()
+    with _state_lock:
+        _redirect_depth = max(0, _redirect_depth - 1)
+        if _redirect_depth > 0:
+            return
+        if _saved_stdout is not None:
+            sys.stdout = _saved_stdout
+        if _saved_stderr is not None:
+            sys.stderr = _saved_stderr
+        root_logger.handlers = _saved_root_handlers
+        root_logger.setLevel(_saved_root_level)
+        _saved_stdout = None
+        _saved_stderr = None
+        _saved_root_handlers = []
 
 
 @contextmanager
 def job_logging_ctx(job_id: str | UUID) -> Generator[str]:
-    """Add a temporary log sink for a specific job.
+    """Add a log sink scoped to a single job.
 
-    Captures all logs emitted during the context to
-    logs/jobs/{type}_{job_id}.log.  The sink is automatically removed on
-    exit, but the log file persists.  Logs also continue to go to other
-    configured sinks.
+    Captures logs emitted inside the context -- including from asyncio tasks and
+    ``asyncio.to_thread`` calls started within it -- to
+    ``logs/jobs/{job_id}.log``. The sink is removed on exit, but the log file
+    persists. Logs also continue to go to the other configured sinks.
+
+    Safe to run concurrently with contexts for other jobs: each job's records are
+    tagged and its sink filters on that tag, so overlapping jobs (e.g. one per
+    remote trainer) keep separate logs. See :func:`_job_sink_filter` for how the
+    few records that cannot carry a tag are handled.
 
     Args:
         job_id: Unique identifier for the job, used as the log filename
-        job_type: The job type (e.g. "training", "import", "export")
 
     Yields:
-        str: Path to the created log file (e.g. logs/jobs/{type}_{job_id}.log)
+        str: Path to the created log file (e.g. logs/jobs/{job_id}.log)
 
     Raises:
-        ValueError: If job_id contains invalid characters or job_type is unknown
+        ValueError: If job_id is not a valid UUID
         RuntimeError: If log directory creation or sink addition fails
     """
-    job_id = _validate_uuid(job_id)
+    job_key = str(_validate_uuid(job_id))
+    log_file = get_job_logs_path(job_key)
 
-    log_file = get_job_logs_path(job_id)
-
-    root_logger = logging.getLogger()
-    original_root_handlers = list(root_logger.handlers)
-    original_root_level = root_logger.level
-    original_stdout = sys.stdout
-    original_stderr = sys.stderr
-
+    _register_job(job_key)
     try:
         sink_id = logger.add(
             log_file,
             rotation=global_log_config.rotation,
             retention=global_log_config.retention,
             level=global_log_config.level,
+            filter=lambda record, job_key=job_key: _job_sink_filter(record, job_key),
             serialize=global_log_config.serialize,
             enqueue=True,
         )
     except Exception as e:
-        raise RuntimeError(f"Failed to add log sink for job {job_id}: {e}") from e
+        _unregister_job(job_key)
+        raise RuntimeError(f"Failed to add log sink for job {job_key}: {e}") from e
 
+    _install_redirects()
     try:
-        root_logger.handlers = [InterceptHandler()]
-        root_logger.setLevel(logging.NOTSET)
-        sys.stdout = LoggerStdoutWriter(level="INFO")  # type: ignore[assignment]
-        sys.stderr = LoggerStdoutWriter(level="WARNING")  # type: ignore[assignment]
-
-        logger.info(f"Started logging to {log_file}")
-        yield log_file
+        # Tag every record emitted in this block -- and in the asyncio tasks and
+        # threads it spawns -- so the sink above claims exactly its own records.
+        with logger.contextualize(job_id=job_key):
+            logger.info(f"Started logging to {log_file}")
+            try:
+                yield log_file
+            finally:
+                logger.info(f"Stopped logging to {log_file}")
     finally:
-        logger.info(f"Stopped logging to {log_file}")
-        sys.stdout = original_stdout
-        sys.stderr = original_stderr
-        root_logger.handlers = original_root_handlers
-        root_logger.setLevel(original_root_level)
+        _remove_redirects()
+        _unregister_job(job_key)
         logger.remove(sink_id)

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -104,6 +104,10 @@ class TrainJobPayload(BaseModel):
         default=None,
         description="Resolved remote trainer URL pinned when the job is submitted for restart recovery",
     )
+    remote_trainer_name: str | None = Field(
+        default=None,
+        description="Resolved remote trainer name pinned when the job is submitted, for display in job logs",
+    )
 
     remote_job_id: UUID | None = Field(
         default=None, description="Remote trainer job id, set when a remote run is in flight (for restart reattach)"
@@ -116,7 +120,11 @@ class TrainJobPayload(BaseModel):
     def validate_training_target(self) -> "TrainJobPayload":
         """Keep local jobs and pinned remote endpoints mutually consistent."""
         if self.training_target is TrainingTarget.LOCAL:
-            if self.remote_trainer_id is not None or self.remote_trainer_url is not None:
+            if (
+                self.remote_trainer_id is not None
+                or self.remote_trainer_url is not None
+                or self.remote_trainer_name is not None
+            ):
                 raise ValueError("Local training cannot specify a remote trainer")
             return self
         if self.remote_trainer_id is None:

--- a/application/backend/src/services/job_service.py
+++ b/application/backend/src/services/job_service.py
@@ -53,7 +53,8 @@ class JobService:
             remote_trainer_service = self.remote_trainer_service or RemoteTrainerService(self.session)
             remote_trainer = await remote_trainer_service.get_remote_trainer(payload.remote_trainer_id)
             payload = TrainJobPayload.model_validate(
-                payload.model_dump() | {"remote_trainer_url": str(remote_trainer.url)}
+                payload.model_dump()
+                | {"remote_trainer_url": str(remote_trainer.url), "remote_trainer_name": remote_trainer.name}
             )
 
         # A remote trainer validates its own devices. Validate only local device choices here.

--- a/application/backend/src/services/training_backends/__init__.py
+++ b/application/backend/src/services/training_backends/__init__.py
@@ -28,7 +28,7 @@ def get_training_backend(payload: TrainJobPayload) -> TrainingBackend:
 
         if payload.remote_trainer_url is None:
             raise ValueError("Remote training job is missing its pinned trainer URL")
-        return RemoteTrainingBackend(payload.remote_trainer_url)
+        return RemoteTrainingBackend(payload.remote_trainer_url, trainer_name=payload.remote_trainer_name)
 
     from services.training_backends.local import LocalTrainingBackend
 

--- a/application/backend/src/services/training_backends/_transfer_progress.py
+++ b/application/backend/src/services/training_backends/_transfer_progress.py
@@ -10,8 +10,12 @@ render identical human-readable sizes, throughput, and heartbeat log lines.
 from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    from loguru import Logger
 
 # Minimum wall-clock gap between intermediate transfer progress log lines.
 _TRANSFER_LOG_INTERVAL_S = 15.0
@@ -43,9 +47,10 @@ class TransferProgressLogger:
     instantaneous throughput; otherwise it reports transferred bytes and rate.
     """
 
-    def __init__(self, verb: str, total_bytes: int | None) -> None:
+    def __init__(self, verb: str, total_bytes: int | None, *, logger_: Logger | None = None) -> None:
         self._verb = verb
         self._total = total_bytes if total_bytes and total_bytes > 0 else None
+        self._log = logger_ if logger_ is not None else logger
         now = time.monotonic()
         self._start = now
         self._last_log = now
@@ -64,7 +69,7 @@ class TransferProgressLogger:
             remaining = self._total - transferred
             avg_rate = window_bytes / window_s if window_s > 0 else 0
             eta = f"{remaining / avg_rate:.0f}s" if avg_rate > 0 else "n/a"
-            logger.info(
+            self._log.info(
                 "{} progress: {}/{} ({}%) at {}, ETA {}",
                 self._verb,
                 format_bytes(transferred),
@@ -74,7 +79,7 @@ class TransferProgressLogger:
                 eta,
             )
         else:
-            logger.info(
+            self._log.info(
                 "{} progress: {} transferred at {}",
                 self._verb,
                 format_bytes(transferred),

--- a/application/backend/src/services/training_backends/remote.py
+++ b/application/backend/src/services/training_backends/remote.py
@@ -91,8 +91,6 @@ class RemoteTrainingBackend:
         # Prefix every log line from this backend with its trainer, so a job's
         # log (and the shared "training" worker log) identify which remote
         # server produced each line when several trainers run concurrently.
-        # Falls back to the base URL when no name was pinned (e.g. older
-        # persisted jobs from before this field existed).
         label = trainer_name or self._base_url
 
         def _prefix_with_trainer(record: Record, label: str = label) -> None:

--- a/application/backend/src/services/training_backends/remote.py
+++ b/application/backend/src/services/training_backends/remote.py
@@ -38,6 +38,8 @@ from settings import get_settings
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
+    from loguru import Logger, Record
+
     from services.training_backends._training_methods import TrainingMethod
     from services.training_backends.base import TrainingContext
 
@@ -75,7 +77,7 @@ class RemoteTrainingBackend:
 
     _last_progress_log: str | None = None
 
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, *, trainer_name: str | None = None) -> None:
         settings = get_settings()
         self._base_url = base_url.rstrip("/")
         self._timeout = settings.trainer_request_timeout_s
@@ -86,6 +88,17 @@ class RemoteTrainingBackend:
         # Suppress duplicate consecutive progress lines (e.g. the trainer
         # re-emitting the final training state while it optimizes/exports).
         self._last_progress_log: str | None = None
+        # Prefix every log line from this backend with its trainer, so a job's
+        # log (and the shared "training" worker log) identify which remote
+        # server produced each line when several trainers run concurrently.
+        # Falls back to the base URL when no name was pinned (e.g. older
+        # persisted jobs from before this field existed).
+        label = trainer_name or self._base_url
+
+        def _prefix_with_trainer(record: Record, label: str = label) -> None:
+            record["message"] = f"[{label}] {record['message']}"
+
+        self._log: Logger = logger.patch(_prefix_with_trainer)
 
     async def _resolve_trust_env(self) -> bool:
         """Decide once whether proxy env vars should be honored for trainer calls.
@@ -114,9 +127,9 @@ class RemoteTrainingBackend:
                 response = await client.get(f"{self._base_url}/health")
                 response.raise_for_status()
         except httpx.HTTPError:
-            logger.debug("Trainer not reachable via proxy; bypassing proxy for trainer calls")
+            self._log.debug("Trainer not reachable via proxy; bypassing proxy for trainer calls")
             return False
-        logger.debug("Trainer reachable via proxy; honoring proxy settings for trainer calls")
+        self._log.debug("Trainer reachable via proxy; honoring proxy settings for trainer calls")
         return True
 
     async def _client(self, client_timeout: httpx.Timeout | float | None = None) -> httpx.AsyncClient:
@@ -158,7 +171,7 @@ class RemoteTrainingBackend:
         model rather than submitting a new job.
         """
         if context.remote_job_id:
-            logger.info("Reattaching to in-flight remote training job")
+            self._log.info("Reattaching to in-flight remote training job")
             await self._resume_pending_http_upload(context, context.remote_job_id)
             await self.await_and_ingest(context, context.remote_job_id)
             return
@@ -207,7 +220,7 @@ class RemoteTrainingBackend:
         total = archive_path.stat().st_size
         report = context.progress
         to_percent = self._upload_progress
-        logger.info(
+        self._log.info(
             "Uploading dataset snapshot to trainer: {} ({}) -> job {}",
             archive_path.name,
             format_bytes(total),
@@ -218,7 +231,7 @@ class RemoteTrainingBackend:
         async def _read_chunks(offset: int) -> AsyncIterator[bytes]:
             sent = offset
             last_percent = -1
-            heartbeat = TransferProgressLogger("Dataset upload", total)
+            heartbeat = TransferProgressLogger("Dataset upload", total, logger_=self._log)
             with archive_path.open("rb") as fobj:
                 fobj.seek(offset)
                 while chunk := await asyncio.to_thread(fobj.read, _UPLOAD_CHUNK_SIZE):
@@ -261,12 +274,12 @@ class RemoteTrainingBackend:
             except (httpx.HTTPError, ValueError) as exc:
                 if attempt == _TRANSFER_RETRY_LIMIT:
                     raise RemoteTrainingError("Dataset upload could not be resumed") from exc
-                logger.warning("Dataset upload interrupted; resuming from trainer offset")
+                self._log.warning("Dataset upload interrupted; resuming from trainer offset")
                 offset = await self._get_upload_offset(remote_job_id, total, stream_timeout)
         if offset != total:
             raise RemoteTrainingError(f"Trainer accepted an incomplete dataset upload ({offset} of {total} bytes)")
         elapsed = time.monotonic() - started
-        logger.info(
+        self._log.info(
             "Snapshot uploaded to trainer: {} in {:.1f}s ({})",
             format_bytes(total),
             elapsed,
@@ -319,7 +332,7 @@ class RemoteTrainingBackend:
             remote_job_uuid = uuid.UUID(remote_job_id)
         except ValueError as exc:
             raise RemoteTrainingError("Trainer did not return a valid remote_job_id") from exc
-        logger.info("Remote training job submitted")
+        self._log.info("Remote training job submitted")
         return remote_job_uuid
 
     async def _wait_for_completion(self, context: TrainingContext, remote_job_id: uuid.UUID) -> None:
@@ -344,7 +357,7 @@ class RemoteTrainingBackend:
                 completed, received_event = await self._consume_event_stream(context, remote_job_id)
             except httpx.HTTPError as exc:
                 # Connection-level failure while opening or reading the stream.
-                logger.warning("Trainer event stream connection failed, reconnecting: {}", exc)
+                self._log.warning("Trainer event stream connection failed, reconnecting: {}", exc)
                 completed, received_event = False, False
 
             if completed:
@@ -423,7 +436,7 @@ class RemoteTrainingBackend:
                         continue
                     if kind == "error":
                         # Transient read error: surface to the reconnect loop.
-                        logger.warning("Trainer event stream read error: {}", payload)
+                        self._log.warning("Trainer event stream read error: {}", payload)
                         result = False, received_event
                         continue
 
@@ -485,7 +498,7 @@ class RemoteTrainingBackend:
         if extra_info is not None:
             line = render_progress_log(extra_info)
             if line is not None and line != self._last_progress_log:
-                logger.info(line)
+                self._log.info(line)
                 self._last_progress_log = line
 
         if status in _TERMINAL_STATES:
@@ -496,8 +509,7 @@ class RemoteTrainingBackend:
             raise RemoteTrainingError(f"Remote training {status}: {state.get('message')}")
         return False
 
-    @staticmethod
-    def _sanitize_extra_info(raw_extra: object) -> dict[str, Any] | None:
+    def _sanitize_extra_info(self, raw_extra: object) -> dict[str, Any] | None:
         """Return the trainer's telemetry dict, or None if absent or too large.
 
         extra_info is untrusted and persisted verbatim, so reject any blob whose
@@ -508,10 +520,10 @@ class RemoteTrainingBackend:
         try:
             size = len(json.dumps(raw_extra).encode())
         except (TypeError, ValueError, RecursionError, OverflowError):
-            logger.warning("Dropping non-serializable extra_info from trainer state")
+            self._log.warning("Dropping non-serializable extra_info from trainer state")
             return None
         if size > _MAX_EXTRA_INFO_BYTES:
-            logger.warning("Dropping oversized extra_info from trainer state ({} bytes)", size)
+            self._log.warning("Dropping oversized extra_info from trainer state ({} bytes)", size)
             return None
         return raw_extra
 
@@ -533,19 +545,19 @@ class RemoteTrainingBackend:
         settings = get_settings()
         tmp_archive = Path(tempfile.gettempdir()) / f"remote-model-{uuid.uuid4().hex}.zip"
         stream_timeout = httpx.Timeout(self._timeout, read=settings.trainer_download_read_timeout_s)
-        logger.info("Downloading trained model artifact from trainer job {}", remote_job_id)
+        self._log.info("Downloading trained model artifact from trainer job {}", remote_job_id)
         started = time.monotonic()
         try:
             received = await self._stream_archive(context, remote_job_id, tmp_archive, stream_timeout)
             elapsed = time.monotonic() - started
-            logger.info(
+            self._log.info(
                 "Downloaded model artifact: {} in {:.1f}s ({})",
                 format_bytes(received),
                 elapsed,
                 format_throughput(received, elapsed),
             )
 
-            logger.info("Extracting model artifact into {}", context.output_dir)
+            self._log.info("Extracting model artifact into {}", context.output_dir)
             await asyncio.to_thread(
                 self._extract_archive,
                 tmp_archive,
@@ -553,7 +565,7 @@ class RemoteTrainingBackend:
                 settings.data_import_max_uncompressed_bytes,
                 settings.data_import_min_free_bytes,
             )
-            logger.info("Model artifact extracted into {}", context.output_dir)
+            self._log.info("Model artifact extracted into {}", context.output_dir)
         finally:
             tmp_archive.unlink(missing_ok=True)
 
@@ -586,7 +598,7 @@ class RemoteTrainingBackend:
                     response.raise_for_status()
                     expected_bytes = self._artifact_total_bytes(response.headers, received)
                     if heartbeat is None:
-                        heartbeat = TransferProgressLogger("Model download", expected_bytes)
+                        heartbeat = TransferProgressLogger("Model download", expected_bytes, logger_=self._log)
                     with tmp_archive.open("ab") as fobj:
                         async for chunk in response.aiter_bytes(chunk_size=_DOWNLOAD_CHUNK_SIZE):
                             if context.should_stop():
@@ -605,7 +617,7 @@ class RemoteTrainingBackend:
             except (httpx.HTTPError, RemoteTrainingError) as exc:
                 if attempt == _TRANSFER_RETRY_LIMIT:
                     raise RemoteTrainingError(str(exc) or "Model download could not be resumed") from exc
-                logger.warning("Model download interrupted; resuming from {} bytes", received)
+                self._log.warning("Model download interrupted; resuming from {} bytes", received)
         raise RemoteTrainingError("Model download could not be resumed")
 
     @staticmethod
@@ -655,7 +667,7 @@ class RemoteTrainingBackend:
             async with await self._client() as client:
                 await client.post(f"{self._base_url}/jobs/{remote_job_id}/cancel")
         except httpx.HTTPError as exc:
-            logger.warning("Failed to cancel remote job: {}", exc)
+            self._log.warning("Failed to cancel remote job: {}", exc)
 
     async def _delete_remote_job(self, remote_job_id: uuid.UUID) -> None:
         """Ask the trainer to remove its copy of a job's artifacts; best effort."""
@@ -663,7 +675,7 @@ class RemoteTrainingBackend:
             async with await self._client() as client:
                 await client.delete(f"{self._base_url}/jobs/{remote_job_id}")
         except httpx.HTTPError as exc:
-            logger.warning("Failed to clean up remote job artifacts: {}", exc)
+            self._log.warning("Failed to clean up remote job artifacts: {}", exc)
 
     @staticmethod
     def _coerce_progress(value: object) -> int:

--- a/application/backend/tests/core/logging/test_job_logging_ctx.py
+++ b/application/backend/tests/core/logging/test_job_logging_ctx.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for per-job log isolation.
+
+The regression these guard: with several remote trainers, the training worker
+runs one asyncio task per trainer inside a single process, so an unfiltered
+per-job sink captured every concurrent job's records into every job's file.
+"""
+
+import asyncio
+import json
+import logging
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from loguru import logger
+
+from core.logging import utils as logging_utils
+from core.logging.utils import job_logging_ctx
+
+
+@pytest.fixture(autouse=True)
+def _job_logs_in_tmp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
+    """Point job logs at tmp_path and keep sink/stream state from leaking."""
+    monkeypatch.setattr(logging_utils.global_log_config, "log_folder", tmp_path, raising=False)
+    monkeypatch.setattr(logging_utils.global_log_config, "serialize", True, raising=False)
+    monkeypatch.setattr(logging_utils.global_log_config, "level", "INFO", raising=False)
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    root_logger = logging.getLogger()
+    original_handlers, original_level = list(root_logger.handlers), root_logger.level
+    yield
+    sys.stdout, sys.stderr = original_stdout, original_stderr
+    root_logger.handlers, root_logger.level = original_handlers, original_level
+
+
+def _read_messages(log_file: str | Path) -> list[str]:
+    """Return the ``message`` field of every serialized record in a job log."""
+    # enqueue=True writes from a background thread; loguru flushes it on remove().
+    lines = Path(log_file).read_text(encoding="utf-8").splitlines()
+    return [json.loads(line)["record"]["message"] for line in lines if line.strip()]
+
+
+def test_rejects_non_uuid_job_id() -> None:
+    with pytest.raises(ValueError, match="Only valid UUIDs are allowed"), job_logging_ctx(job_id="../../etc/passwd"):
+        pass
+
+
+def test_single_job_captures_its_logs() -> None:
+    job_id = str(uuid4())
+
+    with job_logging_ctx(job_id=job_id) as log_file:
+        logger.info("hello from the job")
+
+    assert "hello from the job" in _read_messages(log_file)
+
+
+def test_untagged_thread_logs_land_in_the_sole_active_job() -> None:
+    """A lone job still collects records from threads that miss the context var."""
+    job_id = str(uuid4())
+
+    with job_logging_ctx(job_id=job_id) as log_file:
+        # logger.contextualize() uses a contextvar, which a bare thread started
+        # from a snapshot-free context (as third-party libs do) does not inherit.
+        ctx_free = logger.bind()
+        ctx_free.patch(lambda record: record["extra"].pop("job_id", None)).info("untagged line")
+
+    assert "untagged line" in _read_messages(log_file)
+
+
+@pytest.mark.anyio
+async def test_concurrent_jobs_do_not_mix_logs() -> None:
+    """Two overlapping jobs must each log only their own lines."""
+    job_a, job_b = str(uuid4()), str(uuid4())
+    both_open = asyncio.Event()
+    files: dict[str, str] = {}
+
+    async def run_job(job_id: str, other_started: asyncio.Event) -> None:
+        with job_logging_ctx(job_id=job_id) as log_file:
+            files[job_id] = log_file
+            logger.info("start {}", job_id)
+            other_started.set()
+            await both_open.wait()
+            # Both sinks are open at this point: the interleaving that used to
+            # duplicate every line into both files.
+            logger.info("work {}", job_id)
+            await asyncio.sleep(0)
+            logger.info("done {}", job_id)
+
+    a_started, b_started = asyncio.Event(), asyncio.Event()
+    task_a = asyncio.create_task(run_job(job_a, a_started))
+    task_b = asyncio.create_task(run_job(job_b, b_started))
+    await a_started.wait()
+    await b_started.wait()
+    both_open.set()
+    await asyncio.gather(task_a, task_b)
+
+    messages_a = _read_messages(files[job_a])
+    messages_b = _read_messages(files[job_b])
+
+    assert f"work {job_a}" in messages_a
+    assert f"done {job_a}" in messages_a
+    assert f"work {job_b}" in messages_b
+    assert f"done {job_b}" in messages_b
+    # The actual bug: neither file may contain the other job's lines.
+    assert not [message for message in messages_a if job_b in message]
+    assert not [message for message in messages_b if job_a in message]
+
+
+@pytest.mark.anyio
+async def test_tasks_spawned_inside_a_job_inherit_its_tag() -> None:
+    """Background work started inside a job context stays attributed to it."""
+    job_a, job_b = str(uuid4()), str(uuid4())
+    files: dict[str, str] = {}
+    ready = asyncio.Event()
+
+    async def nested_work(job_id: str) -> None:
+        await ready.wait()
+        logger.info("nested {}", job_id)
+
+    async def run_job(job_id: str, started: asyncio.Event) -> None:
+        with job_logging_ctx(job_id=job_id) as log_file:
+            files[job_id] = log_file
+            # create_task copies the current context, tag included.
+            nested = asyncio.create_task(nested_work(job_id))
+            started.set()
+            await asyncio.sleep(0)
+            ready.set()
+            await nested
+
+    a_started, b_started = asyncio.Event(), asyncio.Event()
+    await asyncio.gather(run_job(job_a, a_started), run_job(job_b, b_started))
+
+    assert f"nested {job_a}" in _read_messages(files[job_a])
+    assert f"nested {job_b}" in _read_messages(files[job_b])
+    assert f"nested {job_b}" not in _read_messages(files[job_a])
+    assert f"nested {job_a}" not in _read_messages(files[job_b])
+
+
+@pytest.mark.anyio
+async def test_to_thread_calls_inherit_the_job_tag() -> None:
+    """asyncio.to_thread copies the context, so offloaded work keeps its tag."""
+    job_id = str(uuid4())
+
+    with job_logging_ctx(job_id=job_id) as log_file:
+        await asyncio.to_thread(logger.info, "from a worker thread")
+
+    assert "from a worker thread" in _read_messages(log_file)
+
+
+@pytest.mark.anyio
+async def test_streams_restored_only_after_the_last_job_exits() -> None:
+    """An inner job's exit must not hand the real stdout back early."""
+    real_stdout = sys.stdout
+    job_a, job_b = str(uuid4()), str(uuid4())
+
+    with job_logging_ctx(job_id=job_a):
+        assert sys.stdout is not real_stdout
+        with job_logging_ctx(job_id=job_b):
+            assert sys.stdout is not real_stdout
+        # job_b closed, job_a is still running: stdout must stay redirected.
+        assert sys.stdout is not real_stdout
+
+    assert sys.stdout is real_stdout
+
+
+def test_sink_is_removed_and_state_cleaned_after_exit() -> None:
+    job_id = str(uuid4())
+
+    with job_logging_ctx(job_id=job_id) as log_file:
+        pass
+
+    logger.info("after the job closed")
+
+    assert "after the job closed" not in _read_messages(log_file)
+    assert logging_utils._active_jobs == {}
+    assert logging_utils._sole_active_job is None
+    assert logging_utils._redirect_depth == 0

--- a/application/backend/tests/services/test_job_service_remote_target.py
+++ b/application/backend/tests/services/test_job_service_remote_target.py
@@ -47,4 +47,6 @@ async def test_submit_remote_job_pins_configured_url_and_ignores_client_url() ->
 
     assert str(job.payload.remote_trainer_url) == "https://configured-trainer.test/"
     assert job.payload.remote_trainer_id == remote_trainer_id
+    # Pinned from the configured trainer's record, for display in job logs.
+    assert job.payload.remote_trainer_name == "trainer"
     repository.save.assert_awaited_once()

--- a/application/backend/tests/services/test_remote_training_backend.py
+++ b/application/backend/tests/services/test_remote_training_backend.py
@@ -17,6 +17,7 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
+from loguru import logger
 
 from schemas.dataset import Snapshot
 from schemas.job import TrainJobPayload
@@ -865,21 +866,25 @@ class TestSnapshotUploadHeartbeat:
         # Give the archive real bytes so the streaming read loop runs and updates the heartbeat.
         (tmp_path / "snap" / "info.json").write_text("x" * 4096)
         controller = _Controller(states=[{"status": "completed", "progress": 100, "message": "Done"}])
+        messages: list[str] = []
+        sink_id = logger.add(lambda m: messages.append(m.record["message"]), level="INFO")
 
-        with (
-            patch(f"{REMOTE}.get_settings", return_value=settings),
-            patch(f"{REMOTE}.httpx.AsyncClient", lambda **kw: _FakeClient(controller, **kw)),
-            patch(f"{REMOTE}.SafeZipArchive", return_value=MagicMock()),
-            patch(f"{REMOTE}._EVENT_WAIT_TIMEOUT_S", 0.01),
-            # A negative interval forces a heartbeat on the first streamed chunk.
-            patch(f"{TRANSFER}._TRANSFER_LOG_INTERVAL_S", -1.0),
-            patch(f"{TRANSFER}.logger") as mock_logger,
-        ):
-            backend = _backend(settings)
-            await backend.train(context)
+        try:
+            with (
+                patch(f"{REMOTE}.get_settings", return_value=settings),
+                patch(f"{REMOTE}.httpx.AsyncClient", lambda **kw: _FakeClient(controller, **kw)),
+                patch(f"{REMOTE}.SafeZipArchive", return_value=MagicMock()),
+                patch(f"{REMOTE}._EVENT_WAIT_TIMEOUT_S", 0.01),
+                # A negative interval forces a heartbeat on the first streamed chunk.
+                patch(f"{TRANSFER}._TRANSFER_LOG_INTERVAL_S", -1.0),
+            ):
+                backend = _backend(settings)
+                await backend.train(context)
+        finally:
+            logger.remove(sink_id)
 
-        templates = [call for call in mock_logger.info.call_args_list if call.args and "progress:" in call.args[0]]
-        assert any(call.args[1] == "Dataset upload" for call in templates)
+        # Heartbeats go through the backend's trainer-prefixed logger, not the bare module logger.
+        assert any("progress:" in message and "Dataset upload" in message for message in messages)
 
 
 class TestModelDownloadProgress:
@@ -943,21 +948,25 @@ class TestModelDownloadProgress:
         controller = _Controller(states=[{"status": "completed", "progress": 100, "message": "Done"}])
         controller.artifact_chunks = [b"a" * 500, b"b" * 500]
         controller.artifact_headers = {"content-length": "1000"}
+        messages: list[str] = []
+        sink_id = logger.add(lambda m: messages.append(m.record["message"]), level="INFO")
 
-        with (
-            patch(f"{REMOTE}.get_settings", return_value=settings),
-            patch(f"{REMOTE}.httpx.AsyncClient", lambda **kw: _FakeClient(controller, **kw)),
-            patch(f"{REMOTE}.SafeZipArchive", return_value=MagicMock()),
-            patch(f"{REMOTE}._EVENT_WAIT_TIMEOUT_S", 0.01),
-            # A negative interval makes every update cross the throttle threshold.
-            patch(f"{TRANSFER}._TRANSFER_LOG_INTERVAL_S", -1.0),
-            patch(f"{TRANSFER}.logger") as mock_logger,
-        ):
-            backend = _backend(settings)
-            await backend.train(context)
+        try:
+            with (
+                patch(f"{REMOTE}.get_settings", return_value=settings),
+                patch(f"{REMOTE}.httpx.AsyncClient", lambda **kw: _FakeClient(controller, **kw)),
+                patch(f"{REMOTE}.SafeZipArchive", return_value=MagicMock()),
+                patch(f"{REMOTE}._EVENT_WAIT_TIMEOUT_S", 0.01),
+                # A negative interval makes every update cross the throttle threshold.
+                patch(f"{TRANSFER}._TRANSFER_LOG_INTERVAL_S", -1.0),
+            ):
+                backend = _backend(settings)
+                await backend.train(context)
+        finally:
+            logger.remove(sink_id)
 
-        templates = [call for call in mock_logger.info.call_args_list if call.args and "progress:" in call.args[0]]
-        assert any(call.args[1] == "Model download" for call in templates)
+        # Heartbeats go through the backend's trainer-prefixed logger, not the bare module logger.
+        assert any("progress:" in message and "Model download" in message for message in messages)
 
     @pytest.mark.anyio
     async def test_download_resumes_with_range_after_short_response(self, tmp_path):
@@ -980,6 +989,61 @@ class TestModelDownloadProgress:
             await backend.train(context)
 
         assert controller.artifact_range_headers == [None, "bytes=4-"]
+
+
+class TestTrainerNameLogPrefix:
+    """Every log line from a remote backend identifies which trainer produced it.
+
+    With several remote trainers running concurrently in one worker process,
+    an unprefixed line gives no way to tell which server it came from once
+    it's mixed into the process-wide worker/application log.
+    """
+
+    def _capture(self):
+        messages: list[str] = []
+        sink_id = logger.add(lambda m: messages.append(m.record["message"]), level="DEBUG")
+        return messages, sink_id
+
+    def test_prefixes_log_lines_with_the_pinned_trainer_name(self):
+        from services.training_backends.remote import RemoteTrainingBackend
+
+        messages, sink_id = self._capture()
+        try:
+            backend = RemoteTrainingBackend("https://trainer.test", trainer_name="gpu-box-1")
+            backend._log.info("hello")
+        finally:
+            logger.remove(sink_id)
+
+        assert messages == ["[gpu-box-1] hello"]
+
+    def test_falls_back_to_the_base_url_when_no_name_is_pinned(self):
+        """Older persisted jobs (submitted before this field existed) have no pinned name."""
+        from services.training_backends.remote import RemoteTrainingBackend
+
+        messages, sink_id = self._capture()
+        try:
+            backend = RemoteTrainingBackend("https://trainer.test/")
+            backend._log.info("hello")
+        finally:
+            logger.remove(sink_id)
+
+        assert messages == ["[https://trainer.test] hello"]
+
+    def test_two_concurrent_backends_prefix_independently(self):
+        """Two trainers logging interleaved must stay individually attributable."""
+        from services.training_backends.remote import RemoteTrainingBackend
+
+        messages, sink_id = self._capture()
+        try:
+            backend_a = RemoteTrainingBackend("https://trainer-a.test", trainer_name="trainer-a")
+            backend_b = RemoteTrainingBackend("https://trainer-b.test", trainer_name="trainer-b")
+            backend_a._log.info("from a")
+            backend_b._log.info("from b")
+            backend_a._log.info("from a again")
+        finally:
+            logger.remove(sink_id)
+
+        assert messages == ["[trainer-a] from a", "[trainer-b] from b", "[trainer-a] from a again"]
 
 
 class TestByteFormatting:

--- a/application/backend/tests/services/test_training_backends.py
+++ b/application/backend/tests/services/test_training_backends.py
@@ -9,6 +9,8 @@ import multiprocessing as mp
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+from loguru import logger
+
 from schemas.job import TrainingTarget, TrainJobPayload
 from services.training_backends import get_training_backend
 from services.training_backends.local import LocalTrainingBackend
@@ -31,6 +33,7 @@ def _payload(target: TrainingTarget) -> TrainJobPayload:
         training_target=target,
         remote_trainer_id=uuid4() if target is TrainingTarget.REMOTE else None,
         remote_trainer_url="https://trainer.test" if target is TrainingTarget.REMOTE else None,
+        remote_trainer_name="gpu-box-1" if target is TrainingTarget.REMOTE else None,
     )
 
 
@@ -47,6 +50,15 @@ def test_get_training_backend_returns_remote_for_remote_job() -> None:
     ):
         backend = get_training_backend(_payload(TrainingTarget.REMOTE))
     assert isinstance(backend, RemoteTrainingBackend)
+
+    # The pinned trainer name reaches the backend, so its job logs are attributable.
+    messages: list[str] = []
+    sink_id = logger.add(lambda m: messages.append(m.record["message"]), level="INFO")
+    try:
+        backend._log.info("check")
+    finally:
+        logger.remove(sink_id)
+    assert messages == ["[gpu-box-1] check"]
 
 
 def test_dispatcher_report_enqueues_progress_tuple() -> None:

--- a/application/backend/tests/services/test_training_log_format.py
+++ b/application/backend/tests/services/test_training_log_format.py
@@ -19,6 +19,11 @@ from services.training_backends.remote import RemoteTrainingBackend
 REMOTE = "services.training_backends.remote"
 
 
+def _backend() -> RemoteTrainingBackend:
+    with patch(f"{REMOTE}.get_settings", return_value=MagicMock(trainer_request_timeout_s=5.0)):
+        return RemoteTrainingBackend("https://trainer.test", trainer_name="trainer")
+
+
 class TestFormatTrainingProgress:
     def test_renders_step_progress_and_loss(self) -> None:
         line = format_training_progress(global_step=250, max_steps=1000, loss=0.125)
@@ -111,11 +116,11 @@ def test_apply_state_mirrors_detailed_fields_to_job_log() -> None:
         "message": "Training",
         "extra_info": {"train/loss_step": 0.1, "global_step": 500, "max_steps": 1000, "epoch": 1},
     }
-    backend = RemoteTrainingBackend.__new__(RemoteTrainingBackend)
-    with patch(f"{REMOTE}.logger") as logger:
+    backend = _backend()
+    with patch.object(backend, "_log") as bound_logger:
         completed = backend._apply_state(context, state)
     assert completed is False
-    logger.info.assert_called_once_with("Training progress: step=500/1000 (50%), train/loss_step=0.1")
+    bound_logger.info.assert_called_once_with("Training progress: step=500/1000 (50%), train/loss_step=0.1")
 
 
 def test_apply_state_mirrors_validation_fields_to_job_log() -> None:
@@ -127,11 +132,11 @@ def test_apply_state_mirrors_validation_fields_to_job_log() -> None:
         "message": "Validating",
         "extra_info": {"val_event": "batch", "val_batch": 1, "val/loss_step": 0.3},
     }
-    backend = RemoteTrainingBackend.__new__(RemoteTrainingBackend)
-    with patch(f"{REMOTE}.logger") as logger:
+    backend = _backend()
+    with patch.object(backend, "_log") as bound_logger:
         completed = backend._apply_state(context, state)
     assert completed is False
-    logger.info.assert_called_once_with("Validation progress: batch=1, val/loss_step=0.3")
+    bound_logger.info.assert_called_once_with("Validation progress: batch=1, val/loss_step=0.3")
 
 
 def test_apply_state_suppresses_duplicate_progress_lines() -> None:
@@ -143,9 +148,9 @@ def test_apply_state_suppresses_duplicate_progress_lines() -> None:
         "message": "Training",
         "extra_info": {"train/loss_step": 4.48, "global_step": 100, "max_steps": 100, "epoch": 1},
     }
-    backend = RemoteTrainingBackend.__new__(RemoteTrainingBackend)
-    with patch(f"{REMOTE}.logger") as logger:
+    backend = _backend()
+    with patch.object(backend, "_log") as bound_logger:
         backend._apply_state(context, state)
         backend._apply_state(context, dict(state))
         backend._apply_state(context, dict(state))
-    logger.info.assert_called_once_with("Training progress: step=100/100 (100%), train/loss_step=4.48")
+    bound_logger.info.assert_called_once_with("Training progress: step=100/100 (100%), train/loss_step=4.48")


### PR DESCRIPTION
## Description

Concurrent train jobs would mix the logs stored for each job. This PR ensures each log is identified by its job id and also prefixes the remote trainer name in the local backend logs to identify from which trainer the result is coming. 