### PR TITLE
fix: sanitize camera names for safe video feature keys

### DIFF
--- a/application/backend/src/control/environment_integration.py
+++ b/application/backend/src/control/environment_integration.py
@@ -181,7 +181,7 @@ class EnvironmentIntegration:
         return base64.b64encode(encode_jpeg_rgb(observation)).decode()
 
     def _remap_camera_observations(self, observations: dict) -> dict:
-        """Remap camera observations from camera ID keys to lowercase camera name keys."""
+        """Remap camera observations from camera ID keys to sanitized camera name keys."""
         lerobot_observations = dict(observations)
         for camera in self.environment.cameras:
             lerobot_observations[sanitize_camera_name(camera.name)] = lerobot_observations.pop(str(camera.id))

--- a/application/backend/src/control/environment_integration.py
+++ b/application/backend/src/control/environment_integration.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import re
 from typing import Any
 
 import numpy as np
@@ -17,6 +18,17 @@ from schemas.environment import EnvironmentWithRelations, TeleoperatorRobotWithR
 from schemas.project_camera import Camera
 from utils.camera_factory import build_shared_camera
 from utils.jpeg import encode_jpeg_rgb
+
+
+def sanitize_camera_name(name: str) -> str:
+    """Turn a camera name into a safe video feature key.
+
+    Preserve lowercase letters, spaces, ``_``, and ``-`` for compatibility;
+    replace other characters because feature keys become dataset paths and
+    single-quoted ffconcat entries during recording, where they can invalidate
+    ffmpeg parsing.
+    """
+    return re.sub(r"[^a-z0-9 _-]+", "_", name.lower())
 
 
 class EnvironmentIntegration:
@@ -85,7 +97,7 @@ class EnvironmentIntegration:
             observation_features[feature] = float
 
         for camera in self.environment.cameras:
-            observation_features[camera.name.lower()] = self._get_camera_features(camera)
+            observation_features[sanitize_camera_name(camera.name)] = self._get_camera_features(camera)
 
         return combine_feature_dicts(
             aggregate_pipeline_dataset_features(
@@ -147,7 +159,7 @@ class EnvironmentIntegration:
         state = np.array([[observation[k] for k in self.action_keys]], dtype=np.float32)
         images: dict = {}
         for camera in self.environment.cameras:
-            camera_name = camera.name.lower()
+            camera_name = sanitize_camera_name(camera.name)
             # SWAP HWC, RGB2BGR and in float 0..1 range.
             images[camera_name] = np.ascontiguousarray(
                 observation[camera_name][..., ::-1].transpose(2, 0, 1).astype(np.float32)[np.newaxis] / 255
@@ -172,7 +184,7 @@ class EnvironmentIntegration:
         """Remap camera observations from camera ID keys to lowercase camera name keys."""
         lerobot_observations = dict(observations)
         for camera in self.environment.cameras:
-            lerobot_observations[camera.name.lower()] = lerobot_observations.pop(str(camera.id))
+            lerobot_observations[sanitize_camera_name(camera.name)] = lerobot_observations.pop(str(camera.id))
         return lerobot_observations
 
     @staticmethod

--- a/application/backend/tests/control/test_environment_integration.py
+++ b/application/backend/tests/control/test_environment_integration.py
@@ -6,7 +6,20 @@ import pytest
 import torch
 from physicalai.capture import SharedCamera
 
-from control.environment_integration import EnvironmentIntegration
+from control.environment_integration import EnvironmentIntegration, sanitize_camera_name
+
+
+def test_sanitize_camera_name():
+    assert sanitize_camera_name("Bob's view") == "bob_s view"
+    assert sanitize_camera_name("global view") == "global view"
+    assert sanitize_camera_name("Left Camera") == "left camera"
+    assert sanitize_camera_name("Front") == "front"
+    assert sanitize_camera_name("  -front-  ") == "  -front-  "
+    assert sanitize_camera_name("grabber") == "grabber"
+    assert sanitize_camera_name("cámara-1") == "c_mara-1"
+    assert sanitize_camera_name("bob\\view") == "bob_view"
+    assert sanitize_camera_name("my\ncam") == "my_cam"
+    assert sanitize_camera_name(sanitize_camera_name("Bob's view")) == sanitize_camera_name("Bob's view")
 
 
 def _make_mock_camera():
@@ -96,6 +109,41 @@ class TestInferenceEnvironmentIntegration:
         assert "shoulder_pan.pos" in report_obs["state"]
         assert "3ed60255-04ae-407b-8e2c-c3281847a4e0" in report_obs["cameras"]  # camera id 1
         assert "4629e172-2aa7-4fde-86b1-e19eb1d210ff" in report_obs["cameras"]  # camera id 2
+
+    def test_build_features_sanitizes_camera_names(self, inference_environment_integration) -> None:
+        camera = inference_environment_integration.environment.cameras[0]
+        camera.name = "Bob's view"
+
+        features = inference_environment_integration.build_lerobot_dataset_features()
+
+        assert "observation.images.bob_s view" in features
+        assert "observation.images.bob's view" not in features
+
+    def test_model_input_sanitizes_camera_names(self, inference_environment_integration, event_loop) -> None:
+        camera = inference_environment_integration.environment.cameras[0]
+        camera.name = "Bob's view"
+
+        observation = event_loop.run_until_complete(inference_environment_integration.get_observation())
+        phy_ai_obs = inference_environment_integration.format_model_input_observation(observation)
+
+        assert "bob_s view" in phy_ai_obs.images
+        assert "bob's view" not in phy_ai_obs.images
+
+    def test_remap_camera_observations_sanitizes_camera_names(self, inference_environment_integration) -> None:
+        camera = inference_environment_integration.environment.cameras[0]
+        camera.name = "Bob's view"
+        camera_id = str(camera.id)
+        other_id = str(inference_environment_integration.environment.cameras[1].id)
+        observation = {
+            camera_id: np.zeros([480, 640, 3], dtype=np.uint8),
+            other_id: np.zeros([480, 640, 3], dtype=np.uint8),
+        }
+
+        remapped = inference_environment_integration._remap_camera_observations(observation)
+
+        assert "bob_s view" in remapped
+        assert camera_id not in remapped
+        assert other_id not in remapped
 
     def test_teardown_disconnects_robot_and_stops_cameras(
         self,

--- a/application/backend/tests/control/test_environment_integration.py
+++ b/application/backend/tests/control/test_environment_integration.py
@@ -116,7 +116,7 @@ class TestInferenceEnvironmentIntegration:
 
         features = inference_environment_integration.build_lerobot_dataset_features()
 
-        assert "observation.images.bob_s view" in features
+        assert f"observation.images.{sanitize_camera_name(camera.name)}" in features
         assert "observation.images.bob's view" not in features
 
     def test_model_input_sanitizes_camera_names(self, inference_environment_integration, event_loop) -> None:
@@ -126,7 +126,7 @@ class TestInferenceEnvironmentIntegration:
         observation = event_loop.run_until_complete(inference_environment_integration.get_observation())
         phy_ai_obs = inference_environment_integration.format_model_input_observation(observation)
 
-        assert "bob_s view" in phy_ai_obs.images
+        assert sanitize_camera_name(camera.name) in phy_ai_obs.images
         assert "bob's view" not in phy_ai_obs.images
 
     def test_remap_camera_observations_sanitizes_camera_names(self, inference_environment_integration) -> None:
@@ -141,7 +141,7 @@ class TestInferenceEnvironmentIntegration:
 
         remapped = inference_environment_integration._remap_camera_observations(observation)
 
-        assert "bob_s view" in remapped
+        assert sanitize_camera_name(camera.name) in remapped
         assert camera_id not in remapped
         assert other_id not in remapped
 


### PR DESCRIPTION
While doing manual tests I found that a camera name like "SO101's overview" would break dataset recording.
The reason for that is that the camera name is used as a feature name, which gets used in ffmpeg processes, specifically only after trying to save the second episode which explains why in #664 the errors seemed to be inconsistent.

We now sanitize the camera name while trying to keep any backwards compatibility.
Initially I also planned to sanitize spaces to underscores, but this can break existing datasets that do include a space in their feature names.
