### PR TITLE
feat: add a LR monitor to a set of trainer's default callbacks

### DIFF
--- a/library/src/physicalai/train/trainer.py
+++ b/library/src/physicalai/train/trainer.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import lightning
 import torch
-from lightning.pytorch.callbacks import BatchSizeFinder
+from lightning.pytorch.callbacks import BatchSizeFinder, LearningRateMonitor
 from lightning.pytorch.strategies import DDPStrategy
 
 from physicalai.train.callbacks import PolicyDatasetInteraction
@@ -23,6 +23,7 @@ class Trainer(lightning.Trainer):
 
     This subclasses Lightning's Trainer to add:
     - Automatic PolicyDatasetInteraction callback injection
+    - Automatic LearningRateMonitor callback injection (per-step logging)
     - Better default directory structure (experiments/ instead of current directory)
     - Optional experiment naming for better organization
 
@@ -143,7 +144,8 @@ class Trainer(lightning.Trainer):
             max_epochs: Maximum number of epochs to train
             logger: Logger instance. None (default) creates TensorBoardLogger automatically.
                    False disables logging. Or pass custom logger instance.
-            callbacks: List of callbacks. PolicyDatasetInteraction is auto-added.
+            callbacks: List of callbacks. PolicyDatasetInteraction is auto-added, and a
+                LearningRateMonitor logging per step is added unless one is already provided.
             num_sanity_val_steps: Number of validation sanity steps (default: 0)
             devices: Number/list of devices to use
             precision: Training precision ('32', '16', 'bf16', etc.)
@@ -180,6 +182,9 @@ class Trainer(lightning.Trainer):
                 normalized_callbacks.append(callback)
 
         callbacks = [*normalized_callbacks, PolicyDatasetInteraction()]
+
+        if not any(isinstance(callback, LearningRateMonitor) for callback in callbacks):
+            callbacks.append(LearningRateMonitor(logging_interval="step"))
 
         if auto_scale_batch_size:
             callbacks.append(BatchSizeFinder(mode="power"))

--- a/library/src/physicalai/train/trainer.py
+++ b/library/src/physicalai/train/trainer.py
@@ -183,7 +183,9 @@ class Trainer(lightning.Trainer):
 
         callbacks = [*normalized_callbacks, PolicyDatasetInteraction()]
 
-        if not any(isinstance(callback, LearningRateMonitor) for callback in callbacks):
+        # LearningRateMonitor raises if the trainer has no logger, so skip it when logging is disabled.
+        logging_enabled = logger is not False and not barebones
+        if logging_enabled and not any(isinstance(callback, LearningRateMonitor) for callback in callbacks):
             callbacks.append(LearningRateMonitor(logging_interval="step"))
 
         if auto_scale_batch_size:

--- a/library/tests/unit/train/test_trainer.py
+++ b/library/tests/unit/train/test_trainer.py
@@ -28,6 +28,31 @@ class TestTrainer:
         callback_types = [type(cb) for cb in trainer.callbacks]
         assert PolicyDatasetInteraction in callback_types
 
+    def test_learning_rate_monitor_callback_injected(self):
+        """Verify LearningRateMonitor callback is automatically added with per-step logging."""
+        from lightning.pytorch.callbacks import LearningRateMonitor
+
+        trainer = Trainer(accelerator="cpu", logger=False, enable_checkpointing=False)
+
+        monitors = [cb for cb in trainer.callbacks if isinstance(cb, LearningRateMonitor)]
+        assert len(monitors) == 1
+        assert monitors[0].logging_interval == "step"
+
+    def test_user_learning_rate_monitor_not_duplicated(self):
+        """Verify a user-provided LearningRateMonitor is used instead of injecting another."""
+        from lightning.pytorch.callbacks import LearningRateMonitor
+
+        user_monitor = LearningRateMonitor(logging_interval="epoch")
+        trainer = Trainer(
+            accelerator="cpu",
+            logger=False,
+            enable_checkpointing=False,
+            callbacks=[user_monitor],
+        )
+
+        monitors = [cb for cb in trainer.callbacks if isinstance(cb, LearningRateMonitor)]
+        assert monitors == [user_monitor]
+
     def test_user_callbacks_preserved(self):
         """Verify user callbacks are preserved alongside auto-injected callback."""
         from lightning.pytorch.callbacks import EarlyStopping

--- a/library/tests/unit/train/test_trainer.py
+++ b/library/tests/unit/train/test_trainer.py
@@ -28,24 +28,32 @@ class TestTrainer:
         callback_types = [type(cb) for cb in trainer.callbacks]
         assert PolicyDatasetInteraction in callback_types
 
-    def test_learning_rate_monitor_callback_injected(self):
+    def test_learning_rate_monitor_callback_injected(self, tmp_path):
         """Verify LearningRateMonitor callback is automatically added with per-step logging."""
         from lightning.pytorch.callbacks import LearningRateMonitor
 
-        trainer = Trainer(accelerator="cpu", logger=False, enable_checkpointing=False)
+        trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path), enable_checkpointing=False)
 
         monitors = [cb for cb in trainer.callbacks if isinstance(cb, LearningRateMonitor)]
         assert len(monitors) == 1
         assert monitors[0].logging_interval == "step"
 
-    def test_user_learning_rate_monitor_not_duplicated(self):
+    def test_learning_rate_monitor_skipped_without_logger(self):
+        """Verify LearningRateMonitor is not injected when logging is disabled."""
+        from lightning.pytorch.callbacks import LearningRateMonitor
+
+        trainer = Trainer(accelerator="cpu", logger=False, enable_checkpointing=False)
+
+        assert not any(isinstance(cb, LearningRateMonitor) for cb in trainer.callbacks)
+
+    def test_user_learning_rate_monitor_not_duplicated(self, tmp_path):
         """Verify a user-provided LearningRateMonitor is used instead of injecting another."""
         from lightning.pytorch.callbacks import LearningRateMonitor
 
         user_monitor = LearningRateMonitor(logging_interval="epoch")
         trainer = Trainer(
             accelerator="cpu",
-            logger=False,
+            default_root_dir=str(tmp_path),
             enable_checkpointing=False,
             callbacks=[user_monitor],
         )


### PR DESCRIPTION
## Description

Adding LR monitoring by default makes trainer's logs more complete, as now we monitor only a small subset of training metrics.
Changes only affect library
