### PR TITLE
fix: use custom tabs component

### DIFF
--- a/application/ui/src/features/datasets/dataset-tabs.module.css
+++ b/application/ui/src/features/datasets/dataset-tabs.module.css
@@ -1,0 +1,73 @@
+.tabBar {
+    display: flex;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    border-bottom: var(--spectrum-alias-border-size-thick) solid var(--spectrum-global-color-gray-300);
+}
+
+.tabList {
+    display: flex;
+    min-width: 0;
+    flex: 1 1 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-color: var(--spectrum-global-color-gray-500) transparent;
+    scrollbar-width: thin;
+}
+
+.tabList::-webkit-scrollbar {
+    height: 6px;
+}
+
+.tabList::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.tabList::-webkit-scrollbar-thumb {
+    background: var(--spectrum-global-color-gray-500);
+    border-radius: 999px;
+}
+
+.tab {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    min-height: var(--spectrum-global-dimension-size-600);
+    padding: 0 var(--spectrum-global-dimension-size-50);
+    color: var(--spectrum-global-color-gray-700);
+    white-space: nowrap;
+    cursor: pointer;
+    border-bottom: var(--spectrum-alias-border-size-thick) solid transparent;
+}
+
+.tab[data-hovered] {
+    color: var(--spectrum-global-color-gray-900);
+}
+
+.tab:not([data-selected])::after {
+    width: var(--spectrum-global-dimension-size-200);
+    height: var(--spectrum-global-dimension-size-200);
+    content: '';
+    flex: 0 0 auto;
+    margin-inline-start: var(--spectrum-global-dimension-size-50);
+}
+
+.tab[data-selected] {
+    color: var(--spectrum-global-color-gray-900);
+    border-bottom-color: white;
+}
+
+.tab[data-focus-visible] {
+    outline: 2px solid var(--energy-blue);
+    outline-offset: -2px;
+}
+
+.addActions {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    padding: 0 var(--spectrum-global-dimension-size-100);
+    background: var(--spectrum-global-color-gray-100);
+}

--- a/application/ui/src/features/datasets/dataset-tabs.test.tsx
+++ b/application/ui/src/features/datasets/dataset-tabs.test.tsx
@@ -1,0 +1,91 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tabs } from 'react-aria-components';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SchemaDatasetOutput } from '../../api/openapi-spec';
+import { render } from '../../test-utils/render';
+import { DatasetTabs } from './dataset-tabs';
+
+const PROJECT_ID = 'project-id';
+const FIRST_DATASET_ID = 'first-dataset-id';
+const SECOND_DATASET_ID = 'second-dataset-id';
+
+const datasets: SchemaDatasetOutput[] = [
+    {
+        id: FIRST_DATASET_ID,
+        name: 'First dataset',
+        default_task: 'first task',
+        project_id: PROJECT_ID,
+        environment_id: 'first-environment-id',
+    },
+    {
+        id: SECOND_DATASET_ID,
+        name: 'Second dataset',
+        default_task: 'second task',
+        project_id: PROJECT_ID,
+        environment_id: 'second-environment-id',
+    },
+];
+
+const renderDatasetTabs = (selectedDatasetId = FIRST_DATASET_ID) => {
+    return render(
+        <Tabs selectedKey={selectedDatasetId}>
+            <DatasetTabs datasets={datasets} selectedDatasetId={selectedDatasetId} />
+        </Tabs>,
+        {
+            route: `/projects/${PROJECT_ID}/datasets/${selectedDatasetId}`,
+            path: '/projects/:project_id/datasets/:dataset_id',
+        }
+    );
+};
+
+describe('DatasetTabs', () => {
+    it('renders the action menu only for the selected dataset tab', async () => {
+        renderDatasetTabs();
+
+        const firstTab = await screen.findByRole('tab', { name: /first dataset/i });
+        const secondTab = screen.getByRole('tab', { name: /second dataset/i });
+
+        expect(firstTab).toHaveAttribute('data-selected');
+        expect(firstTab).toHaveTextContent('First dataset');
+        expect(secondTab).not.toHaveAttribute('data-selected');
+        expect(secondTab).toHaveTextContent('Second dataset');
+        expect(firstTab.querySelector('svg')).not.toBeNull();
+        expect(secondTab.querySelector('svg')).toBeNull();
+    });
+
+    it('exports the selected dataset from its contextual menu', async () => {
+        const user = userEvent.setup();
+        const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+        renderDatasetTabs();
+
+        const selectedTab = await screen.findByRole('tab', { name: /first dataset/i });
+        const menuTrigger = selectedTab.querySelector('[aria-haspopup="true"]');
+
+        expect(menuTrigger).not.toBeNull();
+        if (menuTrigger === null) {
+            return;
+        }
+
+        await user.click(menuTrigger);
+        await user.click(await screen.findByRole('menuitem', { name: 'Export dataset' }));
+
+        expect(open).toHaveBeenCalledWith(
+            `http://localhost:7860/api/dataset/${FIRST_DATASET_ID}/download`,
+            '_blank',
+            'noopener,noreferrer'
+        );
+    });
+
+    it('opens the add and import menu', async () => {
+        const user = userEvent.setup();
+        renderDatasetTabs();
+
+        const addDatasetButton = await screen.findByRole('button', { name: 'Add dataset' });
+        await user.click(addDatasetButton);
+
+        expect(addDatasetButton).toHaveAttribute('aria-expanded', 'true');
+    });
+});

--- a/application/ui/src/features/datasets/dataset-tabs.tsx
+++ b/application/ui/src/features/datasets/dataset-tabs.tsx
@@ -1,8 +1,9 @@
 import { Suspense, useState } from 'react';
 
 import { ManagedTab, type ManagedTabAction } from '@geti-ui/blocks';
-import { ActionButton, DialogContainer, Flex, Icon, Item, Menu, MenuTrigger, TabList } from '@geti-ui/ui';
+import { ActionButton, DialogContainer, Icon, Item, Menu, MenuTrigger } from '@geti-ui/ui';
 import { Add } from '@geti-ui/ui/icons';
+import { Tab, TabList } from 'react-aria-components';
 import { useNavigate } from 'react-router';
 
 import { fetchClient } from '../../api/client';
@@ -13,6 +14,8 @@ import { NewDatasetForm } from '../../routes/datasets/new-dataset.component';
 import { useProjectId } from '../projects/use-project';
 import { DeleteDatasetDialog } from './delete-dataset-dialog';
 import { RenameDatasetDialog } from './rename-dataset-dialog';
+
+import styles from './dataset-tabs.module.css';
 
 type Dataset = SchemaDatasetOutput;
 
@@ -30,7 +33,7 @@ export const DatasetTabs = ({
     selectedDatasetId: string | undefined;
 }) => {
     const { project_id } = useProjectId();
-
+    const navigate = useNavigate();
     const [action, setAction] = useState<null | 'rename' | 'delete' | 'add' | 'import'>(null);
     const selectedDataset = datasets.find((dataset) => dataset.id === selectedDatasetId);
 
@@ -55,7 +58,6 @@ export const DatasetTabs = ({
         }
     };
 
-    const navigate = useNavigate();
     const onAddDataset = (dataset: SchemaDatasetOutput | undefined) => {
         setAction(null);
 
@@ -82,60 +84,57 @@ export const DatasetTabs = ({
     };
 
     return (
-        <Flex>
-            <TabList>
-                {datasets.map((dataset) => {
-                    return (
-                        <Item
-                            aria-label={dataset.name}
-                            key={dataset.id}
-                            href={paths.project.datasets.show({ project_id, dataset_id: dataset.id! })}
-                        >
-                            <ManagedTab
-                                label={dataset.name}
-                                isSelected={dataset.id === selectedDatasetId}
-                                actions={ACTIONS}
-                                onAction={onItemAction}
-                            />
-                        </Item>
-                    );
-                })}
-            </TabList>
+        <>
+            <div className={styles.tabBar}>
+                <TabList aria-label='Datasets' className={styles.tabList}>
+                    {datasets.map((dataset) => {
+                        const isSelected = dataset.id === selectedDatasetId;
 
-            <div
-                style={{
-                    display: 'flex',
-                    flex: '1 1 auto',
-                    alignItems: 'center',
-                    borderBottom: 'var(--spectrum-alias-border-size-thick) solid var(--spectrum-global-color-gray-300)',
-                }}
-            >
-                <MenuTrigger>
-                    <ActionButton
-                        isQuiet
-                        aria-label='Add dataset'
-                        onPress={() => {
-                            setAction('add');
-                        }}
-                    >
-                        <Icon>
-                            <Add />
-                        </Icon>
-                    </ActionButton>
-                    <Menu
-                        onAction={(key) => {
-                            if (key === 'add') {
+                        return (
+                            <Tab className={styles.tab} id={dataset.id} key={dataset.id}>
+                                {isSelected ? (
+                                    <ManagedTab
+                                        label={dataset.name}
+                                        isSelected
+                                        actions={ACTIONS}
+                                        onAction={onItemAction}
+                                    />
+                                ) : (
+                                    dataset.name
+                                )}
+                            </Tab>
+                        );
+                    })}
+                </TabList>
+
+                <div className={styles.addActions}>
+                    <MenuTrigger>
+                        <ActionButton
+                            isQuiet
+                            aria-label='Add dataset'
+                            onPress={() => {
                                 setAction('add');
-                            }
-                            if (key === 'import') {
-                                setAction('import');
-                            }
-                        }}
-                    >
-                        <Item key='add'>Add</Item>
-                        <Item key='import'>Import</Item>
-                    </Menu>
-                </MenuTrigger>
+                            }}
+                        >
+                            <Icon>
+                                <Add />
+                            </Icon>
+                        </ActionButton>
+                        <Menu
+                            onAction={(key) => {
+                                if (key === 'add') {
+                                    setAction('add');
+                                }
+                                if (key === 'import') {
+                                    setAction('import');
+                                }
+                            }}
+                        >
+                            <Item key='add'>Add</Item>
+                            <Item key='import'>Import</Item>
+                        </Menu>
+                    </MenuTrigger>
+                </div>
             </div>
 
             <DialogContainer
@@ -164,6 +163,6 @@ export const DatasetTabs = ({
                     />
                 )}
             </DialogContainer>
-        </Flex>
+        </>
     );
 };

--- a/application/ui/src/routes/datasets/index.tsx
+++ b/application/ui/src/routes/datasets/index.tsx
@@ -1,11 +1,13 @@
 import { Suspense } from 'react';
 
-import { Content, Flex, Heading, IllustratedMessage, Item, Loading, TabPanels, Tabs, Text } from '@geti-ui/ui';
-import { useParams } from 'react-router';
+import { Content, Flex, Heading, IllustratedMessage, Loading, Text } from '@geti-ui/ui';
+import { TabPanel, Tabs } from 'react-aria-components';
+import { useNavigate, useParams } from 'react-router';
 
 import { SchemaDatasetOutput } from '../../api/openapi-spec';
 import { DatasetTabs } from '../../features/datasets/dataset-tabs';
 import { useProject, useProjectId } from '../../features/projects/use-project';
+import { paths } from '../../router';
 import { ReactComponent as EmptyIllustration } from './../../assets/illustration.svg';
 import { DatasetProvider } from './dataset-provider';
 import { DatasetViewer } from './dataset-viewer';
@@ -18,6 +20,7 @@ interface DatasetsProps {
 
 const Datasets = ({ datasets }: DatasetsProps) => {
     const { project_id } = useProjectId();
+    const navigate = useNavigate();
     const params = useParams();
     const dataset_id = params.dataset_id ?? datasets[0]?.id;
 
@@ -39,32 +42,48 @@ const Datasets = ({ datasets }: DatasetsProps) => {
     }
 
     return (
-        <Flex height='100%'>
+        <Flex
+            height='100%'
+            width='100%'
+            minWidth={0}
+            UNSAFE_style={{ padding: 'var(--spectrum-global-dimension-size-200)' }}
+        >
             <Tabs
                 aria-label='Datasets'
                 selectedKey={dataset_id}
-                flex='1'
-                margin={'size-200'}
-                UNSAFE_style={{
-                    '--spectrum-tabs-item-gap': 'var(--spectrum-global-dimension-size-100)',
+                onSelectionChange={(key) => {
+                    navigate(paths.project.datasets.show({ project_id, dataset_id: String(key) }));
+                }}
+                style={{
+                    display: 'flex',
+                    flex: 1,
+                    width: '100%',
+                    minWidth: 0,
+                    flexDirection: 'column',
                 }}
             >
                 <DatasetTabs datasets={datasets} selectedDatasetId={dataset_id} />
-                <TabPanels UNSAFE_style={{ border: 'none' }} marginTop={'size-200'} minHeight={0}>
-                    <Item key={dataset_id}>
-                        <Flex height='100%' flex>
-                            {dataset_id === undefined ? (
-                                <Text>No datasets yet...</Text>
-                            ) : (
-                                <Suspense fallback={<Loading />}>
-                                    <DatasetProvider dataset_id={dataset_id}>
-                                        <DatasetViewer />
-                                    </DatasetProvider>
-                                </Suspense>
-                            )}
-                        </Flex>
-                    </Item>
-                </TabPanels>
+                <TabPanel
+                    id={dataset_id}
+                    style={{
+                        display: 'flex',
+                        minHeight: 0,
+                        flex: 1,
+                        marginTop: 'var(--spectrum-global-dimension-size-200)',
+                    }}
+                >
+                    <Flex height='100%' flex>
+                        {dataset_id === undefined ? (
+                            <Text>No datasets yet...</Text>
+                        ) : (
+                            <Suspense fallback={<Loading />}>
+                                <DatasetProvider dataset_id={dataset_id}>
+                                    <DatasetViewer />
+                                </DatasetProvider>
+                            </Suspense>
+                        )}
+                    </Flex>
+                </TabPanel>
             </Tabs>
         </Flex>
     );

--- a/application/ui/src/routes/projects/project.layout.tsx
+++ b/application/ui/src/routes/projects/project.layout.tsx
@@ -134,6 +134,7 @@ export const ProjectLayout = () => {
             <Grid
                 areas={['header', 'subheader', 'content', 'footer']}
                 UNSAFE_style={{
+                    gridTemplateColumns: 'minmax(0, 1fr)',
                     gridTemplateRows:
                         // eslint-disable-next-line max-len
                         'var(--spectrum-global-dimension-size-800, 4rem) min-content minmax(0, 1fr) var(--spectrum-global-dimension-size-400)',
@@ -142,7 +143,7 @@ export const ProjectLayout = () => {
                 height={'100%'}
             >
                 <Header project_id={project_id} />
-                <View gridArea={'content'} maxHeight={'100vh'} minHeight={0} height='100%'>
+                <View gridArea={'content'} maxHeight={'100vh'} minWidth={0} minHeight={0} height='100%'>
                     <Suspense fallback={<Loading mode='overlay' />}>
                         <Outlet />
                     </Suspense>


### PR DESCRIPTION
This fixes an issue where the dataset tab list became collapsed due to it having too many (or too large/long) tabs. While this normally is a nice convenience it does not play well with our `ManagedTab` which shows a menu item (to edit, delete, export a dataset) for the selected tab.

This PR avoids the collapsing behaviour by implementing our own tabs. We do still use `react-aria-components` but apply our own styling.