### PR TITLE
feat: add loggers dep group to library

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -132,7 +132,7 @@ jobs:
         working-directory: library
         run: |
           # Note: We install 'tests', 'pi0', and 'libero' extras, not 'groot' which requires CUDA/flash-attn
-          uv sync --frozen --extra tests --extra pi0 --extra libero --extra smolvla --extra cpu
+          uv sync --frozen --extra tests --extra pi0 --extra libero --extra smolvla --extra cpu --extra loggers
 
       - name: Run python unit tests
         working-directory: library

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -3040,6 +3040,7 @@ requires-dist = [
     { name = "safetensors", marker = "extra == 'pi0'", specifier = ">=0.4.3,<1.0.0" },
     { name = "safetensors", marker = "extra == 'smolvla'", specifier = ">=0.4.3,<1.0.0" },
     { name = "sentencepiece", marker = "extra == 'pi0'", specifier = "<=0.2.1" },
+    { name = "tensorboard", marker = "extra == 'loggers'", specifier = ">=2.20" },
     { name = "timm", marker = "extra == 'groot'", specifier = ">=1.0.0,<1.1.0" },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "physicalai-train", extra = "cpu" } },
     { name = "torch", marker = "extra == 'cu128'", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "physicalai-train", extra = "cu128" } },
@@ -3050,8 +3051,9 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'groot'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'pi0'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'smolvla'", specifier = ">=5.5.0,<5.6.0" },
+    { name = "wandb", marker = "extra == 'loggers'", specifier = ">0.22" },
 ]
-provides-extras = ["cpu", "cu128", "xpu", "tests", "libero", "diffusion", "pi0", "pi05", "groot", "smolvla", "executorch", "executorch-openvino", "all"]
+provides-extras = ["cpu", "cu128", "xpu", "tests", "loggers", "libero", "diffusion", "pi0", "pi05", "groot", "smolvla", "executorch", "executorch-openvino", "all"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -3051,7 +3051,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'groot'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'pi0'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'smolvla'", specifier = ">=5.5.0,<5.6.0" },
-    { name = "wandb", marker = "extra == 'loggers'", specifier = ">0.22" },
+    { name = "wandb", marker = "extra == 'loggers'", specifier = ">=0.22" },
 ]
 provides-extras = ["cpu", "cu128", "xpu", "tests", "loggers", "libero", "diffusion", "pi0", "pi05", "groot", "smolvla", "executorch", "executorch-openvino", "all"]
 

--- a/application/trainer/uv.lock
+++ b/application/trainer/uv.lock
@@ -2556,7 +2556,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'groot'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'pi0'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'smolvla'", specifier = ">=5.5.0,<5.6.0" },
-    { name = "wandb", marker = "extra == 'loggers'", specifier = ">0.22" },
+    { name = "wandb", marker = "extra == 'loggers'", specifier = ">=0.22" },
 ]
 provides-extras = ["cpu", "cu128", "xpu", "tests", "loggers", "libero", "diffusion", "pi0", "pi05", "groot", "smolvla", "executorch", "executorch-openvino", "all"]
 

--- a/application/trainer/uv.lock
+++ b/application/trainer/uv.lock
@@ -2545,6 +2545,7 @@ requires-dist = [
     { name = "safetensors", marker = "extra == 'pi0'", specifier = ">=0.4.3,<1.0.0" },
     { name = "safetensors", marker = "extra == 'smolvla'", specifier = ">=0.4.3,<1.0.0" },
     { name = "sentencepiece", marker = "extra == 'pi0'", specifier = "<=0.2.1" },
+    { name = "tensorboard", marker = "extra == 'loggers'", specifier = ">=2.20" },
     { name = "timm", marker = "extra == 'groot'", specifier = ">=1.0.0,<1.1.0" },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "physicalai-train", extra = "cpu" } },
     { name = "torch", marker = "extra == 'cu128'", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "physicalai-train", extra = "cu128" } },
@@ -2555,8 +2556,9 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'groot'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'pi0'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'smolvla'", specifier = ">=5.5.0,<5.6.0" },
+    { name = "wandb", marker = "extra == 'loggers'", specifier = ">0.22" },
 ]
-provides-extras = ["cpu", "cu128", "xpu", "tests", "libero", "diffusion", "pi0", "pi05", "groot", "smolvla", "executorch", "executorch-openvino", "all"]
+provides-extras = ["cpu", "cu128", "xpu", "tests", "loggers", "libero", "diffusion", "pi0", "pi05", "groot", "smolvla", "executorch", "executorch-openvino", "all"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -65,6 +65,7 @@ tests = [
     "mypy",
     "diffusers>=0.38.0",
 ]
+loggers = ["wandb>0.22", "tensorboard>=2.20"]
 libero = ["hf-libero>=0.1.3,<0.2.0"]
 diffusion = ["diffusers>=0.38.0"]
 

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -65,7 +65,7 @@ tests = [
     "mypy",
     "diffusers>=0.38.0",
 ]
-loggers = ["wandb>0.22", "tensorboard>=2.20"]
+loggers = ["wandb>=0.22", "tensorboard>=2.20"]
 libero = ["hf-libero>=0.1.3,<0.2.0"]
 diffusion = ["diffusers>=0.38.0"]
 

--- a/library/tests/unit/train/test_trainer.py
+++ b/library/tests/unit/train/test_trainer.py
@@ -98,6 +98,25 @@ class TestTrainer:
         assert any(isinstance(cb, EarlyStopping) for cb in trainer.callbacks)
 
 
+class TestTensorBoardLogging:
+    """Tests that TensorBoard logging works end to end."""
+
+    def test_experiment_name_creates_tensorboard_logger(self, tmp_path):
+        """Verify experiment_name auto-creates a TensorBoardLogger rooted at default_root_dir."""
+        from lightning.pytorch.loggers import TensorBoardLogger
+
+        trainer = Trainer(
+            accelerator="cpu",
+            default_root_dir=str(tmp_path),
+            experiment_name="pusht_act",
+            enable_checkpointing=False,
+        )
+
+        assert isinstance(trainer.logger, TensorBoardLogger)
+        assert trainer.logger.name == "pusht_act"
+        assert trainer.logger.save_dir == str(tmp_path)
+
+
 class TestAutoScaleBatchSize:
     """Tests for the auto_scale_batch_size feature."""
 

--- a/library/tests/unit/train/test_trainer.py
+++ b/library/tests/unit/train/test_trainer.py
@@ -1,3 +1,4 @@
+import pytest
 from lightning.pytorch.callbacks import BatchSizeFinder
 from physicalai.train.trainer import Trainer
 
@@ -103,6 +104,7 @@ class TestTensorBoardLogging:
 
     def test_experiment_name_creates_tensorboard_logger(self, tmp_path):
         """Verify experiment_name auto-creates a TensorBoardLogger rooted at default_root_dir."""
+        pytest.importorskip("tensorboard")
         from lightning.pytorch.loggers import TensorBoardLogger
 
         trainer = Trainer(

--- a/library/uv.lock
+++ b/library/uv.lock
@@ -3853,7 +3853,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'groot'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'pi0'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'smolvla'", specifier = ">=5.5.0,<5.6.0" },
-    { name = "wandb", marker = "extra == 'loggers'", specifier = ">0.22" },
+    { name = "wandb", marker = "extra == 'loggers'", specifier = ">=0.22" },
 ]
 provides-extras = ["cpu", "cu128", "xpu", "tests", "loggers", "libero", "diffusion", "pi0", "pi05", "groot", "smolvla", "executorch", "executorch-openvino", "all"]
 

--- a/library/uv.lock
+++ b/library/uv.lock
@@ -3749,6 +3749,10 @@ groot = [
 libero = [
     { name = "hf-libero" },
 ]
+loggers = [
+    { name = "tensorboard" },
+    { name = "wandb" },
+]
 pi0 = [
     { name = "peft" },
     { name = "pillow" },
@@ -3838,6 +3842,7 @@ requires-dist = [
     { name = "safetensors", marker = "extra == 'pi0'", specifier = ">=0.4.3,<1.0.0" },
     { name = "safetensors", marker = "extra == 'smolvla'", specifier = ">=0.4.3,<1.0.0" },
     { name = "sentencepiece", marker = "extra == 'pi0'", specifier = "<=0.2.1" },
+    { name = "tensorboard", marker = "extra == 'loggers'", specifier = ">=2.20" },
     { name = "timm", marker = "extra == 'groot'", specifier = ">=1.0.0,<1.1.0" },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "physicalai-train", extra = "cpu" } },
     { name = "torch", marker = "extra == 'cu128'", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "physicalai-train", extra = "cu128" } },
@@ -3848,8 +3853,9 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'groot'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'pi0'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'smolvla'", specifier = ">=5.5.0,<5.6.0" },
+    { name = "wandb", marker = "extra == 'loggers'", specifier = ">0.22" },
 ]
-provides-extras = ["cpu", "cu128", "xpu", "tests", "libero", "diffusion", "pi0", "pi05", "groot", "smolvla", "executorch", "executorch-openvino", "all"]
+provides-extras = ["cpu", "cu128", "xpu", "tests", "loggers", "libero", "diffusion", "pi0", "pi05", "groot", "smolvla", "executorch", "executorch-openvino", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Description

Running a training via API can result in a failure, because lightning defaults to tensorboard logging.
New dependencies group allows to explicitly install popular loggers (wandb, tensorboard)
