### PR TITLE
feat(training): Release accelerator memory after training

### DIFF
--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -153,6 +153,13 @@ def run_training_job(
     has no artifact worth keeping. Callers distinguish a canceled run from a
     completed one by consulting ``should_stop`` again after this returns.
 
+    Before export, the trainer, datamodule, and their references back into the
+    policy are dropped and accelerator memory is released (see
+    :func:`_detach_trainer` and :func:`_release_memory`): the trainer's
+    optimizer state and dataloaders would otherwise stay resident throughout
+    export, and export conversion (OpenVINO in particular) can need several GB
+    on top of that.
+
     Args:
         spec: What to train.
         dataset_root: Local root of the LeRobot dataset to train on.
@@ -210,9 +217,10 @@ def run_training_job(
     _publish(cache_dir, output_dir)
 
     export_policy = _export_policy(spec, policy, output_dir)
+    _detach_trainer(export_policy, trainer)
     del trainer, datamodule, policy
-    _release_memory(accelerator)
-    _export(export_policy, output_dir, report, accelerator=accelerator)
+    _release_memory()
+    _export(export_policy, output_dir, report)
 
 
 def _load_policy_from_checkpoint(spec: TrainingJobSpec, checkpoint: Path) -> Policy:
@@ -272,29 +280,59 @@ def _export_policy(spec: TrainingJobSpec, policy: Policy, output_dir: Path) -> P
         return policy
 
 
-def _release_memory(accelerator: str | None = None) -> None:
+def _detach_trainer(export_policy: Policy, trainer: Any) -> None:
+    """Break the trainer<->policy<->datamodule reference cycle before export.
+
+    Lightning wires ``policy._trainer = trainer``, ``trainer.datamodule =
+    datamodule``, and ``trainer.strategy._lightning_module = policy`` during
+    ``fit``, and never undoes it. When ``export_policy`` is the very policy
+    that was just trained (the common case: no ``torch.compile`` reload), it
+    still holds that ``_trainer`` reference, which keeps the trainer — and
+    everything it holds: optimizer state, dataloaders, the strategy — alive
+    and reachable no matter how many local names ``run_training_job`` deletes.
+    ``gc.collect()`` only reclaims *unreachable* cycles, so without this the
+    memory release below is a no-op on the export object it matters most for.
+
+    Best-effort: a failure here must not abort the job.
+    """
+    try:
+        export_policy._trainer = None
+        if getattr(trainer, "strategy", None) is not None:
+            trainer.strategy._lightning_module = None
+        trainer.datamodule = None
+    except Exception as exc:
+        logger.warning("Could not detach trainer from policy: %s", exc)
+
+
+def _release_memory() -> None:
     """Return held host and device memory to the OS/allocator before the next stage.
 
     Export conversion (OpenVINO in particular) allocates several GB above the
     model's resident size, on top of whatever the just-finished trainer and
-    dataloaders still hold. A garbage-collection pass plus clearing the active
-    accelerator's cache prevents that peak from stacking on top of memory this
-    process no longer needs. Best-effort: a failure here must not abort the job.
+    dataloaders still hold. A garbage-collection pass plus clearing every
+    available accelerator's cache prevents that peak from stacking on top of
+    memory this process no longer needs. Best-effort: a failure here must not
+    abort the job.
     """
     gc.collect()
     try:
         import torch
 
-        if accelerator == "xpu" and torch.xpu.is_available():
-            torch.xpu.empty_cache()
+        if torch.xpu.is_available():
             torch.xpu.synchronize()
-        elif accelerator == "cuda" and torch.cuda.is_available():
+            torch.xpu.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
             torch.cuda.empty_cache()
+        if torch.mps.is_available():
+            torch.mps.empty_cache()
+    except ImportError:
+        pass
     except Exception as exc:
         logger.warning("Could not release device cache: %s", exc)
 
 
-def _export(policy: Policy, output_dir: Path, report: ReportFn, *, accelerator: str | None = None) -> None:
+def _export(policy: Policy, output_dir: Path, report: ReportFn) -> None:
     """Export the policy to every backend it declares support for."""
     from physicalai.export import ExportablePolicyMixin
 
@@ -304,7 +342,6 @@ def _export(policy: Policy, output_dir: Path, report: ReportFn, *, accelerator: 
 
     for backend in policy.get_supported_export_backends():
         name = backend.value if hasattr(backend, "value") else str(backend)
-        _release_memory(accelerator)
         try:
             logger.info("Exporting model to %s format", name)
             report(99, f"Exporting to {name} format", {})
@@ -317,3 +354,7 @@ def _export(policy: Policy, output_dir: Path, report: ReportFn, *, accelerator: 
         except Exception:
             # Export is best-effort: one failing backend must not abort the job.
             logger.exception("Failed exporting model to %s format", name)
+        finally:
+            # Conversion peaks well above the model's resident size, so release
+            # after every backend — not just before the first one.
+            _release_memory()

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -228,6 +228,11 @@ def run_training_job(
         auto_scale_batch_size=spec.auto_scale_batch_size,
         precision=spec.precision,
         val_check_interval=min(CHECKPOINT_EVERY_N_STEPS, spec.max_steps),
+        # None tells Lightning val_check_interval counts global steps rather than
+        # batches within one epoch, so it still applies once max_steps is below
+        # one epoch's batch count (an epoch is ~11k steps at batch 8 on the
+        # dataset this cadence was tuned for; shorter runs are common in tests).
+        check_val_every_n_epoch=None,
         gradient_clip_val=1.0,
     )
 

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -49,15 +49,6 @@ CHECKPOINT_NAME = "model.ckpt"
 EXPORTS_DIRNAME = "exports"
 """Subdirectory of ``output_dir`` holding one directory per export backend."""
 
-CHECKPOINT_EVERY_N_STEPS = 1000
-"""Interval checkpoint cadence.
-
-A ``val/loss``-monitored checkpoint never fires on a sub-epoch run (one whose
-``max_steps`` is smaller than one epoch's batch count), so checkpointing is
-driven by step count instead: it fires regardless of validation, so a hang
-mid-training still leaves the most recent interval's weights on disk.
-"""
-
 _DATASET_REPO_ID = "snapshot"
 """Placeholder repo id: datasets are always loaded from a local root here."""
 
@@ -197,13 +188,7 @@ def run_training_job(
     trainer = Trainer(
         logger=CSVLogger(cache_dir.parent, name=cache_dir.stem),
         callbacks=[
-            ModelCheckpoint(
-                dirpath=cache_dir,
-                filename="step{step:06d}",
-                every_n_train_steps=min(CHECKPOINT_EVERY_N_STEPS, spec.max_steps),
-                save_top_k=-1,
-                monitor=None,
-            ),
+            ModelCheckpoint(dirpath=cache_dir, filename="model", save_top_k=1, monitor="val/loss", mode="min"),
             ProgressReportingCallback(report=report, should_stop=should_stop),
         ],
         accelerator=accelerator,
@@ -212,11 +197,6 @@ def run_training_job(
         max_steps=spec.max_steps,
         auto_scale_batch_size=spec.auto_scale_batch_size,
         precision=spec.precision,
-        val_check_interval=min(CHECKPOINT_EVERY_N_STEPS, spec.max_steps),
-        # None tells Lightning val_check_interval counts global steps rather than
-        # batches within one epoch, so it still applies once max_steps is below
-        # one epoch's batch count.
-        check_val_every_n_epoch=None,
         gradient_clip_val=1.0,
     )
 
@@ -324,8 +304,6 @@ def _export(policy: Policy, output_dir: Path, report: ReportFn, *, accelerator: 
 
     for backend in policy.get_supported_export_backends():
         name = backend.value if hasattr(backend, "value") else str(backend)
-        # Conversion peaks well above the model's resident size; hand back
-        # whatever the previous backend cached before starting the next one.
         _release_memory(accelerator)
         try:
             logger.info("Exporting model to %s format", name)

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -310,7 +310,7 @@ def _release_memory(accelerator: str | None = None) -> None:
             torch.xpu.synchronize()
         elif accelerator == "cuda" and torch.cuda.is_available():
             torch.cuda.empty_cache()
-    except Exception as exc
+    except Exception as exc:
         logger.warning("Could not release device cache: %s", exc)
 
 

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -11,9 +11,10 @@ in both places.
 
 :func:`run_training_job` executes a spec: it builds the datamodule and policy,
 runs Lightning, saves the final checkpoint into ``output_dir``, and exports the
-policy to every backend it supports. Where the data comes from, where the
-result goes, how progress is reported, and how cancellation is signalled are all
-arguments — the runner owns none of that policy.
+policy to the backends enabled by ``PHYSICALAI_EXPORT_BACKENDS`` (default
+``"torch"`` only). Where the data comes from, where the result goes, how
+progress is reported, and how cancellation is signalled are all arguments —
+the runner owns none of that policy.
 
 Example:
     >>> spec = TrainingJobSpec(policy="act", max_steps=1000, batch_size=8)
@@ -29,7 +30,9 @@ Example:
 
 from __future__ import annotations
 
+import gc
 import logging
+import os
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -47,6 +50,26 @@ CHECKPOINT_NAME = "model.ckpt"
 
 EXPORTS_DIRNAME = "exports"
 """Subdirectory of ``output_dir`` holding one directory per export backend."""
+
+CHECKPOINT_EVERY_N_STEPS = 500
+"""Interval checkpoint cadence.
+
+Sub-epoch runs on this dataset never trigger a ``val/loss``-monitored
+checkpoint (an epoch is ~11k steps at batch 8), so checkpointing is driven by
+step count instead: it fires regardless of validation, so a hang mid-training
+still leaves the most recent interval's weights on disk.
+"""
+
+_EXPORT_BACKENDS_ENV_VAR = "PHYSICALAI_EXPORT_BACKENDS"
+"""Comma-separated list of export backend names to run after training."""
+
+_DEFAULT_EXPORT_BACKENDS = frozenset({"torch"})
+"""Backends exported when :data:`_EXPORT_BACKENDS_ENV_VAR` is unset.
+
+Torch export alone is enough to load a model in the GUI. Other backends
+(OpenVINO in particular) convert well above the model's resident memory
+footprint and have OOM-killed completed runs; they are opt-in.
+"""
 
 _DATASET_REPO_ID = "snapshot"
 """Placeholder repo id: datasets are always loaded from a local root here."""
@@ -186,7 +209,13 @@ def run_training_job(
     trainer = Trainer(
         logger=CSVLogger(cache_dir.parent, name=cache_dir.stem),
         callbacks=[
-            ModelCheckpoint(dirpath=cache_dir, filename="model", save_top_k=1, monitor="val/loss", mode="min"),
+            ModelCheckpoint(
+                dirpath=cache_dir,
+                filename="model-{step}",
+                every_n_train_steps=min(CHECKPOINT_EVERY_N_STEPS, spec.max_steps),
+                save_top_k=-1,
+                monitor=None,
+            ),
             ProgressReportingCallback(report=report, should_stop=should_stop),
         ],
         accelerator=resolve_accelerator(spec.device_type),
@@ -195,7 +224,8 @@ def run_training_job(
         max_steps=spec.max_steps,
         auto_scale_batch_size=spec.auto_scale_batch_size,
         precision=spec.precision,
-        check_val_every_n_epoch=1,
+        val_check_interval=min(CHECKPOINT_EVERY_N_STEPS, spec.max_steps),
+        gradient_clip_val=1.0,
     )
 
     report(0, "Training model", {})
@@ -206,7 +236,11 @@ def run_training_job(
 
     trainer.save_checkpoint(cache_dir / CHECKPOINT_NAME)
     _publish(cache_dir, output_dir)
-    _export(_export_policy(spec, policy, output_dir), output_dir, report)
+
+    export_policy = _export_policy(spec, policy, output_dir)
+    del trainer, datamodule, policy
+    _release_memory()
+    _export(export_policy, output_dir, report)
 
 
 def _load_policy_from_checkpoint(spec: TrainingJobSpec, checkpoint: Path) -> Policy:
@@ -266,16 +300,52 @@ def _export_policy(spec: TrainingJobSpec, policy: Policy, output_dir: Path) -> P
         return policy
 
 
+def _enabled_export_backends() -> frozenset[str]:
+    """Return the export backend names enabled for this process.
+
+    Controlled by :data:`_EXPORT_BACKENDS_ENV_VAR`; defaults to
+    :data:`_DEFAULT_EXPORT_BACKENDS` when unset. OpenVINO conversion peaks
+    well above the model's resident memory and has OOM-killed completed runs,
+    so it (like any non-default backend) must be opted into explicitly.
+    """
+    raw = os.environ.get(_EXPORT_BACKENDS_ENV_VAR)
+    if raw is None:
+        return frozenset(_DEFAULT_EXPORT_BACKENDS)
+    return frozenset(name.strip().lower() for name in raw.split(",") if name.strip())
+
+
+def _release_memory() -> None:
+    """Return held host and device memory to the OS/allocator before the next stage.
+
+    Export conversion (OpenVINO in particular) allocates several GB above the
+    model's resident size, on top of whatever the just-finished trainer and
+    dataloaders still hold. A garbage-collection pass plus clearing the device
+    allocator's cache prevents that peak from stacking on top of memory this
+    process no longer needs.
+    """
+    import torch
+
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    if torch.xpu.is_available():
+        torch.xpu.empty_cache()
+
+
 def _export(policy: Policy, output_dir: Path, report: ReportFn) -> None:
-    """Export the policy to every backend it declares support for."""
+    """Export the policy to every enabled backend it declares support for."""
     from physicalai.export import ExportablePolicyMixin
 
     if not isinstance(policy, ExportablePolicyMixin):
         logger.info("Skipping export: policy does not support export backends")
         return
 
+    enabled = _enabled_export_backends()
     for backend in policy.get_supported_export_backends():
         name = backend.value if hasattr(backend, "value") else str(backend)
+        if name.lower() not in enabled:
+            logger.info("Skipping %s export: not in %s", name, _EXPORT_BACKENDS_ENV_VAR)
+            continue
         try:
             logger.info("Exporting model to %s format", name)
             report(99, f"Exporting to {name} format", {})
@@ -288,3 +358,7 @@ def _export(policy: Policy, output_dir: Path, report: ReportFn) -> None:
         except Exception:
             # Export is best-effort: one failing backend must not abort the job.
             logger.exception("Failed exporting model to %s format", name)
+        finally:
+            # Conversion peaks well above the model's resident size; release it
+            # before the next backend allocates its own peak.
+            _release_memory()

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -197,6 +197,7 @@ def run_training_job(
         max_steps=spec.max_steps,
         auto_scale_batch_size=spec.auto_scale_batch_size,
         precision=spec.precision,
+        check_val_every_n_epoch=1,
         gradient_clip_val=1.0,
     )
 

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -11,10 +11,9 @@ in both places.
 
 :func:`run_training_job` executes a spec: it builds the datamodule and policy,
 runs Lightning, saves the final checkpoint into ``output_dir``, and exports the
-policy to the backends enabled by ``PHYSICALAI_EXPORT_BACKENDS`` (default
-``"torch"`` only). Where the data comes from, where the result goes, how
-progress is reported, and how cancellation is signalled are all arguments —
-the runner owns none of that policy.
+policy to every backend it supports. Where the data comes from, where the
+result goes, how progress is reported, and how cancellation is signalled are all
+arguments — the runner owns none of that policy.
 
 Example:
     >>> spec = TrainingJobSpec(policy="act", max_steps=1000, batch_size=8)
@@ -32,7 +31,6 @@ from __future__ import annotations
 
 import gc
 import logging
-import os
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -54,23 +52,10 @@ EXPORTS_DIRNAME = "exports"
 CHECKPOINT_EVERY_N_STEPS = 1000
 """Interval checkpoint cadence.
 
-Sub-epoch runs on this dataset never trigger a ``val/loss``-monitored
-checkpoint (an epoch is ~11k steps at batch 8), so checkpointing is driven by
-step count instead: it fires regardless of validation, so a hang mid-training
-still leaves the most recent interval's weights on disk. 1000 is a divisor of
-the step budgets actually used in practice (1000 / 3000 / 5000 / 12000), so
-the final step always lands on an interval too.
-"""
-
-_EXPORT_BACKENDS_ENV_VAR = "PHYSICALAI_EXPORT_BACKENDS"
-"""Comma-separated list of export backend names to run after training."""
-
-_DEFAULT_EXPORT_BACKENDS = frozenset({"torch"})
-"""Backends exported when :data:`_EXPORT_BACKENDS_ENV_VAR` is unset.
-
-Torch export alone is enough to load a model in the GUI. Other backends
-(OpenVINO in particular) convert well above the model's resident memory
-footprint and have OOM-killed completed runs; they are opt-in.
+A ``val/loss``-monitored checkpoint never fires on a sub-epoch run (one whose
+``max_steps`` is smaller than one epoch's batch count), so checkpointing is
+driven by step count instead: it fires regardless of validation, so a hang
+mid-training still leaves the most recent interval's weights on disk.
 """
 
 _DATASET_REPO_ID = "snapshot"
@@ -230,8 +215,7 @@ def run_training_job(
         val_check_interval=min(CHECKPOINT_EVERY_N_STEPS, spec.max_steps),
         # None tells Lightning val_check_interval counts global steps rather than
         # batches within one epoch, so it still applies once max_steps is below
-        # one epoch's batch count (an epoch is ~11k steps at batch 8 on the
-        # dataset this cadence was tuned for; shorter runs are common in tests).
+        # one epoch's batch count.
         check_val_every_n_epoch=None,
         gradient_clip_val=1.0,
     )
@@ -308,20 +292,6 @@ def _export_policy(spec: TrainingJobSpec, policy: Policy, output_dir: Path) -> P
         return policy
 
 
-def _enabled_export_backends() -> frozenset[str]:
-    """Return the export backend names enabled for this process.
-
-    Controlled by :data:`_EXPORT_BACKENDS_ENV_VAR`; defaults to
-    :data:`_DEFAULT_EXPORT_BACKENDS` when unset. OpenVINO conversion peaks
-    well above the model's resident memory and has OOM-killed completed runs,
-    so it (like any non-default backend) must be opted into explicitly.
-    """
-    raw = os.environ.get(_EXPORT_BACKENDS_ENV_VAR)
-    if raw is None:
-        return frozenset(_DEFAULT_EXPORT_BACKENDS)
-    return frozenset(name.strip().lower() for name in raw.split(",") if name.strip())
-
-
 def _release_memory(accelerator: str | None = None) -> None:
     """Return held host and device memory to the OS/allocator before the next stage.
 
@@ -345,19 +315,15 @@ def _release_memory(accelerator: str | None = None) -> None:
 
 
 def _export(policy: Policy, output_dir: Path, report: ReportFn, *, accelerator: str | None = None) -> None:
-    """Export the policy to every enabled backend it declares support for."""
+    """Export the policy to every backend it declares support for."""
     from physicalai.export import ExportablePolicyMixin
 
     if not isinstance(policy, ExportablePolicyMixin):
         logger.info("Skipping export: policy does not support export backends")
         return
 
-    enabled = _enabled_export_backends()
     for backend in policy.get_supported_export_backends():
         name = backend.value if hasattr(backend, "value") else str(backend)
-        if name.lower() not in enabled:
-            logger.info("Skipping %s export: not in %s", name, _EXPORT_BACKENDS_ENV_VAR)
-            continue
         # Conversion peaks well above the model's resident size; hand back
         # whatever the previous backend cached before starting the next one.
         _release_memory(accelerator)

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -308,9 +308,8 @@ def _release_memory(accelerator: str | None = None) -> None:
         if accelerator == "xpu" and torch.xpu.is_available():
             torch.xpu.empty_cache()
             torch.xpu.synchronize()
-        elif torch.cuda.is_available():
+        elif accelerator == "cuda" and torch.cuda.is_available():
             torch.cuda.empty_cache()
-    except Exception as exc:
         logger.warning("Could not release device cache: %s", exc)
 
 

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -198,7 +198,6 @@ def run_training_job(
         auto_scale_batch_size=spec.auto_scale_batch_size,
         precision=spec.precision,
         check_val_every_n_epoch=1,
-        gradient_clip_val=1.0,
     )
 
     report(0, "Training model", {})

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -310,6 +310,7 @@ def _release_memory(accelerator: str | None = None) -> None:
             torch.xpu.synchronize()
         elif accelerator == "cuda" and torch.cuda.is_available():
             torch.cuda.empty_cache()
+    except Exception as exc
         logger.warning("Could not release device cache: %s", exc)
 
 

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -51,13 +51,15 @@ CHECKPOINT_NAME = "model.ckpt"
 EXPORTS_DIRNAME = "exports"
 """Subdirectory of ``output_dir`` holding one directory per export backend."""
 
-CHECKPOINT_EVERY_N_STEPS = 500
+CHECKPOINT_EVERY_N_STEPS = 1000
 """Interval checkpoint cadence.
 
 Sub-epoch runs on this dataset never trigger a ``val/loss``-monitored
 checkpoint (an epoch is ~11k steps at batch 8), so checkpointing is driven by
 step count instead: it fires regardless of validation, so a hang mid-training
-still leaves the most recent interval's weights on disk.
+still leaves the most recent interval's weights on disk. 1000 is a divisor of
+the step budgets actually used in practice (1000 / 3000 / 5000 / 12000), so
+the final step always lands on an interval too.
 """
 
 _EXPORT_BACKENDS_ENV_VAR = "PHYSICALAI_EXPORT_BACKENDS"
@@ -194,6 +196,7 @@ def run_training_job(
 
     from training.device import resolve_accelerator, resolve_devices, resolve_strategy
 
+    accelerator = resolve_accelerator(spec.device_type)
     output_dir, cache_dir = Path(output_dir), Path(cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -211,14 +214,14 @@ def run_training_job(
         callbacks=[
             ModelCheckpoint(
                 dirpath=cache_dir,
-                filename="model-{step}",
+                filename="step{step:06d}",
                 every_n_train_steps=min(CHECKPOINT_EVERY_N_STEPS, spec.max_steps),
                 save_top_k=-1,
                 monitor=None,
             ),
             ProgressReportingCallback(report=report, should_stop=should_stop),
         ],
-        accelerator=resolve_accelerator(spec.device_type),
+        accelerator=accelerator,
         strategy=resolve_strategy(spec.device_type),
         devices=resolve_devices(spec.device_index),
         max_steps=spec.max_steps,
@@ -239,8 +242,8 @@ def run_training_job(
 
     export_policy = _export_policy(spec, policy, output_dir)
     del trainer, datamodule, policy
-    _release_memory()
-    _export(export_policy, output_dir, report)
+    _release_memory(accelerator)
+    _export(export_policy, output_dir, report, accelerator=accelerator)
 
 
 def _load_policy_from_checkpoint(spec: TrainingJobSpec, checkpoint: Path) -> Policy:
@@ -314,25 +317,29 @@ def _enabled_export_backends() -> frozenset[str]:
     return frozenset(name.strip().lower() for name in raw.split(",") if name.strip())
 
 
-def _release_memory() -> None:
+def _release_memory(accelerator: str | None = None) -> None:
     """Return held host and device memory to the OS/allocator before the next stage.
 
     Export conversion (OpenVINO in particular) allocates several GB above the
     model's resident size, on top of whatever the just-finished trainer and
-    dataloaders still hold. A garbage-collection pass plus clearing the device
-    allocator's cache prevents that peak from stacking on top of memory this
-    process no longer needs.
+    dataloaders still hold. A garbage-collection pass plus clearing the active
+    accelerator's cache prevents that peak from stacking on top of memory this
+    process no longer needs. Best-effort: a failure here must not abort the job.
     """
-    import torch
-
     gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-    if torch.xpu.is_available():
-        torch.xpu.empty_cache()
+    try:
+        import torch
+
+        if accelerator == "xpu" and torch.xpu.is_available():
+            torch.xpu.empty_cache()
+            torch.xpu.synchronize()
+        elif torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception as exc:
+        logger.warning("Could not release device cache: %s", exc)
 
 
-def _export(policy: Policy, output_dir: Path, report: ReportFn) -> None:
+def _export(policy: Policy, output_dir: Path, report: ReportFn, *, accelerator: str | None = None) -> None:
     """Export the policy to every enabled backend it declares support for."""
     from physicalai.export import ExportablePolicyMixin
 
@@ -346,6 +353,9 @@ def _export(policy: Policy, output_dir: Path, report: ReportFn) -> None:
         if name.lower() not in enabled:
             logger.info("Skipping %s export: not in %s", name, _EXPORT_BACKENDS_ENV_VAR)
             continue
+        # Conversion peaks well above the model's resident size; hand back
+        # whatever the previous backend cached before starting the next one.
+        _release_memory(accelerator)
         try:
             logger.info("Exporting model to %s format", name)
             report(99, f"Exporting to {name} format", {})
@@ -358,7 +368,3 @@ def _export(policy: Policy, output_dir: Path, report: ReportFn) -> None:
         except Exception:
             # Export is best-effort: one failing backend must not abort the job.
             logger.exception("Failed exporting model to %s format", name)
-        finally:
-            # Conversion peaks well above the model's resident size; release it
-            # before the next backend allocates its own peak.
-            _release_memory()

--- a/application/backend/tests/integration/test_e2e_dataset_to_export.py
+++ b/application/backend/tests/integration/test_e2e_dataset_to_export.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 import io
 import multiprocessing as mp
+import os
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -187,7 +189,10 @@ def test_dataset_upload_train_export_infer_e2e(
     train_job = response.json()
     train_job_id = train_job["id"]
 
-    _run_training_job_step()
+    # ONNX export is opt-in (PHYSICALAI_EXPORT_BACKENDS defaults to torch-only,
+    # see training.job) but this test exercises the ONNX download/inference path.
+    with patch.dict(os.environ, {"PHYSICALAI_EXPORT_BACKENDS": f"torch,{_ONNX_BACKEND}"}):
+        _run_training_job_step()
 
     response = client.get(f"/api/jobs/{train_job_id}")
     assert response.status_code == 200, response.text

--- a/application/backend/tests/integration/test_e2e_dataset_to_export.py
+++ b/application/backend/tests/integration/test_e2e_dataset_to_export.py
@@ -19,10 +19,8 @@ from __future__ import annotations
 
 import io
 import multiprocessing as mp
-import os
 import zipfile
 from pathlib import Path
-from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -189,10 +187,7 @@ def test_dataset_upload_train_export_infer_e2e(
     train_job = response.json()
     train_job_id = train_job["id"]
 
-    # ONNX export is opt-in (PHYSICALAI_EXPORT_BACKENDS defaults to torch-only,
-    # see training.job) but this test exercises the ONNX download/inference path.
-    with patch.dict(os.environ, {"PHYSICALAI_EXPORT_BACKENDS": f"torch,{_ONNX_BACKEND}"}):
-        _run_training_job_step()
+    _run_training_job_step()
 
     response = client.get(f"/api/jobs/{train_job_id}")
     assert response.status_code == 200, response.text

--- a/application/backend/tests/training/test_job.py
+++ b/application/backend/tests/training/test_job.py
@@ -12,6 +12,8 @@ is mocked out; it is not under test.
 
 from __future__ import annotations
 
+import gc
+import weakref
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -266,3 +268,48 @@ class TestRunTrainingJob:
         _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy)
 
         assert [backend for _, backend in policy.exported] == [ExportBackend.OPENVINO]
+
+    def test_trainer_and_datamodule_are_released_before_export(self, tmp_path: Path) -> None:
+        """The trainer must not still be resident (optimizer state, dataloaders) during export.
+
+        Lightning wires ``policy._trainer = trainer`` and ``trainer.datamodule =
+        datamodule`` during ``fit`` and never undoes it; that link is simulated
+        here since the real ``Trainer`` is mocked out. Without breaking it, the
+        exported policy keeps the whole trainer graph reachable and no amount of
+        ``gc.collect()`` can reclaim it: this is what regresses if the reference
+        cycle is left in place instead of explicitly detached before export.
+        """
+        policy = _ExportablePolicy([ExportBackend.TORCH])
+
+        with (
+            patch("physicalai.data.LeRobotDataModule") as datamodule_class,
+            patch(f"{JOB}.build_policy", return_value=policy),
+            patch("physicalai.train.trainer.Trainer") as trainer_class,
+        ):
+            trainer_instance = trainer_class.return_value
+            datamodule_instance = datamodule_class.return_value
+            # Simulate what Lightning's real `trainer.fit(policy, datamodule)` wires up.
+            policy._trainer = trainer_instance
+            trainer_instance.datamodule = datamodule_instance
+            trainer_instance.strategy._lightning_module = policy
+
+            trainer_ref = weakref.ref(trainer_instance)
+            datamodule_ref = weakref.ref(datamodule_instance)
+
+            run_training_job(
+                TrainingJobSpec(policy="act"),
+                dataset_root=tmp_path / "snapshot",
+                output_dir=tmp_path / "model",
+                cache_dir=tmp_path / "cache" / "job",
+                report=MagicMock(),
+                should_stop=lambda: False,
+            )
+
+        # Drop the test's own strong refs before collecting, mirroring what
+        # run_training_job does internally with its local `trainer`/`datamodule`.
+        del trainer_instance, datamodule_instance, trainer_class, datamodule_class
+        gc.collect()
+
+        assert trainer_ref() is None, "trainer is still reachable; the reference cycle was not broken"
+        assert datamodule_ref() is None, "datamodule is still reachable; the reference cycle was not broken"
+        assert policy._trainer is None

--- a/application/backend/tests/training/test_job.py
+++ b/application/backend/tests/training/test_job.py
@@ -12,7 +12,6 @@ is mocked out; it is not under test.
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -244,34 +243,18 @@ class TestRunTrainingJob:
 
         assert report.call_args_list[0].args == (0, "Training model", {})
 
-    def test_only_the_default_backend_is_exported_by_default(self, tmp_path: Path) -> None:
-        """Torch alone is enough to load a model in the GUI; other backends are opt-in.
-
-        OpenVINO conversion has OOM-killed completed runs, so it must not run
-        unless ``PHYSICALAI_EXPORT_BACKENDS`` explicitly enables it.
-        """
+    def test_policy_is_exported_to_every_supported_backend(self, tmp_path: Path) -> None:
         policy = _ExportablePolicy([ExportBackend.TORCH, ExportBackend.OPENVINO])
         report = MagicMock()
 
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("PHYSICALAI_EXPORT_BACKENDS", None)
-            _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy, report=report)
-
-        exports = tmp_path / "model" / EXPORTS_DIRNAME
-        assert policy.exported == [(str(exports / "torch"), ExportBackend.TORCH)]
-        assert (99, "Exporting to torch format", {}) in [call.args for call in report.call_args_list]
-
-    def test_export_backends_env_var_opts_into_additional_backends(self, tmp_path: Path) -> None:
-        policy = _ExportablePolicy([ExportBackend.TORCH, ExportBackend.OPENVINO])
-
-        with patch.dict(os.environ, {"PHYSICALAI_EXPORT_BACKENDS": "torch,openvino"}):
-            _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy)
+        _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy, report=report)
 
         exports = tmp_path / "model" / EXPORTS_DIRNAME
         assert policy.exported == [
             (str(exports / "torch"), ExportBackend.TORCH),
             (str(exports / "openvino"), ExportBackend.OPENVINO),
         ]
+        assert (99, "Exporting to torch format", {}) in [call.args for call in report.call_args_list]
 
     def test_a_failing_export_backend_does_not_fail_the_job(self, tmp_path: Path) -> None:
         """Weights are already saved by then; one bad backend must not lose them."""
@@ -280,7 +263,6 @@ class TestRunTrainingJob:
             failing={ExportBackend.TORCH},
         )
 
-        with patch.dict(os.environ, {"PHYSICALAI_EXPORT_BACKENDS": "torch,openvino"}):
-            _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy)
+        _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy)
 
         assert [backend for _, backend in policy.exported] == [ExportBackend.OPENVINO]

--- a/application/backend/tests/training/test_job.py
+++ b/application/backend/tests/training/test_job.py
@@ -12,6 +12,7 @@ is mocked out; it is not under test.
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -243,18 +244,34 @@ class TestRunTrainingJob:
 
         assert report.call_args_list[0].args == (0, "Training model", {})
 
-    def test_policy_is_exported_to_every_supported_backend(self, tmp_path: Path) -> None:
+    def test_only_the_default_backend_is_exported_by_default(self, tmp_path: Path) -> None:
+        """Torch alone is enough to load a model in the GUI; other backends are opt-in.
+
+        OpenVINO conversion has OOM-killed completed runs, so it must not run
+        unless ``PHYSICALAI_EXPORT_BACKENDS`` explicitly enables it.
+        """
         policy = _ExportablePolicy([ExportBackend.TORCH, ExportBackend.OPENVINO])
         report = MagicMock()
 
-        _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy, report=report)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PHYSICALAI_EXPORT_BACKENDS", None)
+            _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy, report=report)
+
+        exports = tmp_path / "model" / EXPORTS_DIRNAME
+        assert policy.exported == [(str(exports / "torch"), ExportBackend.TORCH)]
+        assert (99, "Exporting to torch format", {}) in [call.args for call in report.call_args_list]
+
+    def test_export_backends_env_var_opts_into_additional_backends(self, tmp_path: Path) -> None:
+        policy = _ExportablePolicy([ExportBackend.TORCH, ExportBackend.OPENVINO])
+
+        with patch.dict(os.environ, {"PHYSICALAI_EXPORT_BACKENDS": "torch,openvino"}):
+            _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy)
 
         exports = tmp_path / "model" / EXPORTS_DIRNAME
         assert policy.exported == [
             (str(exports / "torch"), ExportBackend.TORCH),
             (str(exports / "openvino"), ExportBackend.OPENVINO),
         ]
-        assert (99, "Exporting to torch format", {}) in [call.args for call in report.call_args_list]
 
     def test_a_failing_export_backend_does_not_fail_the_job(self, tmp_path: Path) -> None:
         """Weights are already saved by then; one bad backend must not lose them."""
@@ -263,6 +280,7 @@ class TestRunTrainingJob:
             failing={ExportBackend.TORCH},
         )
 
-        _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy)
+        with patch.dict(os.environ, {"PHYSICALAI_EXPORT_BACKENDS": "torch,openvino"}):
+            _run(TrainingJobSpec(policy="act"), tmp_path, policy=policy)
 
         assert [backend for _, backend in policy.exported] == [ExportBackend.OPENVINO]


### PR DESCRIPTION
Copy of #894 changed to align with training centralization in #904.

## Description

## Failure A — run finishes training, then dies during save/export

A completed 5000-step run and a 2000-step run both reached their full step target and produced **no model**. The process held ~26 GB of trainer/dataloader state on a 30 GB host, and OpenVINO's conversion pass asked for several GB more. An OOM kill is `SIGKILL`, so no downstream `try/except` can rescue it — the memory has to be handed back first.

- drop `trainer` and the datamodule, then `_release_memory()`, **before** export
- release cached memory *between* backends, since conversion peaks well above the model's resident size