### PR TITLE
fix: Increment _init_state_id in Libero gym

### DIFF
--- a/library/src/physicalai/eval/rollout/functional.py
+++ b/library/src/physicalai/eval/rollout/functional.py
@@ -233,6 +233,7 @@ def setup_rollout(
     policy: Policy,
     seed: int | None,
     max_steps: int | None,
+    rollout_idx: int = 0,
 ) -> tuple[Observation, int]:
     """Set up rollout by attaching max_steps, seed, resetting policy and providing first observation.
 
@@ -241,6 +242,7 @@ def setup_rollout(
         policy (Policy): policy to reset if it has attribute.
         seed (int | None): seed to init reset.
         max_steps (int | None): maximum number of steps
+        rollout_idx (int): index of the current rollout. Defaults to 0.
 
     Returns:
         tuple[Observation, int]: First Observation and maximum number of steps of rollout
@@ -248,7 +250,7 @@ def setup_rollout(
     max_steps = _get_max_steps(env, max_steps)
 
     # Reset environment → batched observation
-    observation, _ = env.reset(seed=seed)
+    observation, _ = env.reset(seed=seed, episode_index=rollout_idx)
 
     # Reset policy if needed
     if hasattr(policy, "reset") and callable(policy.reset):
@@ -421,6 +423,7 @@ def rollout(
     frame_key: str = "image",
     render_callback: Callable[[Gym], None] | None = None,
     video_recorder: VideoRecorder | None = None,
+    rollout_idx: int = 0,
 ) -> dict[str, Any]:
     """Runs a policy in an environment for a single episode.
 
@@ -453,6 +456,7 @@ def rollout(
         video_recorder (VideoRecorder | None, optional): Video recorder for capturing
             frames during the rollout. Call start_episode() before and finish_episode()
             after. Defaults to None.
+        rollout_idx (int, optional): Index of the current rollout. Defaults to 0.
 
     Returns:
         dict[str, Any]: Episode information containing:
@@ -468,7 +472,7 @@ def rollout(
             - observation: Observations - if return_observations=True
     """
     # init rollout and policy
-    initial_observation, max_steps = setup_rollout(env, policy, seed, max_steps)
+    initial_observation, max_steps = setup_rollout(env, policy, seed, max_steps, rollout_idx)
 
     # if render callback, call for first observation
     if render_callback:
@@ -598,7 +602,6 @@ def evaluate_policy(
 
     while episodes_collected < n_episodes:
         seed = None if start_seed is None else start_seed + rollout_idx
-        rollout_idx += 1
 
         # Start video recording for this episode
         if video_recorder is not None:
@@ -613,7 +616,10 @@ def evaluate_policy(
             return_observations=return_episode_data,
             frame_key=frame_key,
             video_recorder=video_recorder,
+            rollout_idx=rollout_idx,
         )
+
+        rollout_idx += 1
 
         # Finish video recording
         if video_recorder is not None:

--- a/library/src/physicalai/gyms/base.py
+++ b/library/src/physicalai/gyms/base.py
@@ -29,12 +29,14 @@ class Gym(ABC):
         self,
         *,
         seed: int | None = None,
+        episode_index: int = 0,
         **reset_kwargs: Any,  # noqa: ANN401
     ) -> tuple[Observation, dict[str, Any] | list[dict[str, Any]]]:
         """Resets the environment.
 
         Args:
             seed: Optional random seed for resetting the environment.
+            episode_index: Index of the episode being reset. Defaults to 0.
             **reset_kwargs: Additional backend-specific reset arguments.
 
         Returns:

--- a/library/src/physicalai/gyms/gymnasium_gym.py
+++ b/library/src/physicalai/gyms/gymnasium_gym.py
@@ -199,12 +199,14 @@ class GymnasiumGym(Gym):
         self,
         *,
         seed: int | None = None,
+        episode_index: int = 0,  # noqa: ARG002
         **reset_kwargs: Any,  # noqa: ANN401
     ) -> tuple[Observation, dict[str, Any] | list[dict[str, Any]]]:
         """Reset the environment.
 
         Args:
             seed: Optional seed.
+            episode_index: Index of the episode being reset (unused). Defaults to 0.
             **reset_kwargs: Additional reset arguments.
 
         Returns:

--- a/library/src/physicalai/gyms/libero.py
+++ b/library/src/physicalai/gyms/libero.py
@@ -166,7 +166,6 @@ class LiberoGym(Gym):
         observation_height: int = 256,
         observation_width: int = 256,
         init_states: bool = True,
-        episode_index: int = 0,
         num_steps_wait: int = 10,
         control_mode: str = "relative",
     ) -> None:
@@ -180,7 +179,6 @@ class LiberoGym(Gym):
             observation_height: Image height in pixels (default: 256)
             observation_width: Image width in pixels (default: 256)
             init_states: Whether to use pre-defined init states for reproducibility
-            episode_index: Which init state to use (when init_states=True)
             num_steps_wait: Steps to wait after reset for stabilization (default: 10)
             control_mode: "relative" for delta actions, "absolute" for absolute control
         """
@@ -197,7 +195,6 @@ class LiberoGym(Gym):
         self.observation_height = observation_height
         self.observation_width = observation_width
         self.init_states = init_states
-        self.episode_index = episode_index
         self.num_steps_wait = num_steps_wait
         self.control_mode = control_mode
 
@@ -211,7 +208,6 @@ class LiberoGym(Gym):
 
         # Load init states if requested
         self._init_states: np.ndarray | None = None
-        self._init_state_id = episode_index
         if self.init_states:
             self._init_states = self._load_init_states(task)
 
@@ -347,6 +343,7 @@ class LiberoGym(Gym):
         self,
         *,
         seed: int | None = None,
+        episode_index: int = 0,
         **reset_kwargs: Any,  # noqa: ANN401, ARG002
     ) -> tuple[Observation, dict[str, Any]]:
         """Reset environment with optional init state.
@@ -355,6 +352,7 @@ class LiberoGym(Gym):
 
         Args:
             seed: Random seed for reproducibility
+            episode_index: Index of the episode being reset. Defaults to 0.
             **reset_kwargs: Additional reset options (unused, for base class compatibility)
 
         Returns:
@@ -367,9 +365,8 @@ class LiberoGym(Gym):
 
         # Apply init state if available
         if self.init_states and self._init_states is not None:
-            raw_obs = self.env.set_init_state(self._init_states[self._init_state_id])
-            # Advance to the next init state, wrapping around modulo the number of available init states.
-            self._init_state_id = (self._init_state_id + 1) % len(self._init_states)
+            init_state_id = episode_index % len(self._init_states)
+            raw_obs = self.env.set_init_state(self._init_states[init_state_id])
 
         # After reset, objects may be unstable (slightly floating, intersecting, etc.).
         # Step the simulator with a no-op action for a few frames so everything settles.

--- a/library/src/physicalai/gyms/libero.py
+++ b/library/src/physicalai/gyms/libero.py
@@ -368,6 +368,8 @@ class LiberoGym(Gym):
         # Apply init state if available
         if self.init_states and self._init_states is not None:
             raw_obs = self.env.set_init_state(self._init_states[self._init_state_id])
+            # Advance to the next init state, wrapping around modulo the number of available init states.
+            self._init_state_id = (self._init_state_id + 1) % len(self._init_states)
 
         # After reset, objects may be unstable (slightly floating, intersecting, etc.).
         # Step the simulator with a no-op action for a few frames so everything settles.

--- a/library/src/physicalai/gyms/robocasa.py
+++ b/library/src/physicalai/gyms/robocasa.py
@@ -427,12 +427,14 @@ class RoboCasaGym(Gym):
         self,
         *,
         seed: int | None = None,
+        episode_index: int = 0,  # noqa: ARG002
         **reset_kwargs: Any,  # noqa: ANN401, ARG002
     ) -> tuple[Observation, dict[str, Any]]:
         """Reset the environment and return ``(Observation, info)``.
 
         Args:
             seed: Optional random seed forwarded to the MuJoCo env.
+            episode_index: Index of the episode being reset (unused). Defaults to 0.
             **reset_kwargs: Ignored, present for ``Gym`` ABC compatibility.
 
         Returns:

--- a/library/src/physicalai/gyms/step_limit.py
+++ b/library/src/physicalai/gyms/step_limit.py
@@ -52,6 +52,7 @@ class StepLimit(Gym):
         self,
         *args: Any,  # noqa: ANN401
         seed: int | None = None,
+        episode_index: int = 0,
         **kwargs: Any,  # noqa: ANN401
     ) -> tuple[Observation, dict[str, Any] | list[dict[str, Any]]]:
         """Reset the environment and reset the step counter.
@@ -59,13 +60,14 @@ class StepLimit(Gym):
         Args:
             *args: Additional positional arguments.
             seed: Optional RNG seed.
+            episode_index: Index of the episode being reset. Defaults to 0.
             **kwargs: Additional reset kwargs.
 
         Returns:
             A tuple ``(observation, info)``.
         """
         self.step_count = 0
-        return self.gym.reset(*args, seed=seed, **kwargs)
+        return self.gym.reset(*args, seed=seed, episode_index=episode_index, **kwargs)
 
     def step(
         self,

--- a/library/tests/unit/eval/test_rollout.py
+++ b/library/tests/unit/eval/test_rollout.py
@@ -163,3 +163,120 @@ class TestCollectFrame:
         obs = Observation(state=torch.randn(1, 4), images="not_an_image")
         frame = _collect_frame(obs, "camera")
         assert frame is None
+
+
+# ============================================================================ #
+# episode_index / rollout_idx forwarding Tests                                 #
+# ============================================================================ #
+
+
+class _SpyGym:
+    """Minimal Gym that records the kwargs passed to ``reset``.
+
+    Terminates every episode after a single step so rollouts stay tiny.
+    """
+
+    def __init__(self, batch_size: int = 1, action_dim: int = 2) -> None:
+        self.reset_calls: list[dict] = []
+        self.max_steps = 100
+        self._batch_size = batch_size
+        self._action_dim = action_dim
+
+    def _obs(self):
+        from physicalai.data import Observation
+
+        return Observation(state=torch.zeros(self._batch_size, 4))
+
+    def reset(self, *, seed=None, episode_index=0, **_kwargs):
+        self.reset_calls.append({"seed": seed, "episode_index": episode_index})
+        return self._obs(), {}
+
+    def step(self, _action):
+        reward = torch.zeros(self._batch_size)
+        terminated = torch.ones(self._batch_size, dtype=torch.bool)  # end after 1 step
+        truncated = torch.zeros(self._batch_size, dtype=torch.bool)
+        info = {"is_success": True}
+        return self._obs(), reward, terminated, truncated, info
+
+    def close(self) -> None:
+        pass
+
+    def sample_action(self) -> torch.Tensor:
+        return torch.zeros(self._batch_size, self._action_dim)
+
+    def to_observation(self, raw_obs):
+        return raw_obs
+
+
+class TestEpisodeIndexForwarding:
+    """Tests that rollout_idx flows through as env.reset(episode_index=...)."""
+
+    def test_setup_rollout_forwards_rollout_idx(self, dummy_policy) -> None:
+        """setup_rollout passes rollout_idx as episode_index to env.reset."""
+        from physicalai.eval.rollout.functional import setup_rollout
+
+        env = _SpyGym()
+        setup_rollout(env, dummy_policy, seed=1, max_steps=5, rollout_idx=7)
+
+        assert env.reset_calls == [{"seed": 1, "episode_index": 7}]
+
+    def test_rollout_forwards_rollout_idx(self, dummy_policy) -> None:
+        """rollout forwards rollout_idx down to env.reset."""
+        from physicalai.eval import rollout
+
+        env = _SpyGym()
+        rollout(env=env, policy=dummy_policy, seed=0, max_steps=1, rollout_idx=3)
+
+        assert env.reset_calls[0]["episode_index"] == 3
+
+    def test_rollout_default_rollout_idx_is_zero(self, dummy_policy) -> None:
+        """rollout defaults episode_index to 0 when rollout_idx is omitted."""
+        from physicalai.eval import rollout
+
+        env = _SpyGym()
+        rollout(env=env, policy=dummy_policy, seed=0, max_steps=1)
+
+        assert env.reset_calls[0]["episode_index"] == 0
+
+    def test_evaluate_policy_increments_episode_index(self, dummy_policy) -> None:
+        """evaluate_policy resets with episode_index 0, 1, 2 across episodes."""
+        from physicalai.eval.rollout.functional import evaluate_policy
+
+        env = _SpyGym()
+        evaluate_policy(env, dummy_policy, n_episodes=3, start_seed=100, max_steps=1)
+
+        episode_indices = [call["episode_index"] for call in env.reset_calls]
+        assert episode_indices == [0, 1, 2]
+
+    def test_evaluate_policy_episode_index_aligned_with_seed(self, dummy_policy) -> None:
+        """episode_index stays aligned with seed offset (guards off-by-one)."""
+        from physicalai.eval.rollout.functional import evaluate_policy
+
+        env = _SpyGym()
+        start_seed = 100
+        evaluate_policy(env, dummy_policy, n_episodes=3, start_seed=start_seed, max_steps=1)
+
+        for call in env.reset_calls:
+            assert call["episode_index"] == call["seed"] - start_seed
+
+    def test_evaluate_policy_episode_index_without_seed(self, dummy_policy) -> None:
+        """episode_index still increments when start_seed is None."""
+        from physicalai.eval.rollout.functional import evaluate_policy
+
+        env = _SpyGym()
+        evaluate_policy(env, dummy_policy, n_episodes=3, start_seed=None, max_steps=1)
+
+        episode_indices = [call["episode_index"] for call in env.reset_calls]
+        seeds = [call["seed"] for call in env.reset_calls]
+        assert episode_indices == [0, 1, 2]
+        assert seeds == [None, None, None]
+
+    def test_evaluate_policy_vectorized_indexes_rollouts_not_episodes(self, dummy_policy) -> None:
+        """With a batched env one rollout covers all episodes -> single reset at index 0."""
+        from physicalai.eval.rollout.functional import evaluate_policy
+
+        env = _SpyGym(batch_size=3)
+        evaluate_policy(env, dummy_policy, n_episodes=3, start_seed=0, max_steps=1)
+
+        episode_indices = [call["episode_index"] for call in env.reset_calls]
+        assert episode_indices == [0]

--- a/library/tests/unit/gyms/test_step_limit.py
+++ b/library/tests/unit/gyms/test_step_limit.py
@@ -67,3 +67,36 @@ class TestStepLimit:
         assert base.sample_action().shape == env.sample_action().shape
 
         env.close()
+
+    def test_reset_forwards_episode_index(self):
+        """Wrapper forwards episode_index to the underlying env.reset."""
+        import torch
+
+        from physicalai.data import Observation
+
+        class _SpyGym:
+            def __init__(self):
+                self.reset_calls = []
+
+            def reset(self, *, seed=None, episode_index=0, **_kwargs):
+                self.reset_calls.append({"seed": seed, "episode_index": episode_index})
+                return Observation(state=torch.zeros(1, 4)), {}
+
+            def step(self, action):
+                obs = Observation(state=torch.zeros(1, 4))
+                return obs, 0.0, False, False, {}
+
+            def sample_action(self):
+                return torch.zeros(1, 2)
+
+            def close(self):
+                pass
+
+        spy = _SpyGym()
+        env = with_step_limit(spy, max_steps=5)
+        env.step_count = 4  # non-zero to verify reset clears it
+
+        env.reset(episode_index=5)
+
+        assert spy.reset_calls == [{"seed": None, "episode_index": 5}]
+        assert env.step_count == 0


### PR DESCRIPTION
## Description

`_init_state_id` is aligned with the original implementation - increments by 1 for each episode and do `% len(init_states)`
With this fix the physicalAI implementation of Libero gym should be aligned with the original evaluation pipeline

Model: lerobot/pi05_libero_finetuned_v044 (episodes=10):

| Run | libero_10_0 | libero_10_1 | libero_10_2 | libero_10_3 | libero_10_4 | libero_10_5 | libero_10_6 | libero_10_7 | libero_10_8 | libero_10_9 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Before fix | 80.0 / 327.0 | 100.0 / 240.1 | 80.0 / 288.3 | 70.0 / 317.0 | 100.0 / 244.0 | 100.0 / 175.4 | 100.0 / 223.1 | 100.0 / 266.8 | 50.0 / 457.7 | 100.0 / 255.8 |
| After fix | 70.0 / 346.5 | 100.0 / 242.3 | 80.0 / 300.8 | 90.0 / 268.6 | 80.0 / 291.1 | 100.0 / 189.6 | 100.0 / 221.3 | 90.0 / 289.9 | 60.0 / 448.3 | 90.0 / 298.5 |

Shows that the increment makes the libero benchmark more difficult on average - aligned with the original implementation
https://github.com/Lifelong-Robot-Learning/LIBERO/blob/master/libero/lifelong/evaluate.py#L255

## Implementation

`Gym.reset` method now accepts a non required `episode_id` param - which is used to get `_init_step_id` for the libero benchmark

## Related Issues