### PR TITLE
docs: Add demo video url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ For users who prefer a visual interface for end-to-end workflow:
 </p>
 <!-- markdownlint-enable MD033 -->
 
+[Watch the full demo video →](docs/assets/physical_ai_studio_full_overview.mp4)
+
 [Application Documentation →](./application/README.md)
 
 #### Docker

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For users who prefer a visual interface for end-to-end workflow:
 </p>
 <!-- markdownlint-enable MD033 -->
 
-[Watch the full demo video →](docs/assets/physical_ai_studio_full_overview.mp4)
+[Download the full demo video →](docs/assets/physical_ai_studio_full_overview.mp4)
 
 [Application Documentation →](./application/README.md)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ For users who prefer a visual interface for end-to-end workflow:
 
 <!-- markdownlint-disable MD033 -->
 <p align="center">
-  <img src="docs/assets/physical_ai_studio_overview.gif" alt="Application demo" width="100%">
+  <a href="docs/assets/physical_ai_studio_full_overview.mp4">
+    <img src="docs/assets/physical_ai_studio_overview.gif" alt="Application demo" width="100%">
+  </a>
 </p>
 <!-- markdownlint-enable MD033 -->
 


### PR DESCRIPTION
Adds a direct link to download the full demo video in the README. The video is not directly viewable in github so it needs to be downloaded instead. 