### PR TITLE
fix: gh-918 prefill default task when importing dataset

### DIFF
--- a/application/backend/src/schemas/dataset_import_job.py
+++ b/application/backend/src/schemas/dataset_import_job.py
@@ -26,6 +26,7 @@ class DatasetManifestRecordingSchema(BaseModel):
 
     cameras: list[ManifestCameraEntry] = Field(default_factory=list)
     robots: list[ManifestRobotEntry] = Field(default_factory=list)
+    tasks: list[str] = Field(default_factory=list)
 
 
 class ImportStep(StrEnum):

--- a/application/backend/src/services/dataset_import/adapters/lerobot_v3.py
+++ b/application/backend/src/services/dataset_import/adapters/lerobot_v3.py
@@ -228,7 +228,7 @@ class LeRobotV3Adapter(DatasetImportAdapter):
         info: dict = {}
         episode_count = 0
         frame_count = 0
-        tasks: list[str] = []
+        tasks: set[str] = set()
 
         try:
             info = self._load_info(archive=archive, report=report)

--- a/application/backend/src/services/dataset_import/adapters/lerobot_v3.py
+++ b/application/backend/src/services/dataset_import/adapters/lerobot_v3.py
@@ -44,14 +44,15 @@ class LeRobotV3Adapter(DatasetImportAdapter):
             return {}
         return raw_info
 
-    def _load_episode_counts(  # noqa: C901, PLR0912, PLR0915
+    def _load_episode_metadata(  # noqa: C901, PLR0912, PLR0915
         self,
         archive: SafeZipArchive,
         report: ImportValidationReport,
         info: dict | None = None,
-    ) -> tuple[int, int]:
+    ) -> tuple[int, int, set[str]]:
         episode_count = 0
         frame_count = 0
+        tasks: set[str] = set()
 
         episode_shards: list[tuple[int, int, str]] = []
         for name in archive.iter_normalized_names():
@@ -60,7 +61,7 @@ class LeRobotV3Adapter(DatasetImportAdapter):
 
         if not episode_shards:
             report.add_error("No episode parquet found under 'meta/episodes/chunk-*/file-*.parquet'.")
-            return episode_count, frame_count
+            return episode_count, frame_count, tasks
 
         episode_shards.sort(key=lambda item: (item[0], item[1], item[2]))
 
@@ -104,9 +105,17 @@ class LeRobotV3Adapter(DatasetImportAdapter):
             else:
                 shard_count_without_length += 1
 
+            if "tasks" in episodes_df.columns:
+                for episode_tasks in episodes_df["tasks"]:
+                    if isinstance(episode_tasks, str) or not isinstance(episode_tasks, Iterable):
+                        continue
+                    for task in episode_tasks:
+                        if isinstance(task, str):
+                            tasks.add(task)
+
         if readable_shard_count == 0:
             report.add_error("No readable episode parquet found under 'meta/episodes/chunk-*/file-*.parquet'.")
-            return 0, 0
+            return 0, 0, tasks
 
         if shard_count_with_episode_index == 0:
             episode_count = episode_rows_total
@@ -142,40 +151,10 @@ class LeRobotV3Adapter(DatasetImportAdapter):
                     f"{expected_frame_count}, parsed episode shards report {frame_count}."
                 )
 
-        return episode_count, frame_count
-
-    def _load_tasks(self, archive: SafeZipArchive, report: ImportValidationReport) -> list[str]:
-        episode_shards: list[tuple[int, int, str]] = []
-        for name in archive.iter_normalized_names():
-            if match := self._EPISODE_PARQUET_PATTERN.search(name):
-                episode_shards.append((int(match.group(1)), int(match.group(2)), name))
-
-        tasks: list[str] = []
-        for _chunk_index, _file_index, shard_name in sorted(episode_shards):
-            shard_bytes = archive.read_bytes(shard_name)
-            if shard_bytes is None:
-                continue
-
-            try:
-                episodes_df = pd.read_parquet(BytesIO(shard_bytes), columns=["tasks"])
-            except Exception as error:
-                logger.debug("Could not parse task metadata from '{}': {}", shard_name, type(error).__name__)
-                continue
-
-            if episodes_df.empty:
-                continue
-
-            for episode_tasks in episodes_df["tasks"]:
-                if isinstance(episode_tasks, str) or not isinstance(episode_tasks, Iterable):
-                    continue
-                for task in episode_tasks:
-                    if isinstance(task, str) and task not in tasks:
-                        tasks.append(task)
-
         if not tasks:
             report.add_warning("Could not infer tasks from episode metadata.")
 
-        return tasks
+        return episode_count, frame_count, tasks
 
     def detect(self, archive: SafeZipArchive) -> tuple[bool, ImportValidationReport]:
         """Return (matched, report) for LeRobot v3 archives.
@@ -253,8 +232,7 @@ class LeRobotV3Adapter(DatasetImportAdapter):
 
         try:
             info = self._load_info(archive=archive, report=report)
-            episode_count, frame_count = self._load_episode_counts(archive=archive, report=report, info=info)
-            tasks = self._load_tasks(archive=archive, report=report)
+            episode_count, frame_count, tasks = self._load_episode_metadata(archive=archive, report=report, info=info)
 
             if archive.read_json("meta/stats.json") is None:
                 report.add_warning("No global stats metadata found in 'meta/stats.json'.")
@@ -288,7 +266,7 @@ class LeRobotV3Adapter(DatasetImportAdapter):
                 episode_count=episode_count,
                 frame_count=frame_count,
             ),
-            dataset_schema=recording_schema.model_copy(update={"tasks": tasks}),
+            dataset_schema=recording_schema.model_copy(update={"tasks": sorted(tasks)}),
         )
 
         return manifest, report

--- a/application/backend/src/services/dataset_import/adapters/lerobot_v3.py
+++ b/application/backend/src/services/dataset_import/adapters/lerobot_v3.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import shutil
+from collections.abc import Iterable
 from io import BytesIO
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
@@ -143,6 +144,39 @@ class LeRobotV3Adapter(DatasetImportAdapter):
 
         return episode_count, frame_count
 
+    def _load_tasks(self, archive: SafeZipArchive, report: ImportValidationReport) -> list[str]:
+        episode_shards: list[tuple[int, int, str]] = []
+        for name in archive.iter_normalized_names():
+            if match := self._EPISODE_PARQUET_PATTERN.search(name):
+                episode_shards.append((int(match.group(1)), int(match.group(2)), name))
+
+        tasks: list[str] = []
+        for _chunk_index, _file_index, shard_name in sorted(episode_shards):
+            shard_bytes = archive.read_bytes(shard_name)
+            if shard_bytes is None:
+                continue
+
+            try:
+                episodes_df = pd.read_parquet(BytesIO(shard_bytes), columns=["tasks"])
+            except Exception as error:
+                logger.debug("Could not parse task metadata from '{}': {}", shard_name, type(error).__name__)
+                continue
+
+            if episodes_df.empty:
+                continue
+
+            for episode_tasks in episodes_df["tasks"]:
+                if isinstance(episode_tasks, str) or not isinstance(episode_tasks, Iterable):
+                    continue
+                for task in episode_tasks:
+                    if isinstance(task, str) and task not in tasks:
+                        tasks.append(task)
+
+        if not tasks:
+            report.add_warning("Could not infer tasks from episode metadata.")
+
+        return tasks
+
     def detect(self, archive: SafeZipArchive) -> tuple[bool, ImportValidationReport]:
         """Return (matched, report) for LeRobot v3 archives.
 
@@ -215,10 +249,12 @@ class LeRobotV3Adapter(DatasetImportAdapter):
         info: dict = {}
         episode_count = 0
         frame_count = 0
+        tasks: list[str] = []
 
         try:
             info = self._load_info(archive=archive, report=report)
             episode_count, frame_count = self._load_episode_counts(archive=archive, report=report, info=info)
+            tasks = self._load_tasks(archive=archive, report=report)
 
             if archive.read_json("meta/stats.json") is None:
                 report.add_warning("No global stats metadata found in 'meta/stats.json'.")
@@ -252,7 +288,7 @@ class LeRobotV3Adapter(DatasetImportAdapter):
                 episode_count=episode_count,
                 frame_count=frame_count,
             ),
-            dataset_schema=recording_schema,
+            dataset_schema=recording_schema.model_copy(update={"tasks": tasks}),
         )
 
         return manifest, report

--- a/application/backend/tests/services/dataset_import/adapters/test_lerobot_v3_adapter.py
+++ b/application/backend/tests/services/dataset_import/adapters/test_lerobot_v3_adapter.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import numpy as np
 import pandas as pd
 from physicalai.data.archive_safety import SafeZipArchive
 
@@ -32,6 +33,15 @@ def _episodes_parquet_bytes(
     df = pd.DataFrame(data)
     buffer = BytesIO()
     df.to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
+def _episodes_with_tasks_parquet_bytes(tasks: list[list[str]], *, as_arrays: bool = False) -> bytes:
+    buffer = BytesIO()
+    serialized_tasks = [np.array(task, dtype=object) for task in tasks] if as_arrays else tasks
+    pd.DataFrame(
+        {"episode_index": list(range(len(tasks))), "length": [1] * len(tasks), "tasks": serialized_tasks}
+    ).to_parquet(buffer, index=False)
     return buffer.getvalue()
 
 
@@ -164,6 +174,28 @@ def test_lerobot_v3_parse_manifest_counts_all_episode_parquet_shards(tmp_path: P
 
     assert manifest.statistics.episode_count == 5
     assert manifest.statistics.frame_count == 45
+
+
+def test_lerobot_v3_parse_manifest_collects_unique_episode_tasks_in_order(tmp_path: Path) -> None:
+    adapter = LeRobotV3Adapter()
+    archive_path = tmp_path / "v3-default-task.zip"
+    _write_zip(
+        archive_path,
+        {
+            "meta/info.json": json.dumps({"codebase_version": "v3.0"}).encode("utf-8"),
+            "meta/tasks.parquet": b"PAR1",
+            "meta/episodes/chunk-000/file-000.parquet": _episodes_with_tasks_parquet_bytes(
+                [["Fold the Garment", "Place the Garment"], ["Fold the Garment"]], as_arrays=True
+            ),
+            "meta/episodes/chunk-000/file-001.parquet": _episodes_with_tasks_parquet_bytes([["Hang the Garment"]]),
+            "data/chunk-000/file-000.parquet": b"PAR1",
+        },
+    )
+
+    safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
+    manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
+
+    assert manifest.dataset_schema.tasks == ["Fold the Garment", "Place the Garment", "Hang the Garment"]
 
 
 def test_lerobot_v3_parse_manifest_counts_episode_shards_when_file_000_is_missing(tmp_path: Path) -> None:

--- a/application/backend/tests/services/dataset_import/adapters/test_lerobot_v3_adapter.py
+++ b/application/backend/tests/services/dataset_import/adapters/test_lerobot_v3_adapter.py
@@ -176,7 +176,7 @@ def test_lerobot_v3_parse_manifest_counts_all_episode_parquet_shards(tmp_path: P
     assert manifest.statistics.frame_count == 45
 
 
-def test_lerobot_v3_parse_manifest_collects_unique_episode_tasks_in_order(tmp_path: Path) -> None:
+def test_lerobot_v3_parse_manifest_collects_unique_episode_tasks(tmp_path: Path) -> None:
     adapter = LeRobotV3Adapter()
     archive_path = tmp_path / "v3-default-task.zip"
     _write_zip(
@@ -195,7 +195,7 @@ def test_lerobot_v3_parse_manifest_collects_unique_episode_tasks_in_order(tmp_pa
     safe_archive = SafeZipArchive(archive_path, max_uncompressed_bytes=5 * 1024 * 1024 * 1024)
     manifest, _report = adapter.build_draft(safe_archive, payload=MagicMock())
 
-    assert manifest.dataset_schema.tasks == ["Fold the Garment", "Place the Garment", "Hang the Garment"]
+    assert manifest.dataset_schema.tasks == ["Fold the Garment", "Hang the Garment", "Place the Garment"]
 
 
 def test_lerobot_v3_parse_manifest_counts_episode_shards_when_file_000_is_missing(tmp_path: Path) -> None:

--- a/application/backend/tests/services/dataset_import/test_dataset_import_service.py
+++ b/application/backend/tests/services/dataset_import/test_dataset_import_service.py
@@ -352,8 +352,8 @@ async def test_cancel_succeeds_for_awaiting_user_review_with_staging_id() -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_dataset_manifest_identity_slim_shape_no_default_task() -> None:
-    """DatasetManifest no longer carries identity fields such as suggested_name/default_task."""
+def test_dataset_manifest_identity_slim_shape_has_no_default_task() -> None:
+    """DatasetManifest does not carry the selected default task."""
     from schemas.dataset_import_job import DatasetManifest
 
     manifest = DatasetManifest()

--- a/application/ui/src/routes/datasets/import/import-dataset-dialog.tsx
+++ b/application/ui/src/routes/datasets/import/import-dataset-dialog.tsx
@@ -111,20 +111,13 @@ const InternalImportDatasetDialog = ({
     const queryClient = useQueryClient();
     const [datasetName, setDatasetName] = useState('');
     const [finalizeFields, setFinalizeFields] = useState<FinalizeFields>({
-        defaultTask: '',
+        defaultTask: undefined,
         environmentId: undefined,
     });
     const [importJobId, setImportJobId] = useState<string | undefined>(initialJobId);
 
     const importJobQuery = useDatasetImportJobQuery(importJobId);
     const importJob = importJobQuery.data as SchemaDatasetImportJob | undefined;
-    const inferredDefaultTask = importJob?.payload?.dataset_manifest_draft?.dataset_schema?.tasks?.at(0);
-
-    useEffect(() => {
-        if (inferredDefaultTask && finalizeFields.defaultTask === '') {
-            setFinalizeFields((fields) => ({ ...fields, defaultTask: inferredDefaultTask }));
-        }
-    }, [finalizeFields.defaultTask, inferredDefaultTask]);
 
     const status = getDialogViewStatus(importJob);
 

--- a/application/ui/src/routes/datasets/import/import-dataset-dialog.tsx
+++ b/application/ui/src/routes/datasets/import/import-dataset-dialog.tsx
@@ -118,6 +118,13 @@ const InternalImportDatasetDialog = ({
 
     const importJobQuery = useDatasetImportJobQuery(importJobId);
     const importJob = importJobQuery.data as SchemaDatasetImportJob | undefined;
+    const inferredDefaultTask = importJob?.payload?.dataset_manifest_draft?.dataset_schema?.tasks?.at(0);
+
+    useEffect(() => {
+        if (inferredDefaultTask && finalizeFields.defaultTask === '') {
+            setFinalizeFields((fields) => ({ ...fields, defaultTask: inferredDefaultTask }));
+        }
+    }, [finalizeFields.defaultTask, inferredDefaultTask]);
 
     const status = getDialogViewStatus(importJob);
 

--- a/application/ui/src/routes/datasets/import/import-step-user-review.tsx
+++ b/application/ui/src/routes/datasets/import/import-step-user-review.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import {
     Button,
     ButtonGroup,
@@ -113,22 +111,18 @@ export const ImportStepUserReview = ({
     const { data: environments } = $api.useSuspenseQuery('get', '/api/projects/{project_id}/environments', {
         params: { path: { project_id } },
     });
-
-    useEffect(() => {
-        if (environments.length === 1 && fields.environmentId === undefined) {
-            onFieldsChange({ ...fields, environmentId: environments[0].id });
-        }
-    }, [environments, fields, onFieldsChange]);
+    const defaultTask = fields.defaultTask ?? tasks.at(0) ?? '';
+    const environmentId = fields.environmentId ?? (environments.length === 1 ? environments[0].id : undefined);
 
     const finalizeMutation = $api.useMutation('post', '/api/projects/{project_id}/imports/datasets/{job_id}:finalize', {
         meta: {
             invalidates: [['get', '/api/jobs/{job_id}', { params: { path: { job_id: importJob.id! } } }]],
         },
     });
-    const canFinalize = fields.environmentId !== undefined;
+    const canFinalize = environmentId !== undefined;
 
     const onFinalize = () => {
-        if (!canFinalize || fields.environmentId === undefined) {
+        if (!canFinalize || environmentId === undefined) {
             return;
         }
 
@@ -137,8 +131,8 @@ export const ImportStepUserReview = ({
                 path: { project_id, job_id: importJob.id! },
             },
             body: {
-                environment_id: fields.environmentId,
-                default_task: fields.defaultTask,
+                environment_id: environmentId,
+                default_task: defaultTask,
             },
         });
     };
@@ -174,7 +168,7 @@ export const ImportStepUserReview = ({
                         label='Recording environment'
                         width='100%'
                         items={environments}
-                        selectedKey={fields.environmentId}
+                        selectedKey={environmentId}
                         onSelectionChange={(value) =>
                             onFieldsChange({
                                 ...fields,
@@ -189,8 +183,8 @@ export const ImportStepUserReview = ({
                         width='100%'
                         label='Task'
                         allowsCustomValue
-                        inputValue={fields.defaultTask}
-                        onInputChange={(defaultTask) => onFieldsChange({ ...fields, defaultTask })}
+                        inputValue={defaultTask}
+                        onInputChange={(task) => onFieldsChange({ ...fields, defaultTask: task })}
                     >
                         {tasks.map((task) => (
                             <Item key={task}>{task}</Item>

--- a/application/ui/src/routes/datasets/import/import-step-user-review.tsx
+++ b/application/ui/src/routes/datasets/import/import-step-user-review.tsx
@@ -1,6 +1,9 @@
+import { useEffect } from 'react';
+
 import {
     Button,
     ButtonGroup,
+    ComboBox,
     Content,
     Flex,
     Heading,
@@ -8,7 +11,6 @@ import {
     Item,
     Picker,
     Text,
-    TextField,
     View,
 } from '@geti-ui/ui';
 import { isNumber } from 'lodash-es';
@@ -63,6 +65,7 @@ const DatasetManifestSummary = ({ importJob }: { importJob: SchemaDatasetImportJ
 
     const cameras = draft.dataset_schema?.cameras ?? [];
     const robots = draft.dataset_schema?.robots ?? [];
+    const tasks = draft.dataset_schema?.tasks ?? [];
 
     const fps = draft.dataset_schema?.cameras?.at(0)?.fps;
     const episodeCount = draft.statistics?.episode_count;
@@ -81,6 +84,11 @@ const DatasetManifestSummary = ({ importJob }: { importJob: SchemaDatasetImportJ
                 {robots.length > 0 && <RobotsSummary robots={robots} />}
 
                 {cameras.length > 0 && <CamerasSummary cameras={cameras} />}
+                {tasks.length > 0 && (
+                    <Text>
+                        <strong>Tasks</strong>: {tasks.join(', ')}
+                    </Text>
+                )}
             </Flex>
         </Flex>
     );
@@ -101,9 +109,16 @@ export const ImportStepUserReview = ({
     fields,
     onFieldsChange,
 }: ImportStepUserReviewProps) => {
+    const tasks = importJob.payload?.dataset_manifest_draft?.dataset_schema?.tasks ?? [];
     const { data: environments } = $api.useSuspenseQuery('get', '/api/projects/{project_id}/environments', {
         params: { path: { project_id } },
     });
+
+    useEffect(() => {
+        if (environments.length === 1 && fields.environmentId === undefined) {
+            onFieldsChange({ ...fields, environmentId: environments[0].id });
+        }
+    }, [environments, fields, onFieldsChange]);
 
     const finalizeMutation = $api.useMutation('post', '/api/projects/{project_id}/imports/datasets/{job_id}:finalize', {
         meta: {
@@ -170,12 +185,17 @@ export const ImportStepUserReview = ({
                         {(item) => <Item key={item.id}>{item.name}</Item>}
                     </Picker>
 
-                    <TextField
+                    <ComboBox
                         width='100%'
                         label='Task'
-                        value={fields.defaultTask}
-                        onChange={(value) => onFieldsChange({ ...fields, defaultTask: value })}
-                    />
+                        allowsCustomValue
+                        inputValue={fields.defaultTask}
+                        onInputChange={(defaultTask) => onFieldsChange({ ...fields, defaultTask })}
+                    >
+                        {tasks.map((task) => (
+                            <Item key={task}>{task}</Item>
+                        ))}
+                    </ComboBox>
                 </Flex>
             </Content>
 

--- a/application/ui/src/routes/datasets/import/use-dataset-import-job-state.ts
+++ b/application/ui/src/routes/datasets/import/use-dataset-import-job-state.ts
@@ -1,7 +1,7 @@
 import { $api } from '../../../api/client';
 
 export interface FinalizeFields {
-    defaultTask: string;
+    defaultTask: string | undefined;
     environmentId: string | undefined;
 }
 


### PR DESCRIPTION
Fixes #918: we now load the tasks found in the imported datasets and allow the user to select these.
The UI automatically selects the first task.
We now also select the first environment if the user has only 1 environment, making the whole importing process a bit simpler.

<img width="1920" height="1080" alt="localhost_3000_projects_c7d7e1f1-d9da-408c-9694-ed52bddb58cb_datasets_07e4bd63-10e0-4b42-8ae8-f74f950df0fe(Full HD)" src="https://github.com/user-attachments/assets/a2c414db-7d24-49ca-8c15-cba9394d6c31" />

One other improvement we do need to make here is to check if the recording environment the user has selected is compatible with the dataset.
At the moment we don't do that yet so that users can create an "empty" environment and import a dataset using that. This is mainly as a workaround for #849, so that you can import datasets without having a ready environment.