### PR TITLE
feat(backend): persist SSH-provisioned remote training servers

### DIFF
--- a/application/backend/src/alembic/versions/20260803_000000_b7a4c1e9f0d2_add_remote_servers.py
+++ b/application/backend/src/alembic/versions/20260803_000000_b7a4c1e9f0d2_add_remote_servers.py
@@ -1,0 +1,76 @@
+"""add remote servers and per-job provisioning state
+
+Creates ``remote_servers`` (SSH-provisioned training targets, identified only by
+an SSH config alias) and ``job_provisioning`` (per-job container state).
+
+``remote_servers`` deliberately has no ``username``, ``auth_type``,
+``ssh_secret_encrypted``, ``ssh_key_passphrase_encrypted``, or ``host_key``
+column, and no host/port/username unique constraint: Studio never receives SSH
+credentials, and hostname/port/user are resolved from the user's SSH config at
+read time so a stored row cannot silently disagree with it.
+
+Revision ID: b7a4c1e9f0d2
+Revises: e4b2f1c8a907
+Create Date: 2026-08-03 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7a4c1e9f0d2"
+down_revision: str | Sequence[str] | None = "e4b2f1c8a907"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the remote server registry and its per-job provisioning table."""
+    op.create_table(
+        "remote_servers",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("ssh_host_alias", sa.String(length=255), nullable=False),
+        sa.Column("device_type", sa.String(), nullable=False),
+        sa.Column("last_check_status", sa.String(length=32), nullable=False, server_default=sa.text("'unknown'")),
+        sa.Column("last_check_at", sa.DateTime(), nullable=True),
+        sa.Column("last_check_latency_ms", sa.Integer(), nullable=True),
+        sa.Column("last_check_reason_code", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("ssh_host_alias", name="uq_remote_servers_ssh_host_alias"),
+    )
+    op.create_table(
+        "job_provisioning",
+        sa.Column("job_id", sa.Text(), nullable=False),
+        sa.Column("remote_server_id", sa.Text(), nullable=False),
+        sa.Column("ssh_host_alias", sa.String(length=255), nullable=False),
+        sa.Column("image_ref", sa.String(length=512), nullable=True),
+        sa.Column("image_fallback_reason", sa.String(length=512), nullable=True),
+        sa.Column("image_digest", sa.String(length=255), nullable=True),
+        sa.Column("container_id", sa.String(length=128), nullable=True),
+        sa.Column("container_name", sa.String(length=255), nullable=True),
+        sa.Column("remote_port", sa.Integer(), nullable=True),
+        sa.Column("local_tunnel_port", sa.Integer(), nullable=True),
+        sa.Column("backend_instance_id", sa.String(length=255), nullable=True),
+        sa.Column("trainer_build_version", sa.String(length=255), nullable=True),
+        sa.Column("trainer_protocol_version", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+        sa.PrimaryKeyConstraint("job_id"),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"], ondelete="CASCADE"),
+        # RESTRICT: deleting a server whose job is still running would drop the
+        # only record of the container that has to be cleaned up.
+        sa.ForeignKeyConstraint(["remote_server_id"], ["remote_servers.id"], ondelete="RESTRICT"),
+    )
+
+
+def downgrade() -> None:
+    """Drop both tables, children first."""
+    op.drop_table("job_provisioning")
+    op.drop_table("remote_servers")

--- a/application/backend/src/db/schema.py
+++ b/application/backend/src/db/schema.py
@@ -26,6 +26,76 @@ class RemoteTrainerDB(Base):
     )
 
 
+class RemoteServerDB(Base):
+    """An SSH-provisioned training server, identified by an SSH config alias.
+
+    Holds no credential. ``ssh_host_alias`` names a ``Host`` stanza in the user's
+    own SSH config; the SSH client library resolves it and authenticates, so
+    Studio never receives a key, password, or passphrase. Hostname, port, and
+    user are derived from the SSH config at read time rather than persisted, so a
+    stored record can never silently disagree with the config that defines it.
+    """
+
+    __tablename__ = "remote_servers"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=lambda: str(uuid4()))
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Unique: a second record for the same alias describes the same machine.
+    ssh_host_alias: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    device_type: Mapped[str] = mapped_column(String, nullable=False)
+    # Summary of the most recent preflight. A transient failure updates these
+    # columns instead of destroying the record.
+    last_check_status: Mapped[str] = mapped_column(String(32), nullable=False, default="unknown")
+    last_check_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_check_latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_check_reason_code: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+    )
+
+
+class JobProvisioningDB(Base):
+    """What Studio provisioned on a remote server for one job.
+
+    Keyed by ``job_id`` in its own table rather than stored in the job payload
+    JSON, so a restarted backend can sweep or reclaim an orphaned container with
+    a query instead of parsing every job's payload.
+    """
+
+    __tablename__ = "job_provisioning"
+
+    job_id: Mapped[str] = mapped_column(Text, ForeignKey("jobs.id", ondelete="CASCADE"), primary_key=True)
+    # RESTRICT, not CASCADE: deleting a server while one of its jobs is still
+    # running would drop the only record of the container to clean up.
+    remote_server_id: Mapped[str] = mapped_column(
+        Text,
+        ForeignKey("remote_servers.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    ssh_host_alias: Mapped[str] = mapped_column(String(255), nullable=False)
+    image_ref: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    image_fallback_reason: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    image_digest: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    container_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    container_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    remote_port: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    local_tunnel_port: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Ownership marker for the orphan sweep: two Studio instances can target the
+    # same host, so a sweep must prove the container is its own.
+    backend_instance_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    trainer_build_version: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    trainer_protocol_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+    )
+
+
 class ProjectDB(Base):
     __tablename__ = "projects"
 

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -13,6 +13,7 @@ class ResourceType(StrEnum):
     DATASET = "Dataset"
     MODEL = "Model"
     REMOTE_TRAINER = "Remote trainer"
+    REMOTE_SERVER = "Remote server"
     JOB = "JOB"
     JOB_FILE = "JOB_FILE"
 

--- a/application/backend/src/repositories/job_provisioning_repo.py
+++ b/application/backend/src/repositories/job_provisioning_repo.py
@@ -1,0 +1,93 @@
+from collections.abc import Callable
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio.session import AsyncSession
+
+from db.schema import JobDB, JobProvisioningDB
+from repositories.base import BaseRepository
+from repositories.mappers.job_provisioning_mapper import JobProvisioningMapper
+from schemas.base_job import JobStatus
+from schemas.job_provisioning import JobProvisioning, JobProvisioningUpdate
+
+# Jobs that can still own a live container. Anything else has finished, so its
+# provisioning row only describes something already torn down.
+_NON_TERMINAL_JOB_STATUSES = (JobStatus.PENDING.value, JobStatus.RUNNING.value)
+
+
+class JobProvisioningRepository(BaseRepository[JobProvisioning, JobProvisioningDB]):
+    """Persistence for per-job SSH provisioning state.
+
+    The table is keyed by ``job_id``, not ``id``, so the ``id``-based helpers on
+    ``BaseRepository`` (``get_by_id``, ``delete_by_id``, ``update``) do not apply.
+    Use the ``*_by_job_id`` methods below instead.
+    """
+
+    def __init__(self, db: AsyncSession):
+        super().__init__(db, JobProvisioningDB)
+
+    @property
+    def to_schema(self) -> Callable[[JobProvisioning], JobProvisioningDB]:
+        return JobProvisioningMapper.to_schema
+
+    @property
+    def from_schema(self) -> Callable[[JobProvisioningDB], JobProvisioning]:
+        return JobProvisioningMapper.from_schema
+
+    async def get_by_job_id(self, job_id: str | UUID) -> JobProvisioning | None:
+        """Return the provisioning state recorded for one job."""
+        return await self.get_one(extra_filters={"job_id": self._id_to_str(job_id)})
+
+    async def update_by_job_id(self, job_id: str | UUID, update: JobProvisioningUpdate) -> JobProvisioning:
+        """Merge the fields set on ``update`` into a job's provisioning row.
+
+        Overrides the ``id``-keyed base ``update``: provisioning rows have no
+        ``id`` column, so the base implementation's refresh-by-id cannot work.
+        Unset fields are left alone rather than nulled, because each provisioning
+        stage writes only what it just learned.
+        """
+        job_id = self._id_to_str(job_id)
+        current = await self.get_by_job_id(job_id)
+        if current is None:
+            raise ValueError(f"No provisioning state recorded for job `{job_id}`")
+
+        changes = update.model_dump(exclude_unset=True, exclude_none=True)
+        merged = JobProvisioning.model_validate(dict(current.model_copy(update=changes, deep=True)))
+        await self.db.merge(self.to_schema(merged))
+        await self.db.commit()
+
+        refreshed = await self.get_by_job_id(job_id)
+        if refreshed is None:
+            raise ValueError(f"Provisioning state for job `{job_id}` disappeared during update")
+        return refreshed
+
+    async def delete_by_job_id(self, job_id: str | UUID) -> None:
+        """Remove a job's provisioning row once its container is gone."""
+        query = delete(JobProvisioningDB).where(JobProvisioningDB.job_id == self._id_to_str(job_id))
+        await self.db.execute(query)
+        await self.db.commit()
+
+    async def list_active(self) -> list[JobProvisioning]:
+        """Return provisioning rows for jobs that can still own a container.
+
+        Drives startup reattach and the orphan sweep: a row whose job has already
+        reached a terminal state describes nothing left to reclaim.
+        """
+        query = (
+            select(JobProvisioningDB)
+            .join(JobDB, JobDB.id == JobProvisioningDB.job_id)
+            .where(JobDB.status.in_(_NON_TERMINAL_JOB_STATUSES))
+            .order_by(JobProvisioningDB.created_at.asc())
+        )
+        results = await self.db.execute(query)
+        return [self.from_schema(model) for model in results.scalars().all()]
+
+    async def list_for_server(self, remote_server_id: str | UUID) -> list[JobProvisioning]:
+        """Return every provisioning row that targets one server."""
+        query = (
+            select(JobProvisioningDB)
+            .where(JobProvisioningDB.remote_server_id == self._id_to_str(remote_server_id))
+            .order_by(JobProvisioningDB.created_at.asc())
+        )
+        results = await self.db.execute(query)
+        return [self.from_schema(model) for model in results.scalars().all()]

--- a/application/backend/src/repositories/mappers/job_provisioning_mapper.py
+++ b/application/backend/src/repositories/mappers/job_provisioning_mapper.py
@@ -1,0 +1,49 @@
+from db.schema import JobProvisioningDB
+from repositories.mappers.base_mapper_interface import IBaseMapper
+from schemas.job_provisioning import JobProvisioning
+
+
+class JobProvisioningMapper(IBaseMapper):
+    """Map persisted per-job provisioning state to API schemas."""
+
+    @staticmethod
+    def to_schema(db_schema: JobProvisioning) -> JobProvisioningDB:
+        """Convert an API schema to its database model."""
+        return JobProvisioningDB(
+            job_id=str(db_schema.job_id),
+            remote_server_id=str(db_schema.remote_server_id),
+            ssh_host_alias=db_schema.ssh_host_alias,
+            image_ref=db_schema.image_ref,
+            image_fallback_reason=db_schema.image_fallback_reason,
+            image_digest=db_schema.image_digest,
+            container_id=db_schema.container_id,
+            container_name=db_schema.container_name,
+            remote_port=db_schema.remote_port,
+            local_tunnel_port=db_schema.local_tunnel_port,
+            backend_instance_id=db_schema.backend_instance_id,
+            trainer_build_version=db_schema.trainer_build_version,
+            trainer_protocol_version=db_schema.trainer_protocol_version,
+        )
+
+    @staticmethod
+    def from_schema(model: JobProvisioningDB) -> JobProvisioning:
+        """Convert a database model to its API schema."""
+        return JobProvisioning.model_validate(
+            {
+                "job_id": model.job_id,
+                "remote_server_id": model.remote_server_id,
+                "ssh_host_alias": model.ssh_host_alias,
+                "image_ref": model.image_ref,
+                "image_fallback_reason": model.image_fallback_reason,
+                "image_digest": model.image_digest,
+                "container_id": model.container_id,
+                "container_name": model.container_name,
+                "remote_port": model.remote_port,
+                "local_tunnel_port": model.local_tunnel_port,
+                "backend_instance_id": model.backend_instance_id,
+                "trainer_build_version": model.trainer_build_version,
+                "trainer_protocol_version": model.trainer_protocol_version,
+                "created_at": model.created_at,
+                "updated_at": model.updated_at,
+            }
+        )

--- a/application/backend/src/repositories/mappers/remote_server_mapper.py
+++ b/application/backend/src/repositories/mappers/remote_server_mapper.py
@@ -1,0 +1,39 @@
+from db.schema import RemoteServerDB
+from repositories.mappers.base_mapper_interface import IBaseMapper
+from schemas.remote_server import RemoteServer
+
+
+class RemoteServerMapper(IBaseMapper):
+    """Map persisted SSH-provisioned training servers to API schemas."""
+
+    @staticmethod
+    def to_schema(db_schema: RemoteServer) -> RemoteServerDB:
+        """Convert an API schema to its database model."""
+        return RemoteServerDB(
+            id=str(db_schema.id),
+            name=db_schema.name,
+            ssh_host_alias=db_schema.ssh_host_alias,
+            device_type=db_schema.device_type.value,
+            last_check_status=db_schema.last_check_status,
+            last_check_at=db_schema.last_check_at,
+            last_check_latency_ms=db_schema.last_check_latency_ms,
+            last_check_reason_code=db_schema.last_check_reason_code,
+        )
+
+    @staticmethod
+    def from_schema(model: RemoteServerDB) -> RemoteServer:
+        """Convert a database model to its API schema."""
+        return RemoteServer.model_validate(
+            {
+                "id": model.id,
+                "name": model.name,
+                "ssh_host_alias": model.ssh_host_alias,
+                "device_type": model.device_type,
+                "last_check_status": model.last_check_status,
+                "last_check_at": model.last_check_at,
+                "last_check_latency_ms": model.last_check_latency_ms,
+                "last_check_reason_code": model.last_check_reason_code,
+                "created_at": model.created_at,
+                "updated_at": model.updated_at,
+            }
+        )

--- a/application/backend/src/repositories/remote_server_repo.py
+++ b/application/backend/src/repositories/remote_server_repo.py
@@ -1,0 +1,38 @@
+from collections.abc import Callable
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio.session import AsyncSession
+
+from db.schema import RemoteServerDB
+from repositories.base import BaseRepository
+from repositories.mappers.remote_server_mapper import RemoteServerMapper
+from schemas.remote_server import RemoteServer
+
+
+class RemoteServerRepository(BaseRepository[RemoteServer, RemoteServerDB]):
+    """Persistence for SSH-provisioned training servers."""
+
+    def __init__(self, db: AsyncSession):
+        super().__init__(db, RemoteServerDB)
+
+    @property
+    def to_schema(self) -> Callable[[RemoteServer], RemoteServerDB]:
+        return RemoteServerMapper.to_schema
+
+    @property
+    def from_schema(self) -> Callable[[RemoteServerDB], RemoteServer]:
+        return RemoteServerMapper.from_schema
+
+    async def list_ordered(self) -> list[RemoteServer]:
+        """Return servers in stable creation order."""
+        query = select(RemoteServerDB).order_by(RemoteServerDB.created_at.asc(), RemoteServerDB.name.asc())
+        results = await self.db.execute(query)
+        return [self.from_schema(model) for model in results.scalars().all()]
+
+    async def get_by_alias(self, alias: str) -> RemoteServer | None:
+        """Return the server registered for an SSH host alias, if any.
+
+        The alias is unique, so this identifies at most one server. Used to turn a
+        duplicate registration into a clear conflict instead of a database error.
+        """
+        return await self.get_one(extra_filters={"ssh_host_alias": alias})

--- a/application/backend/src/schemas/job_provisioning.py
+++ b/application/backend/src/schemas/job_provisioning.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-job SSH provisioning state.
+
+Stored in its own table keyed by ``job_id`` rather than inside the job payload
+JSON, so a crashed backend can sweep or reclaim an orphaned container from
+durable, queryable columns instead of parsing every job's payload.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from schemas.remote_server import SSH_HOST_ALIAS_PATTERN
+
+
+class JobProvisioning(BaseModel):
+    """What Studio provisioned on a remote server for one job.
+
+    Written before the job accepts work so startup reattach and the orphan sweep
+    can always find the container. Holds no credential: ``ssh_host_alias`` is the
+    name of a Host stanza in the user's SSH config.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    job_id: UUID
+    remote_server_id: UUID
+    ssh_host_alias: str = Field(min_length=1, max_length=255, pattern=SSH_HOST_ALIAS_PATTERN)
+
+    # Which image was selected, why, and the immutable digest it resolved to.
+    # The container always launches by digest, never by the mutable tag.
+    image_ref: str | None = Field(default=None, max_length=512)
+    image_fallback_reason: str | None = Field(
+        default=None,
+        max_length=512,
+        description="Set when the protocol-<N> tag could not be resolved and `latest` was used instead.",
+    )
+    image_digest: str | None = Field(default=None, max_length=255)
+
+    container_id: str | None = Field(default=None, max_length=128)
+    container_name: str | None = Field(default=None, max_length=255)
+
+    # Trainer port published on the remote host's loopback, and the local end of
+    # the SSH forward. The local port is re-assigned on every reattach.
+    remote_port: int | None = Field(default=None, ge=1, le=65535)
+    local_tunnel_port: int | None = Field(default=None, ge=1, le=65535)
+
+    # Per-process ownership marker. Remote servers are global and two Studio
+    # instances can legitimately target the same host, so the orphan sweep must
+    # prove ownership rather than assume it from the management labels alone.
+    backend_instance_id: str | None = Field(default=None, max_length=255)
+
+    # Reported by the provisioned trainer's /health, recorded for diagnosis.
+    trainer_build_version: str | None = Field(default=None, max_length=255)
+    trainer_protocol_version: int | None = Field(default=None, ge=0)
+
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class JobProvisioningUpdate(BaseModel):
+    """Mutable provisioning state, written as each stage completes."""
+
+    image_ref: str | None = Field(default=None, max_length=512)
+    image_fallback_reason: str | None = Field(default=None, max_length=512)
+    image_digest: str | None = Field(default=None, max_length=255)
+    container_id: str | None = Field(default=None, max_length=128)
+    container_name: str | None = Field(default=None, max_length=255)
+    remote_port: int | None = Field(default=None, ge=1, le=65535)
+    local_tunnel_port: int | None = Field(default=None, ge=1, le=65535)
+    backend_instance_id: str | None = Field(default=None, max_length=255)
+    trainer_build_version: str | None = Field(default=None, max_length=255)
+    trainer_protocol_version: int | None = Field(default=None, ge=0)

--- a/application/backend/src/schemas/remote_server.py
+++ b/application/backend/src/schemas/remote_server.py
@@ -17,8 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from schemas.hardware import DeviceType
 
-# Devices a remote trainer image exists for. CPU/NPU have no trainer image, so a
-# server may not declare them.
+# Devices a remote trainer image exists for.
 SSH_SERVER_DEVICE_TYPES = frozenset({DeviceType.CUDA, DeviceType.XPU})
 
 # Health of the last recorded preflight. ``unknown`` means never checked.

--- a/application/backend/src/schemas/remote_server.py
+++ b/application/backend/src/schemas/remote_server.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Schemas for SSH-provisioned remote training servers.
+
+Studio stores no SSH credentials. A remote server is identified by the name of a
+``Host`` stanza in the user's own ``~/.ssh/config``; ``asyncssh`` resolves that
+alias and authenticates. No field here holds a key, password, or passphrase, and
+none ever will - ``tests/schemas/test_remote_server.py`` asserts that.
+"""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from schemas.hardware import DeviceType
+
+# Devices a remote trainer image exists for. CPU/NPU have no trainer image, so a
+# server may not declare them.
+SSH_SERVER_DEVICE_TYPES = frozenset({DeviceType.CUDA, DeviceType.XPU})
+
+# Health of the last recorded preflight. ``unknown`` means never checked.
+RemoteServerCheckStatus = Literal["healthy", "degraded", "unreachable", "unknown"]
+
+# An SSH config alias. Deliberately narrow: the value is interpolated into no
+# shell string anywhere, but a strict charset keeps it out of argument arrays
+# that a future change might pass to a shell, and rejects wildcard patterns.
+SSH_HOST_ALIAS_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$"
+
+
+class RemoteServerCreate(BaseModel):
+    """User-supplied configuration for an SSH-provisioned training server."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    name: str = Field(min_length=1, max_length=255)
+    ssh_host_alias: str = Field(
+        min_length=1,
+        max_length=255,
+        pattern=SSH_HOST_ALIAS_PATTERN,
+        description="Name of a Host stanza in the user's SSH config. Non-secret.",
+    )
+    device_type: DeviceType = Field(description="Accelerator on the server. Only cuda and xpu are supported.")
+
+    @field_validator("device_type")
+    @classmethod
+    def _reject_unsupported_device(cls, value: DeviceType) -> DeviceType:
+        """Reject devices with no published trainer image."""
+        if value not in SSH_SERVER_DEVICE_TYPES:
+            supported = ", ".join(sorted(device.value for device in SSH_SERVER_DEVICE_TYPES))
+            raise ValueError(f"device_type must be one of: {supported}")
+        return value
+
+
+class RemoteServerUpdate(BaseModel):
+    """Mutable fields for an SSH-provisioned training server."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    ssh_host_alias: str | None = Field(default=None, min_length=1, max_length=255, pattern=SSH_HOST_ALIAS_PATTERN)
+    device_type: DeviceType | None = None
+
+    @field_validator("device_type")
+    @classmethod
+    def _reject_unsupported_device(cls, value: DeviceType | None) -> DeviceType | None:
+        """Reject devices with no published trainer image."""
+        if value is not None and value not in SSH_SERVER_DEVICE_TYPES:
+            supported = ", ".join(sorted(device.value for device in SSH_SERVER_DEVICE_TYPES))
+            raise ValueError(f"device_type must be one of: {supported}")
+        return value
+
+
+class RemoteServer(RemoteServerCreate):
+    """A persisted SSH-provisioned training server.
+
+    ``last_check_*`` carries the summary of the most recent preflight so a
+    transient failure marks the record unhealthy instead of destroying it.
+    """
+
+    id: UUID
+    last_check_status: RemoteServerCheckStatus = "unknown"
+    last_check_at: datetime | None = None
+    last_check_latency_ms: int | None = Field(default=None, ge=0)
+    last_check_reason_code: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class ResolvedSshHost(BaseModel):
+    """The effective connection target an alias resolves to, for display only.
+
+    Derived from the SSH config at read time rather than persisted, so a stored
+    server can never disagree with the config it is defined by. Carries no
+    ``IdentityFile``, ``IdentityAgent``, ``CertificateFile``, or password: the
+    reader must not surface credential material even in resolved form.
+    """
+
+    alias: str
+    hostname: str | None = None
+    port: int | None = Field(default=None, ge=1, le=65535)
+    user: str | None = None
+    found: bool = Field(description="False when the alias is absent from the SSH config or matches only a wildcard.")
+
+
+class RemoteServerWithResolution(RemoteServer):
+    """A persisted server plus the connection target its alias resolves to now."""
+
+    resolved: ResolvedSshHost
+
+
+class SshHostAliasOption(BaseModel):
+    """A selectable SSH host alias for the create/edit form."""
+
+    alias: str
+    hostname: str | None = None
+    port: int | None = Field(default=None, ge=1, le=65535)
+    user: str | None = None

--- a/application/backend/src/services/__init__.py
+++ b/application/backend/src/services/__init__.py
@@ -12,6 +12,7 @@ from .model_service import ModelService
 from .project_camera_service import ProjectCameraService
 from .project_service import ProjectService
 from .project_thumbnail_service import ProjectThumbnailService
+from .remote_server_service import RemoteServerService
 from .remote_trainer_service import RemoteTrainerService
 from .robot_catalog_service import RobotCatalogService
 from .system_service import SystemService
@@ -29,6 +30,7 @@ __all__ = [
     "ProjectCameraService",
     "ProjectService",
     "ProjectThumbnailService",
+    "RemoteServerService",
     "RemoteTrainerService",
     "RobotCatalogService",
     "RobotService",

--- a/application/backend/src/services/remote_server_service.py
+++ b/application/backend/src/services/remote_server_service.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistence for SSH-provisioned training servers.
+
+Create and update here only persist the row. Tier-1-preflight-gated saves and
+resolved-host display are layered on top by the API (PR 4); this service never
+dials SSH.
+"""
+
+from uuid import UUID, uuid4
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from exceptions import ResourceAlreadyExistsError, ResourceNotFoundError, ResourceType
+from repositories.remote_server_repo import RemoteServerRepository
+from schemas.remote_server import RemoteServer, RemoteServerCreate, RemoteServerUpdate
+
+
+class RemoteServerService:
+    """Manage SSH-provisioned training server registrations."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        self.repo = RemoteServerRepository(session)
+
+    async def list_remote_servers(self) -> list[RemoteServer]:
+        """Return registered servers in stable creation order."""
+        return await self.repo.list_ordered()
+
+    async def get_remote_server(self, remote_server_id: UUID) -> RemoteServer:
+        """Return one registered server or raise a not-found error."""
+        remote_server = await self.repo.get_by_id(remote_server_id)
+        if remote_server is None:
+            raise ResourceNotFoundError(ResourceType.REMOTE_SERVER, str(remote_server_id))
+        return remote_server
+
+    async def create_remote_server(self, config: RemoteServerCreate) -> RemoteServer:
+        """Persist an SSH-provisioned training server."""
+        remote_server = RemoteServer(id=uuid4(), **config.model_dump())
+        try:
+            return await self.repo.save(remote_server)
+        except IntegrityError as error:
+            await self.session.rollback()
+            raise ResourceAlreadyExistsError(
+                "Remote server",
+                "A server with this SSH host alias is already configured.",
+            ) from error
+
+    async def update_remote_server(self, remote_server_id: UUID, update: RemoteServerUpdate) -> RemoteServer:
+        """Update a registered server's mutable fields."""
+        remote_server = await self.repo.get_by_id(remote_server_id)
+        if remote_server is None:
+            raise ResourceNotFoundError(ResourceType.REMOTE_SERVER, str(remote_server_id))
+        try:
+            return await self.repo.update(remote_server, update.model_dump(exclude_none=True, exclude_unset=True))
+        except IntegrityError as error:
+            await self.session.rollback()
+            raise ResourceAlreadyExistsError(
+                "Remote server",
+                "A server with this SSH host alias is already configured.",
+            ) from error
+
+    async def delete_remote_server(self, remote_server_id: UUID) -> None:
+        """Delete a registered server."""
+        if await self.repo.get_by_id(remote_server_id) is None:
+            raise ResourceNotFoundError(ResourceType.REMOTE_SERVER, str(remote_server_id))
+        await self.repo.delete_by_id(remote_server_id)

--- a/application/backend/src/services/remote_server_service.py
+++ b/application/backend/src/services/remote_server_service.py
@@ -4,7 +4,7 @@
 """Persistence for SSH-provisioned training servers.
 
 Create and update here only persist the row. Tier-1-preflight-gated saves and
-resolved-host display are layered on top by the API (PR 4); this service never
+resolved-host display are layered on top by the API; this service never
 dials SSH.
 """
 

--- a/application/backend/src/services/ssh_config_reader.py
+++ b/application/backend/src/services/ssh_config_reader.py
@@ -178,15 +178,35 @@ def resolve_alias(config_path: Path, alias: str) -> ResolvedSshHost:
     Matches only a literal ``Host`` pattern equal to ``alias``: a wildcard
     stanza that would match it via glob is not a usable target, since aliases
     are created by literal name, and resolution here does no glob matching.
+
+    If the alias is defined by more than one stanza (common with ``Include``),
+    every matching stanza is scanned in file order and a later one overrides an
+    earlier one field-by-field, mirroring real ssh's "first obtained value is
+    used, but Included files are read in-place" semantics as they apply to
+    later stanzas overriding earlier ones - only a field the later stanza
+    actually sets is overridden, not the whole result.
     """
+    found = False
+    hostname: str | None = None
+    port: int | None = None
+    user: str | None = None
     for block in _iter_blocks(config_path):
         for pattern in block.patterns:
             if _is_literal_pattern(pattern) and pattern == alias:
-                return ResolvedSshHost(
-                    alias=alias,
-                    hostname=block.hostname or alias,
-                    port=block.port,
-                    user=block.user,
-                    found=True,
-                )
-    return ResolvedSshHost(alias=alias, found=False)
+                found = True
+                if block.hostname is not None:
+                    hostname = block.hostname
+                if block.port is not None:
+                    port = block.port
+                if block.user is not None:
+                    user = block.user
+                break
+    if not found:
+        return ResolvedSshHost(alias=alias, found=False)
+    return ResolvedSshHost(
+        alias=alias,
+        hostname=hostname or alias,
+        port=port,
+        user=user,
+        found=True,
+    )

--- a/application/backend/src/services/ssh_config_reader.py
+++ b/application/backend/src/services/ssh_config_reader.py
@@ -1,0 +1,192 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only parser for ``~/.ssh/config``-style files.
+
+Never dials SSH. Detects but never surfaces credential-adjacent directives -
+``IdentityFile``, ``IdentityAgent``, ``CertificateFile``, and any ``Password*``
+keyword - so a resolved host can be shown for display without ever risking a
+key path or secret reaching an API response. ``tests/services/test_ssh_config_reader.py``
+asserts this with a fixture where every one of those directives is set.
+
+This is a small hand-rolled reader, not a full ``asyncssh``/OpenSSH-config
+parser: it understands ``Host``, ``Include`` (relative and absolute glob
+patterns, expanded relative to the directory of the file doing the
+including), ``HostName``, ``Port``, and ``User``. That is enough to list and
+resolve aliases, which is all a persistence-only PR needs.
+"""
+
+import re
+import shlex
+from glob import glob
+from pathlib import Path
+
+from schemas.remote_server import ResolvedSshHost, SshHostAliasOption
+
+# "Keyword value", "Keyword=value", and "Keyword = value" are all valid.
+_DIRECTIVE_PATTERN = re.compile(r"^(\S+?)(?:\s+|\s*=\s*)(.*)$")
+
+# Keywords that name credential material. Matched by prefix (already
+# lowercased) so both "Password" and "PasswordAuthentication" are caught, not
+# just an exact keyword. Detected only to be skipped, never stored or read.
+_CREDENTIAL_DIRECTIVE_PREFIXES = ("identityfile", "identityagent", "certificatefile", "password")
+
+
+class _HostBlock:
+    """One ``Host`` stanza: its patterns plus the directives this reader cares about."""
+
+    __slots__ = ("hostname", "patterns", "port", "user")
+
+    def __init__(self, patterns: list[str]) -> None:
+        self.patterns = patterns
+        self.hostname: str | None = None
+        self.port: int | None = None
+        self.user: str | None = None
+
+
+def _is_literal_pattern(pattern: str) -> bool:
+    """Return True for a plain host name, False for a wildcard or negated pattern."""
+    return not pattern.startswith("!") and "*" not in pattern and "?" not in pattern
+
+
+def _parse_line(line: str) -> tuple[str, list[str]] | None:
+    """Split one config line into a lowercased keyword and its arguments.
+
+    Returns None for blank lines, comments, and lines shlex cannot tokenize
+    (e.g. unbalanced quotes) - malformed input is skipped, never raised.
+    """
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    match = _DIRECTIVE_PATTERN.match(stripped)
+    if match is None:
+        return None
+    keyword = match.group(1).lower()
+    try:
+        args = shlex.split(match.group(2), comments=True)
+    except ValueError:
+        return None
+    return keyword, args
+
+
+def _resolve_include_paths(pattern: str, including_dir: Path) -> list[Path]:
+    """Expand one ``Include`` argument to the files it names.
+
+    A relative pattern is resolved against the directory of the file doing the
+    including, so a config and the files it includes can be moved together.
+    """
+    candidate = Path(pattern).expanduser()
+    if not candidate.is_absolute():
+        candidate = including_dir / candidate
+    return sorted(Path(match) for match in glob(str(candidate)))
+
+
+def _apply_directive(current: _HostBlock, keyword: str, args: list[str]) -> None:
+    """Apply one directive to the ``Host`` block it belongs to.
+
+    Silently ignores anything this reader does not need, including every
+    credential-adjacent keyword - those are recognized only so they can be
+    skipped, never so their value can be read.
+    """
+    if keyword.startswith(_CREDENTIAL_DIRECTIVE_PREFIXES):
+        return
+    if keyword == "hostname":
+        current.hostname = args[0]
+    elif keyword == "port":
+        try:
+            current.port = int(args[0])
+        except ValueError:
+            pass
+    elif keyword == "user":
+        current.user = args[0]
+
+
+def _iter_blocks(path: Path, _visited: set[Path] | None = None) -> list[_HostBlock]:
+    """Parse one config file into an ordered list of ``Host`` blocks.
+
+    Follows ``Include`` one or more levels deep. A missing or empty file
+    yields no blocks rather than raising, so an absent SSH config behaves like
+    an empty one. ``_visited`` guards against an ``Include`` cycle.
+    """
+    visited = _visited if _visited is not None else set()
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+    if resolved in visited:
+        return []
+    visited.add(resolved)
+
+    try:
+        text = path.read_text()
+    except OSError:
+        return []
+
+    blocks: list[_HostBlock] = []
+    current: _HostBlock | None = None
+
+    for line in text.splitlines():
+        parsed = _parse_line(line)
+        if parsed is None:
+            continue
+        keyword, args = parsed
+        if not args:
+            continue
+
+        if keyword == "host":
+            current = _HostBlock(patterns=args)
+            blocks.append(current)
+        elif keyword == "include":
+            for pattern in args:
+                for include_path in _resolve_include_paths(pattern, path.parent):
+                    blocks.extend(_iter_blocks(include_path, visited))
+        elif current is not None:
+            # A directive outside any Host stanza is only informative to real
+            # ssh, never to this reader, so it is skipped when `current` is None.
+            _apply_directive(current, keyword, args)
+
+    return blocks
+
+
+def list_host_aliases(config_path: Path) -> list[SshHostAliasOption]:
+    """Return every literal ``Host`` alias in the config as a selectable option.
+
+    Wildcard and negated patterns are excluded: an alias is created by a
+    literal ``Host`` name, not a pattern that happens to match one. When
+    ``HostName`` is unset, the alias itself is the effective hostname - real
+    ssh behavior, not an invented default.
+    """
+    options: list[SshHostAliasOption] = []
+    for block in _iter_blocks(config_path):
+        for pattern in block.patterns:
+            if not _is_literal_pattern(pattern):
+                continue
+            options.append(
+                SshHostAliasOption(
+                    alias=pattern,
+                    hostname=block.hostname or pattern,
+                    port=block.port,
+                    user=block.user,
+                )
+            )
+    return options
+
+
+def resolve_alias(config_path: Path, alias: str) -> ResolvedSshHost:
+    """Resolve one alias to its effective hostname/port/user, for display only.
+
+    Matches only a literal ``Host`` pattern equal to ``alias``: a wildcard
+    stanza that would match it via glob is not a usable target, since aliases
+    are created by literal name, and resolution here does no glob matching.
+    """
+    for block in _iter_blocks(config_path):
+        for pattern in block.patterns:
+            if _is_literal_pattern(pattern) and pattern == alias:
+                return ResolvedSshHost(
+                    alias=alias,
+                    hostname=block.hostname or alias,
+                    port=block.port,
+                    user=block.user,
+                    found=True,
+                )
+    return ResolvedSshHost(alias=alias, found=False)

--- a/application/backend/src/services/ssh_config_reader.py
+++ b/application/backend/src/services/ssh_config_reader.py
@@ -8,12 +8,6 @@ Never dials SSH. Detects but never surfaces credential-adjacent directives -
 keyword - so a resolved host can be shown for display without ever risking a
 key path or secret reaching an API response. ``tests/services/test_ssh_config_reader.py``
 asserts this with a fixture where every one of those directives is set.
-
-This is a small hand-rolled reader, not a full ``asyncssh``/OpenSSH-config
-parser: it understands ``Host``, ``Include`` (relative and absolute glob
-patterns, expanded relative to the directory of the file doing the
-including), ``HostName``, ``Port``, and ``User``. That is enough to list and
-resolve aliases, which is all a persistence-only PR needs.
 """
 
 import re

--- a/application/backend/src/services/ssh_config_reader.py
+++ b/application/backend/src/services/ssh_config_reader.py
@@ -149,21 +149,39 @@ def list_host_aliases(config_path: Path) -> list[SshHostAliasOption]:
     literal ``Host`` name, not a pattern that happens to match one. When
     ``HostName`` is unset, the alias itself is the effective hostname - real
     ssh behavior, not an invented default.
+
+    If an alias is defined by more than one stanza (common with ``Include``),
+    the stanzas are merged field-by-field with the same last-stanza-wins rule
+    as ``resolve_alias``, so each alias appears exactly once and both
+    functions agree on its resolved fields.
     """
-    options: list[SshHostAliasOption] = []
+    merged: dict[str, _HostBlock] = {}
+    order: list[str] = []
     for block in _iter_blocks(config_path):
         for pattern in block.patterns:
             if not _is_literal_pattern(pattern):
                 continue
-            options.append(
-                SshHostAliasOption(
-                    alias=pattern,
-                    hostname=block.hostname or pattern,
-                    port=block.port,
-                    user=block.user,
-                )
-            )
-    return options
+            existing = merged.get(pattern)
+            if existing is None:
+                order.append(pattern)
+                existing = _HostBlock(patterns=[pattern])
+                merged[pattern] = existing
+            if block.hostname is not None:
+                existing.hostname = block.hostname
+            if block.port is not None:
+                existing.port = block.port
+            if block.user is not None:
+                existing.user = block.user
+
+    return [
+        SshHostAliasOption(
+            alias=alias,
+            hostname=merged[alias].hostname or alias,
+            port=merged[alias].port,
+            user=merged[alias].user,
+        )
+        for alias in order
+    ]
 
 
 def resolve_alias(config_path: Path, alias: str) -> ResolvedSshHost:
@@ -175,10 +193,11 @@ def resolve_alias(config_path: Path, alias: str) -> ResolvedSshHost:
 
     If the alias is defined by more than one stanza (common with ``Include``),
     every matching stanza is scanned in file order and a later one overrides an
-    earlier one field-by-field, mirroring real ssh's "first obtained value is
-    used, but Included files are read in-place" semantics as they apply to
-    later stanzas overriding earlier ones - only a field the later stanza
-    actually sets is overridden, not the whole result.
+    earlier one field-by-field - only a field the later stanza actually sets is
+    overridden, not the whole result. This is last-stanza-wins, the opposite of
+    real ssh's first-obtained-value-wins rule: it is deliberate here so an
+    ``Include``d override file takes effect, since display-only resolution has
+    no reason to replicate ssh's actual precedence.
     """
     found = False
     hostname: str | None = None

--- a/application/backend/tests/schemas/test_remote_server.py
+++ b/application/backend/tests/schemas/test_remote_server.py
@@ -4,10 +4,7 @@
 """Security-gate and validation tests for the remote-server schemas.
 
 The most important assertion here is the absence one: no field on any of
-these models ever names or carries a credential.  PR 2's whole design is that
-Studio never receives a key, password, or passphrase - the SSH client library
-resolves the alias itself - so this test exists to catch a regression, not to
-describe expected behavior.
+these models ever names or carries a credential.
 """
 
 from uuid import uuid4
@@ -36,11 +33,7 @@ _FORBIDDEN_FIELD_WORDS = (
 
 # `ssh_host_alias` is the one deliberate, documented exception: it is the name
 # of an SSH config `Host` stanza, not a hostname, credential, or port, and its
-# presence is the entire point of this schema (see `schemas/remote_server.py`
-# module docstring and PR plan: "Host/port/user are derived from the SSH
-# config at read time" - referring to values this schema never stores, not to
-# the alias name itself). Without this exception, the whole-word match on
-# "host" below would misfire on the one field that must exist.
+# presence is the entire point of this schema
 _KNOWN_SAFE_FIELDS = frozenset({"ssh_host_alias"})
 
 

--- a/application/backend/tests/schemas/test_remote_server.py
+++ b/application/backend/tests/schemas/test_remote_server.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Security-gate and validation tests for the remote-server schemas.
+
+The most important assertion here is the absence one: no field on any of
+these models ever names or carries a credential.  PR 2's whole design is that
+Studio never receives a key, password, or passphrase - the SSH client library
+resolves the alias itself - so this test exists to catch a regression, not to
+describe expected behavior.
+"""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.hardware import DeviceType
+from schemas.remote_server import RemoteServer, RemoteServerCreate, RemoteServerUpdate
+
+# Matched as whole underscore-delimited words, not raw substrings, so a
+# multi-word forbidden phrase (e.g. "host_key") only matches when a field
+# spells out that exact sequence of words.
+_FORBIDDEN_FIELD_WORDS = (
+    "username",
+    "auth_type",
+    "ssh_secret_encrypted",
+    "ssh_key_passphrase_encrypted",
+    "host_key",
+    "host",
+    "port",
+    "password",
+    "identity_file",
+    "private_key",
+)
+
+# `ssh_host_alias` is the one deliberate, documented exception: it is the name
+# of an SSH config `Host` stanza, not a hostname, credential, or port, and its
+# presence is the entire point of this schema (see `schemas/remote_server.py`
+# module docstring and PR plan: "Host/port/user are derived from the SSH
+# config at read time" - referring to values this schema never stores, not to
+# the alias name itself). Without this exception, the whole-word match on
+# "host" below would misfire on the one field that must exist.
+_KNOWN_SAFE_FIELDS = frozenset({"ssh_host_alias"})
+
+
+def _contains_word_sequence(words: list[str], needle_words: list[str]) -> bool:
+    """Return True if ``needle_words`` appears as a contiguous run in ``words``."""
+    span = len(needle_words)
+    return any(words[start : start + span] == needle_words for start in range(len(words) - span + 1))
+
+
+def _assert_no_secret_fields(model_fields: dict) -> None:
+    for field_name in model_fields:
+        if field_name in _KNOWN_SAFE_FIELDS:
+            continue
+        words = field_name.lower().split("_")
+        for forbidden in _FORBIDDEN_FIELD_WORDS:
+            matched = _contains_word_sequence(words, forbidden.split("_"))
+            assert not matched, f"field `{field_name}` looks like a secret field (matched `{forbidden}`)"
+
+
+def test_remote_server_create_has_no_secret_fields() -> None:
+    _assert_no_secret_fields(RemoteServerCreate.model_fields)
+
+
+def test_remote_server_update_has_no_secret_fields() -> None:
+    _assert_no_secret_fields(RemoteServerUpdate.model_fields)
+
+
+def test_remote_server_has_no_secret_fields() -> None:
+    _assert_no_secret_fields(RemoteServer.model_fields)
+
+
+@pytest.mark.parametrize("device_type", [DeviceType.CPU, DeviceType.NPU])
+def test_create_rejects_unsupported_device_type(device_type: DeviceType) -> None:
+    with pytest.raises(ValidationError):
+        RemoteServerCreate(name="server", ssh_host_alias="my-gpu-box", device_type=device_type)
+
+
+@pytest.mark.parametrize("device_type", [DeviceType.CUDA, DeviceType.XPU])
+def test_create_accepts_supported_device_type(device_type: DeviceType) -> None:
+    config = RemoteServerCreate(name="server", ssh_host_alias="my-gpu-box", device_type=device_type)
+    assert config.device_type == device_type
+
+
+@pytest.mark.parametrize("device_type", [DeviceType.CPU, DeviceType.NPU])
+def test_update_rejects_unsupported_device_type(device_type: DeviceType) -> None:
+    with pytest.raises(ValidationError):
+        RemoteServerUpdate(device_type=device_type)
+
+
+@pytest.mark.parametrize("device_type", [DeviceType.CUDA, DeviceType.XPU])
+def test_update_accepts_supported_device_type(device_type: DeviceType) -> None:
+    update = RemoteServerUpdate(device_type=device_type)
+    assert update.device_type == device_type
+
+
+@pytest.mark.parametrize("alias", ["*", "foo*", "192.168.*.1", "host name", "host;rm -rf", "$(whoami)", "host`x`"])
+def test_create_rejects_glob_and_shell_chars_in_alias(alias: str) -> None:
+    with pytest.raises(ValidationError):
+        RemoteServerCreate(name="server", ssh_host_alias=alias, device_type=DeviceType.CUDA)
+
+
+@pytest.mark.parametrize("alias", ["*", "foo*", "host name", "host;rm -rf"])
+def test_update_rejects_glob_and_shell_chars_in_alias(alias: str) -> None:
+    with pytest.raises(ValidationError):
+        RemoteServerUpdate(ssh_host_alias=alias)
+
+
+def test_create_strips_whitespace_from_name_and_alias() -> None:
+    config = RemoteServerCreate(name="  server  ", ssh_host_alias="my-gpu-box", device_type=DeviceType.CUDA)
+    assert config.name == "server"
+    assert config.ssh_host_alias == "my-gpu-box"
+
+
+def test_create_rejects_whitespace_only_name() -> None:
+    with pytest.raises(ValidationError):
+        RemoteServerCreate(name="   ", ssh_host_alias="my-gpu-box", device_type=DeviceType.CUDA)
+
+
+def test_update_strips_whitespace_from_name_and_alias() -> None:
+    update = RemoteServerUpdate(name="  server  ", ssh_host_alias="  my-gpu-box  ")
+    assert update.name == "server"
+    assert update.ssh_host_alias == "my-gpu-box"
+
+
+def test_remote_server_defaults_to_unknown_check_status() -> None:
+    server = RemoteServer(id=uuid4(), name="server", ssh_host_alias="my-gpu-box", device_type=DeviceType.CUDA)
+    assert server.last_check_status == "unknown"
+    assert server.last_check_at is None

--- a/application/backend/tests/services/test_remote_server_service.py
+++ b/application/backend/tests/services/test_remote_server_service.py
@@ -1,0 +1,165 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from exceptions import ResourceAlreadyExistsError, ResourceNotFoundError
+from schemas.hardware import DeviceType
+from schemas.remote_server import RemoteServer, RemoteServerCreate, RemoteServerUpdate
+from services import RemoteServerService
+
+MODULE = "services.remote_server_service"
+
+
+def _session() -> AsyncMock:
+    return AsyncMock()
+
+
+def _remote_server() -> RemoteServer:
+    return RemoteServer(id=uuid4(), name="server", ssh_host_alias="my-gpu-box", device_type=DeviceType.CUDA)
+
+
+@pytest.mark.anyio
+async def test_list_remote_servers_uses_stable_repository_order() -> None:
+    session = _session()
+    repository = MagicMock()
+    repository.list_ordered = AsyncMock(return_value=[_remote_server()])
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository):
+        result = await RemoteServerService(session).list_remote_servers()
+
+    assert result == [repository.list_ordered.return_value[0]]
+    repository.list_ordered.assert_awaited_once_with()
+
+
+@pytest.mark.anyio
+async def test_get_remote_server_returns_match() -> None:
+    session = _session()
+    remote_server = _remote_server()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=remote_server)
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository):
+        result = await RemoteServerService(session).get_remote_server(remote_server.id)
+
+    assert result == remote_server
+
+
+@pytest.mark.anyio
+async def test_get_missing_remote_server_raises_not_found() -> None:
+    session = _session()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=None)
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository), pytest.raises(ResourceNotFoundError):
+        await RemoteServerService(session).get_remote_server(uuid4())
+
+
+@pytest.mark.anyio
+async def test_create_remote_server_persists_via_repository() -> None:
+    session = _session()
+    repository = MagicMock()
+    repository.save = AsyncMock(side_effect=lambda item: item)
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository):
+        result = await RemoteServerService(session).create_remote_server(
+            RemoteServerCreate(name="server", ssh_host_alias="my-gpu-box", device_type=DeviceType.CUDA)
+        )
+
+    assert result.name == "server"
+    assert result.ssh_host_alias == "my-gpu-box"
+    repository.save.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_create_duplicate_remote_server_returns_conflict() -> None:
+    session = _session()
+    repository = MagicMock()
+    repository.save = AsyncMock(side_effect=IntegrityError("insert", {}, Exception("duplicate")))
+
+    with (
+        patch(f"{MODULE}.RemoteServerRepository", return_value=repository),
+        pytest.raises(ResourceAlreadyExistsError) as error,
+    ):
+        await RemoteServerService(session).create_remote_server(
+            RemoteServerCreate(name="server", ssh_host_alias="my-gpu-box", device_type=DeviceType.CUDA)
+        )
+
+    assert error.value.http_status == 409
+    session.rollback.assert_awaited_once_with()
+
+
+@pytest.mark.anyio
+async def test_update_ignores_explicit_null_fields() -> None:
+    session = _session()
+    remote_server = _remote_server()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=remote_server)
+    repository.update = AsyncMock(return_value=remote_server)
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository):
+        await RemoteServerService(session).update_remote_server(remote_server.id, RemoteServerUpdate(name=None))
+
+    repository.update.assert_awaited_once_with(remote_server, {})
+
+
+@pytest.mark.anyio
+async def test_update_missing_remote_server_raises_not_found() -> None:
+    session = _session()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=None)
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository), pytest.raises(ResourceNotFoundError):
+        await RemoteServerService(session).update_remote_server(uuid4(), RemoteServerUpdate(name="new name"))
+
+    repository.update.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_update_duplicate_remote_server_returns_conflict() -> None:
+    session = _session()
+    remote_server = _remote_server()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=remote_server)
+    repository.update = AsyncMock(side_effect=IntegrityError("update", {}, Exception("duplicate")))
+
+    with (
+        patch(f"{MODULE}.RemoteServerRepository", return_value=repository),
+        pytest.raises(ResourceAlreadyExistsError) as error,
+    ):
+        await RemoteServerService(session).update_remote_server(
+            remote_server.id, RemoteServerUpdate(ssh_host_alias="other-box")
+        )
+
+    assert error.value.http_status == 409
+    session.rollback.assert_awaited_once_with()
+
+
+@pytest.mark.anyio
+async def test_delete_remote_server_deletes_by_id() -> None:
+    session = _session()
+    remote_server = _remote_server()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=remote_server)
+    repository.delete_by_id = AsyncMock()
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository):
+        await RemoteServerService(session).delete_remote_server(remote_server.id)
+
+    repository.delete_by_id.assert_awaited_once_with(remote_server.id)
+
+
+@pytest.mark.anyio
+async def test_delete_missing_remote_server_raises_not_found() -> None:
+    session = _session()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=None)
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository), pytest.raises(ResourceNotFoundError):
+        await RemoteServerService(session).delete_remote_server(uuid4())
+
+    repository.delete_by_id.assert_not_called()

--- a/application/backend/tests/services/test_ssh_config_reader.py
+++ b/application/backend/tests/services/test_ssh_config_reader.py
@@ -1,0 +1,267 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the read-only SSH config reader.
+
+The critical test here is ``test_resolve_never_leaks_credential_directives``:
+it builds a fixture stanza where ``IdentityFile``, ``IdentityAgent``,
+``CertificateFile``, and a fabricated ``Password`` directive are all present
+with recognizable dummy values, then asserts none of those values appear
+anywhere in the serialized response - not just that the schema has no field
+for them.
+"""
+
+from pathlib import Path
+
+from services.ssh_config_reader import list_host_aliases, resolve_alias
+
+_DUMMY_IDENTITY_FILE = "id_dummy_test_key"
+_DUMMY_IDENTITY_AGENT = "SSH_AUTH_SOCK"
+_DUMMY_CERTIFICATE = "id_dummy-cert.pub"
+_DUMMY_PASSWORD = "somesecretvalue"
+
+
+def _write_config(tmp_path: Path, contents: str, name: str = "config") -> Path:
+    config_path = tmp_path / name
+    config_path.write_text(contents)
+    return config_path
+
+
+def test_resolve_alias_missing_config_file_returns_not_found(tmp_path: Path) -> None:
+    missing_path = tmp_path / "does-not-exist"
+
+    result = resolve_alias(missing_path, "my-gpu-box")
+
+    assert result.found is False
+    assert result.alias == "my-gpu-box"
+    assert result.hostname is None
+    assert result.port is None
+    assert result.user is None
+
+
+def test_list_host_aliases_missing_config_file_returns_empty(tmp_path: Path) -> None:
+    missing_path = tmp_path / "does-not-exist"
+
+    assert list_host_aliases(missing_path) == []
+
+
+def test_resolve_alias_empty_config_file_returns_not_found(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, "")
+
+    result = resolve_alias(config_path, "my-gpu-box")
+
+    assert result.found is False
+
+
+def test_list_host_aliases_empty_config_file_returns_empty(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, "")
+
+    assert list_host_aliases(config_path) == []
+
+
+def test_resolve_alias_finds_literal_host_stanza(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+        Host my-gpu-box
+            HostName 10.0.0.5
+            Port 2222
+            User trainer
+        """,
+    )
+
+    result = resolve_alias(config_path, "my-gpu-box")
+
+    assert result.found is True
+    assert result.alias == "my-gpu-box"
+    assert result.hostname == "10.0.0.5"
+    assert result.port == 2222
+    assert result.user == "trainer"
+
+
+def test_resolve_alias_falls_back_to_alias_as_hostname(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+        Host my-gpu-box
+            User trainer
+        """,
+    )
+
+    result = resolve_alias(config_path, "my-gpu-box")
+
+    assert result.found is True
+    assert result.hostname == "my-gpu-box"
+    assert result.port is None
+
+
+def test_resolve_alias_missing_alias_returns_not_found(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+        Host my-gpu-box
+            HostName 10.0.0.5
+        """,
+    )
+
+    result = resolve_alias(config_path, "some-other-box")
+
+    assert result.found is False
+
+
+def test_resolve_alias_wildcard_only_stanza_returns_not_found(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+        Host my-gpu-*
+            HostName 10.0.0.5
+        """,
+    )
+
+    result = resolve_alias(config_path, "my-gpu-box")
+
+    assert result.found is False
+
+
+def test_list_host_aliases_excludes_wildcard_only_stanza(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+        Host *
+            User default-user
+
+        Host bastion*
+            HostName 10.0.0.9
+
+        Host my-gpu-box
+            HostName 10.0.0.5
+            Port 2222
+            User trainer
+        """,
+    )
+
+    aliases = list_host_aliases(config_path)
+
+    assert [option.alias for option in aliases] == ["my-gpu-box"]
+    assert aliases[0].hostname == "10.0.0.5"
+    assert aliases[0].port == 2222
+    assert aliases[0].user == "trainer"
+
+
+def test_list_host_aliases_falls_back_to_alias_as_hostname(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+        Host my-gpu-box
+        """,
+    )
+
+    aliases = list_host_aliases(config_path)
+
+    assert len(aliases) == 1
+    assert aliases[0].alias == "my-gpu-box"
+    assert aliases[0].hostname == "my-gpu-box"
+
+
+def test_resolve_alias_follows_include_one_level_deep(tmp_path: Path) -> None:
+    included_path = _write_config(
+        tmp_path,
+        """
+        Host my-gpu-box
+            HostName 10.0.0.5
+            Port 2222
+            User trainer
+        """,
+        name="included_config",
+    )
+    main_path = _write_config(
+        tmp_path,
+        f"""
+        Include {included_path.name}
+        """,
+    )
+
+    result = resolve_alias(main_path, "my-gpu-box")
+
+    assert result.found is True
+    assert result.hostname == "10.0.0.5"
+    assert result.port == 2222
+    assert result.user == "trainer"
+
+
+def test_list_host_aliases_follows_include_one_level_deep(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        """
+        Host my-gpu-box
+            HostName 10.0.0.5
+        """,
+        name="included_config",
+    )
+    main_path = _write_config(
+        tmp_path,
+        """
+        Include included_config
+        """,
+    )
+
+    aliases = list_host_aliases(main_path)
+
+    assert [option.alias for option in aliases] == ["my-gpu-box"]
+
+
+def test_resolve_never_leaks_credential_directives(tmp_path: Path) -> None:
+    """The reader must never surface identity/credential directive values.
+
+    A fabricated ``Password`` directive is included even though real
+    ssh_config has no such keyword - this is a defense-in-depth check, not a
+    claim that ssh_config supports it.
+    """
+    config_path = _write_config(
+        tmp_path,
+        f"""
+        Host my-gpu-box
+            HostName 10.0.0.5
+            Port 2222
+            User trainer
+            IdentityFile ~/.ssh/{_DUMMY_IDENTITY_FILE}
+            IdentityAgent {_DUMMY_IDENTITY_AGENT}
+            CertificateFile ~/.ssh/{_DUMMY_CERTIFICATE}
+            Password {_DUMMY_PASSWORD}
+        """,
+    )
+
+    result = resolve_alias(config_path, "my-gpu-box")
+    serialized_json = result.model_dump_json()
+    serialized_dict = str(result.model_dump())
+
+    for dummy_secret in (_DUMMY_IDENTITY_FILE, _DUMMY_IDENTITY_AGENT, _DUMMY_CERTIFICATE, _DUMMY_PASSWORD):
+        assert dummy_secret not in serialized_json
+        assert dummy_secret not in serialized_dict
+
+    # Sanity: the non-secret fields still resolved correctly around the
+    # credential directives, proving the parser did not just fail silently.
+    assert result.found is True
+    assert result.hostname == "10.0.0.5"
+    assert result.port == 2222
+    assert result.user == "trainer"
+
+
+def test_list_host_aliases_never_leaks_credential_directives(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        f"""
+        Host my-gpu-box
+            HostName 10.0.0.5
+            IdentityFile ~/.ssh/{_DUMMY_IDENTITY_FILE}
+            IdentityAgent {_DUMMY_IDENTITY_AGENT}
+            CertificateFile ~/.ssh/{_DUMMY_CERTIFICATE}
+            Password {_DUMMY_PASSWORD}
+        """,
+    )
+
+    aliases = list_host_aliases(config_path)
+    serialized_json = "".join(option.model_dump_json() for option in aliases)
+
+    for dummy_secret in (_DUMMY_IDENTITY_FILE, _DUMMY_IDENTITY_AGENT, _DUMMY_CERTIFICATE, _DUMMY_PASSWORD):
+        assert dummy_secret not in serialized_json

--- a/application/backend/tests/services/test_ssh_config_reader.py
+++ b/application/backend/tests/services/test_ssh_config_reader.py
@@ -192,10 +192,10 @@ def test_resolve_alias_follows_include_one_level_deep(tmp_path: Path) -> None:
 def test_resolve_alias_later_stanza_overrides_earlier_one(tmp_path: Path) -> None:
     """A later ``Host`` stanza with the same alias overrides earlier fields.
 
-    This mirrors real ssh behavior where later-declared values win, which
-    matters most for ``Include``d configs that redefine the same alias.
-    Fields the later stanza does not set (here, ``User``) keep the earlier
-    stanza's value rather than being cleared.
+    This is last-stanza-wins, deliberately the opposite of real ssh's
+    first-obtained-value-wins rule, so an ``Include``d override file takes
+    effect. Fields the later stanza does not set (here, ``User``) keep the
+    earlier stanza's value rather than being cleared.
     """
     config_path = _write_config(
         tmp_path,
@@ -216,6 +216,35 @@ def test_resolve_alias_later_stanza_overrides_earlier_one(tmp_path: Path) -> Non
     assert result.hostname == "10.0.0.9"
     assert result.port == 2222
     assert result.user == "trainer"
+
+
+def test_list_host_aliases_merges_duplicate_alias_last_stanza_wins(tmp_path: Path) -> None:
+    """A duplicate ``Host`` alias must be listed once, merged like ``resolve_alias``.
+
+    Mirrors ``test_resolve_alias_later_stanza_overrides_earlier_one``: the two
+    functions must agree on the resolved fields for the same alias, and the
+    alias must not appear twice just because two stanzas define it.
+    """
+    config_path = _write_config(
+        tmp_path,
+        """
+        Host my-gpu-box
+            HostName 10.0.0.5
+            Port 2222
+            User trainer
+
+        Host my-gpu-box
+            HostName 10.0.0.9
+        """,
+    )
+
+    aliases = list_host_aliases(config_path)
+
+    assert [option.alias for option in aliases] == ["my-gpu-box"]
+    option = aliases[0]
+    assert option.hostname == "10.0.0.9"
+    assert option.port == 2222
+    assert option.user == "trainer"
 
 
 def test_list_host_aliases_follows_include_one_level_deep(tmp_path: Path) -> None:

--- a/application/backend/tests/services/test_ssh_config_reader.py
+++ b/application/backend/tests/services/test_ssh_config_reader.py
@@ -189,6 +189,35 @@ def test_resolve_alias_follows_include_one_level_deep(tmp_path: Path) -> None:
     assert result.user == "trainer"
 
 
+def test_resolve_alias_later_stanza_overrides_earlier_one(tmp_path: Path) -> None:
+    """A later ``Host`` stanza with the same alias overrides earlier fields.
+
+    This mirrors real ssh behavior where later-declared values win, which
+    matters most for ``Include``d configs that redefine the same alias.
+    Fields the later stanza does not set (here, ``User``) keep the earlier
+    stanza's value rather than being cleared.
+    """
+    config_path = _write_config(
+        tmp_path,
+        """
+        Host my-gpu-box
+            HostName 10.0.0.5
+            Port 2222
+            User trainer
+
+        Host my-gpu-box
+            HostName 10.0.0.9
+        """,
+    )
+
+    result = resolve_alias(config_path, "my-gpu-box")
+
+    assert result.found is True
+    assert result.hostname == "10.0.0.9"
+    assert result.port == 2222
+    assert result.user == "trainer"
+
+
 def test_list_host_aliases_follows_include_one_level_deep(tmp_path: Path) -> None:
     _write_config(
         tmp_path,


### PR DESCRIPTION
Studio needs to remember which remote machines a user can train on. The safest way to do that is to store nothing secret at all — just a pointer into the SSH config the user already maintains.

## What changed

- `RemoteServerDB` + rewritten `d4f8a1c9b3e6_add_remote_servers.py` (edited in place — it never reached `main`, so there's no released schema and no legacy data).
- `JobProvisioningDB`, keyed by `job_id`: image ref/digest, container id/name, remote and local tunnel ports, alias, trainer build/protocol versions.
- Repository, mapper, schema, and `services/remote_server_service.py`.
- Read-only SSH config reader: lists selectable `Host` aliases (excluding wildcards) and resolves one to its effective hostname/port/user for display.

## Design notes

- A server is identified by one non-secret value, an `ssh_host_alias` naming a `Host` stanza in `~/.ssh/config`. Hostname, port, and user resolve at read time rather than being persisted, so a stored record can't silently disagree with the config.
- **No secret fields.** `username`, `auth_type`, `ssh_secret_encrypted`, `ssh_key_passphrase_encrypted`, `host_key`, `host`, `port`, and the `uq_remote_servers_host_port_username` constraint are deliberately absent.
- **No `to_public()` sanitizer or internal/public schema split** — nothing is secret, so the machinery would imply otherwise.
- The config reader never surfaces `IdentityFile`, `IdentityAgent`, `CertificateFile`, or password directives.

## Out of scope

Nothing here opens a network connection — the reader parses a file, it doesn't dial. The CRUD router lands in #926.

---

**Plan:** [PR 2 — Remote-server persistence by SSH host alias](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md#pr-2--remote-server-persistence-by-ssh-host-alias) · [backend plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-plan.md) · [full PR plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md)
