### PR TITLE
feat(backend): add asyncssh transport, output sanitization, and two-tier preflight

### DIFF
--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "huggingface-hub>=0.27",
   "psutil~=7.2",
   "physicalai-studio-plugin",
-  "asyncssh>=2.14",
+  "asyncssh~=2.24",
 ]
 
 [project.scripts]

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "huggingface-hub>=0.27",
   "psutil~=7.2",
   "physicalai-studio-plugin",
+  "asyncssh>=2.14",
 ]
 
 [project.scripts]

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -433,5 +433,3 @@ class RemoteServerPreflightError(BaseException):
             error_code="remote_server_preflight_failed",
             http_status=http.HTTPStatus.BAD_REQUEST,
         )
-
-

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -313,3 +313,125 @@ class RobotIdentifyError(BaseException):
             error_code="robot_identify_error",
             http_status=http.HTTPStatus.BAD_REQUEST,
         )
+
+
+class SshHostAliasNotFoundError(BaseException):
+    """Raised when a server's SSH host alias is absent from the user's SSH config.
+
+    Distinct from a connection failure: nothing was dialed, because there was no
+    host to dial. A wildcard-only match lands here too - a pattern stanza is not
+    a usable target.
+    """
+
+    def __init__(self, alias: str) -> None:
+        super().__init__(
+            message=(
+                f"SSH host alias '{alias}' was not found in your SSH config. "
+                f"Add a Host entry named '{alias}' to ~/.ssh/config, then try again."
+            ),
+            error_code="ssh_host_alias_not_found",
+            http_status=http.HTTPStatus.BAD_REQUEST,
+        )
+
+
+class SshHostKeyUnknownError(BaseException):
+    """Raised when the host is absent from ``known_hosts``.
+
+    Fails closed. Studio neither pins nor writes host keys, so the recovery is
+    for the user to accept the fingerprint themselves.
+    """
+
+    def __init__(self, alias: str) -> None:
+        super().__init__(
+            message=(
+                f"The host key for '{alias}' has not been accepted yet. "
+                f"Run `ssh {alias}` once and accept its fingerprint, then try again."
+            ),
+            error_code="ssh_host_key_unknown",
+            http_status=http.HTTPStatus.BAD_REQUEST,
+        )
+
+
+class SshHostKeyMismatchError(BaseException):
+    """Raised when the host key differs from the one in ``known_hosts``.
+
+    Treated as untrusted rather than as a stale entry: this is what a
+    machine-in-the-middle looks like, and it is also what a legitimately
+    rebuilt host looks like. Studio cannot tell them apart, so it refuses.
+    """
+
+    def __init__(self, alias: str) -> None:
+        super().__init__(
+            message=(
+                f"The host key for '{alias}' does not match the one in your known_hosts file. "
+                "The server may have been rebuilt, or the connection may be intercepted. "
+                "Verify the new fingerprint out of band before updating known_hosts."
+            ),
+            error_code="ssh_host_key_mismatch",
+            http_status=http.HTTPStatus.BAD_REQUEST,
+        )
+
+
+class SshAgentRequiredError(BaseException):
+    """Raised when the resolved identity is passphrase-protected and no agent can unlock it.
+
+    Studio never prompts for or stores a passphrase, so an agent is the only way
+    a protected key can be used.
+    """
+
+    def __init__(self, alias: str) -> None:
+        super().__init__(
+            message=(
+                f"The SSH key for '{alias}' is passphrase-protected and no SSH agent is available. "
+                f"Start an agent and run `ssh-add`, then try again."
+            ),
+            error_code="ssh_agent_required",
+            http_status=http.HTTPStatus.BAD_REQUEST,
+        )
+
+
+class SshAuthenticationError(BaseException):
+    """Raised when the server rejected every identity the SSH config offered."""
+
+    def __init__(self, alias: str) -> None:
+        super().__init__(
+            message=(
+                f"Authentication failed for '{alias}'. Check that `ssh {alias}` works from a terminal, then try again."
+            ),
+            error_code="ssh_authentication_failed",
+            http_status=http.HTTPStatus.BAD_REQUEST,
+        )
+
+
+class SshConnectionError(BaseException):
+    """Raised when the resolved host could not be reached.
+
+    Carries no underlying exception text: a raw SSH error can contain resolved
+    hostnames and key paths, which must not reach an API response.
+    """
+
+    def __init__(self, alias: str, reason: str | None = None) -> None:
+        detail = f" ({reason})" if reason else ""
+        super().__init__(
+            message=f"Could not connect to '{alias}'{detail}. Check that the server is reachable.",
+            error_code="ssh_connection_failed",
+            http_status=http.HTTPStatus.BAD_GATEWAY,
+        )
+
+
+class RemoteServerPreflightError(BaseException):
+    """Raised when a server's blocking Tier 1 checks fail on create or update.
+
+    Carries the structured per-check results so the UI can show which check
+    failed rather than only that something did.
+    """
+
+    def __init__(self, message: str, failures: list[str] | None = None) -> None:
+        self.failures = failures or []
+        super().__init__(
+            message=message,
+            error_code="remote_server_preflight_failed",
+            http_status=http.HTTPStatus.BAD_REQUEST,
+        )
+
+

--- a/application/backend/src/schemas/ssh_preflight.py
+++ b/application/backend/src/schemas/ssh_preflight.py
@@ -1,0 +1,132 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structured results for the two-tier SSH preflight.
+
+Tier 1 is cheap and gates a save. Tier 2 pulls a multi-gigabyte image and runs a
+one-shot GPU container, so it is an explicit action and never runs inline in a
+create/update request.
+
+Every result is tagged with its tier and its own ``checked_at`` so the UI can
+group them and never present a stale Tier 2 result as current. ``blocking``
+separates a real misconfiguration from a reported-but-transient condition: GPU
+occupancy is reported and never blocks a save.
+"""
+
+from datetime import datetime
+from enum import IntEnum, StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class PreflightTier(IntEnum):
+    """Which tier a check belongs to."""
+
+    # Cheap, bounded, gates create/update.
+    TIER_1 = 1
+    # Expensive (registry pull, one-shot GPU container). Explicitly invoked.
+    TIER_2 = 2
+
+
+class CheckOutcome(StrEnum):
+    """Result of a single preflight check."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+    # Ran, and the answer is a condition the user should see but which does not
+    # make the server unusable. GPU occupancy is the canonical case.
+    WARNING = "warning"
+    # Not attempted, because a prerequisite check failed or the tier was not run.
+    SKIPPED = "skipped"
+
+
+class CheckKey(StrEnum):
+    """Stable identifiers for each preflight check.
+
+    Shared with the UI, which groups and labels results by these keys. Renaming
+    one is a breaking change.
+    """
+
+    # --- Tier 1 -------------------------------------------------------------
+    ALIAS_RESOLVED = "alias_resolved"
+    REACHABLE = "reachable"
+    AUTHENTICATED = "authenticated"
+    HOST_KEY_VERIFIED = "host_key_verified"
+    DOCKER_USABLE = "docker_usable"
+    DISK_SPACE = "disk_space"
+    DRIVER_PRESENT = "driver_present"
+    REGISTRY_REACHABLE = "registry_reachable"
+    GPU_FREE = "gpu_free"
+    # --- Tier 2 -------------------------------------------------------------
+    IMAGE_RESOLVED = "image_resolved"
+    IMAGE_SIGNATURE = "image_signature"
+    CONTAINER_DEVICE_PROBE = "container_device_probe"
+    PROTOCOL_COMPATIBLE = "protocol_compatible"
+
+
+class PreflightCheck(BaseModel):
+    """One preflight check's outcome.
+
+    ``detail`` is operator-facing text. It is sanitized and length-capped before
+    it lands here: remote command output is environment-influenced, not trusted.
+    """
+
+    key: CheckKey
+    tier: PreflightTier
+    outcome: CheckOutcome
+    blocking: bool = Field(
+        description="Whether a FAILED outcome for this check prevents saving the server.",
+    )
+    checked_at: datetime
+    # Stable machine-readable cause, e.g. "alias_not_found", "host_key_unknown".
+    reason_code: str | None = None
+    # Short human-readable explanation. Sanitized; never contains a key path,
+    # host key, raw SSH exception text, or remote command text.
+    detail: str | None = None
+    # Which detection method answered, e.g. "nvidia-smi", "xpu-smi", "render-node".
+    method: str | None = None
+    duration_ms: int | None = Field(default=None, ge=0)
+
+
+class PreflightResult(BaseModel):
+    """The outcome of running one or both preflight tiers against a server."""
+
+    remote_server_id: UUID | None = None
+    tiers_run: list[PreflightTier] = Field(default_factory=list)
+    checks: list[PreflightCheck] = Field(default_factory=list)
+    checked_at: datetime
+    latency_ms: int | None = Field(default=None, ge=0)
+
+    @property
+    def blocking_failures(self) -> list[PreflightCheck]:
+        """Checks whose failure must prevent a save."""
+        return [check for check in self.checks if check.blocking and check.outcome is CheckOutcome.FAILED]
+
+    @property
+    def passed(self) -> bool:
+        """True when no blocking check failed."""
+        return not self.blocking_failures
+
+    def check(self, key: CheckKey) -> PreflightCheck | None:
+        """Return the result for one check, when it was run."""
+        return next((candidate for candidate in self.checks if candidate.key is key), None)
+
+
+class RemoteServerStatus(BaseModel):
+    """Structured status for the remote-server status endpoint.
+
+    Combines the last recorded preflight with live in-use information, keeping
+    each check's own tier and timestamp so the UI never renders a stale Tier 2
+    result as current.
+    """
+
+    remote_server_id: UUID
+    status: str = Field(description="Rolled-up health: healthy, degraded, unreachable, or unknown.")
+    device_type: str = Field(description="The server's configured device type, served from the DB record.")
+    checks: list[PreflightCheck] = Field(default_factory=list)
+    checked_at: datetime | None = None
+    latency_ms: int | None = Field(default=None, ge=0)
+    reason_code: str | None = None
+    in_use_by_job_id: UUID | None = None
+    waiting_for_gpu: bool = False

--- a/application/backend/src/services/ssh/__init__.py
+++ b/application/backend/src/services/ssh/__init__.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSH remote-execution boundary for SSH-provisioned remote training servers.
+
+Everything that runs a command on a user's GPU box goes through this package:
+
+* :mod:`services.ssh.transport` owns the connection, argument quoting, the
+  bounded timeouts, and the mapping from ``asyncssh`` failures to actionable
+  Studio exceptions that carry no host or key detail.
+* :mod:`services.ssh.preflight` owns the two-tier verification built on top of it.
+* :mod:`services.ssh.sanitize` strips and caps remote output before any of it
+  reaches an API response.
+
+Studio never receives, reads, stores, or transports SSH key material. A remote
+server is identified only by a non-secret ``ssh_host_alias``, and ``asyncssh``
+resolves that alias against the user's own ``~/.ssh/config`` and verifies the host
+against their own ``~/.ssh/known_hosts``.
+"""
+
+from services.ssh.preflight import (
+    DEFAULT_PROTOCOL_VERSION,
+    reset_transport_factory,
+    run_tier1_preflight,
+    run_tier2_preflight,
+    set_transport_factory,
+)
+from services.ssh.sanitize import sanitize_output
+from services.ssh.transport import CommandFailure, CommandResult, SshTransport, open_transport, reset_alias_gates
+
+__all__ = [
+    "DEFAULT_PROTOCOL_VERSION",
+    "CommandFailure",
+    "CommandResult",
+    "SshTransport",
+    "open_transport",
+    "reset_alias_gates",
+    "reset_transport_factory",
+    "run_tier1_preflight",
+    "run_tier2_preflight",
+    "sanitize_output",
+    "set_transport_factory",
+]

--- a/application/backend/src/services/ssh/preflight.py
+++ b/application/backend/src/services/ssh/preflight.py
@@ -139,6 +139,27 @@ def _failure_detail(result: CommandResult) -> str | None:
     return _detail(result.stderr or result.stdout)
 
 
+# `xpu-smi discovery` renders an ASCII box-drawing table, e.g.:
+#   +-----------+--------------------------------------------------+
+#   | Device ID | Device Information                                |
+#   +-----------+--------------------------------------------------+
+#   | 0         | Device Name: Intel(R) Data Center GPU Max 1100    |
+#   |           | Vendor Name: Intel(R) Corporation                  |
+#   ...
+# `first_line()` would return the top border, not a device name, so this pulls
+# the "Device Name: ..." cell out of the table instead.
+_XPU_DEVICE_NAME_PATTERN: Final = re.compile(r"Device Name:\s*(.+?)\s*\|?\s*$")
+
+
+def _xpu_discovery_detail(result: CommandResult) -> str:
+    """Return a short device-name summary from `xpu-smi discovery`'s table output."""
+    for line in result.stdout.splitlines():
+        match = _XPU_DEVICE_NAME_PATTERN.search(line)
+        if match:
+            return match.group(1).strip()
+    return result.first_line()
+
+
 class _CheckRecorder:
     """Accumulates one tier's checks, timing each one individually."""
 
@@ -409,7 +430,9 @@ async def _check_driver_xpu(recorder: _CheckRecorder, transport: SshTransport) -
     """
     smi = await transport.run_command(["xpu-smi", "discovery"])
     if smi.ok:
-        recorder.add(CheckKey.DRIVER_PRESENT, CheckOutcome.PASSED, detail=smi.first_line(), method=METHOD_XPU_SMI)
+        recorder.add(
+            CheckKey.DRIVER_PRESENT, CheckOutcome.PASSED, detail=_xpu_discovery_detail(smi), method=METHOD_XPU_SMI
+        )
         return METHOD_XPU_SMI
 
     render = await _probe_intel_render_node(transport)

--- a/application/backend/src/services/ssh/preflight.py
+++ b/application/backend/src/services/ssh/preflight.py
@@ -26,6 +26,7 @@ The transport is reached through :data:`transport_factory`, so a caller can
 substitute a fake without patching ``asyncssh``.
 """
 
+import hashlib
 import re
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -91,6 +92,10 @@ REASON_TOOL_MISSING: Final = "tool_missing"
 REASON_DEVICE_UNAVAILABLE: Final = "device_unavailable"
 REASON_PROTOCOL_MISMATCH: Final = "protocol_mismatch"
 REASON_PROTOCOL_UNKNOWN: Final = "protocol_unknown"
+# The image was not yet present locally when the probe ran, so it was handed
+# to a background pull. Distinct from REASON_DEVICE_UNAVAILABLE: this is a
+# multi-gigabyte transfer still in flight, not a broken accelerator.
+REASON_IMAGE_PULLING: Final = "image_pulling"
 
 # Which probe answered a check, so the UI can show how a result was obtained.
 METHOD_SSH_CONFIG: Final = "ssh-config"
@@ -907,18 +912,111 @@ def _device_probe_expression(device_type: DeviceType) -> str:
     return f"import torch; print(torch.{accelerator}.is_available())"
 
 
+# Substrings Docker's own client prints while it pulls an image inline for a
+# `docker run` whose image is not yet cached locally. Matched against a failed
+# probe's output as a defense-in-depth fallback for the race between
+# `_image_present_locally` and the `docker run` a few lines later - e.g.
+# another process evicting the image in between. The normal path never hits
+# this: the presence check below routes a genuinely absent image to a
+# background pull instead of an inline one.
+_IMAGE_PULL_MARKERS: Final = ("unable to find image", "pulling fs layer", "pulling from")
+
+
+def _is_pulling_image(result: CommandResult) -> bool:
+    """True when a failed command's output shows Docker mid-pull, not broken."""
+    text = f"{result.stdout}\n{result.stderr}".lower()
+    return any(marker in text for marker in _IMAGE_PULL_MARKERS)
+
+
+async def _image_present_locally(transport: SshTransport, image_ref: str) -> bool:
+    """True when the image is already cached in the remote Docker image store."""
+    result = await transport.run_command(["docker", "image", "inspect", image_ref])
+    return result.ok
+
+
+def _pull_state_paths(image_ref: str) -> tuple[str, str]:
+    """Return the (pid file, log file) paths a background pull for this image uses.
+
+    Named from a hash of the image reference rather than the reference itself,
+    so the path is stable across calls and never carries `/`, `:`, or other
+    reference characters into a filename.
+    """
+    digest = hashlib.sha256(image_ref.encode()).hexdigest()[:16]
+    return f"/tmp/physicalai-pull-{digest}.pid", f"/tmp/physicalai-pull-{digest}.log"  # noqa: S108 - a remote-host path, not a local temp-file access
+
+
+async def _pull_already_running(transport: SshTransport, pidfile: str) -> bool:
+    """True when a previously started background pull's PID is still alive."""
+    result = await transport.run_command(
+        ["sh", "-c", 'test -f "$1" && kill -0 "$(cat "$1" 2>/dev/null)" 2>/dev/null', "sh", pidfile]
+    )
+    return result.ok
+
+
+async def _start_background_pull(transport: SshTransport, image_ref: str, pidfile: str, logfile: str) -> None:
+    """Launch ``docker pull`` detached from this SSH session so it outlives it.
+
+    ``nohup`` plus stdio redirected away from the exec channel is what makes
+    this survive: Tier 2 closes its SSH connection right after this check
+    returns, which would otherwise SIGHUP a foreground pull mid-transfer,
+    aborting it and discarding an already-mostly-downloaded image. Progress
+    and PID land in host-local files under ``/tmp`` so a later check can tell
+    "still pulling" from "pull finished or died" without needing this SSH
+    connection to still be open.
+    """
+    await transport.run_command(
+        [
+            "sh",
+            "-c",
+            'nohup docker pull "$1" >"$2" 2>&1 </dev/null & echo "$!" >"$3"',
+            "sh",
+            image_ref,
+            logfile,
+            pidfile,
+        ]
+    )
+
+
 async def _check_device_probe(
     recorder: _CheckRecorder,
     transport: SshTransport,
     device_type: DeviceType,
     image_ref: str,
-) -> None:
+) -> bool:
     """Run a one-shot container and record whether it sees the accelerator.
 
     The authoritative check, and the reason Tier 2 exists: a driver visible on the
     host still tells you nothing about whether the container runtime passes the
     device through.
+
+    Checks the image is already cached locally before running anything: a
+    `docker run` against a cold image pulls it inline, tying the transfer to
+    this check's short timeout and to this SSH connection's lifetime - both of
+    which end long before a multi-gigabyte image finishes. An absent image is
+    instead handed to a detached background pull that keeps going after this
+    check (and the whole preflight) returns.
+
+    Returns:
+        True when the image was still being pulled when this probe ran, so the
+        caller can skip the protocol check rather than have it fail against an
+        image that is not there yet.
     """
+    if not await _image_present_locally(transport, image_ref):
+        pidfile, logfile = _pull_state_paths(image_ref)
+        already_running = await _pull_already_running(transport, pidfile)
+        if not already_running:
+            await _start_background_pull(transport, image_ref, pidfile, logfile)
+
+        verb = "Still pulling" if already_running else "Started pulling"
+        recorder.add(
+            CheckKey.CONTAINER_DEVICE_PROBE,
+            CheckOutcome.SKIPPED,
+            reason_code=REASON_IMAGE_PULLING,
+            detail=f"{verb} {image_ref} in the background. Run Test connection again once it finishes.",
+            method=METHOD_CONTAINER,
+        )
+        return True
+
     render_gid = None if device_type is DeviceType.CUDA else await resolve_render_group_gid(transport)
     argv = [
         "docker",
@@ -934,7 +1032,16 @@ async def _check_device_probe(
     result = await transport.run_command(argv, timeout=get_settings().ssh_preflight_timeout_s)
     if result.ok and result.first_line().lower() == "true":
         recorder.add(CheckKey.CONTAINER_DEVICE_PROBE, CheckOutcome.PASSED, method=METHOD_CONTAINER)
-        return
+        return False
+    if _is_pulling_image(result):
+        recorder.add(
+            CheckKey.CONTAINER_DEVICE_PROBE,
+            CheckOutcome.SKIPPED,
+            reason_code=REASON_IMAGE_PULLING,
+            detail=f"Started pulling {image_ref}. Run Test connection again once the pull finishes.",
+            method=METHOD_CONTAINER,
+        )
+        return True
     recorder.add(
         CheckKey.CONTAINER_DEVICE_PROBE,
         CheckOutcome.FAILED,
@@ -942,6 +1049,7 @@ async def _check_device_probe(
         detail=_failure_detail(result) or "The container did not report the device as available.",
         method=METHOD_CONTAINER,
     )
+    return False
 
 
 async def _check_protocol(
@@ -1040,8 +1148,15 @@ async def run_tier2_preflight(
             return _result(server, recorder, started, checked_at)
 
         await _check_signature(recorder, transport, image_ref)
-        await _check_device_probe(recorder, transport, server.device_type, image_ref)
-        await _check_protocol(recorder, transport, image_ref, protocol_version)
+        pulling = await _check_device_probe(recorder, transport, server.device_type, image_ref)
+        if pulling:
+            # The protocol check reads a label off the local image via `docker
+            # image inspect`; with the pull still in flight that image is not
+            # there yet, and running it now would report a spurious
+            # "no protocol version" failure instead of the real cause.
+            recorder.skip(CheckKey.PROTOCOL_COMPATIBLE, reason_code=REASON_IMAGE_PULLING)
+        else:
+            await _check_protocol(recorder, transport, image_ref, protocol_version)
     except SshConnectionError as error:
         logger.warning(
             "SSH connection lost during Tier 2 preflight for alias '{}': {}",

--- a/application/backend/src/services/ssh/preflight.py
+++ b/application/backend/src/services/ssh/preflight.py
@@ -115,7 +115,7 @@ _INTEL_VENDOR_ID: Final = "0x8086"
 
 # Fraction of device memory in use above which an accelerator counts as busy.
 # Used only where per-process attribution is unavailable (the XPU case).
-_GPU_BUSY_MEMORY_FRACTION: Final = 0.5
+_GPU_BUSY_MEMORY_FRACTION: Final = 0.3
 
 # Cap on `detail`, so a check can never carry an essay from a remote host.
 _DETAIL_MAX_CHARS: Final = 240

--- a/application/backend/src/services/ssh/preflight.py
+++ b/application/backend/src/services/ssh/preflight.py
@@ -865,14 +865,40 @@ async def _check_signature(recorder: _CheckRecorder, transport: SshTransport, im
     )
 
 
-def _device_run_args(device_type: DeviceType) -> list[str]:
+async def resolve_render_group_gid(transport: SshTransport) -> str | None:
+    """Return the host GID that owns the first Intel render node, or ``None``.
+
+    The trainer container always runs as a fixed non-root UID/GID (see
+    ``docker_ops.build_run_argv``'s ``--user 10001:10001``), which is never a
+    member of the host's render group by default. ``--device /dev/dri`` alone
+    passes the device node through but leaves it unreadable by that user - the
+    node's group ownership still gates access, and without ``--group-add
+    <gid>`` the container's ``torch.xpu.is_available()`` reports zero devices
+    even though the host driver and render node are both fine. The GID is
+    discovered per host, never hardcoded, because it is not portable across
+    distributions.
+    """
+    result = await transport.run_command(
+        ["sh", "-c", "stat -c %g $(ls /dev/dri/renderD* 2>/dev/null | head -n1) 2>/dev/null"]
+    )
+    gid = result.first_line().strip()
+    return gid or None
+
+
+def _device_run_args(device_type: DeviceType, render_gid: str | None = None) -> list[str]:
     """Return the ``docker run`` flags that expose the accelerator.
 
     Derived from the configured device type, never from user-supplied text.
+    ``render_gid``, when known, is added via ``--group-add`` so the
+    container's non-root user can actually read/write the render node -
+    without it the device node is present but access is denied.
     """
     if device_type is DeviceType.CUDA:
         return ["--gpus", "all"]
-    return ["--device", "/dev/dri"]
+    args = ["--device", "/dev/dri"]
+    if render_gid:
+        args.extend(["--group-add", render_gid])
+    return args
 
 
 def _device_probe_expression(device_type: DeviceType) -> str:
@@ -893,11 +919,12 @@ async def _check_device_probe(
     host still tells you nothing about whether the container runtime passes the
     device through.
     """
+    render_gid = None if device_type is DeviceType.CUDA else await resolve_render_group_gid(transport)
     argv = [
         "docker",
         "run",
         "--rm",
-        *_device_run_args(device_type),
+        *_device_run_args(device_type, render_gid),
         "--entrypoint",
         "python",
         image_ref,

--- a/application/backend/src/services/ssh/preflight.py
+++ b/application/backend/src/services/ssh/preflight.py
@@ -144,15 +144,6 @@ def _failure_detail(result: CommandResult) -> str | None:
     return _detail(result.stderr or result.stdout)
 
 
-# `xpu-smi discovery` renders an ASCII box-drawing table, e.g.:
-#   +-----------+--------------------------------------------------+
-#   | Device ID | Device Information                                |
-#   +-----------+--------------------------------------------------+
-#   | 0         | Device Name: Intel(R) Data Center GPU Max 1100    |
-#   |           | Vendor Name: Intel(R) Corporation                  |
-#   ...
-# `first_line()` would return the top border, not a device name, so this pulls
-# the "Device Name: ..." cell out of the table instead.
 _XPU_DEVICE_NAME_PATTERN: Final = re.compile(r"Device Name:\s*(.+?)\s*\|?\s*$")
 
 
@@ -942,7 +933,11 @@ def _pull_state_paths(image_ref: str) -> tuple[str, str]:
     reference characters into a filename.
     """
     digest = hashlib.sha256(image_ref.encode()).hexdigest()[:16]
-    return f"/tmp/physicalai-pull-{digest}.pid", f"/tmp/physicalai-pull-{digest}.log"  # noqa: S108 - a remote-host path, not a local temp-file access
+    # These are a remote-host path (run over SSH on the target machine), not a local temp-file access.
+    return (
+        f"/tmp/physicalai-pull-{digest}.pid",  # noqa: S108 # nosec B108
+        f"/tmp/physicalai-pull-{digest}.log",  # noqa: S108 # nosec B108
+    )
 
 
 async def _pull_already_running(transport: SshTransport, pidfile: str) -> bool:

--- a/application/backend/src/services/ssh/preflight.py
+++ b/application/backend/src/services/ssh/preflight.py
@@ -1,0 +1,1016 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Two-tier preflight for SSH-provisioned remote training servers.
+
+Tier 1 is cheap and bounded, so it can gate a create/update request. Tier 2
+resolves and inspects the trainer image and runs a one-shot GPU container, so it
+is an explicit action and never runs inline in a request handler.
+
+**Tier 1 performs no image work at all.** Its registry check is an
+unauthenticated ``HEAD`` against the registry's ``/v2/`` API root, which
+separates "this host cannot reach the registry" from "the pull failed midway" -
+the latter being Tier 2's job. Nothing in :func:`run_tier1_preflight` resolves a
+manifest, pulls a layer, or starts a container.
+
+Every check is blocking except ``GPU_FREE``: a busy GPU is a transient state, not
+a misconfiguration, and a user must be able to register or edit a target while a
+job runs on it. A busy GPU reports ``WARNING``; a probe that cannot answer
+reports ``SKIPPED``. Neither blocks.
+
+Neither entry point raises for a server that fails its checks. A failure is a
+``FAILED`` check, so the caller can surface every cause at once instead of only
+the first one.
+
+The transport is reached through :data:`transport_factory`, so a caller can
+substitute a fake without patching ``asyncssh``.
+"""
+
+import re
+from collections.abc import Callable
+from datetime import UTC, datetime
+from time import perf_counter
+from typing import Final
+from urllib.parse import urlsplit
+
+from loguru import logger
+
+from exceptions import (
+    SshAgentRequiredError,
+    SshAuthenticationError,
+    SshConnectionError,
+    SshHostAliasNotFoundError,
+    SshHostKeyMismatchError,
+    SshHostKeyUnknownError,
+)
+from schemas.hardware import DeviceType
+from schemas.remote_server import SSH_SERVER_DEVICE_TYPES, RemoteServer
+from schemas.ssh_preflight import CheckKey, CheckOutcome, PreflightCheck, PreflightResult, PreflightTier
+from services.ssh.sanitize import sanitize_output
+from services.ssh.transport import CommandResult, SshTransport, open_transport
+from services.ssh_config_reader import resolve_alias
+from settings import Settings, get_settings
+
+# Both tiers obtain their transport here, so a test or a future provisioning path
+# can substitute a fake without patching asyncssh. Use `set_transport_factory` to
+# replace it.
+transport_factory: Callable[[str], SshTransport] = open_transport
+
+# Every Ssh* failure a connect attempt can raise. Listed once so both tiers catch
+# exactly the same set and an unexpected exception type is never swallowed.
+_CONNECT_FAILURES: Final = (
+    SshHostAliasNotFoundError,
+    SshHostKeyUnknownError,
+    SshHostKeyMismatchError,
+    SshAgentRequiredError,
+    SshAuthenticationError,
+    SshConnectionError,
+)
+
+# Reason codes are stable machine-readable strings the UI groups and labels on.
+# Renaming one is a breaking change.
+REASON_ALIAS_NOT_FOUND: Final = "alias_not_found"
+REASON_HOST_KEY_UNKNOWN: Final = "host_key_unknown"
+REASON_HOST_KEY_MISMATCH: Final = "host_key_mismatch"
+REASON_AGENT_REQUIRED: Final = "ssh_agent_required"
+REASON_AUTH_FAILED: Final = "authentication_failed"
+REASON_UNREACHABLE: Final = "unreachable"
+REASON_NOT_ATTEMPTED: Final = "not_attempted"
+REASON_COMMAND_FAILED: Final = "command_failed"
+REASON_DOCKER_UNAVAILABLE: Final = "docker_unavailable"
+REASON_INSUFFICIENT_DISK: Final = "insufficient_disk"
+REASON_UNPARSEABLE_OUTPUT: Final = "unparseable_output"
+REASON_DRIVER_MISSING: Final = "driver_missing"
+REASON_REGISTRY_UNREACHABLE: Final = "registry_unreachable"
+REASON_GPU_BUSY: Final = "gpu_busy"
+REASON_NO_SIGNAL: Final = "no_signal"
+REASON_UNSUPPORTED_DEVICE: Final = "unsupported_device_type"
+REASON_PROTOCOL_TAG_UNRESOLVED: Final = "protocol_tag_unresolved"
+REASON_IMAGE_UNRESOLVED: Final = "image_unresolved"
+REASON_TOOL_MISSING: Final = "tool_missing"
+REASON_DEVICE_UNAVAILABLE: Final = "device_unavailable"
+REASON_PROTOCOL_MISMATCH: Final = "protocol_mismatch"
+REASON_PROTOCOL_UNKNOWN: Final = "protocol_unknown"
+
+# Which probe answered a check, so the UI can show how a result was obtained.
+METHOD_SSH_CONFIG: Final = "ssh-config"
+METHOD_SSH_CONNECT: Final = "ssh-connect"
+METHOD_DOCKER: Final = "docker"
+METHOD_DF: Final = "df"
+METHOD_CURL: Final = "curl"
+METHOD_NVIDIA_SMI: Final = "nvidia-smi"
+METHOD_XPU_SMI: Final = "xpu-smi"
+METHOD_RENDER_NODE: Final = "render-node"
+METHOD_DOCKER_MANIFEST: Final = "docker-manifest"
+METHOD_COSIGN: Final = "cosign"
+METHOD_CONTAINER: Final = "container"
+
+# `df -B1 -P` prints one header line, then rows of:
+# filesystem 1-blocks used available capacity mounted-on
+_DF_AVAILABLE_COLUMN: Final = 3
+_DF_MIN_COLUMNS: Final = 5
+
+# Intel PCI vendor id, for the XPU render-node fallback probe.
+_INTEL_VENDOR_ID: Final = "0x8086"
+
+# Fraction of device memory in use above which an accelerator counts as busy.
+# Used only where per-process attribution is unavailable (the XPU case).
+_GPU_BUSY_MEMORY_FRACTION: Final = 0.5
+
+# Cap on `detail`, so a check can never carry an essay from a remote host.
+_DETAIL_MAX_CHARS: Final = 240
+
+_BYTES_PER_GIB: Final = 1024**3
+
+
+def _now() -> datetime:
+    """Current UTC time, matching how the rest of the backend stamps records."""
+    return datetime.now(UTC)
+
+
+def _detail(text: str) -> str | None:
+    """Sanitize and shorten operator-facing text taken from remote output."""
+    cleaned = sanitize_output(text, max_line_chars=_DETAIL_MAX_CHARS, max_total_chars=_DETAIL_MAX_CHARS)
+    return cleaned.strip() or None
+
+
+def _failure_detail(result: CommandResult) -> str | None:
+    """Best available explanation for a failed command."""
+    return _detail(result.stderr or result.stdout)
+
+
+class _CheckRecorder:
+    """Accumulates one tier's checks, timing each one individually."""
+
+    def __init__(self, tier: PreflightTier) -> None:
+        self.tier = tier
+        self.checks: list[PreflightCheck] = []
+        self._started = perf_counter()
+
+    @property
+    def recorded(self) -> set[CheckKey]:
+        """Keys already recorded, so a partial tier can be completed."""
+        return {check.key for check in self.checks}
+
+    def add(
+        self,
+        key: CheckKey,
+        outcome: CheckOutcome,
+        *,
+        blocking: bool = True,
+        reason_code: str | None = None,
+        detail: str | None = None,
+        method: str | None = None,
+        duration_ms: int | None = None,
+    ) -> None:
+        """Record one check outcome and start timing the next."""
+        elapsed = round((perf_counter() - self._started) * 1000) if duration_ms is None else duration_ms
+        self.checks.append(
+            PreflightCheck(
+                key=key,
+                tier=self.tier,
+                outcome=outcome,
+                blocking=blocking,
+                checked_at=_now(),
+                reason_code=reason_code,
+                detail=detail,
+                method=method,
+                duration_ms=max(0, elapsed),
+            )
+        )
+        self._started = perf_counter()
+
+    def skip(self, *keys: CheckKey, blocking: bool = True, reason_code: str = REASON_NOT_ATTEMPTED) -> None:
+        """Record checks that were never attempted because a prerequisite failed."""
+        for key in keys:
+            self.add(key, CheckOutcome.SKIPPED, blocking=blocking, reason_code=reason_code, duration_ms=0)
+
+
+def _result(server: RemoteServer, recorder: _CheckRecorder, started: float, checked_at: datetime) -> PreflightResult:
+    """Assemble one tier's checks into a ``PreflightResult``."""
+    return PreflightResult(
+        remote_server_id=server.id,
+        tiers_run=[recorder.tier],
+        checks=recorder.checks,
+        checked_at=checked_at,
+        latency_ms=round((perf_counter() - started) * 1000),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Connection stage, shared by both tiers                                      #
+# --------------------------------------------------------------------------- #
+
+# Maps a connect failure to (reason_code, whether the TCP dial got through). An
+# auth or host-key failure proves reachability; a dial failure does not, and its
+# dependent checks must then be SKIPPED rather than FAILED - Studio should not
+# claim Docker is broken on a host it never reached.
+_CONNECT_ERROR_CLASSES: Final[tuple[tuple[type[Exception], str, bool], ...]] = (
+    (SshHostAliasNotFoundError, REASON_ALIAS_NOT_FOUND, False),
+    (SshHostKeyUnknownError, REASON_HOST_KEY_UNKNOWN, True),
+    (SshHostKeyMismatchError, REASON_HOST_KEY_MISMATCH, True),
+    (SshAgentRequiredError, REASON_AGENT_REQUIRED, True),
+    (SshAuthenticationError, REASON_AUTH_FAILED, True),
+    (SshConnectionError, REASON_UNREACHABLE, False),
+)
+
+_HOST_KEY_REASONS: Final = frozenset({REASON_HOST_KEY_UNKNOWN, REASON_HOST_KEY_MISMATCH})
+
+
+def _classify_connect_error(error: Exception) -> tuple[str, bool]:
+    """Return one connect failure's reason code and whether the host answered."""
+    for error_type, reason_code, reachable in _CONNECT_ERROR_CLASSES:
+        if isinstance(error, error_type):
+            return reason_code, reachable
+    return REASON_UNREACHABLE, False
+
+
+def _record_connect_failure(recorder: _CheckRecorder, error: Exception) -> None:
+    """Record REACHABLE, AUTHENTICATED and HOST_KEY_VERIFIED from one failure.
+
+    A single connect attempt answers all three, and which exception came back says
+    which of them got as far as being tested.
+    """
+    reason_code, reachable = _classify_connect_error(error)
+    host_key_failed = reason_code in _HOST_KEY_REASONS
+
+    if reachable:
+        recorder.add(CheckKey.REACHABLE, CheckOutcome.PASSED, method=METHOD_SSH_CONNECT)
+    else:
+        recorder.add(CheckKey.REACHABLE, CheckOutcome.FAILED, reason_code=reason_code, method=METHOD_SSH_CONNECT)
+
+    if host_key_failed:
+        # Verification happens before authentication, so authentication was never
+        # attempted - reporting it as failed would send the user chasing keys.
+        recorder.add(CheckKey.HOST_KEY_VERIFIED, CheckOutcome.FAILED, reason_code=reason_code)
+        recorder.skip(CheckKey.AUTHENTICATED, reason_code=reason_code)
+        return
+
+    if not reachable:
+        recorder.skip(CheckKey.AUTHENTICATED, CheckKey.HOST_KEY_VERIFIED, reason_code=reason_code)
+        return
+
+    recorder.add(CheckKey.HOST_KEY_VERIFIED, CheckOutcome.PASSED, method=METHOD_SSH_CONNECT)
+    recorder.add(CheckKey.AUTHENTICATED, CheckOutcome.FAILED, reason_code=reason_code)
+
+
+def _record_alias_check(recorder: _CheckRecorder, server: RemoteServer, settings: Settings) -> bool:
+    """Record ``ALIAS_RESOLVED`` and return whether the alias is usable.
+
+    Resolution goes through the read-only SSH config reader, which rejects a
+    wildcard-only match: a pattern stanza is not a usable target.
+    """
+    resolved = resolve_alias(settings.ssh_config_path, server.ssh_host_alias)
+    if resolved.found:
+        recorder.add(CheckKey.ALIAS_RESOLVED, CheckOutcome.PASSED, method=METHOD_SSH_CONFIG)
+        return True
+    recorder.add(
+        CheckKey.ALIAS_RESOLVED,
+        CheckOutcome.FAILED,
+        reason_code=REASON_ALIAS_NOT_FOUND,
+        detail="Alias is absent from the SSH config, or matches only a wildcard stanza.",
+        method=METHOD_SSH_CONFIG,
+    )
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1 checks                                                               #
+# --------------------------------------------------------------------------- #
+
+
+async def _check_docker(recorder: _CheckRecorder, transport: SshTransport) -> None:
+    """Record whether the SSH user can talk to the Docker daemon.
+
+    Queries the *server* version rather than ``docker --version``: the client
+    binary existing says nothing about the socket being reachable by this user,
+    which is the failure this check is for.
+    """
+    result = await transport.run_command(["docker", "version", "--format", "{{.Server.Version}}"])
+    if result.ok:
+        recorder.add(CheckKey.DOCKER_USABLE, CheckOutcome.PASSED, detail=result.first_line(), method=METHOD_DOCKER)
+        return
+    recorder.add(
+        CheckKey.DOCKER_USABLE,
+        CheckOutcome.FAILED,
+        reason_code=REASON_DOCKER_UNAVAILABLE,
+        detail=_failure_detail(result) or "The Docker daemon did not respond.",
+        method=METHOD_DOCKER,
+    )
+
+
+def _parse_free_bytes(stdout: str) -> int | None:
+    """Parse available bytes out of ``df -B1 -P`` output.
+
+    Returns ``None`` when no data row parses, so an unexpected ``df`` reports an
+    unparseable-output failure rather than a confidently wrong number.
+    """
+    for line in stdout.splitlines()[1:]:
+        columns = line.split()
+        if len(columns) < _DF_MIN_COLUMNS:
+            continue
+        try:
+            return int(columns[_DF_AVAILABLE_COLUMN])
+        except ValueError:
+            continue
+    return None
+
+
+async def _check_disk(recorder: _CheckRecorder, transport: SshTransport, settings: Settings) -> None:
+    """Record whether the host has room for the trainer image plus a job."""
+    result = await transport.run_command(["df", "-B1", "-P", "/var/lib/docker"])
+    if not result.ok:
+        # A rootless or relocated data root means /var/lib/docker need not exist;
+        # the root filesystem is the useful approximation, not a failure.
+        result = await transport.run_command(["df", "-B1", "-P", "/"])
+    if not result.ok:
+        recorder.add(
+            CheckKey.DISK_SPACE,
+            CheckOutcome.FAILED,
+            reason_code=REASON_COMMAND_FAILED,
+            detail=_failure_detail(result) or "Could not measure free disk space.",
+            method=METHOD_DF,
+        )
+        return
+
+    free_bytes = _parse_free_bytes(result.stdout)
+    if free_bytes is None:
+        recorder.add(
+            CheckKey.DISK_SPACE,
+            CheckOutcome.FAILED,
+            reason_code=REASON_UNPARSEABLE_OUTPUT,
+            detail="Could not parse free disk space from df output.",
+            method=METHOD_DF,
+        )
+        return
+
+    required = settings.ssh_min_free_disk_bytes
+    free_gib = free_bytes / _BYTES_PER_GIB
+    if free_bytes >= required:
+        recorder.add(CheckKey.DISK_SPACE, CheckOutcome.PASSED, detail=f"{free_gib:.1f} GiB free", method=METHOD_DF)
+        return
+    recorder.add(
+        CheckKey.DISK_SPACE,
+        CheckOutcome.FAILED,
+        reason_code=REASON_INSUFFICIENT_DISK,
+        detail=f"{free_gib:.1f} GiB free, {required / _BYTES_PER_GIB:.1f} GiB required",
+        method=METHOD_DF,
+    )
+
+
+async def _probe_intel_render_node(transport: SshTransport) -> CommandResult:
+    """Probe for an Intel render node, the XPU fallback signal.
+
+    Two signals are required: a ``/dev/dri/renderD*`` node must exist, and some
+    DRM device must report the Intel PCI vendor id. Both the script and the vendor
+    id are application constants, and the transport shell-quotes every element, so
+    the remote shell only ever expands the globs in this fixed text.
+    """
+    return await transport.run_command(
+        [
+            "sh",
+            "-c",
+            'ls /dev/dri/renderD* >/dev/null 2>&1 && grep -qil "$1" /sys/class/drm/*/device/vendor',
+            "sh",
+            _INTEL_VENDOR_ID,
+        ]
+    )
+
+
+async def _check_driver_cuda(recorder: _CheckRecorder, transport: SshTransport) -> str | None:
+    """Record ``DRIVER_PRESENT`` for a CUDA host."""
+    result = await transport.run_command(["nvidia-smi", "--query-gpu=name,driver_version", "--format=csv,noheader"])
+    if result.ok and result.first_line():
+        recorder.add(
+            CheckKey.DRIVER_PRESENT,
+            CheckOutcome.PASSED,
+            detail=result.first_line(),
+            method=METHOD_NVIDIA_SMI,
+        )
+        return METHOD_NVIDIA_SMI
+    recorder.add(
+        CheckKey.DRIVER_PRESENT,
+        CheckOutcome.FAILED,
+        reason_code=REASON_DRIVER_MISSING,
+        detail=_failure_detail(result) or "nvidia-smi is not available on the remote host.",
+        method=METHOD_NVIDIA_SMI,
+    )
+    return None
+
+
+async def _check_driver_xpu(recorder: _CheckRecorder, transport: SshTransport) -> str | None:
+    """Record ``DRIVER_PRESENT`` for an XPU host.
+
+    ``xpu-smi`` first, then the render-node fallback: ``xpu-smi`` is frequently
+    absent on hosts whose XPUs work perfectly, so requiring it would reject valid
+    targets. Tier 2's in-container ``torch.xpu.is_available()`` is the
+    authoritative answer; Tier 1 needs only enough signal to reject a host with no
+    Intel accelerator at all.
+    """
+    smi = await transport.run_command(["xpu-smi", "discovery"])
+    if smi.ok:
+        recorder.add(CheckKey.DRIVER_PRESENT, CheckOutcome.PASSED, detail=smi.first_line(), method=METHOD_XPU_SMI)
+        return METHOD_XPU_SMI
+
+    render = await _probe_intel_render_node(transport)
+    if render.ok:
+        recorder.add(
+            CheckKey.DRIVER_PRESENT,
+            CheckOutcome.PASSED,
+            detail="Intel render node present.",
+            method=METHOD_RENDER_NODE,
+        )
+        return METHOD_RENDER_NODE
+
+    recorder.add(
+        CheckKey.DRIVER_PRESENT,
+        CheckOutcome.FAILED,
+        reason_code=REASON_DRIVER_MISSING,
+        detail="Neither xpu-smi nor an Intel render node was found.",
+        method=METHOD_RENDER_NODE,
+    )
+    return None
+
+
+async def _check_driver(recorder: _CheckRecorder, transport: SshTransport, device_type: DeviceType) -> str | None:
+    """Record ``DRIVER_PRESENT`` and return the method that answered."""
+    if device_type is DeviceType.CUDA:
+        return await _check_driver_cuda(recorder, transport)
+    return await _check_driver_xpu(recorder, transport)
+
+
+def registry_probe_url(registry: str) -> str:
+    """Return the registry-API URL whose reachability Tier 1 checks.
+
+    Only the registry host matters: this is a reachability probe, and resolving a
+    repository or tag is Tier 2's job.
+
+    Args:
+        registry: Configured registry, e.g. ``ghcr.io/open-edge-platform``.
+
+    Returns:
+        The ``https://<host>/v2/`` URL to issue a ``HEAD`` against.
+    """
+    candidate = registry if "://" in registry else f"https://{registry}"
+    host = urlsplit(candidate).netloc or registry.split("/", 1)[0]
+    return f"https://{host}/v2/"
+
+
+async def _check_registry(recorder: _CheckRecorder, transport: SshTransport, settings: Settings) -> None:
+    """Record whether the remote host can reach the trainer image registry.
+
+    Probed *from the remote host*, because that is where the eventual
+    ``docker pull`` runs - a registry reachable from the Studio machine but
+    firewalled on the GPU box is exactly the misconfiguration worth catching
+    before a job is accepted.
+
+    A ``HEAD`` and nothing more: no manifest, no layer, no image. ``/v2/`` answers
+    ``401`` to an anonymous client on GHCR, which still proves reachability, so any
+    HTTP response counts as reachable and only a transport-level failure counts as
+    unreachable.
+    """
+    url = registry_probe_url(settings.trainer_image_registry)
+    result = await transport.run_command(
+        ["curl", "--head", "--silent", "--show-error", "--max-time", "10", "--output", "/dev/null", url]
+    )
+    if result.ok:
+        recorder.add(CheckKey.REGISTRY_REACHABLE, CheckOutcome.PASSED, detail=url, method=METHOD_CURL)
+        return
+    recorder.add(
+        CheckKey.REGISTRY_REACHABLE,
+        CheckOutcome.FAILED,
+        reason_code=REASON_REGISTRY_UNREACHABLE,
+        detail=_failure_detail(result) or f"Could not reach {url}",
+        method=METHOD_CURL,
+    )
+
+
+async def _check_gpu_free_cuda(recorder: _CheckRecorder, transport: SshTransport) -> None:
+    """Record CUDA GPU occupancy. Never blocking, and "busy" is never FAILED."""
+    apps = await transport.run_command(["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"])
+    if not apps.ok:
+        recorder.add(
+            CheckKey.GPU_FREE,
+            CheckOutcome.SKIPPED,
+            blocking=False,
+            reason_code=REASON_COMMAND_FAILED,
+            detail=_failure_detail(apps) or "Could not query GPU compute processes.",
+            method=METHOD_NVIDIA_SMI,
+        )
+        return
+
+    processes = [line for line in apps.stdout.splitlines() if line.strip()]
+    if processes:
+        recorder.add(
+            CheckKey.GPU_FREE,
+            CheckOutcome.WARNING,
+            blocking=False,
+            reason_code=REASON_GPU_BUSY,
+            detail=f"{len(processes)} process(es) currently hold the GPU.",
+            method=METHOD_NVIDIA_SMI,
+        )
+        return
+    recorder.add(CheckKey.GPU_FREE, CheckOutcome.PASSED, blocking=False, method=METHOD_NVIDIA_SMI)
+
+
+def _parse_memory_fraction(stdout: str) -> float | None:
+    """Parse the first two numbers on a ``used,total`` line into a fraction."""
+    numbers = [float(match) for match in re.findall(r"\d+(?:\.\d+)?", stdout)]
+    if len(numbers) < 2 or numbers[1] <= 0:
+        return None
+    return numbers[0] / numbers[1]
+
+
+async def _check_gpu_free_xpu(recorder: _CheckRecorder, transport: SshTransport, driver_method: str | None) -> None:
+    """Record XPU occupancy, best effort.
+
+    XPU offers no per-process attribution comparable to ``nvidia-smi``, so this
+    falls back to a memory-utilization heuristic. With no usable signal the check
+    is ``SKIPPED``, never ``PASSED``: reporting a busy accelerator as free would
+    send a job straight into an out-of-memory failure.
+    """
+    if driver_method != METHOD_XPU_SMI:
+        recorder.add(
+            CheckKey.GPU_FREE,
+            CheckOutcome.SKIPPED,
+            blocking=False,
+            reason_code=REASON_NO_SIGNAL,
+            detail="xpu-smi is not available, so occupancy cannot be determined.",
+            method=METHOD_RENDER_NODE,
+        )
+        return
+
+    stats = await transport.run_command(["xpu-smi", "stats", "-d", "0"])
+    if not stats.ok:
+        recorder.add(
+            CheckKey.GPU_FREE,
+            CheckOutcome.SKIPPED,
+            blocking=False,
+            reason_code=REASON_COMMAND_FAILED,
+            detail=_failure_detail(stats) or "Could not query xpu-smi statistics.",
+            method=METHOD_XPU_SMI,
+        )
+        return
+
+    fraction = _parse_memory_fraction(stats.stdout)
+    if fraction is None:
+        recorder.add(
+            CheckKey.GPU_FREE,
+            CheckOutcome.SKIPPED,
+            blocking=False,
+            reason_code=REASON_NO_SIGNAL,
+            detail="Could not parse XPU memory usage.",
+            method=METHOD_XPU_SMI,
+        )
+        return
+    if fraction >= _GPU_BUSY_MEMORY_FRACTION:
+        recorder.add(
+            CheckKey.GPU_FREE,
+            CheckOutcome.WARNING,
+            blocking=False,
+            reason_code=REASON_GPU_BUSY,
+            detail=f"{fraction:.0%} of XPU memory is in use.",
+            method=METHOD_XPU_SMI,
+        )
+        return
+    recorder.add(CheckKey.GPU_FREE, CheckOutcome.PASSED, blocking=False, method=METHOD_XPU_SMI)
+
+
+async def _check_gpu_free(
+    recorder: _CheckRecorder,
+    transport: SshTransport,
+    device_type: DeviceType,
+    driver_method: str | None,
+) -> None:
+    """Record GPU occupancy for the configured device type."""
+    if device_type is DeviceType.CUDA:
+        await _check_gpu_free_cuda(recorder, transport)
+        return
+    await _check_gpu_free_xpu(recorder, transport, driver_method)
+
+
+# Tier 1 checks that need an open connection, in the order they run.
+_TIER1_REMOTE_KEYS: Final = (
+    CheckKey.DOCKER_USABLE,
+    CheckKey.DISK_SPACE,
+    CheckKey.DRIVER_PRESENT,
+    CheckKey.REGISTRY_REACHABLE,
+)
+
+
+def _complete_tier1(recorder: _CheckRecorder, reason_code: str) -> None:
+    """Record every not-yet-attempted Tier 1 check as skipped."""
+    recorded = recorder.recorded
+    recorder.skip(*(key for key in _TIER1_REMOTE_KEYS if key not in recorded), reason_code=reason_code)
+    if CheckKey.GPU_FREE not in recorded:
+        recorder.skip(CheckKey.GPU_FREE, blocking=False, reason_code=reason_code)
+
+
+async def _run_tier1_remote_checks(
+    recorder: _CheckRecorder,
+    transport: SshTransport,
+    server: RemoteServer,
+    settings: Settings,
+) -> None:
+    """Run the Tier 1 checks that need an open connection."""
+    recorder.add(CheckKey.REACHABLE, CheckOutcome.PASSED, method=METHOD_SSH_CONNECT)
+    recorder.add(CheckKey.HOST_KEY_VERIFIED, CheckOutcome.PASSED, method=METHOD_SSH_CONNECT)
+    recorder.add(CheckKey.AUTHENTICATED, CheckOutcome.PASSED, method=METHOD_SSH_CONNECT)
+
+    await _check_docker(recorder, transport)
+    await _check_disk(recorder, transport, settings)
+    driver_method = await _check_driver(recorder, transport, server.device_type)
+    await _check_registry(recorder, transport, settings)
+    await _check_gpu_free(recorder, transport, server.device_type, driver_method)
+
+
+async def run_tier1_preflight(server: RemoteServer) -> PreflightResult:
+    """Run the cheap, save-gating preflight against one server.
+
+    Resolves the alias, opens one bounded SSH connection, and runs four short
+    remote probes plus a non-blocking occupancy check. Performs no image
+    resolution, no pull, and starts no container: the registry check is a ``HEAD``
+    against the registry API root.
+
+    Does not raise for a server that fails its checks. Callers decide from
+    :attr:`~schemas.ssh_preflight.PreflightResult.blocking_failures` whether to
+    reject a save, so the user sees every cause at once.
+
+    Args:
+        server: The server whose configuration to verify.
+
+    Returns:
+        One check per Tier 1 key, each with its own outcome and duration.
+    """
+    settings = get_settings()
+    started = perf_counter()
+    checked_at = _now()
+    recorder = _CheckRecorder(PreflightTier.TIER_1)
+
+    if not _record_alias_check(recorder, server, settings):
+        recorder.skip(
+            CheckKey.REACHABLE,
+            CheckKey.AUTHENTICATED,
+            CheckKey.HOST_KEY_VERIFIED,
+            reason_code=REASON_ALIAS_NOT_FOUND,
+        )
+        _complete_tier1(recorder, REASON_ALIAS_NOT_FOUND)
+        return _result(server, recorder, started, checked_at)
+
+    if server.device_type not in SSH_SERVER_DEVICE_TYPES:
+        # The schema rejects this on save, but a record predating that validation
+        # must not silently pass a driver check that cannot be performed.
+        recorder.skip(
+            CheckKey.REACHABLE,
+            CheckKey.AUTHENTICATED,
+            CheckKey.HOST_KEY_VERIFIED,
+            reason_code=REASON_UNSUPPORTED_DEVICE,
+        )
+        recorder.add(
+            CheckKey.DRIVER_PRESENT,
+            CheckOutcome.FAILED,
+            reason_code=REASON_UNSUPPORTED_DEVICE,
+            detail=f"No trainer image exists for device type '{server.device_type.value}'.",
+        )
+        _complete_tier1(recorder, REASON_UNSUPPORTED_DEVICE)
+        return _result(server, recorder, started, checked_at)
+
+    transport = transport_factory(server.ssh_host_alias)
+    try:
+        await transport.connect()
+    except _CONNECT_FAILURES as error:
+        _record_connect_failure(recorder, error)
+        _complete_tier1(recorder, _classify_connect_error(error)[0])
+        return _result(server, recorder, started, checked_at)
+
+    try:
+        await _run_tier1_remote_checks(recorder, transport, server, settings)
+    except SshConnectionError as error:
+        # The connection dropped partway through: the remaining checks are
+        # unknown, not failed.
+        logger.warning(
+            "SSH connection lost during Tier 1 preflight for alias '{}': {}",
+            server.ssh_host_alias,
+            error.message,
+        )
+        _complete_tier1(recorder, REASON_UNREACHABLE)
+    finally:
+        await transport.close()
+
+    return _result(server, recorder, started, checked_at)
+
+
+# --------------------------------------------------------------------------- #
+# Tier 2 checks                                                               #
+# --------------------------------------------------------------------------- #
+
+# Protocol version this backend speaks. Callers pass the compiled-in value from
+# the trainer package; importing it here would couple the SSH service to the
+# trainer, which the preflight must be able to run without.
+DEFAULT_PROTOCOL_VERSION: Final = 1
+
+# Label the trainer images carry their protocol version in, set by
+# `docker/Dockerfile.trainer` from TRAINER_API_PROTOCOL_VERSION.
+PROTOCOL_LABEL: Final = "org.open-edge-platform.physicalai.trainer.api-protocol"
+
+_TIER2_KEYS: Final = (
+    CheckKey.IMAGE_RESOLVED,
+    CheckKey.IMAGE_SIGNATURE,
+    CheckKey.CONTAINER_DEVICE_PROBE,
+    CheckKey.PROTOCOL_COMPATIBLE,
+)
+
+# IMAGE_SIGNATURE is advisory: the images are signed at publish time, so a host
+# without cosign is informative, not broken.
+_TIER2_NON_BLOCKING: Final = frozenset({CheckKey.IMAGE_SIGNATURE})
+
+
+def trainer_image_ref(registry: str, device_type: DeviceType, tag: str) -> str:
+    """Build a trainer image reference from application constants.
+
+    Args:
+        registry: Configured registry.
+        device_type: The server's accelerator.
+        tag: Image tag.
+
+    Returns:
+        The ``<registry>/physicalai-trainer-<device>:<tag>`` reference.
+    """
+    return f"{registry.rstrip('/')}/physicalai-trainer-{device_type.value}:{tag}"
+
+
+def protocol_tag(protocol_version: int) -> str:
+    """Return the protocol-pinned image tag for a protocol version."""
+    return f"protocol-{protocol_version}"
+
+
+def _complete_tier2(recorder: _CheckRecorder, reason_code: str) -> None:
+    """Record every not-yet-attempted Tier 2 check as skipped."""
+    recorded = recorder.recorded
+    for key in _TIER2_KEYS:
+        if key not in recorded:
+            recorder.skip(key, blocking=key not in _TIER2_NON_BLOCKING, reason_code=reason_code)
+
+
+async def _resolve_image(
+    recorder: _CheckRecorder,
+    transport: SshTransport,
+    server: RemoteServer,
+    protocol_version: int,
+    image_ref_hint: str | None,
+) -> str | None:
+    """Resolve the trainer image, recording ``IMAGE_RESOLVED``.
+
+    Prefers the protocol-pinned tag and falls back to ``latest``. The fallback is
+    a ``WARNING``, not a failure: a protocol bump can land in Studio before CI has
+    published a matching trainer image, and blocking every verification until then
+    would be worse than telling the user which tag was actually used. Only failing
+    both tags is fatal.
+
+    Args:
+        recorder: Recorder for this tier.
+        transport: Open transport to the server.
+        server: The server being verified.
+        protocol_version: Protocol version this backend speaks.
+        image_ref_hint: Image reference to try ahead of the pinned tag.
+
+    Returns:
+        The resolved image reference, or ``None`` when nothing resolved.
+    """
+    registry = get_settings().trainer_image_registry
+    preferred = image_ref_hint or trainer_image_ref(registry, server.device_type, protocol_tag(protocol_version))
+
+    result = await transport.run_command(["docker", "manifest", "inspect", preferred])
+    if result.ok:
+        recorder.add(CheckKey.IMAGE_RESOLVED, CheckOutcome.PASSED, detail=preferred, method=METHOD_DOCKER_MANIFEST)
+        return preferred
+
+    fallback = trainer_image_ref(registry, server.device_type, "latest")
+    if fallback != preferred:
+        fallback_result = await transport.run_command(["docker", "manifest", "inspect", fallback])
+        if fallback_result.ok:
+            logger.warning("Trainer image '{}' did not resolve; falling back to '{}'", preferred, fallback)
+            recorder.add(
+                CheckKey.IMAGE_RESOLVED,
+                CheckOutcome.WARNING,
+                reason_code=REASON_PROTOCOL_TAG_UNRESOLVED,
+                detail=f"{preferred} did not resolve; using {fallback}",
+                method=METHOD_DOCKER_MANIFEST,
+            )
+            return fallback
+
+    recorder.add(
+        CheckKey.IMAGE_RESOLVED,
+        CheckOutcome.FAILED,
+        reason_code=REASON_IMAGE_UNRESOLVED,
+        detail=_failure_detail(result) or f"Could not resolve {preferred}",
+        method=METHOD_DOCKER_MANIFEST,
+    )
+    return None
+
+
+async def _check_signature(recorder: _CheckRecorder, transport: SshTransport, image_ref: str) -> None:
+    """Verify the image signature when ``cosign`` is available on the host.
+
+    Defense in depth rather than required infrastructure, so a host without
+    ``cosign`` is ``SKIPPED`` and a failed verification is a non-blocking
+    ``WARNING``: the publish-time signature is the primary control.
+    """
+    available = await transport.run_command(["cosign", "version"])
+    if not available.ok:
+        recorder.add(
+            CheckKey.IMAGE_SIGNATURE,
+            CheckOutcome.SKIPPED,
+            blocking=False,
+            reason_code=REASON_TOOL_MISSING,
+            detail="cosign is not installed on the remote host, so the signature was not verified there.",
+            method=METHOD_COSIGN,
+        )
+        return
+
+    verified = await transport.run_command(["cosign", "verify", image_ref])
+    if verified.ok:
+        recorder.add(CheckKey.IMAGE_SIGNATURE, CheckOutcome.PASSED, blocking=False, method=METHOD_COSIGN)
+        return
+    recorder.add(
+        CheckKey.IMAGE_SIGNATURE,
+        CheckOutcome.WARNING,
+        blocking=False,
+        reason_code=REASON_COMMAND_FAILED,
+        detail=_failure_detail(verified) or "cosign could not verify the image signature.",
+        method=METHOD_COSIGN,
+    )
+
+
+def _device_run_args(device_type: DeviceType) -> list[str]:
+    """Return the ``docker run`` flags that expose the accelerator.
+
+    Derived from the configured device type, never from user-supplied text.
+    """
+    if device_type is DeviceType.CUDA:
+        return ["--gpus", "all"]
+    return ["--device", "/dev/dri"]
+
+
+def _device_probe_expression(device_type: DeviceType) -> str:
+    """Return the in-container device-availability expression."""
+    accelerator = "cuda" if device_type is DeviceType.CUDA else "xpu"
+    return f"import torch; print(torch.{accelerator}.is_available())"
+
+
+async def _check_device_probe(
+    recorder: _CheckRecorder,
+    transport: SshTransport,
+    device_type: DeviceType,
+    image_ref: str,
+) -> None:
+    """Run a one-shot container and record whether it sees the accelerator.
+
+    The authoritative check, and the reason Tier 2 exists: a driver visible on the
+    host still tells you nothing about whether the container runtime passes the
+    device through.
+    """
+    argv = [
+        "docker",
+        "run",
+        "--rm",
+        *_device_run_args(device_type),
+        "--entrypoint",
+        "python",
+        image_ref,
+        "-c",
+        _device_probe_expression(device_type),
+    ]
+    result = await transport.run_command(argv, timeout=get_settings().ssh_preflight_timeout_s)
+    if result.ok and result.first_line().lower() == "true":
+        recorder.add(CheckKey.CONTAINER_DEVICE_PROBE, CheckOutcome.PASSED, method=METHOD_CONTAINER)
+        return
+    recorder.add(
+        CheckKey.CONTAINER_DEVICE_PROBE,
+        CheckOutcome.FAILED,
+        reason_code=REASON_DEVICE_UNAVAILABLE,
+        detail=_failure_detail(result) or "The container did not report the device as available.",
+        method=METHOD_CONTAINER,
+    )
+
+
+async def _check_protocol(
+    recorder: _CheckRecorder,
+    transport: SshTransport,
+    image_ref: str,
+    protocol_version: int,
+) -> None:
+    """Compare the image's advertised protocol version against the expected one.
+
+    Read from the image label rather than by standing the trainer up and calling
+    ``/health``: the label is baked in at build time by the same CI that sets the
+    trainer's runtime value, so reading it needs no container, no port, and no
+    tunnel. Provisioning re-verifies against the live ``/health`` response before
+    uploading a dataset.
+    """
+    label_format = f'{{{{index .Config.Labels "{PROTOCOL_LABEL}"}}}}'
+    result = await transport.run_command(["docker", "image", "inspect", "--format", label_format, image_ref])
+    reported = result.first_line() if result.ok else ""
+    if not reported or reported == "<no value>":
+        recorder.add(
+            CheckKey.PROTOCOL_COMPATIBLE,
+            CheckOutcome.FAILED,
+            reason_code=REASON_PROTOCOL_UNKNOWN,
+            detail="The image advertises no trainer protocol version.",
+            method=METHOD_DOCKER,
+        )
+        return
+
+    try:
+        image_protocol = int(reported)
+    except ValueError:
+        recorder.add(
+            CheckKey.PROTOCOL_COMPATIBLE,
+            CheckOutcome.FAILED,
+            reason_code=REASON_UNPARSEABLE_OUTPUT,
+            detail=_detail(f"Unparseable protocol version: {reported}"),
+            method=METHOD_DOCKER,
+        )
+        return
+
+    if image_protocol == protocol_version:
+        recorder.add(
+            CheckKey.PROTOCOL_COMPATIBLE,
+            CheckOutcome.PASSED,
+            detail=f"protocol {image_protocol}",
+            method=METHOD_DOCKER,
+        )
+        return
+    recorder.add(
+        CheckKey.PROTOCOL_COMPATIBLE,
+        CheckOutcome.FAILED,
+        reason_code=REASON_PROTOCOL_MISMATCH,
+        detail=f"The image speaks protocol {image_protocol}; this backend speaks {protocol_version}.",
+        method=METHOD_DOCKER,
+    )
+
+
+async def run_tier2_preflight(
+    server: RemoteServer,
+    image_ref_hint: str | None = None,
+    protocol_version: int = DEFAULT_PROTOCOL_VERSION,
+) -> PreflightResult:
+    """Run the expensive verification tier against one server.
+
+    Invoked only by an explicit verify action: it inspects the trainer image in
+    the registry and starts a one-shot container, neither of which belongs inside
+    a create/update request. ``protocol_version`` is a parameter so this module
+    stays independent of the trainer package.
+
+    Like Tier 1, does not raise for a server that fails its checks.
+
+    Args:
+        server: The server to verify.
+        image_ref_hint: Image reference to try before the protocol-pinned tag.
+        protocol_version: Trainer API protocol version this backend speaks.
+
+    Returns:
+        One check per Tier 2 key.
+    """
+    started = perf_counter()
+    checked_at = _now()
+    recorder = _CheckRecorder(PreflightTier.TIER_2)
+
+    transport = transport_factory(server.ssh_host_alias)
+    try:
+        await transport.connect()
+    except _CONNECT_FAILURES as error:
+        _complete_tier2(recorder, _classify_connect_error(error)[0])
+        return _result(server, recorder, started, checked_at)
+
+    try:
+        image_ref = await _resolve_image(recorder, transport, server, protocol_version, image_ref_hint)
+        if image_ref is None:
+            _complete_tier2(recorder, REASON_IMAGE_UNRESOLVED)
+            return _result(server, recorder, started, checked_at)
+
+        await _check_signature(recorder, transport, image_ref)
+        await _check_device_probe(recorder, transport, server.device_type, image_ref)
+        await _check_protocol(recorder, transport, image_ref, protocol_version)
+    except SshConnectionError as error:
+        logger.warning(
+            "SSH connection lost during Tier 2 preflight for alias '{}': {}",
+            server.ssh_host_alias,
+            error.message,
+        )
+        _complete_tier2(recorder, REASON_UNREACHABLE)
+    finally:
+        await transport.close()
+
+    return _result(server, recorder, started, checked_at)
+
+
+def set_transport_factory(factory: Callable[[str], SshTransport]) -> None:
+    """Replace the transport factory both tiers use."""
+    global transport_factory  # noqa: PLW0603 - the module-level factory is the documented seam.
+    transport_factory = factory
+
+
+def reset_transport_factory() -> None:
+    """Restore the real transport factory."""
+    set_transport_factory(open_transport)

--- a/application/backend/src/services/ssh/sanitize.py
+++ b/application/backend/src/services/ssh/sanitize.py
@@ -97,6 +97,17 @@ def _skip_escape_sequence(text: str, start: int) -> int:  # noqa: PLR0911 - one 
             index += 1
         return length
 
+    # nF escape sequences: ESC, zero or more intermediate bytes (0x20-0x2F), then
+    # one final byte (0x30-0x7E). Character-set designations (e.g. `ESC ( B`) are
+    # the common case; a plain two-byte sequence (e.g. `ESC c`) is just the
+    # zero-intermediate-bytes case of this same rule.
+    if "\x20" <= introducer <= "\x2f":
+        index += 1
+        while index < length and "\x20" <= text[index] <= "\x2f":
+            index += 1
+        # Past the final byte, or end-of-string for an unterminated sequence.
+        return min(index + 1, length)
+
     # Any other ESC sequence is two bytes: ESC plus the following character.
     return index + 1
 

--- a/application/backend/src/services/ssh/sanitize.py
+++ b/application/backend/src/services/ssh/sanitize.py
@@ -1,0 +1,169 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sanitize output streamed from remote commands.
+
+Remote stdout/stderr is environment-influenced content, not trusted text. A
+hostile or merely noisy remote process can emit ANSI/OSC escape sequences that
+rewrite what the operator sees, bidi overrides that reorder rendered text, or
+megabytes of output that blow the ``extra_info`` cap. Everything crossing the
+SSH boundary into an API response or a job message passes through
+:func:`sanitize_output` first.
+
+The stripped set is exactly the one the design doc names:
+
+* Unicode ``Cc`` characters, except ``\\n``, which survives as a line separator;
+* the ``Cf`` bidi-override code points (``U+200F``, ``U+202A``-``U+202E``,
+  ``U+2066``-``U+2069``, ``U+FEFF``) - not all of ``Cf``, which also holds
+  harmless formatting characters;
+* every ESC-introduced sequence, from ``\\x1b`` through its terminator.
+"""
+
+import unicodedata
+from typing import Final
+
+# Cf code points that can reorder or hide rendered text. Deliberately not all of
+# Cf: a soft hyphen or a joiner is harmless and stripping it would corrupt
+# legitimate output.
+# Written as escapes, not literals: a source file containing real bidi overrides
+# is itself unreviewable, which is the whole reason these are being stripped.
+_BIDI_OVERRIDES: Final[frozenset[str]] = frozenset(
+    {
+        "\u200f",  # RIGHT-TO-LEFT MARK
+        "\u202a",  # LEFT-TO-RIGHT EMBEDDING
+        "\u202b",  # RIGHT-TO-LEFT EMBEDDING
+        "\u202c",  # POP DIRECTIONAL FORMATTING
+        "\u202d",  # LEFT-TO-RIGHT OVERRIDE
+        "\u202e",  # RIGHT-TO-LEFT OVERRIDE
+        "\u2066",  # LEFT-TO-RIGHT ISOLATE
+        "\u2067",  # RIGHT-TO-LEFT ISOLATE
+        "\u2068",  # FIRST STRONG ISOLATE
+        "\u2069",  # POP DIRECTIONAL ISOLATE
+        "\ufeff",  # ZERO WIDTH NO-BREAK SPACE / BOM
+    }
+)
+
+_ESC: Final = "\x1b"
+_BEL: Final = "\x07"
+_LINE_SEPARATOR: Final = "\n"
+
+# Appended when the total cap forces a cut, so an operator can tell a truncated
+# message from a command that simply produced short output.
+TRUNCATION_MARKER: Final = "...[truncated]"
+
+
+def _skip_escape_sequence(text: str, start: int) -> int:  # noqa: PLR0911 - one return per terminator rule.
+    """Return the index just past the ESC sequence beginning at ``start``.
+
+    ``start`` indexes the ESC itself. Returns ``len(text)`` for an unterminated
+    sequence so a dangling ESC can never survive into rendered output.
+
+    Args:
+        text: The string being scanned.
+        start: Index of the ESC character.
+
+    Returns:
+        The index of the first character after the sequence.
+    """
+    length = len(text)
+    index = start + 1
+    if index >= length:
+        return length
+
+    introducer = text[index]
+
+    # CSI: ESC [ params... final-byte, where the final byte is in 0x40-0x7E.
+    if introducer == "[":
+        index += 1
+        while index < length and not ("\x40" <= text[index] <= "\x7e"):
+            index += 1
+        # Past the final byte, or end-of-string for an unterminated sequence.
+        return min(index + 1, length)
+
+    # OSC (and the other string-terminated introducers: DCS, SOS, PM, APC).
+    # Terminated by BEL or by the two-byte ST (ESC \).
+    if introducer in {"]", "P", "X", "^", "_"}:
+        index += 1
+        while index < length:
+            char = text[index]
+            if char == _BEL:
+                return index + 1
+            if char == _ESC:
+                # ST is ESC \. A bare ESC starts a new sequence, so stop here
+                # and let the outer scanner handle it rather than swallowing it.
+                if index + 1 < length and text[index + 1] == "\\":
+                    return index + 2
+                return index
+            index += 1
+        return length
+
+    # Any other ESC sequence is two bytes: ESC plus the following character.
+    return index + 1
+
+
+def _strip_control_sequences(text: str) -> str:
+    """Remove ESC sequences, ``Cc`` characters, and bidi overrides.
+
+    ``\\n`` survives; every other control character does not.
+
+    Args:
+        text: Raw text from a remote command.
+
+    Returns:
+        The text with control sequences removed.
+    """
+    kept: list[str] = []
+    index = 0
+    length = len(text)
+
+    while index < length:
+        char = text[index]
+
+        if char == _ESC:
+            index = _skip_escape_sequence(text, index)
+            continue
+
+        if char == _LINE_SEPARATOR:
+            kept.append(char)
+        elif char in _BIDI_OVERRIDES:
+            pass
+        elif unicodedata.category(char) != "Cc":
+            kept.append(char)
+
+        index += 1
+
+    return "".join(kept)
+
+
+def sanitize_output(text: str, *, max_line_chars: int, max_total_chars: int) -> str:
+    """Strip control sequences from remote output and cap its length.
+
+    Applies the per-line cap first, then the total cap, so one pathological line
+    cannot consume the whole budget and hide every following line.
+
+    Args:
+        text: Raw stdout/stderr from a remote command.
+        max_line_chars: Maximum characters kept per line. Non-positive drops all
+            line content.
+        max_total_chars: Maximum characters of the joined result. Non-positive
+            returns an empty string.
+
+    Returns:
+        Sanitized, length-capped text safe to place in an API response or a job
+        message.
+    """
+    if max_total_chars <= 0 or not text:
+        return ""
+
+    stripped = _strip_control_sequences(text)
+    capped_lines = [line[:max_line_chars] if max_line_chars > 0 else "" for line in stripped.split(_LINE_SEPARATOR)]
+    joined = _LINE_SEPARATOR.join(capped_lines)
+
+    if len(joined) <= max_total_chars:
+        return joined
+
+    # Keep the marker inside the cap so the result never exceeds the budget the
+    # caller sized its storage against.
+    if max_total_chars <= len(TRUNCATION_MARKER):
+        return joined[:max_total_chars]
+    return joined[: max_total_chars - len(TRUNCATION_MARKER)] + TRUNCATION_MARKER

--- a/application/backend/src/services/ssh/transport.py
+++ b/application/backend/src/services/ssh/transport.py
@@ -25,9 +25,9 @@ constrained here rather than at the call sites:
 
 Host-key unknown vs. changed
 ----------------------------
-``asyncssh`` 2.24 raises the same :class:`asyncssh.HostKeyNotVerifiable` for a
-host absent from ``known_hosts`` and for a host whose key changed - both arrive
-as ``ValueError('Host key is not trusted')`` inside
+``asyncssh`` Raises the same :class:`asyncssh.HostKeyNotVerifiable` for a host
+  absent from ``known_hosts`` and for a host whose key changed - both arrive as
+``ValueError('Host key is not trusted')`` inside
 ``SSHClientConnection.validate_server_host_key``. To tell them apart, this module
 installs a callable ``known_hosts`` matcher that wraps
 :func:`asyncssh.match_known_hosts` and records how many entries matched the host
@@ -607,16 +607,26 @@ class SshTransport:
         )
 
     async def close(self) -> None:
-        """Close the connection and release the per-alias slot."""
+        """Close the connection and release the per-alias slot.
+
+        The semaphore release happens in a ``finally`` so it runs even if this
+        coroutine is cancelled while awaiting ``wait_closed()``:
+        ``asyncio.CancelledError`` is a ``BaseException`` and is not caught by
+        ``suppress(Exception)``, so without the ``finally`` a cancellation here
+        would skip the release and wedge the alias's concurrency slot for the
+        rest of the process.
+        """
         connection, self._connection = self._connection, None
         gate, self._gate = self._gate, None
 
-        if connection is not None:
-            connection.close()
-            with suppress(Exception):
-                await connection.wait_closed()
-        if gate is not None:
-            gate.semaphore.release()
+        try:
+            if connection is not None:
+                connection.close()
+                with suppress(Exception):
+                    await connection.wait_closed()
+        finally:
+            if gate is not None:
+                gate.semaphore.release()
 
 
 def open_transport(alias: str, settings: Settings | None = None) -> SshTransport:

--- a/application/backend/src/services/ssh/transport.py
+++ b/application/backend/src/services/ssh/transport.py
@@ -1,0 +1,640 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Async SSH transport for SSH-provisioned remote training servers.
+
+This module is the remote-execution trust boundary. Everything crossing it is
+constrained here rather than at the call sites:
+
+* **Credentials stay with the user.** ``asyncssh`` is handed the user's own
+  ``~/.ssh/config`` and ``~/.ssh/known_hosts`` and resolves the alias itself.
+  Studio never reads, stores, or transports key material.
+* **Commands are built from argument lists.** :meth:`SshTransport.run_command`
+  takes ``argv`` and shell-quotes it with :func:`shlex.join`. SSH's ``exec``
+  channel is string-based at the protocol level, so quoting each argument is
+  what makes an argument unable to break out of its position.
+* **Failures map to actionable errors.** Every ``asyncssh`` connect/auth failure
+  becomes one of the ``Ssh*Error`` classes in :mod:`exceptions`, and none of them
+  carry raw ``asyncssh`` exception text: a raw SSH error can contain the resolved
+  hostname or an identity path, neither of which belongs in an API response.
+* **Output is sanitized.** ``stdout``/``stderr`` on a :class:`CommandResult` have
+  already been through :func:`services.ssh.sanitize.sanitize_output`, so remote
+  output cannot carry escape sequences or unbounded length into a job message.
+* **Everything is bounded.** Connect, command, per-alias concurrency, and
+  per-alias connect rate all have caps from :class:`settings.Settings`.
+
+Host-key unknown vs. changed
+----------------------------
+``asyncssh`` 2.24 raises the same :class:`asyncssh.HostKeyNotVerifiable` for a
+host absent from ``known_hosts`` and for a host whose key changed - both arrive
+as ``ValueError('Host key is not trusted')`` inside
+``SSHClientConnection.validate_server_host_key``. To tell them apart, this module
+installs a callable ``known_hosts`` matcher that wraps
+:func:`asyncssh.match_known_hosts` and records how many entries matched the host
+before verification ran. No matching entry means the host was never accepted
+(unknown); entries that matched while verification still failed means the
+presented key differs from the accepted one (mismatch). An ambiguous case fails
+closed as a mismatch, the more suspicious interpretation.
+"""
+
+import asyncio
+import shlex
+import socket
+from collections.abc import Sequence
+from contextlib import suppress
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from time import perf_counter
+from types import TracebackType
+from typing import Final, Self
+
+import asyncssh
+from loguru import logger
+
+from exceptions import (
+    SshAgentRequiredError,
+    SshAuthenticationError,
+    SshConnectionError,
+    SshHostAliasNotFoundError,
+    SshHostKeyMismatchError,
+    SshHostKeyUnknownError,
+)
+from services.ssh.sanitize import sanitize_output
+from services.ssh_config_reader import resolve_alias
+from settings import Settings, get_settings
+
+# Exit status reported for a command that never produced one. 124 is the
+# conventional timeout status; -1 marks a channel that never ran.
+COMMAND_TIMEOUT_EXIT_STATUS: Final = 124
+COMMAND_FAILED_EXIT_STATUS: Final = -1
+
+# Pre-approved `SshConnectionError.reason` categories. The reason reaches an API
+# response, so it is chosen from this set and never derived from exception text.
+_REASON_TIMEOUT: Final = "timeout"
+_REASON_UNREACHABLE: Final = "unreachable"
+_REASON_PROTOCOL: Final = "protocol_error"
+_REASON_CONNECTION_LOST: Final = "connection_lost"
+
+# `asyncssh` reports a passphrase-protected key it cannot decrypt with a
+# KeyImportError whose message starts with this word.
+# S105: this is the first word of an asyncssh error message, not a credential.
+_PASSPHRASE_ERROR_PREFIX: Final = "Passphrase"  # noqa: S105
+
+
+class CommandFailure(StrEnum):
+    """Why a command produced no exit status of its own."""
+
+    TIMEOUT = "timeout"
+    # The server refused to open a session channel (e.g. a forced command, or a
+    # shell-less account).
+    CHANNEL_REFUSED = "channel_refused"
+    # The remote process died on a signal.
+    SIGNALED = "signaled"
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    """Outcome of one remote command.
+
+    ``stdout``/``stderr`` are already sanitized and length-capped: remote output
+    is environment-influenced, not trusted text, so no raw copy is kept.
+
+    Attributes:
+        argv: The argument list as supplied by the caller.
+        command: The shell-quoted string actually sent over the exec channel.
+        exit_status: The remote exit status, or a synthetic status when the
+            command produced none.
+        stdout: Sanitized standard output.
+        stderr: Sanitized standard error.
+        duration_ms: Wall-clock duration of the command.
+        failure: Set when the command produced no exit status of its own.
+    """
+
+    argv: tuple[str, ...]
+    command: str
+    exit_status: int
+    stdout: str = ""
+    stderr: str = ""
+    duration_ms: int = 0
+    failure: CommandFailure | None = None
+
+    @property
+    def ok(self) -> bool:
+        """True when the command ran to completion and exited zero."""
+        return self.failure is None and self.exit_status == 0
+
+    def first_line(self) -> str:
+        """Return the first non-empty stdout line, for a short check detail."""
+        for line in self.stdout.splitlines():
+            if line.strip():
+                return line.strip()
+        return ""
+
+
+@dataclass(slots=True)
+class _HostKeyMatch:
+    """What ``known_hosts`` held for this host before verification ran."""
+
+    consulted: bool = False
+    trusted_keys: int = 0
+    ca_keys: int = 0
+    revoked_keys: int = 0
+
+    @property
+    def has_entry(self) -> bool:
+        """True when ``known_hosts`` already held something for this host."""
+        return bool(self.trusted_keys or self.ca_keys or self.revoked_keys)
+
+
+@dataclass(slots=True)
+class _AliasGate:
+    """Per-alias concurrency cap and connect-rate throttle."""
+
+    semaphore: asyncio.Semaphore
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    last_connect_at: float | None = None
+
+
+class _AliasGateRegistry:
+    """In-process registry of per-alias gates.
+
+    Studio is a single-process, single-user application, so an in-memory
+    registry is the whole coordination requirement - there is no second worker
+    to synchronize with.
+    """
+
+    def __init__(self) -> None:
+        self._gates: dict[str, _AliasGate] = {}
+
+    def get(self, alias: str, max_connections: int) -> _AliasGate:
+        """Return the gate for one alias, creating it on first use."""
+        gate = self._gates.get(alias)
+        if gate is None:
+            gate = _AliasGate(semaphore=asyncio.Semaphore(max(1, max_connections)))
+            self._gates[alias] = gate
+        return gate
+
+    def clear(self) -> None:
+        """Drop every gate. Test-support only."""
+        self._gates.clear()
+
+
+_GATES: Final = _AliasGateRegistry()
+
+
+def _existing_config_paths(config_path: Path) -> list[str]:
+    """Return the SSH config paths to hand ``asyncssh``.
+
+    A missing file is dropped rather than passed through: ``asyncssh`` raises
+    ``FileNotFoundError`` for a config path that does not exist, and an absent
+    SSH config must surface as "alias not found", not as an unhandled OS error.
+    """
+    return [str(config_path)] if config_path.is_file() else []
+
+
+def _identity_files(options: asyncssh.SSHClientConnectionOptions) -> list[str]:
+    """Return the ``IdentityFile`` entries the resolved config names."""
+    configured = options.config.get("IdentityFile")
+    if isinstance(configured, str):
+        return [configured]
+    if isinstance(configured, Sequence):
+        return [str(entry) for entry in configured]
+    return []
+
+
+def _is_passphrase_protected(path: Path) -> bool:
+    """True when importing this private key needs a passphrase.
+
+    Only the exception is inspected. A key that imports successfully is dropped
+    immediately, and no key material is retained or logged.
+    """
+    try:
+        asyncssh.read_private_key(str(path))
+    except asyncssh.KeyImportError as error:
+        return str(error).startswith(_PASSPHRASE_ERROR_PREFIX)
+    except (OSError, asyncssh.KeyEncryptionError, ValueError):
+        return False
+    return False
+
+
+async def _agent_has_keys(agent_path: str | None) -> bool:
+    """True when an SSH agent is reachable and holds at least one identity."""
+    try:
+        agent = await asyncssh.connect_agent(agent_path)
+    except (OSError, ValueError, asyncssh.Error):
+        return False
+    try:
+        return bool(await agent.get_keys())
+    except (OSError, ValueError, asyncssh.Error):
+        return False
+    finally:
+        agent.close()
+
+
+async def _needs_agent(options: asyncssh.SSHClientConnectionOptions) -> bool:
+    """True when the resolved identity is encrypted and no agent can unlock it.
+
+    Studio never prompts for or stores a passphrase, so an agent is the only way
+    a protected key can be used. Checked only after authentication already
+    failed, to turn a generic "permission denied" into the actionable cause.
+    """
+    encrypted = [
+        path
+        for path in (Path(entry).expanduser() for entry in _identity_files(options))
+        if path.is_file() and await asyncio.to_thread(_is_passphrase_protected, path)
+    ]
+    if not encrypted:
+        return False
+    agent_path = options.agent_path if isinstance(options.agent_path, str) else None
+    return not await _agent_has_keys(agent_path)
+
+
+class SshTransport:
+    """One bounded SSH connection to a configured host alias.
+
+    Use as an async context manager so the connection, the per-alias
+    concurrency slot, and the throttle are all released on every path::
+
+        async with SshTransport("gpu-box") as transport:
+            result = await transport.run_command(["docker", "version"])
+
+    Attributes:
+        alias: The SSH config alias this transport dials.
+    """
+
+    def __init__(self, alias: str, settings: Settings | None = None) -> None:
+        self.alias = alias
+        self._settings = settings or get_settings()
+        self._connection: asyncssh.SSHClientConnection | None = None
+        self._gate: _AliasGate | None = None
+        self._host_key_match = _HostKeyMatch()
+
+    async def __aenter__(self) -> Self:
+        """Open the connection."""
+        await self.connect()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the connection and release the per-alias slot."""
+        await self.close()
+
+    @property
+    def connected(self) -> bool:
+        """True while a connection is open."""
+        return self._connection is not None
+
+    def _build_options(self) -> asyncssh.SSHClientConnectionOptions:
+        """Build connect options from the user's SSH config.
+
+        The alias is passed as ``host`` together with the user's config, so
+        ``asyncssh`` performs the ``Host`` stanza resolution itself. Studio does
+        not reimplement hostname/port/user/identity resolution.
+        """
+        settings = self._settings
+        self._host_key_match = _HostKeyMatch()
+        return asyncssh.SSHClientConnectionOptions(
+            host=self.alias,
+            config=_existing_config_paths(settings.ssh_config_path),
+            known_hosts=self._match_known_hosts,
+            connect_timeout=settings.ssh_connect_timeout_s,
+            keepalive_interval=settings.ssh_keepalive_interval_s,
+            keepalive_count_max=settings.ssh_keepalive_count_max,
+        )
+
+    def _match_known_hosts(
+        self,
+        host: str,
+        addr: str,
+        port: int | None,
+    ) -> tuple[Sequence[object], ...]:
+        """Look up the host in ``known_hosts``, recording what matched.
+
+        The recorded counts are the only way to tell an unknown host from a
+        changed key: ``asyncssh`` collapses both into one exception. A missing
+        ``known_hosts`` file is treated as an empty one, which lands on the
+        unknown-host branch - the correct actionable outcome for a user who has
+        never accepted any fingerprint.
+        """
+        known_hosts_path = self._settings.ssh_known_hosts_path
+        source: str | bytes = str(known_hosts_path) if known_hosts_path.is_file() else b""
+        result = asyncssh.match_known_hosts(source, host, addr, port)
+        self._host_key_match = _HostKeyMatch(
+            consulted=True,
+            trusted_keys=len(result[0]),
+            ca_keys=len(result[1]),
+            revoked_keys=len(result[2]),
+        )
+        return result
+
+    def _host_key_error(self) -> SshHostKeyUnknownError | SshHostKeyMismatchError:
+        """Classify a host-key verification failure.
+
+        Fails closed: when the matcher never ran, or ran and found an entry, the
+        presented key is treated as a mismatch. Only a matcher that ran and
+        found nothing yields the "never accepted this host" error, because that
+        error tells the user to accept a fingerprint - advice that must never be
+        given for a key that actually changed.
+        """
+        match = self._host_key_match
+        if match.consulted and not match.has_entry:
+            return SshHostKeyUnknownError(self.alias)
+        return SshHostKeyMismatchError(self.alias)
+
+    def _key_error(self, error: Exception) -> SshAgentRequiredError | SshAuthenticationError:
+        """Classify a private-key load failure.
+
+        A key that could not be decrypted needs an agent; a key that is malformed
+        is not an agent problem, and saying so would send the user to ``ssh-add``
+        for a file that will never load. Only the exception's *category* is
+        inspected - its text can name the identity path.
+        """
+        if str(error).startswith(_PASSPHRASE_ERROR_PREFIX):
+            return SshAgentRequiredError(self.alias)
+        if isinstance(error, asyncssh.KeyEncryptionError):
+            return SshAgentRequiredError(self.alias)
+        return SshAuthenticationError(self.alias)
+
+    async def _acquire_gate(self) -> _AliasGate:
+        """Take a per-alias connection slot, honoring the connect throttle."""
+        settings = self._settings
+        gate = _GATES.get(self.alias, settings.ssh_max_connections_per_server)
+        await gate.semaphore.acquire()
+        try:
+            async with gate.lock:
+                # Status polling and the GPU-busy re-check share this throttle so
+                # UI polling cannot pile connections onto a server running a job.
+                if gate.last_connect_at is not None:
+                    elapsed = perf_counter() - gate.last_connect_at
+                    remaining = settings.ssh_preflight_throttle_s - elapsed
+                    if remaining > 0:
+                        await asyncio.sleep(remaining)
+                gate.last_connect_at = perf_counter()
+        except BaseException:
+            gate.semaphore.release()
+            raise
+        return gate
+
+    async def connect(self) -> None:
+        """Dial the alias and authenticate.
+
+        Raises:
+            SshHostAliasNotFoundError: The alias is absent from the SSH config,
+                or matches only a wildcard stanza.
+            SshHostKeyUnknownError: The host is absent from ``known_hosts``.
+            SshHostKeyMismatchError: The host key differs from the accepted one.
+            SshAgentRequiredError: The identity is passphrase-protected and no
+                agent can unlock it.
+            SshAuthenticationError: Every offered identity was rejected.
+            SshConnectionError: The host could not be reached.
+        """
+        if self._connection is not None:
+            return
+
+        # Pre-validated against the same config asyncssh will read, so an absent
+        # alias is an actionable 400 instead of a connection attempt against a
+        # hostname that is really an unresolved alias.
+        resolved = resolve_alias(self._settings.ssh_config_path, self.alias)
+        if not resolved.found:
+            raise SshHostAliasNotFoundError(self.alias)
+
+        # asyncssh loads the configured identities while building options, so a
+        # missing or corrupt IdentityFile fails here rather than on the wire. It
+        # still has to arrive as an actionable Ssh* error, not a raw OSError.
+        try:
+            options = self._build_options()
+        except (asyncssh.KeyImportError, asyncssh.KeyEncryptionError) as error:
+            raise self._key_error(error) from None
+        except OSError:
+            # A configured identity that cannot be read at all.
+            raise SshAuthenticationError(self.alias) from None
+
+        gate = await self._acquire_gate()
+        try:
+            self._connection = await asyncssh.connect(options=options)
+        except BaseException as error:
+            gate.semaphore.release()
+            raise await self._map_connect_error(error, options) from None
+        self._gate = gate
+
+    # PLR0911: one return per failure category. The isinstance order is load-bearing
+    # (subclasses first), which a lookup table would obscure.
+    async def _map_connect_error(  # noqa: PLR0911
+        self,
+        error: BaseException,
+        options: asyncssh.SSHClientConnectionOptions,
+    ) -> BaseException:
+        """Translate a connect failure into an actionable Studio exception.
+
+        Deliberately drops the original exception text: it can contain the
+        resolved hostname and identity paths, and it reaches an API response.
+        """
+        if isinstance(error, asyncio.CancelledError):
+            return error
+
+        if isinstance(error, asyncssh.HostKeyNotVerifiable):
+            logger.warning("SSH host key verification failed for alias '{}'", self.alias)
+            return self._host_key_error()
+
+        if isinstance(error, asyncssh.PermissionDenied):
+            if await _needs_agent(options):
+                return SshAgentRequiredError(self.alias)
+            return SshAuthenticationError(self.alias)
+
+        # A key asyncssh could not load. An encrypted one needs an agent; a
+        # malformed one does not.
+        if isinstance(error, asyncssh.KeyImportError | asyncssh.KeyEncryptionError):
+            return self._key_error(error)
+
+        if isinstance(error, TimeoutError):
+            return SshConnectionError(self.alias, reason=_REASON_TIMEOUT)
+
+        if isinstance(error, asyncssh.ConnectionLost):
+            return SshConnectionError(self.alias, reason=_REASON_CONNECTION_LOST)
+
+        if isinstance(error, asyncssh.ProtocolError | asyncssh.KeyExchangeFailed):
+            return SshConnectionError(self.alias, reason=_REASON_PROTOCOL)
+
+        if isinstance(error, OSError | socket.gaierror):
+            return SshConnectionError(self.alias, reason=_REASON_UNREACHABLE)
+
+        if isinstance(error, asyncssh.Error):
+            return SshConnectionError(self.alias, reason=_REASON_PROTOCOL)
+
+        if isinstance(error, Exception):
+            logger.warning("Unexpected SSH failure for alias '{}': {}", self.alias, type(error).__name__)
+            return SshConnectionError(self.alias, reason=_REASON_UNREACHABLE)
+
+        return error
+
+    # ASYNC109: an explicit `timeout` is part of this method's contract - a caller
+    # gets a CommandResult carrying a TIMEOUT failure rather than a raised
+    # CancelledError, which `asyncio.timeout` at the call site cannot express.
+    async def run_command(self, argv: Sequence[str], timeout: float | None = None) -> CommandResult:  # noqa: ASYNC109
+        """Run one command on the remote host and return its sanitized output.
+
+        ``argv`` is shell-quoted with :func:`shlex.join` before it reaches the
+        exec channel, so no element can break out of its argument position. An
+        SSH ``exec`` request carries a command *string* at the protocol level;
+        quoting each element is what makes building the command from a list safe.
+
+        A command that times out, is refused a channel, or dies on a signal
+        returns a :class:`CommandResult` carrying a ``failure`` rather than
+        raising, so one failed probe never aborts a whole preflight tier.
+
+        Args:
+            argv: Program and arguments. Every element comes from an application
+                constant or an already-validated identifier.
+            timeout: Per-command budget. Defaults to ``ssh_command_timeout_s``.
+
+        Returns:
+            The command's exit status and sanitized output.
+
+        Raises:
+            SshConnectionError: The connection dropped while the command ran.
+            RuntimeError: The transport is not connected.
+        """
+        if self._connection is None:
+            raise RuntimeError("SshTransport.run_command requires an open connection")
+        if not argv:
+            raise ValueError("argv must not be empty")
+
+        settings = self._settings
+        # shlex.join shell-quotes each argument, so metacharacters in any element
+        # are passed through as literal text instead of being interpreted.
+        command = shlex.join(argv)
+        budget = settings.ssh_command_timeout_s if timeout is None else timeout
+        started = perf_counter()
+
+        try:
+            completed = await self._connection.run(
+                command,
+                check=False,
+                timeout=budget,
+                encoding="utf-8",
+                errors="replace",
+            )
+        except asyncssh.TimeoutError as error:
+            return self._result(
+                argv,
+                command,
+                COMMAND_TIMEOUT_EXIT_STATUS,
+                error.stdout,
+                error.stderr,
+                started,
+                CommandFailure.TIMEOUT,
+            )
+        except asyncssh.ChannelOpenError:
+            return self._result(
+                argv,
+                command,
+                COMMAND_FAILED_EXIT_STATUS,
+                "",
+                "",
+                started,
+                CommandFailure.CHANNEL_REFUSED,
+            )
+        except asyncssh.ProcessError as error:
+            return self._result(
+                argv,
+                command,
+                error.exit_status if error.exit_status is not None else COMMAND_FAILED_EXIT_STATUS,
+                error.stdout,
+                error.stderr,
+                started,
+                CommandFailure.SIGNALED if error.exit_signal else None,
+            )
+        except (asyncssh.ConnectionLost, asyncssh.DisconnectError) as error:
+            raise SshConnectionError(self.alias, reason=_REASON_CONNECTION_LOST) from error
+        except TimeoutError as error:
+            raise SshConnectionError(self.alias, reason=_REASON_TIMEOUT) from error
+
+        if completed.exit_signal:
+            return self._result(
+                argv,
+                command,
+                COMMAND_FAILED_EXIT_STATUS,
+                completed.stdout,
+                completed.stderr,
+                started,
+                CommandFailure.SIGNALED,
+            )
+        return self._result(
+            argv,
+            command,
+            completed.exit_status if completed.exit_status is not None else COMMAND_FAILED_EXIT_STATUS,
+            completed.stdout,
+            completed.stderr,
+            started,
+            None,
+        )
+
+    def _result(
+        self,
+        argv: Sequence[str],
+        command: str,
+        exit_status: int,
+        stdout: object,
+        stderr: object,
+        started: float,
+        failure: CommandFailure | None,
+    ) -> CommandResult:
+        """Build a result with both output streams sanitized."""
+        return CommandResult(
+            argv=tuple(argv),
+            command=command,
+            exit_status=exit_status,
+            stdout=self._sanitize(stdout),
+            stderr=self._sanitize(stderr),
+            duration_ms=round((perf_counter() - started) * 1000),
+            failure=failure,
+        )
+
+    def _sanitize(self, stream: object) -> str:
+        """Sanitize and cap one output stream."""
+        if stream is None:
+            return ""
+        text = stream.decode("utf-8", errors="replace") if isinstance(stream, bytes) else str(stream)
+        return sanitize_output(
+            text,
+            max_line_chars=self._settings.ssh_output_max_line_chars,
+            max_total_chars=self._settings.ssh_output_max_total_chars,
+        )
+
+    async def close(self) -> None:
+        """Close the connection and release the per-alias slot."""
+        connection, self._connection = self._connection, None
+        gate, self._gate = self._gate, None
+
+        if connection is not None:
+            connection.close()
+            with suppress(Exception):
+                await connection.wait_closed()
+        if gate is not None:
+            gate.semaphore.release()
+
+
+def open_transport(alias: str, settings: Settings | None = None) -> SshTransport:
+    """Return a transport for one alias.
+
+    The seam preflight and provisioning go through, so a test can substitute a
+    fake transport without patching ``asyncssh`` itself.
+
+    Args:
+        alias: SSH config alias to dial.
+        settings: Settings override, for tests.
+
+    Returns:
+        An unconnected transport, usable as an async context manager.
+    """
+    return SshTransport(alias, settings)
+
+
+def reset_alias_gates() -> None:
+    """Drop every per-alias concurrency gate. Test-support only."""
+    _GATES.clear()

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -149,7 +149,7 @@ class Settings(BaseSettings):
     # Free disk a server must have at save time for the image plus a nominal job.
     # The actual dataset size is re-checked at provisioning time.
     ssh_min_free_disk_bytes: int = Field(
-        default=60 * 1024 * 1024 * 1024,
+        default=50 * 1024 * 1024 * 1024,
         alias="SSH_MIN_FREE_DISK_BYTES",
     )
     # Maximum characters of streamed remote command output forwarded per line and

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -123,6 +123,51 @@ class Settings(BaseSettings):
     # Upper bound on the exponential backoff between event-stream reconnect attempts.
     trainer_stream_reconnect_backoff_max_s: float = Field(default=30.0, alias="TRAINER_STREAM_RECONNECT_BACKOFF_MAX_S")
 
+    # SSH-provisioned remote training
+    # Path to the user's SSH client config. asyncssh parses it to resolve a saved
+    # `ssh_host_alias` into a hostname, port, user, and identity; Studio never
+    # reads key material out of it.
+    ssh_config_path: Path = Field(default=Path("~/.ssh/config"), alias="SSH_CONFIG_PATH")
+    # Path to the user's known_hosts. Host keys are verified against this file by
+    # asyncssh, which fails closed on an unknown or changed key.
+    ssh_known_hosts_path: Path = Field(default=Path("~/.ssh/known_hosts"), alias="SSH_KNOWN_HOSTS_PATH")
+    # Overall budget for one SSH connect + auth. Bounds a save request.
+    ssh_connect_timeout_s: float = Field(default=10.0, alias="SSH_CONNECT_TIMEOUT_S")
+    # Per-command budget for the cheap Tier 1 probes (docker version, nvidia-smi).
+    ssh_command_timeout_s: float = Field(default=15.0, alias="SSH_COMMAND_TIMEOUT_S")
+    # Overall budget for a full Tier 1 preflight, so a save can never hang.
+    ssh_preflight_timeout_s: float = Field(default=30.0, alias="SSH_PREFLIGHT_TIMEOUT_S")
+    # Minimum time between preflight/status SSH connections to one server. Shared
+    # by the status endpoint and the GPU-busy re-check so UI polling cannot
+    # disrupt a running job or pile up connections.
+    ssh_preflight_throttle_s: float = Field(default=5.0, alias="SSH_PREFLIGHT_THROTTLE_S")
+    # Concurrent SSH connections allowed per server, across preflight and status.
+    ssh_max_connections_per_server: int = Field(default=2, alias="SSH_MAX_CONNECTIONS_PER_SERVER")
+    # SSH keepalive interval, so a dead tunnel is detected rather than hanging.
+    ssh_keepalive_interval_s: float = Field(default=15.0, alias="SSH_KEEPALIVE_INTERVAL_S")
+    ssh_keepalive_count_max: int = Field(default=3, alias="SSH_KEEPALIVE_COUNT_MAX")
+    # Free disk a server must have at save time for the image plus a nominal job.
+    # The actual dataset size is re-checked at provisioning time.
+    ssh_min_free_disk_bytes: int = Field(
+        default=60 * 1024 * 1024 * 1024,
+        alias="SSH_MIN_FREE_DISK_BYTES",
+    )
+    # Maximum characters of streamed remote command output forwarded per line and
+    # per message. Remote output is environment-influenced, not trusted text.
+    ssh_output_max_line_chars: int = Field(default=512, alias="SSH_OUTPUT_MAX_LINE_CHARS")
+    ssh_output_max_total_chars: int = Field(default=4096, alias="SSH_OUTPUT_MAX_TOTAL_CHARS")
+    # Container registry hosting the trainer images resolved for SSH jobs.
+    trainer_image_registry: str = Field(
+        default="ghcr.io/open-edge-platform",
+        alias="TRAINER_IMAGE_REGISTRY",
+    )
+
+    @field_validator("ssh_config_path", "ssh_known_hosts_path", mode="before")
+    @classmethod
+    def expand_ssh_path(cls, value: Path | str) -> Path:
+        """Expand `~` so the default resolves to the running user's SSH config."""
+        return Path(value).expanduser()
+
     # Server
     host: str = Field(default="0.0.0.0", alias="HOST")  # noqa: S104 # nosec B104
     port: int = Field(default=7860, alias="PORT")

--- a/application/backend/tests/services/ssh/test_preflight.py
+++ b/application/backend/tests/services/ssh/test_preflight.py
@@ -79,6 +79,19 @@ _PLENTY_OF_DISK = f"{_DF_HEADER}/dev/sda1 900000000000 100000000000 85899345920 
 # 1 GiB available.
 _ALMOST_NO_DISK = f"{_DF_HEADER}/dev/sda1 900000000000 890000000000 1073741824 99% /var/lib/docker\n"
 
+# Representative `xpu-smi discovery` output: an ASCII box-drawing table, not one
+# plain line. `first_line()` on this would return the top border, not a device
+# name - the regression `_xpu_discovery_detail` guards against.
+_XPU_DISCOVERY_TABLE = (
+    "+-----------+--------------------------------------------------+\n"
+    "| Device ID | Device Information                                |\n"
+    "+-----------+--------------------------------------------------+\n"
+    "| 0         | Device Name: Intel(R) Data Center GPU Max 1100    |\n"
+    "|           | Vendor Name: Intel(R) Corporation                 |\n"
+    "|           | PCI BDF Address: 0000:29:00.0                     |\n"
+    "+-----------+--------------------------------------------------+\n"
+)
+
 
 def _server(device_type: DeviceType = DeviceType.CUDA, alias: str = ALIAS) -> RemoteServer:
     return RemoteServer(
@@ -645,10 +658,13 @@ async def test_tier1_cuda_host_is_never_probed_with_xpu_tools(install_transport)
 
 
 async def test_tier1_xpu_driver_detected_via_xpu_smi(install_transport) -> None:
+    # Real `xpu-smi discovery` output is an ASCII box-drawing table, not one
+    # plain line - `first_line()` would return the top border instead of a
+    # device name (see `_xpu_discovery_detail`).
     script = {
         "docker version": _ok("27.3.1"),
         "df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK),
-        "xpu-smi discovery": _ok("Device 0: Intel(R) Data Center GPU Max 1100"),
+        "xpu-smi discovery": _ok(_XPU_DISCOVERY_TABLE),
         "xpu-smi stats": _ok("GPU Memory Used (MiB), 1024, GPU Memory Total (MiB), 49152"),
         "curl --head": _ok(""),
     }
@@ -660,6 +676,8 @@ async def test_tier1_xpu_driver_detected_via_xpu_smi(install_transport) -> None:
     assert check is not None
     assert check.outcome is CheckOutcome.PASSED
     assert check.method == METHOD_XPU_SMI
+    assert check.detail == "Intel(R) Data Center GPU Max 1100"
+    assert not check.detail.startswith("+")
 
 
 async def test_tier1_xpu_driver_falls_back_to_the_render_node(install_transport) -> None:

--- a/application/backend/tests/services/ssh/test_preflight.py
+++ b/application/backend/tests/services/ssh/test_preflight.py
@@ -1044,6 +1044,7 @@ async def test_tier2_xpu_device_probe_passes_the_dri_device(install_transport) -
     script = {
         f"docker manifest inspect {xpu_image}": _ok("{}"),
         "cosign version": _fail("not found", exit_status=127),
+        "sh -c stat -c %g": _ok("44\n"),
         "docker run": _ok("True"),
         "docker image inspect": _ok("1"),
     }
@@ -1054,6 +1055,30 @@ async def test_tier2_xpu_device_probe_passes_the_dri_device(install_transport) -
     run = next(argv for argv in transport.commands if argv[:2] == ("docker", "run"))
     assert "/dev/dri" in run
     assert "torch.xpu.is_available()" in " ".join(run)
+    # Without --group-add <render gid> the fixed non-root container user cannot
+    # open the render node even though it is passed through by --device.
+    assert "--group-add" in run
+    assert "44" in run
+
+
+async def test_resolve_render_group_gid_returns_none_when_unavailable(install_transport) -> None:
+    from services.ssh.preflight import resolve_render_group_gid
+
+    transport = install_transport(FakeTransport({}))
+
+    gid = await resolve_render_group_gid(transport)
+
+    assert gid is None
+
+
+async def test_resolve_render_group_gid_parses_stat_output(install_transport) -> None:
+    from services.ssh.preflight import resolve_render_group_gid
+
+    transport = install_transport(FakeTransport({"sh -c stat -c %g": _ok("44\n")}))
+
+    gid = await resolve_render_group_gid(transport)
+
+    assert gid == "44"
 
 
 async def test_tier2_device_unavailable_in_the_container_fails(install_transport) -> None:

--- a/application/backend/tests/services/ssh/test_preflight.py
+++ b/application/backend/tests/services/ssh/test_preflight.py
@@ -1,0 +1,1160 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the two-tier SSH preflight.
+
+The fake transport matches remote commands by prefix and returns canned results,
+so every check can be driven independently without an SSH server. Three
+properties are load-bearing:
+
+* ``test_tier1_never_*`` prove Tier 1 does no image work. It gates a save
+  request, so a multi-gigabyte pull inside it would be a timeout waiting to
+  happen - and the router's tests depend on it.
+* ``test_tier1_gpu_busy_*`` prove a busy GPU is a non-blocking ``WARNING``. A
+  user must be able to register or edit a target while a job runs on it.
+* ``test_tier1_*_host_key`` prove an unknown key and a changed key produce
+  different reason codes and never mark authentication as failed - verification
+  happens before authentication is attempted.
+"""
+
+import re
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from exceptions import (
+    SshAgentRequiredError,
+    SshAuthenticationError,
+    SshConnectionError,
+    SshHostAliasNotFoundError,
+    SshHostKeyMismatchError,
+    SshHostKeyUnknownError,
+)
+from schemas.hardware import DeviceType
+from schemas.remote_server import RemoteServer
+from schemas.ssh_preflight import CheckKey, CheckOutcome, PreflightTier
+from services.ssh import preflight as preflight_module
+from services.ssh.preflight import (
+    METHOD_NVIDIA_SMI,
+    METHOD_RENDER_NODE,
+    METHOD_XPU_SMI,
+    PROTOCOL_LABEL,
+    REASON_AGENT_REQUIRED,
+    REASON_ALIAS_NOT_FOUND,
+    REASON_AUTH_FAILED,
+    REASON_COMMAND_FAILED,
+    REASON_DEVICE_UNAVAILABLE,
+    REASON_DOCKER_UNAVAILABLE,
+    REASON_DRIVER_MISSING,
+    REASON_GPU_BUSY,
+    REASON_HOST_KEY_MISMATCH,
+    REASON_HOST_KEY_UNKNOWN,
+    REASON_IMAGE_UNRESOLVED,
+    REASON_INSUFFICIENT_DISK,
+    REASON_NO_SIGNAL,
+    REASON_PROTOCOL_MISMATCH,
+    REASON_PROTOCOL_TAG_UNRESOLVED,
+    REASON_PROTOCOL_UNKNOWN,
+    REASON_REGISTRY_UNREACHABLE,
+    REASON_TOOL_MISSING,
+    REASON_UNPARSEABLE_OUTPUT,
+    REASON_UNREACHABLE,
+    registry_probe_url,
+    reset_transport_factory,
+    run_tier1_preflight,
+    run_tier2_preflight,
+    trainer_image_ref,
+)
+from services.ssh.transport import CommandFailure, CommandResult
+
+ALIAS = "gpu-box"
+_REGISTRY = "ghcr.io/open-edge-platform"
+_CUDA_IMAGE = f"{_REGISTRY}/physicalai-trainer-cuda:protocol-1"
+_CUDA_LATEST = f"{_REGISTRY}/physicalai-trainer-cuda:latest"
+
+_DF_HEADER = "Filesystem 1B-blocks Used Available Capacity Mounted on\n"
+# 80 GiB available, comfortably above the 60 GiB default requirement.
+_PLENTY_OF_DISK = f"{_DF_HEADER}/dev/sda1 900000000000 100000000000 85899345920 12% /var/lib/docker\n"
+# 1 GiB available.
+_ALMOST_NO_DISK = f"{_DF_HEADER}/dev/sda1 900000000000 890000000000 1073741824 99% /var/lib/docker\n"
+
+
+def _server(device_type: DeviceType = DeviceType.CUDA, alias: str = ALIAS) -> RemoteServer:
+    return RemoteServer(
+        id=uuid4(),
+        name="Lab GPU box",
+        ssh_host_alias=alias,
+        device_type=device_type,
+    )
+
+
+class FakeTransport:
+    """Records every command and answers from a prefix-matched script.
+
+    Matching is by command prefix rather than exact equality, so a test only has
+    to name the part of a command it cares about.
+    """
+
+    def __init__(
+        self,
+        script: dict[str, CommandResult] | None = None,
+        connect_error: Exception | None = None,
+        fail_after: int | None = None,
+    ) -> None:
+        self.script = script or {}
+        self.connect_error = connect_error
+        self.fail_after = fail_after
+        self.commands: list[tuple[str, ...]] = []
+        self.connect_count = 0
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connect_count += 1
+        if self.connect_error is not None:
+            raise self.connect_error
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def run_command(self, argv, timeout: float | None = None) -> CommandResult:  # noqa: ASYNC109
+        self.commands.append(tuple(argv))
+        if self.fail_after is not None and len(self.commands) > self.fail_after:
+            raise SshConnectionError(ALIAS, reason="connection_lost")
+
+        joined = " ".join(argv)
+        for prefix, result in self.script.items():
+            if joined.startswith(prefix):
+                return result
+        return _fail(f"unscripted command: {joined}")
+
+    def ran(self, fragment: str) -> bool:
+        return any(fragment in " ".join(argv) for argv in self.commands)
+
+
+def _ok(stdout: str = "") -> CommandResult:
+    return CommandResult(argv=(), command="", exit_status=0, stdout=stdout)
+
+
+def _fail(stderr: str = "command failed", exit_status: int = 1) -> CommandResult:
+    return CommandResult(argv=(), command="", exit_status=exit_status, stderr=stderr)
+
+
+def _timed_out() -> CommandResult:
+    return CommandResult(argv=(), command="", exit_status=124, failure=CommandFailure.TIMEOUT)
+
+
+def _healthy_cuda_script() -> dict[str, CommandResult]:
+    """A script where every Tier 1 check passes on an idle CUDA host."""
+    return {
+        "docker version": _ok("27.3.1\n"),
+        "df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK),
+        "nvidia-smi --query-gpu": _ok("NVIDIA RTX 6000 Ada Generation, 550.90.07\n"),
+        "nvidia-smi --query-compute-apps": _ok("\n"),
+        "curl --head": _ok(""),
+    }
+
+
+def _healthy_tier2_script() -> dict[str, CommandResult]:
+    return {
+        f"docker manifest inspect {_CUDA_IMAGE}": _ok('{"schemaVersion": 2}'),
+        "cosign version": _ok("v2.4.1"),
+        "cosign verify": _ok("Verified OK"),
+        "docker run": _ok("True\n"),
+        "docker image inspect": _ok("1\n"),
+    }
+
+
+@pytest.fixture
+def install_transport(monkeypatch):
+    """Install a fake transport and return it, restoring the real one after."""
+
+    def install(transport: FakeTransport) -> FakeTransport:
+        monkeypatch.setattr(preflight_module, "transport_factory", lambda _alias: transport)
+        return transport
+
+    yield install
+    reset_transport_factory()
+
+
+@pytest.fixture(autouse=True)
+def resolvable_alias(monkeypatch, tmp_path):
+    """Make the alias resolve, without touching the developer's real SSH config."""
+    from schemas.remote_server import ResolvedSshHost
+
+    def fake_resolve(_config_path, alias: str) -> ResolvedSshHost:
+        return ResolvedSshHost(alias=alias, hostname=f"{alias}.example.com", port=22, user="tester", found=True)
+
+    monkeypatch.setattr(preflight_module, "resolve_alias", fake_resolve)
+
+
+def _outcome(result, key: CheckKey) -> CheckOutcome:
+    check = result.check(key)
+    assert check is not None, f"missing check: {key}"
+    return check.outcome
+
+
+def _reason(result, key: CheckKey) -> str | None:
+    check = result.check(key)
+    assert check is not None, f"missing check: {key}"
+    return check.reason_code
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1: result shape                                                        #
+# --------------------------------------------------------------------------- #
+
+_TIER1_KEYS = (
+    CheckKey.ALIAS_RESOLVED,
+    CheckKey.REACHABLE,
+    CheckKey.AUTHENTICATED,
+    CheckKey.HOST_KEY_VERIFIED,
+    CheckKey.DOCKER_USABLE,
+    CheckKey.DISK_SPACE,
+    CheckKey.DRIVER_PRESENT,
+    CheckKey.REGISTRY_REACHABLE,
+    CheckKey.GPU_FREE,
+)
+
+
+async def test_tier1_healthy_cuda_server_passes_every_check(install_transport) -> None:
+    install_transport(FakeTransport(_healthy_cuda_script()))
+
+    result = await run_tier1_preflight(_server())
+
+    assert result.passed is True
+    assert [check.outcome for check in result.checks] == [CheckOutcome.PASSED] * len(_TIER1_KEYS)
+
+
+async def test_tier1_always_reports_every_check(install_transport) -> None:
+    # The UI renders a fixed list of checks, so a tier that ended early must still
+    # account for every key rather than silently omitting some.
+    install_transport(FakeTransport(connect_error=SshConnectionError(ALIAS, reason="timeout")))
+
+    result = await run_tier1_preflight(_server())
+
+    assert {check.key for check in result.checks} == set(_TIER1_KEYS)
+
+
+async def test_tier1_result_is_tagged_and_timed(install_transport) -> None:
+    install_transport(FakeTransport(_healthy_cuda_script()))
+    server = _server()
+
+    result = await run_tier1_preflight(server)
+
+    assert result.tiers_run == [PreflightTier.TIER_1]
+    assert result.remote_server_id == server.id
+    assert result.latency_ms is not None
+    assert result.checked_at.tzinfo is not None
+    assert result.checked_at <= datetime.now(UTC)
+    assert all(check.tier is PreflightTier.TIER_1 for check in result.checks)
+    assert all(check.duration_ms is not None for check in result.checks)
+
+
+async def test_tier1_closes_the_transport(install_transport) -> None:
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    await run_tier1_preflight(_server())
+
+    assert transport.closed is True
+
+
+async def test_tier1_opens_exactly_one_connection(install_transport) -> None:
+    # One connection for all the probes: reconnecting per check would multiply the
+    # handshake cost inside a request that has to stay bounded.
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    await run_tier1_preflight(_server())
+
+    assert transport.connect_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1: the no-image-work guarantee                                         #
+# --------------------------------------------------------------------------- #
+
+
+async def test_tier1_never_pulls_an_image(install_transport) -> None:
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    await run_tier1_preflight(_server())
+
+    assert not transport.ran("docker pull")
+
+
+async def test_tier1_never_inspects_a_manifest(install_transport) -> None:
+    # Not even a manifest inspect: that is Tier 2's IMAGE_RESOLVED check, and it
+    # authenticates against the registry.
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    await run_tier1_preflight(_server())
+
+    assert not transport.ran("docker manifest")
+    assert not transport.ran("docker image inspect")
+
+
+async def test_tier1_never_starts_a_container(install_transport) -> None:
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    await run_tier1_preflight(_server())
+
+    assert not transport.ran("docker run")
+
+
+async def test_tier1_registry_check_is_a_head_request(install_transport) -> None:
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    await run_tier1_preflight(_server())
+
+    curl = next(argv for argv in transport.commands if argv[0] == "curl")
+    assert "--head" in curl
+    assert curl[-1] == "https://ghcr.io/v2/"
+
+
+async def test_tier1_runs_no_tier2_check(install_transport) -> None:
+    install_transport(FakeTransport(_healthy_cuda_script()))
+
+    result = await run_tier1_preflight(_server())
+
+    tier2_keys = {
+        CheckKey.IMAGE_RESOLVED,
+        CheckKey.IMAGE_SIGNATURE,
+        CheckKey.CONTAINER_DEVICE_PROBE,
+        CheckKey.PROTOCOL_COMPATIBLE,
+    }
+    assert tier2_keys.isdisjoint({check.key for check in result.checks})
+    assert PreflightTier.TIER_2 not in result.tiers_run
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1: alias and device gating                                             #
+# --------------------------------------------------------------------------- #
+
+
+async def test_tier1_unresolvable_alias_fails_without_connecting(install_transport, monkeypatch) -> None:
+    from schemas.remote_server import ResolvedSshHost
+
+    monkeypatch.setattr(
+        preflight_module,
+        "resolve_alias",
+        lambda _path, alias: ResolvedSshHost(alias=alias, found=False),
+    )
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.ALIAS_RESOLVED) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.ALIAS_RESOLVED) == REASON_ALIAS_NOT_FOUND
+    assert transport.connect_count == 0
+    assert result.passed is False
+
+
+async def test_tier1_unresolvable_alias_skips_the_remaining_checks(install_transport, monkeypatch) -> None:
+    from schemas.remote_server import ResolvedSshHost
+
+    monkeypatch.setattr(
+        preflight_module,
+        "resolve_alias",
+        lambda _path, alias: ResolvedSshHost(alias=alias, found=False),
+    )
+    install_transport(FakeTransport())
+
+    result = await run_tier1_preflight(_server())
+
+    skipped = [check.key for check in result.checks if check.outcome is CheckOutcome.SKIPPED]
+    assert set(skipped) == set(_TIER1_KEYS) - {CheckKey.ALIAS_RESOLVED}
+
+
+async def test_tier1_rejects_an_unsupported_device_type(install_transport) -> None:
+    # No trainer image exists for CPU, so the driver check cannot be performed and
+    # must not silently pass. Constructed via model_construct because the schema
+    # rejects this on save - only a pre-validation record can reach here.
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+    server = RemoteServer.model_construct(
+        id=uuid4(),
+        name="Old record",
+        ssh_host_alias=ALIAS,
+        device_type=DeviceType.CPU,
+    )
+
+    result = await run_tier1_preflight(server)
+
+    assert _outcome(result, CheckKey.DRIVER_PRESENT) is CheckOutcome.FAILED
+    assert result.passed is False
+    assert transport.connect_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1: connection-stage failures                                           #
+# --------------------------------------------------------------------------- #
+
+
+async def test_tier1_unknown_host_key_is_reported_as_unknown(install_transport) -> None:
+    install_transport(FakeTransport(connect_error=SshHostKeyUnknownError(ALIAS)))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.HOST_KEY_VERIFIED) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.HOST_KEY_VERIFIED) == REASON_HOST_KEY_UNKNOWN
+    assert result.passed is False
+
+
+async def test_tier1_changed_host_key_is_reported_as_a_mismatch(install_transport) -> None:
+    # A different reason code from the unknown case, because the remedies differ:
+    # accepting a fingerprint is right for one and dangerous for the other.
+    install_transport(FakeTransport(connect_error=SshHostKeyMismatchError(ALIAS)))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _reason(result, CheckKey.HOST_KEY_VERIFIED) == REASON_HOST_KEY_MISMATCH
+
+
+@pytest.mark.parametrize("error", [SshHostKeyUnknownError(ALIAS), SshHostKeyMismatchError(ALIAS)])
+async def test_tier1_host_key_failure_does_not_blame_authentication(install_transport, error: Exception) -> None:
+    # Verification happens before authentication is attempted, so reporting
+    # AUTHENTICATED as failed would send the user chasing the wrong problem.
+    install_transport(FakeTransport(connect_error=error))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.AUTHENTICATED) is CheckOutcome.SKIPPED
+    assert _outcome(result, CheckKey.REACHABLE) is CheckOutcome.PASSED
+
+
+async def test_tier1_authentication_failure_reports_a_reachable_host(install_transport) -> None:
+    # The server answered and rejected the identity, so reachability is proven.
+    install_transport(FakeTransport(connect_error=SshAuthenticationError(ALIAS)))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.REACHABLE) is CheckOutcome.PASSED
+    assert _outcome(result, CheckKey.HOST_KEY_VERIFIED) is CheckOutcome.PASSED
+    assert _outcome(result, CheckKey.AUTHENTICATED) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.AUTHENTICATED) == REASON_AUTH_FAILED
+
+
+async def test_tier1_passphrase_protected_key_without_an_agent(install_transport) -> None:
+    install_transport(FakeTransport(connect_error=SshAgentRequiredError(ALIAS)))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.AUTHENTICATED) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.AUTHENTICATED) == REASON_AGENT_REQUIRED
+    assert result.passed is False
+
+
+async def test_tier1_unreachable_host_skips_rather_than_fails_dependent_checks(install_transport) -> None:
+    # Studio never reached the host, so it must not claim Docker is broken there.
+    install_transport(FakeTransport(connect_error=SshConnectionError(ALIAS, reason="timeout")))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.REACHABLE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.REACHABLE) == REASON_UNREACHABLE
+    for key in (CheckKey.DOCKER_USABLE, CheckKey.DISK_SPACE, CheckKey.DRIVER_PRESENT, CheckKey.REGISTRY_REACHABLE):
+        assert _outcome(result, key) is CheckOutcome.SKIPPED
+
+
+async def test_tier1_alias_not_found_at_connect_time_is_handled(install_transport) -> None:
+    # The config can change between resolution and the dial.
+    install_transport(FakeTransport(connect_error=SshHostAliasNotFoundError(ALIAS)))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.REACHABLE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.REACHABLE) == REASON_ALIAS_NOT_FOUND
+
+
+async def test_tier1_connection_lost_midway_skips_the_rest(install_transport) -> None:
+    # Docker answered, then the link dropped: the remaining checks are unknown,
+    # not failed.
+    transport = install_transport(FakeTransport(_healthy_cuda_script(), fail_after=1))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.DOCKER_USABLE) is CheckOutcome.PASSED
+    assert _outcome(result, CheckKey.DISK_SPACE) is CheckOutcome.SKIPPED
+    assert _reason(result, CheckKey.DISK_SPACE) == REASON_UNREACHABLE
+    assert _outcome(result, CheckKey.GPU_FREE) is CheckOutcome.SKIPPED
+    assert transport.closed is True
+
+
+async def test_tier1_a_dropped_connection_never_blocks_on_gpu_free(install_transport) -> None:
+    install_transport(FakeTransport(_healthy_cuda_script(), fail_after=1))
+
+    result = await run_tier1_preflight(_server())
+
+    gpu_free = result.check(CheckKey.GPU_FREE)
+    assert gpu_free is not None
+    assert gpu_free.blocking is False
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1: Docker                                                              #
+# --------------------------------------------------------------------------- #
+
+
+async def test_tier1_docker_socket_denied_fails_the_docker_check(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["docker version"] = _fail("permission denied while trying to connect to the Docker daemon socket")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.DOCKER_USABLE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.DOCKER_USABLE) == REASON_DOCKER_UNAVAILABLE
+    assert result.passed is False
+
+
+async def test_tier1_docker_check_queries_the_server_version(install_transport) -> None:
+    # The client binary existing says nothing about the socket being reachable by
+    # this user, which is the failure this check is for.
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    await run_tier1_preflight(_server())
+
+    assert transport.ran("{{.Server.Version}}")
+
+
+async def test_tier1_docker_failure_detail_is_sanitized(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["docker version"] = _fail("\x1b[31mdenied\x1b[0m\x00")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    check = result.check(CheckKey.DOCKER_USABLE)
+    assert check is not None
+    assert check.detail == "denied"
+
+
+async def test_tier1_docker_timeout_fails_the_docker_check(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["docker version"] = _timed_out()
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.DOCKER_USABLE) is CheckOutcome.FAILED
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1: disk space                                                          #
+# --------------------------------------------------------------------------- #
+
+
+async def test_tier1_insufficient_disk_fails(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["df -B1 -P /var/lib/docker"] = _ok(_ALMOST_NO_DISK)
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.DISK_SPACE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.DISK_SPACE) == REASON_INSUFFICIENT_DISK
+    assert result.passed is False
+
+
+async def test_tier1_disk_check_falls_back_to_the_root_filesystem(install_transport) -> None:
+    # A rootless or relocated Docker data root means /var/lib/docker need not
+    # exist; that is not a failure.
+    script = _healthy_cuda_script()
+    script["df -B1 -P /var/lib/docker"] = _fail("No such file or directory")
+    script["df -B1 -P /"] = _ok(_PLENTY_OF_DISK)
+    transport = install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.DISK_SPACE) is CheckOutcome.PASSED
+    assert transport.ran("df -B1 -P /")
+
+
+async def test_tier1_unparseable_df_output_fails_rather_than_guesses(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["df -B1 -P /var/lib/docker"] = _ok("some totally unexpected output\n")
+    script["df -B1 -P /"] = _ok("some totally unexpected output\n")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.DISK_SPACE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.DISK_SPACE) == REASON_UNPARSEABLE_OUTPUT
+
+
+async def test_tier1_disk_detail_reports_free_and_required_space(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["df -B1 -P /var/lib/docker"] = _ok(_ALMOST_NO_DISK)
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    check = result.check(CheckKey.DISK_SPACE)
+    assert check is not None
+    assert check.detail is not None
+    assert "1.0 GiB free" in check.detail
+    assert "required" in check.detail
+
+
+async def test_tier1_both_df_probes_failing_fails_the_check(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["df -B1 -P /var/lib/docker"] = _fail("df: not found")
+    script["df -B1 -P /"] = _fail("df: not found")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.DISK_SPACE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.DISK_SPACE) == REASON_COMMAND_FAILED
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1: driver detection                                                    #
+# --------------------------------------------------------------------------- #
+
+
+async def test_tier1_cuda_driver_detected_via_nvidia_smi(install_transport) -> None:
+    install_transport(FakeTransport(_healthy_cuda_script()))
+
+    result = await run_tier1_preflight(_server())
+
+    check = result.check(CheckKey.DRIVER_PRESENT)
+    assert check is not None
+    assert check.outcome is CheckOutcome.PASSED
+    assert check.method == METHOD_NVIDIA_SMI
+    assert check.detail == "NVIDIA RTX 6000 Ada Generation, 550.90.07"
+
+
+async def test_tier1_missing_nvidia_smi_fails_the_driver_check(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["nvidia-smi --query-gpu"] = _fail("nvidia-smi: command not found", exit_status=127)
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.DRIVER_PRESENT) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.DRIVER_PRESENT) == REASON_DRIVER_MISSING
+    assert result.passed is False
+
+
+async def test_tier1_cuda_host_is_never_probed_with_xpu_tools(install_transport) -> None:
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    await run_tier1_preflight(_server())
+
+    assert not transport.ran("xpu-smi")
+
+
+async def test_tier1_xpu_driver_detected_via_xpu_smi(install_transport) -> None:
+    script = {
+        "docker version": _ok("27.3.1"),
+        "df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK),
+        "xpu-smi discovery": _ok("Device 0: Intel(R) Data Center GPU Max 1100"),
+        "xpu-smi stats": _ok("GPU Memory Used (MiB), 1024, GPU Memory Total (MiB), 49152"),
+        "curl --head": _ok(""),
+    }
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server(DeviceType.XPU))
+
+    check = result.check(CheckKey.DRIVER_PRESENT)
+    assert check is not None
+    assert check.outcome is CheckOutcome.PASSED
+    assert check.method == METHOD_XPU_SMI
+
+
+async def test_tier1_xpu_driver_falls_back_to_the_render_node(install_transport) -> None:
+    # xpu-smi is frequently absent on hosts whose XPUs work, so requiring it would
+    # reject valid targets.
+    script = {
+        "docker version": _ok("27.3.1"),
+        "df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK),
+        "xpu-smi discovery": _fail("xpu-smi: command not found", exit_status=127),
+        "sh -c": _ok(""),
+        "curl --head": _ok(""),
+    }
+    transport = install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server(DeviceType.XPU))
+
+    check = result.check(CheckKey.DRIVER_PRESENT)
+    assert check is not None
+    assert check.outcome is CheckOutcome.PASSED
+    assert check.method == METHOD_RENDER_NODE
+    assert transport.ran("/dev/dri/renderD")
+
+
+async def test_tier1_render_node_probe_requires_the_intel_vendor_id(install_transport) -> None:
+    # A render node alone is not enough: any DRM device creates one.
+    script = {
+        "docker version": _ok("27.3.1"),
+        "df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK),
+        "xpu-smi discovery": _fail("not found", exit_status=127),
+        "sh -c": _ok(""),
+        "curl --head": _ok(""),
+    }
+    transport = install_transport(FakeTransport(script))
+
+    await run_tier1_preflight(_server(DeviceType.XPU))
+
+    probe = next(argv for argv in transport.commands if argv[0] == "sh")
+    assert "0x8086" in probe
+    assert "/sys/class/drm/*/device/vendor" in " ".join(probe)
+
+
+async def test_tier1_xpu_with_neither_signal_fails(install_transport) -> None:
+    script = {
+        "docker version": _ok("27.3.1"),
+        "df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK),
+        "xpu-smi discovery": _fail("not found", exit_status=127),
+        "sh -c": _fail("", exit_status=1),
+        "curl --head": _ok(""),
+    }
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server(DeviceType.XPU))
+
+    assert _outcome(result, CheckKey.DRIVER_PRESENT) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.DRIVER_PRESENT) == REASON_DRIVER_MISSING
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1: registry reachability                                               #
+# --------------------------------------------------------------------------- #
+
+
+async def test_tier1_unreachable_registry_fails(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["curl --head"] = _fail("curl: (6) Could not resolve host: ghcr.io", exit_status=6)
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    assert _outcome(result, CheckKey.REGISTRY_REACHABLE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.REGISTRY_REACHABLE) == REASON_REGISTRY_UNREACHABLE
+    assert result.passed is False
+
+
+async def test_tier1_registry_is_probed_from_the_remote_host(install_transport) -> None:
+    # A registry reachable from the Studio machine but firewalled on the GPU box is
+    # exactly the misconfiguration this catches, so the probe has to run there.
+    transport = install_transport(FakeTransport(_healthy_cuda_script()))
+
+    await run_tier1_preflight(_server())
+
+    assert transport.ran("curl --head")
+
+
+def test_registry_probe_url_uses_only_the_registry_host() -> None:
+    assert registry_probe_url("ghcr.io/open-edge-platform") == "https://ghcr.io/v2/"
+    assert registry_probe_url("registry.example.com:5000/team/sub") == "https://registry.example.com:5000/v2/"
+    assert registry_probe_url("https://ghcr.io/open-edge-platform") == "https://ghcr.io/v2/"
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1: GPU occupancy is reported, never blocking                           #
+# --------------------------------------------------------------------------- #
+
+
+async def test_tier1_gpu_busy_is_a_non_blocking_warning(install_transport) -> None:
+    # The named requirement: a user must be able to register or edit a server while
+    # a job is running on it, so a busy GPU is reported and never blocks a save.
+    script = _healthy_cuda_script()
+    script["nvidia-smi --query-compute-apps"] = _ok("12345\n12346\n")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    gpu_free = result.check(CheckKey.GPU_FREE)
+    assert gpu_free is not None
+    assert gpu_free.outcome is CheckOutcome.WARNING
+    assert gpu_free.outcome is not CheckOutcome.FAILED
+    assert gpu_free.blocking is False
+    assert gpu_free.reason_code == REASON_GPU_BUSY
+    assert result.passed is True
+    assert result.blocking_failures == []
+
+
+async def test_tier1_gpu_free_check_is_never_blocking(install_transport) -> None:
+    install_transport(FakeTransport(_healthy_cuda_script()))
+
+    result = await run_tier1_preflight(_server())
+
+    gpu_free = result.check(CheckKey.GPU_FREE)
+    assert gpu_free is not None
+    assert gpu_free.blocking is False
+
+
+async def test_tier1_gpu_busy_detail_reports_the_process_count(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["nvidia-smi --query-compute-apps"] = _ok("111\n222\n333\n")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    check = result.check(CheckKey.GPU_FREE)
+    assert check is not None
+    assert check.detail is not None
+    assert "3" in check.detail
+
+
+async def test_tier1_unqueryable_gpu_occupancy_is_skipped_not_failed(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["nvidia-smi --query-compute-apps"] = _fail("Unable to determine the device handle")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    gpu_free = result.check(CheckKey.GPU_FREE)
+    assert gpu_free is not None
+    assert gpu_free.outcome is CheckOutcome.SKIPPED
+    assert gpu_free.blocking is False
+    assert result.passed is True
+
+
+async def test_tier1_xpu_occupancy_warns_when_memory_is_mostly_used(install_transport) -> None:
+    script = {
+        "docker version": _ok("27.3.1"),
+        "df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK),
+        "xpu-smi discovery": _ok("Device 0"),
+        "xpu-smi stats": _ok("40960, 49152"),
+        "curl --head": _ok(""),
+    }
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server(DeviceType.XPU))
+
+    gpu_free = result.check(CheckKey.GPU_FREE)
+    assert gpu_free is not None
+    assert gpu_free.outcome is CheckOutcome.WARNING
+    assert gpu_free.blocking is False
+    assert result.passed is True
+
+
+async def test_tier1_xpu_occupancy_without_a_signal_is_skipped(install_transport) -> None:
+    # Reporting a busy accelerator as free would send a job straight into an
+    # out-of-memory failure, so an unanswerable probe is SKIPPED, never PASSED.
+    script = {
+        "docker version": _ok("27.3.1"),
+        "df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK),
+        "xpu-smi discovery": _fail("not found", exit_status=127),
+        "sh -c": _ok(""),
+        "curl --head": _ok(""),
+    }
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server(DeviceType.XPU))
+
+    gpu_free = result.check(CheckKey.GPU_FREE)
+    assert gpu_free is not None
+    assert gpu_free.outcome is CheckOutcome.SKIPPED
+    assert gpu_free.reason_code == REASON_NO_SIGNAL
+    assert gpu_free.blocking is False
+
+
+async def test_tier1_xpu_unparseable_stats_are_skipped(install_transport) -> None:
+    script = {
+        "docker version": _ok("27.3.1"),
+        "df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK),
+        "xpu-smi discovery": _ok("Device 0"),
+        "xpu-smi stats": _ok("no numbers here"),
+        "curl --head": _ok(""),
+    }
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server(DeviceType.XPU))
+
+    assert _outcome(result, CheckKey.GPU_FREE) is CheckOutcome.SKIPPED
+    assert _reason(result, CheckKey.GPU_FREE) == REASON_NO_SIGNAL
+
+
+async def test_tier1_multiple_failures_are_all_reported(install_transport) -> None:
+    # The user should see every cause at once, not just the first one.
+    script = _healthy_cuda_script()
+    script["docker version"] = _fail("denied")
+    script["nvidia-smi --query-gpu"] = _fail("not found", exit_status=127)
+    script["curl --head"] = _fail("could not resolve host", exit_status=6)
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    failed = {check.key for check in result.blocking_failures}
+    assert failed == {CheckKey.DOCKER_USABLE, CheckKey.DRIVER_PRESENT, CheckKey.REGISTRY_REACHABLE}
+
+
+async def test_tier1_never_raises_for_a_failing_server(install_transport) -> None:
+    install_transport(FakeTransport({}))
+
+    result = await run_tier1_preflight(_server())
+
+    assert result.passed is False
+
+
+async def test_tier1_detail_never_carries_escape_sequences(install_transport) -> None:
+    script = _healthy_cuda_script()
+    script["docker version"] = _fail("\x1b]8;;https://evil.example.com\x07click me\x1b]8;;\x07")
+    script["curl --head"] = _fail("\x1b[2Jcleared\x00")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier1_preflight(_server())
+
+    for check in result.checks:
+        assert check.detail is None or not re.search(r"[\x00-\x08\x0b-\x1f]", check.detail)
+
+
+# --------------------------------------------------------------------------- #
+# Tier 2                                                                      #
+# --------------------------------------------------------------------------- #
+
+_TIER2_KEYS = (
+    CheckKey.IMAGE_RESOLVED,
+    CheckKey.IMAGE_SIGNATURE,
+    CheckKey.CONTAINER_DEVICE_PROBE,
+    CheckKey.PROTOCOL_COMPATIBLE,
+)
+
+
+async def test_tier2_healthy_server_passes_every_check(install_transport) -> None:
+    install_transport(FakeTransport(_healthy_tier2_script()))
+
+    result = await run_tier2_preflight(_server())
+
+    assert result.passed is True
+    assert {check.key for check in result.checks} == set(_TIER2_KEYS)
+    assert result.tiers_run == [PreflightTier.TIER_2]
+    assert all(check.tier is PreflightTier.TIER_2 for check in result.checks)
+
+
+async def test_tier2_resolves_the_protocol_pinned_tag(install_transport) -> None:
+    transport = install_transport(FakeTransport(_healthy_tier2_script()))
+
+    result = await run_tier2_preflight(_server())
+
+    assert transport.ran(f"docker manifest inspect {_CUDA_IMAGE}")
+    check = result.check(CheckKey.IMAGE_RESOLVED)
+    assert check is not None
+    assert check.detail == _CUDA_IMAGE
+
+
+async def test_tier2_honours_an_image_ref_hint(install_transport) -> None:
+    hint = "ghcr.io/example/custom-trainer:dev"
+    transport = install_transport(FakeTransport({f"docker manifest inspect {hint}": _ok("{}")}))
+
+    result = await run_tier2_preflight(_server(), image_ref_hint=hint)
+
+    assert transport.ran(f"docker manifest inspect {hint}")
+    assert _outcome(result, CheckKey.IMAGE_RESOLVED) is CheckOutcome.PASSED
+
+
+async def test_tier2_falls_back_to_latest_with_a_warning(install_transport) -> None:
+    # A protocol bump can land in Studio before CI has published a matching image;
+    # blocking every verification until then would be worse than saying which tag
+    # was used.
+    script = _healthy_tier2_script()
+    script.pop(f"docker manifest inspect {_CUDA_IMAGE}")
+    script[f"docker manifest inspect {_CUDA_LATEST}"] = _ok("{}")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    check = result.check(CheckKey.IMAGE_RESOLVED)
+    assert check is not None
+    assert check.outcome is CheckOutcome.WARNING
+    assert check.reason_code == REASON_PROTOCOL_TAG_UNRESOLVED
+    assert check.detail is not None
+    assert _CUDA_LATEST in check.detail
+    assert result.passed is True
+
+
+async def test_tier2_unresolvable_image_fails_and_skips_the_rest(install_transport) -> None:
+    transport = install_transport(FakeTransport({}))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _outcome(result, CheckKey.IMAGE_RESOLVED) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.IMAGE_RESOLVED) == REASON_IMAGE_UNRESOLVED
+    for key in (CheckKey.IMAGE_SIGNATURE, CheckKey.CONTAINER_DEVICE_PROBE, CheckKey.PROTOCOL_COMPATIBLE):
+        assert _outcome(result, key) is CheckOutcome.SKIPPED
+    assert not transport.ran("docker run")
+
+
+async def test_tier2_missing_cosign_is_skipped_not_failed(install_transport) -> None:
+    # Signature verification here is defense in depth; the publish-time signature
+    # is the primary control.
+    script = _healthy_tier2_script()
+    script["cosign version"] = _fail("cosign: command not found", exit_status=127)
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    check = result.check(CheckKey.IMAGE_SIGNATURE)
+    assert check is not None
+    assert check.outcome is CheckOutcome.SKIPPED
+    assert check.reason_code == REASON_TOOL_MISSING
+    assert check.blocking is False
+    assert result.passed is True
+
+
+async def test_tier2_failed_signature_verification_warns_without_blocking(install_transport) -> None:
+    script = _healthy_tier2_script()
+    script["cosign verify"] = _fail("no matching signatures")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    check = result.check(CheckKey.IMAGE_SIGNATURE)
+    assert check is not None
+    assert check.outcome is CheckOutcome.WARNING
+    assert check.blocking is False
+
+
+async def test_tier2_device_probe_runs_a_one_shot_container(install_transport) -> None:
+    # The authoritative check, and the reason Tier 2 exists: a driver on the host
+    # says nothing about the runtime passing the device into a container.
+    transport = install_transport(FakeTransport(_healthy_tier2_script()))
+
+    result = await run_tier2_preflight(_server())
+
+    run = next(argv for argv in transport.commands if argv[:2] == ("docker", "run"))
+    assert "--rm" in run
+    assert "--gpus" in run
+    assert "torch.cuda.is_available()" in " ".join(run)
+    assert _outcome(result, CheckKey.CONTAINER_DEVICE_PROBE) is CheckOutcome.PASSED
+
+
+async def test_tier2_xpu_device_probe_passes_the_dri_device(install_transport) -> None:
+    xpu_image = f"{_REGISTRY}/physicalai-trainer-xpu:protocol-1"
+    script = {
+        f"docker manifest inspect {xpu_image}": _ok("{}"),
+        "cosign version": _fail("not found", exit_status=127),
+        "docker run": _ok("True"),
+        "docker image inspect": _ok("1"),
+    }
+    transport = install_transport(FakeTransport(script))
+
+    await run_tier2_preflight(_server(DeviceType.XPU))
+
+    run = next(argv for argv in transport.commands if argv[:2] == ("docker", "run"))
+    assert "/dev/dri" in run
+    assert "torch.xpu.is_available()" in " ".join(run)
+
+
+async def test_tier2_device_unavailable_in_the_container_fails(install_transport) -> None:
+    script = _healthy_tier2_script()
+    script["docker run"] = _ok("False\n")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _outcome(result, CheckKey.CONTAINER_DEVICE_PROBE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.CONTAINER_DEVICE_PROBE) == REASON_DEVICE_UNAVAILABLE
+    assert result.passed is False
+
+
+async def test_tier2_device_probe_failure_fails_the_check(install_transport) -> None:
+    script = _healthy_tier2_script()
+    script["docker run"] = _fail("could not select device driver with capabilities: [[gpu]]", exit_status=125)
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _outcome(result, CheckKey.CONTAINER_DEVICE_PROBE) is CheckOutcome.FAILED
+
+
+async def test_tier2_matching_protocol_version_passes(install_transport) -> None:
+    transport = install_transport(FakeTransport(_healthy_tier2_script()))
+
+    result = await run_tier2_preflight(_server(), protocol_version=1)
+
+    assert _outcome(result, CheckKey.PROTOCOL_COMPATIBLE) is CheckOutcome.PASSED
+    assert transport.ran(PROTOCOL_LABEL)
+
+
+async def test_tier2_protocol_mismatch_fails(install_transport) -> None:
+    script = _healthy_tier2_script()
+    script["docker image inspect"] = _ok("7\n")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server(), protocol_version=1)
+
+    assert _outcome(result, CheckKey.PROTOCOL_COMPATIBLE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.PROTOCOL_COMPATIBLE) == REASON_PROTOCOL_MISMATCH
+    assert result.passed is False
+
+
+async def test_tier2_an_unlabelled_image_fails_the_protocol_check(install_transport) -> None:
+    script = _healthy_tier2_script()
+    script["docker image inspect"] = _ok("<no value>\n")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _outcome(result, CheckKey.PROTOCOL_COMPATIBLE) is CheckOutcome.FAILED
+    assert _reason(result, CheckKey.PROTOCOL_COMPATIBLE) == REASON_PROTOCOL_UNKNOWN
+
+
+async def test_tier2_an_unparseable_protocol_label_fails(install_transport) -> None:
+    script = _healthy_tier2_script()
+    script["docker image inspect"] = _ok("v2-beta\n")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _reason(result, CheckKey.PROTOCOL_COMPATIBLE) == REASON_UNPARSEABLE_OUTPUT
+
+
+async def test_tier2_uses_the_expected_protocol_version_parameter(install_transport) -> None:
+    # The version arrives as a parameter, so this module never imports the trainer
+    # package.
+    script = _healthy_tier2_script()
+    script[f"docker manifest inspect {_REGISTRY}/physicalai-trainer-cuda:protocol-3"] = _ok("{}")
+    script["docker image inspect"] = _ok("3\n")
+    transport = install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server(), protocol_version=3)
+
+    assert transport.ran("physicalai-trainer-cuda:protocol-3")
+    assert _outcome(result, CheckKey.PROTOCOL_COMPATIBLE) is CheckOutcome.PASSED
+
+
+async def test_tier2_connect_failure_skips_every_check(install_transport) -> None:
+    install_transport(FakeTransport(connect_error=SshConnectionError(ALIAS, reason="timeout")))
+
+    result = await run_tier2_preflight(_server())
+
+    assert {check.key for check in result.checks} == set(_TIER2_KEYS)
+    assert all(check.outcome is CheckOutcome.SKIPPED for check in result.checks)
+    assert result.passed is True
+
+
+async def test_tier2_connection_lost_midway_skips_the_rest(install_transport) -> None:
+    transport = install_transport(FakeTransport(_healthy_tier2_script(), fail_after=1))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _outcome(result, CheckKey.IMAGE_RESOLVED) is CheckOutcome.PASSED
+    assert _outcome(result, CheckKey.CONTAINER_DEVICE_PROBE) is CheckOutcome.SKIPPED
+    assert _reason(result, CheckKey.CONTAINER_DEVICE_PROBE) == REASON_UNREACHABLE
+    assert transport.closed is True
+
+
+async def test_tier2_closes_the_transport(install_transport) -> None:
+    transport = install_transport(FakeTransport(_healthy_tier2_script()))
+
+    await run_tier2_preflight(_server())
+
+    assert transport.closed is True
+
+
+async def test_tier2_signature_check_is_never_blocking(install_transport) -> None:
+    install_transport(FakeTransport(_healthy_tier2_script()))
+
+    result = await run_tier2_preflight(_server())
+
+    check = result.check(CheckKey.IMAGE_SIGNATURE)
+    assert check is not None
+    assert check.blocking is False
+
+
+def test_trainer_image_ref_is_built_from_constants() -> None:
+    assert trainer_image_ref(_REGISTRY, DeviceType.CUDA, "protocol-1") == _CUDA_IMAGE
+    assert trainer_image_ref(f"{_REGISTRY}/", DeviceType.XPU, "latest").endswith("physicalai-trainer-xpu:latest")

--- a/application/backend/tests/services/ssh/test_preflight.py
+++ b/application/backend/tests/services/ssh/test_preflight.py
@@ -50,6 +50,7 @@ from services.ssh.preflight import (
     REASON_GPU_BUSY,
     REASON_HOST_KEY_MISMATCH,
     REASON_HOST_KEY_UNKNOWN,
+    REASON_IMAGE_PULLING,
     REASON_IMAGE_UNRESOLVED,
     REASON_INSUFFICIENT_DISK,
     REASON_NO_SIGNAL,
@@ -211,6 +212,12 @@ def _reason(result, key: CheckKey) -> str | None:
     check = result.check(key)
     assert check is not None, f"missing check: {key}"
     return check.reason_code
+
+
+def _detail_for(result, key: CheckKey) -> str | None:
+    check = result.check(key)
+    assert check is not None, f"missing check: {key}"
+    return check.detail
 
 
 # --------------------------------------------------------------------------- #
@@ -1201,3 +1208,79 @@ async def test_tier2_signature_check_is_never_blocking(install_transport) -> Non
 def test_trainer_image_ref_is_built_from_constants() -> None:
     assert trainer_image_ref(_REGISTRY, DeviceType.CUDA, "protocol-1") == _CUDA_IMAGE
     assert trainer_image_ref(f"{_REGISTRY}/", DeviceType.XPU, "latest").endswith("physicalai-trainer-xpu:latest")
+
+
+async def test_tier2_device_probe_mid_pull_is_skipped_not_failed(install_transport) -> None:
+    # Defense-in-depth for the race between `_image_present_locally` reporting
+    # present and the `docker run` a few lines later - e.g. another process
+    # evicting the image in between, forcing Docker to pull it inline. The raw
+    # progress output must never read as the compute probe, or the device,
+    # having failed.
+    script = _healthy_tier2_script()
+    script["docker run"] = _fail(
+        "Unable to find image 'ghcr.io/open-edge-platform/physicalai-trainer-cuda:protocol-1' locally\n"
+        "protocol-1: Pulling from open-edge-platform/physicalai-trainer-cuda\n"
+        "26c307b5e35a: Pulling fs layer\n"
+        "b07d7dc8cffa: Pulling fs layer\n"
+    )
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _outcome(result, CheckKey.CONTAINER_DEVICE_PROBE) is CheckOutcome.SKIPPED
+    assert _reason(result, CheckKey.CONTAINER_DEVICE_PROBE) == REASON_IMAGE_PULLING
+    assert result.passed is True
+
+
+async def test_tier2_device_probe_mid_pull_also_skips_the_protocol_check(install_transport) -> None:
+    # `docker image inspect` needs the image locally too, so running it right
+    # after a mid-pull device probe would just produce a second, equally
+    # misleading failure ("no protocol version") for the same root cause.
+    script = _healthy_tier2_script()
+    script["docker run"] = _fail("Unable to find image 'img' locally\nPulling from registry\n")
+    install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _outcome(result, CheckKey.PROTOCOL_COMPATIBLE) is CheckOutcome.SKIPPED
+    assert _reason(result, CheckKey.PROTOCOL_COMPATIBLE) == REASON_IMAGE_PULLING
+
+
+async def test_tier2_device_probe_starts_a_background_pull_when_image_is_absent(install_transport) -> None:
+    # The primary path: the image simply is not cached locally yet (a cold
+    # host, or a protocol bump CI has not published an image for). Rather than
+    # `docker run` pulling it inline - tying the transfer to this check's
+    # short timeout and to the SSH connection Tier 2 is about to close - the
+    # pull is handed to a detached, `nohup`-backed process that keeps going
+    # after this check returns.
+    script = _healthy_tier2_script()
+    script["docker image inspect"] = _fail("Error: No such image: img", exit_status=1)
+    script["sh -c test -f"] = _fail("", exit_status=1)  # no pull already running
+    script["sh -c nohup docker pull"] = _ok("")
+    transport = install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _outcome(result, CheckKey.CONTAINER_DEVICE_PROBE) is CheckOutcome.SKIPPED
+    assert _reason(result, CheckKey.CONTAINER_DEVICE_PROBE) == REASON_IMAGE_PULLING
+    assert "Started pulling" in (_detail_for(result, CheckKey.CONTAINER_DEVICE_PROBE) or "")
+    assert _outcome(result, CheckKey.PROTOCOL_COMPATIBLE) is CheckOutcome.SKIPPED
+    assert _reason(result, CheckKey.PROTOCOL_COMPATIBLE) == REASON_IMAGE_PULLING
+    assert not transport.ran("docker run")
+    assert transport.ran("nohup docker pull")
+    assert result.passed is True
+
+
+async def test_tier2_device_probe_does_not_start_a_second_pull_already_in_flight(install_transport) -> None:
+    # Repeated "Test connection" clicks while a pull is downloading must not
+    # each kick off a competing pull for the same image.
+    script = _healthy_tier2_script()
+    script["docker image inspect"] = _fail("Error: No such image: img", exit_status=1)
+    script["sh -c test -f"] = _ok("")  # a pull is already running
+    transport = install_transport(FakeTransport(script))
+
+    result = await run_tier2_preflight(_server())
+
+    assert _outcome(result, CheckKey.CONTAINER_DEVICE_PROBE) is CheckOutcome.SKIPPED
+    assert "Still pulling" in (_detail_for(result, CheckKey.CONTAINER_DEVICE_PROBE) or "")
+    assert not transport.ran("nohup docker pull")

--- a/application/backend/tests/services/ssh/test_sanitize.py
+++ b/application/backend/tests/services/ssh/test_sanitize.py
@@ -78,6 +78,21 @@ def test_two_byte_escape_sequence_is_removed() -> None:
     assert _sanitize("before\x1bcafter") == "beforeafter"
 
 
+def test_charset_designation_escape_sequence_is_fully_removed() -> None:
+    # ESC ( B designates ASCII as G0: an intermediate byte (`(`) followed by a
+    # final byte (`B`), not a plain two-byte sequence. The final byte must not
+    # leak into the output as literal text.
+    assert _sanitize("before\x1b(Bafter") == "beforeafter"
+
+
+def test_multiple_intermediate_bytes_escape_sequence_is_fully_removed() -> None:
+    assert _sanitize("before\x1b%%Gafter") == "beforeafter"
+
+
+def test_unterminated_intermediate_byte_escape_sequence_is_dropped_entirely() -> None:
+    assert _sanitize("visible\x1b(") == "visible"
+
+
 def test_bare_escape_at_end_is_removed() -> None:
     assert _sanitize("tail\x1b") == "tail"
 

--- a/application/backend/tests/services/ssh/test_sanitize.py
+++ b/application/backend/tests/services/ssh/test_sanitize.py
@@ -1,0 +1,229 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for remote-output sanitization.
+
+Remote stdout/stderr is environment-influenced content that ends up in an API
+response and in job messages, so these tests pin the whole contract: escape
+sequences and control characters are removed, ``\\n`` survives, bidi overrides
+are removed, and both length caps hold. The hostile cases at the end combine all
+of them in one payload, which is how they would actually arrive.
+"""
+
+from services.ssh.sanitize import TRUNCATION_MARKER, sanitize_output
+
+_LINE_CAP = 512
+_TOTAL_CAP = 4096
+
+
+def _sanitize(text: str, line_cap: int = _LINE_CAP, total_cap: int = _TOTAL_CAP) -> str:
+    return sanitize_output(text, max_line_chars=line_cap, max_total_chars=total_cap)
+
+
+def test_plain_text_is_unchanged() -> None:
+    assert _sanitize("Docker version 27.3.1") == "Docker version 27.3.1"
+
+
+def test_empty_text_returns_empty() -> None:
+    assert _sanitize("") == ""
+
+
+def test_newlines_are_preserved() -> None:
+    assert _sanitize("first\nsecond\nthird") == "first\nsecond\nthird"
+
+
+def test_trailing_newline_is_preserved() -> None:
+    assert _sanitize("only line\n") == "only line\n"
+
+
+# --------------------------------------------------------------------------- #
+# Escape sequences                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_ansi_sgr_colour_codes_are_removed() -> None:
+    assert _sanitize("\x1b[31mERROR\x1b[0m: disk full") == "ERROR: disk full"
+
+
+def test_ansi_cursor_movement_is_removed() -> None:
+    # A remote process can use cursor movement to overwrite a line it already
+    # printed, so the visible text no longer matches the recorded text.
+    assert _sanitize("real message\x1b[2K\x1b[1Afake message") == "real messagefake message"
+
+
+def test_osc_8_hyperlink_is_removed_but_label_survives() -> None:
+    # OSC 8 makes arbitrary text a clickable link to an arbitrary URL - the exact
+    # trick for rendering "docs.example.com" as a link to somewhere else.
+    text = "\x1b]8;;https://evil.example.com\x07Intel docs\x1b]8;;\x07"
+
+    assert _sanitize(text) == "Intel docs"
+
+
+def test_osc_terminated_by_string_terminator_is_removed() -> None:
+    assert _sanitize("before\x1b]0;new window title\x1b\\after") == "beforeafter"
+
+
+def test_unterminated_csi_sequence_is_dropped_entirely() -> None:
+    # A dangling ESC must never survive, so an unterminated sequence consumes the
+    # remainder rather than leaking the introducer.
+    assert _sanitize("visible\x1b[38;5;") == "visible"
+
+
+def test_unterminated_osc_sequence_is_dropped_entirely() -> None:
+    assert _sanitize("visible\x1b]8;;https://evil.example.com") == "visible"
+
+
+def test_two_byte_escape_sequence_is_removed() -> None:
+    # ESC c is a full terminal reset.
+    assert _sanitize("before\x1bcafter") == "beforeafter"
+
+
+def test_bare_escape_at_end_is_removed() -> None:
+    assert _sanitize("tail\x1b") == "tail"
+
+
+def test_escape_inside_osc_is_not_swallowed() -> None:
+    # A bare ESC inside an OSC body ends the OSC and starts a new sequence; the
+    # scanner must hand it back rather than consuming the CSI that follows.
+    assert _sanitize("a\x1b]0;title\x1b[31mred\x1b[0mb") == "aredb"
+
+
+# --------------------------------------------------------------------------- #
+# Control characters and bidi overrides                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_nul_and_other_control_bytes_are_removed() -> None:
+    assert _sanitize("a\x00b\x07c\x08d\x1fe") == "abcde"
+
+
+def test_carriage_return_is_removed() -> None:
+    # CR alone returns the cursor to column zero, letting later text overwrite
+    # earlier text on the same rendered line.
+    assert _sanitize("harmless text\rmalicious text") == "harmless textmalicious text"
+
+
+def test_tab_is_removed_as_a_control_character() -> None:
+    assert _sanitize("name\tvalue") == "namevalue"
+
+
+def test_bidi_override_characters_are_removed() -> None:
+    assert _sanitize("start\u202eresrever\u202cend") == "startresreverend"
+
+
+def test_all_bidi_override_code_points_are_removed() -> None:
+    overrides = "\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069\ufeff"
+
+    assert _sanitize(f"a{overrides}b") == "ab"
+
+
+def test_harmless_format_characters_are_preserved() -> None:
+    # Only the reordering subset of Cf is stripped: a soft hyphen and a zero-width
+    # joiner are legitimate content, and removing them would corrupt output.
+    assert _sanitize("soft\u00adhyphen\u200djoiner") == "soft\u00adhyphen\u200djoiner"
+
+
+def test_non_ascii_text_is_preserved() -> None:
+    assert _sanitize("GPU wärmt: 日本語 ✓") == "GPU wärmt: 日本語 ✓"
+
+
+# --------------------------------------------------------------------------- #
+# Length caps                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_over_long_line_is_truncated_to_the_line_cap() -> None:
+    result = _sanitize("x" * 900, line_cap=512)
+
+    assert result == "x" * 512
+
+
+def test_line_cap_applies_per_line_not_to_the_whole_text() -> None:
+    result = _sanitize("\n".join(["y" * 20] * 3), line_cap=5)
+
+    assert result == "yyyyy\nyyyyy\nyyyyy"
+
+
+def test_line_cap_is_applied_before_the_total_cap() -> None:
+    # One pathological first line must not consume the whole budget and hide every
+    # following line.
+    text = "\n".join(["z" * 5_000, "second", "third"])
+
+    result = _sanitize(text, line_cap=10, total_cap=100)
+
+    assert result == "zzzzzzzzzz\nsecond\nthird"
+
+
+def test_non_positive_line_cap_drops_all_line_content() -> None:
+    assert _sanitize("content\nmore", line_cap=0) == "\n"
+
+
+def test_total_cap_truncates_and_marks_the_result() -> None:
+    result = _sanitize("\n".join(f"line {index}" for index in range(500)), total_cap=200)
+
+    assert len(result) == 200
+    assert result.endswith(TRUNCATION_MARKER)
+
+
+def test_result_never_exceeds_the_total_cap() -> None:
+    result = _sanitize("q" * 10_000, line_cap=10_000, total_cap=64)
+
+    assert len(result) == 64
+
+
+def test_total_cap_shorter_than_the_marker_still_holds() -> None:
+    result = _sanitize("w" * 100, total_cap=4)
+
+    assert result == "wwww"
+
+
+def test_non_positive_total_cap_returns_empty() -> None:
+    assert _sanitize("anything", total_cap=0) == ""
+    assert _sanitize("anything", total_cap=-1) == ""
+
+
+def test_text_at_exactly_the_total_cap_is_not_marked() -> None:
+    result = _sanitize("e" * 64, total_cap=64)
+
+    assert result == "e" * 64
+
+
+def test_stripping_happens_before_measuring_the_caps() -> None:
+    # 400 escape sequences must not count against the caller's budget, otherwise a
+    # remote process could hide real output behind invisible padding.
+    text = "\x1b[31m" * 400 + "the real message"
+
+    assert _sanitize(text, total_cap=64) == "the real message"
+
+
+# --------------------------------------------------------------------------- #
+# Combined hostile payload                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_hostile_nested_payload_is_fully_neutralized() -> None:
+    text = (
+        "\x1b[2J\x1b[H"  # clear screen, home cursor
+        "\x1b]8;;https://evil.example.com\x07"  # hyperlink to elsewhere
+        "\u202eLOOKS SAFE\u202c"  # reversed rendering
+        "\x1b]8;;\x07"
+        "\x00\x07\r"  # raw control bytes
+        "\n"
+        "\x1b[31mfailure: pull denied\x1b[0m"
+        "\x1b[999"  # unterminated tail
+    )
+
+    result = _sanitize(text)
+
+    assert result == "LOOKS SAFE\nfailure: pull denied"
+    assert "\x1b" not in result
+    assert "\x00" not in result
+    assert "evil.example.com" not in result
+
+
+def test_sanitized_output_contains_no_escape_or_control_characters() -> None:
+    text = "".join(chr(code) for code in range(0x20)) + "\x1b[1;2;3mtext\x1b]0;title\x07"
+
+    result = _sanitize(text)
+
+    assert result == "\ntext"

--- a/application/backend/tests/services/ssh/test_transport.py
+++ b/application/backend/tests/services/ssh/test_transport.py
@@ -575,7 +575,6 @@ async def test_existing_known_hosts_file_is_passed_by_path(settings: Settings, k
     ("error", "expected", "reason_fragment"),
     [
         (TimeoutError(), SshConnectionError, "timeout"),
-        (TimeoutError(), SshConnectionError, "timeout"),
         (asyncssh.ConnectionLost("lost"), SshConnectionError, "connection_lost"),
         (asyncssh.ProtocolError("bad packet"), SshConnectionError, "protocol_error"),
         (asyncssh.KeyExchangeFailed("no kex"), SshConnectionError, "protocol_error"),

--- a/application/backend/tests/services/ssh/test_transport.py
+++ b/application/backend/tests/services/ssh/test_transport.py
@@ -1,0 +1,836 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the SSH transport - the remote-execution trust boundary.
+
+Three properties matter most here and are tested against real ``asyncssh``
+exception objects rather than sentinels, so an upstream signature change fails
+these tests instead of silently changing behaviour:
+
+* ``test_run_command_quotes_*`` prove that argument text cannot break out of its
+  position: the exact string handed to the exec channel is asserted.
+* ``test_map_*`` prove every ``asyncssh`` connect failure becomes one of the
+  actionable ``Ssh*Error`` classes, and that none of the raw text - hostnames,
+  key paths, exception detail - reaches the resulting message.
+* ``test_host_key_*`` prove the unknown-vs-changed distinction, which
+  ``asyncssh`` itself does not make: both raise the same
+  ``HostKeyNotVerifiable``.
+"""
+
+import asyncio
+import socket
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import asyncssh
+import pytest
+
+from exceptions import BaseException as StudioBaseException
+from exceptions import (
+    SshAgentRequiredError,
+    SshAuthenticationError,
+    SshConnectionError,
+    SshHostAliasNotFoundError,
+    SshHostKeyMismatchError,
+    SshHostKeyUnknownError,
+)
+from services.ssh import transport as transport_module
+from services.ssh.transport import (
+    COMMAND_FAILED_EXIT_STATUS,
+    COMMAND_TIMEOUT_EXIT_STATUS,
+    CommandFailure,
+    CommandResult,
+    SshTransport,
+    open_transport,
+    reset_alias_gates,
+)
+from settings import Settings
+
+ALIAS = "gpu-box"
+_HOSTNAME = "gpu-box.internal.example.com"
+_IDENTITY_PATH = "/home/tester/.ssh/id_secret_test_key"
+
+
+@pytest.fixture(autouse=True)
+def _clear_gates():
+    reset_alias_gates()
+    yield
+    reset_alias_gates()
+
+
+@pytest.fixture
+def ssh_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "config"
+    config_path.write_text(f"Host {ALIAS}\n  HostName {_HOSTNAME}\n  User tester\n")
+    return config_path
+
+
+@pytest.fixture
+def known_hosts(tmp_path: Path) -> Path:
+    return tmp_path / "known_hosts"
+
+
+@pytest.fixture
+def settings(ssh_config: Path, known_hosts: Path) -> Settings:
+    return Settings(
+        SSH_CONFIG_PATH=ssh_config,
+        SSH_KNOWN_HOSTS_PATH=known_hosts,
+        # No throttle delay: the throttle is tested explicitly, and every other
+        # test would otherwise pay for it.
+        SSH_PREFLIGHT_THROTTLE_S=0.0,
+        SSH_OUTPUT_MAX_LINE_CHARS=512,
+        SSH_OUTPUT_MAX_TOTAL_CHARS=4096,
+    )
+
+
+@pytest.fixture
+def encrypted_identity_settings(tmp_path: Path) -> Settings:
+    """Settings whose alias resolves to a genuinely passphrase-protected key.
+
+    A real encrypted key, not a stub, so the passphrase detection is exercised
+    rather than mocked. PKCS#8 PEM is used because OpenSSH-format encryption needs
+    ``bcrypt``, which is not a dependency here.
+    """
+    identity = tmp_path / "id_encrypted"
+    key = asyncssh.generate_private_key("ssh-ed25519")
+    identity.write_bytes(key.export_private_key("pkcs8-pem", passphrase="test-passphrase"))
+    config_path = tmp_path / "config"
+    config_path.write_text(f"Host {ALIAS}\n  HostName {_HOSTNAME}\n  IdentityFile {identity}\n")
+    return Settings(
+        SSH_CONFIG_PATH=config_path,
+        SSH_KNOWN_HOSTS_PATH=tmp_path / "known_hosts",
+        SSH_PREFLIGHT_THROTTLE_S=0.0,
+    )
+
+
+def _completed(
+    stdout: str | bytes = "", stderr: str | bytes = "", exit_status: int | None = 0, exit_signal: Any = None
+) -> MagicMock:
+    completed = MagicMock()
+    completed.stdout = stdout
+    completed.stderr = stderr
+    completed.exit_status = exit_status
+    completed.exit_signal = exit_signal
+    return completed
+
+
+def _await_args(mock: AsyncMock) -> tuple[tuple[Any, ...], Mapping[str, Any]]:
+    """Return one AsyncMock's last call args/kwargs, asserting it was awaited.
+
+    ``await_args`` is typed ``_Call | None`` because an un-awaited mock has none;
+    every caller here has already awaited it, so this narrows that away instead
+    of repeating the same assert at each call site.
+    """
+    call = mock.await_args
+    assert call is not None
+    return call.args, call.kwargs
+
+
+def _connected_transport(settings: Settings, connection: MagicMock) -> SshTransport:
+    """Return a transport with a fake open connection, skipping the dial."""
+    transport = SshTransport(ALIAS, settings)
+    transport._connection = connection
+    return transport
+
+
+def _process_error(*, exit_status: int | None, stdout: str = "", stderr: str = "", exit_signal=None):
+    return asyncssh.ProcessError(
+        env=None,
+        command=None,
+        subsystem=None,
+        exit_status=exit_status,
+        exit_signal=exit_signal,
+        returncode=exit_status,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _timeout_error(stdout: str = "", stderr: str = ""):
+    return asyncssh.TimeoutError(
+        env=None,
+        command=None,
+        subsystem=None,
+        exit_status=None,
+        exit_signal=None,
+        returncode=None,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Command construction: injection safety                                      #
+# --------------------------------------------------------------------------- #
+
+
+async def test_run_command_sends_a_shell_quoted_string(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(return_value=_completed(stdout="27.3.1\n"))
+    transport = _connected_transport(settings, connection)
+
+    result = await transport.run_command(["docker", "version", "--format", "{{.Server.Version}}"])
+
+    sent = _await_args(connection.run)[0][0]
+    assert sent == "docker version --format '{{.Server.Version}}'"
+    assert result.command == sent
+    assert result.ok
+
+
+async def test_run_command_quotes_shell_metacharacters_verbatim(settings: Settings) -> None:
+    # The exact string is asserted because this is the injection boundary: every
+    # metacharacter must arrive as literal text inside a quoted argument.
+    connection = MagicMock()
+    connection.run = AsyncMock(return_value=_completed())
+    transport = _connected_transport(settings, connection)
+
+    hostile = ["docker", "run", "; rm -rf /", "$(whoami)", "`id`", "a && b", "x | y", "n\nm"]
+    result = await transport.run_command(hostile)
+
+    sent = _await_args(connection.run)[0][0]
+    assert sent == "docker run '; rm -rf /' '$(whoami)' '`id`' 'a && b' 'x | y' 'n\nm'"
+    assert result.argv == tuple(hostile)
+
+
+async def test_run_command_quotes_embedded_single_quotes(settings: Settings) -> None:
+    # The classic escape: a bare "'" would otherwise close the quoting shlex
+    # opened and let the rest of the element be interpreted.
+    connection = MagicMock()
+    connection.run = AsyncMock(return_value=_completed())
+    transport = _connected_transport(settings, connection)
+
+    await transport.run_command(["echo", "it's; rm -rf /"])
+
+    assert _await_args(connection.run)[0][0] == """echo 'it'"'"'s; rm -rf /'"""
+
+
+async def test_run_command_rejects_an_empty_argv(settings: Settings) -> None:
+    transport = _connected_transport(settings, MagicMock())
+
+    with pytest.raises(ValueError, match="argv"):
+        await transport.run_command([])
+
+
+async def test_run_command_without_a_connection_raises(settings: Settings) -> None:
+    transport = SshTransport(ALIAS, settings)
+
+    with pytest.raises(RuntimeError):
+        await transport.run_command(["true"])
+
+
+async def test_run_command_passes_the_configured_command_timeout(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(return_value=_completed())
+    transport = _connected_transport(settings, connection)
+
+    await transport.run_command(["true"])
+
+    assert _await_args(connection.run)[1]["timeout"] == settings.ssh_command_timeout_s
+
+
+async def test_run_command_honours_an_explicit_timeout(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(return_value=_completed())
+    transport = _connected_transport(settings, connection)
+
+    await transport.run_command(["true"], timeout=2.5)
+
+    assert _await_args(connection.run)[1]["timeout"] == 2.5
+
+
+# --------------------------------------------------------------------------- #
+# Command results and output sanitization                                     #
+# --------------------------------------------------------------------------- #
+
+
+async def test_command_output_is_sanitized(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(
+        return_value=_completed(stdout="\x1b[31mfail\x1b[0m\x00", stderr="\x1b]8;;https://evil.example.com\x07link")
+    )
+    transport = _connected_transport(settings, connection)
+
+    result = await transport.run_command(["docker", "version"])
+
+    assert result.stdout == "fail"
+    assert result.stderr == "link"
+
+
+async def test_command_output_is_length_capped(ssh_config: Path, known_hosts: Path) -> None:
+    settings = Settings(
+        SSH_CONFIG_PATH=ssh_config,
+        SSH_KNOWN_HOSTS_PATH=known_hosts,
+        SSH_OUTPUT_MAX_LINE_CHARS=16,
+        SSH_OUTPUT_MAX_TOTAL_CHARS=32,
+    )
+    connection = MagicMock()
+    connection.run = AsyncMock(return_value=_completed(stdout="\n".join(["x" * 200] * 20)))
+    transport = _connected_transport(settings, connection)
+
+    result = await transport.run_command(["true"])
+
+    assert len(result.stdout) <= 32
+
+
+async def test_byte_output_is_decoded(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(return_value=_completed(stdout=b"bytes out", stderr=b"\xff\xfe bad"))
+    transport = _connected_transport(settings, connection)
+
+    result = await transport.run_command(["true"])
+
+    assert result.stdout == "bytes out"
+    assert "bad" in result.stderr
+
+
+async def test_nonzero_exit_status_is_not_ok(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(return_value=_completed(stderr="no such file", exit_status=127))
+    transport = _connected_transport(settings, connection)
+
+    result = await transport.run_command(["nvidia-smi"])
+
+    assert result.ok is False
+    assert result.exit_status == 127
+    assert result.stderr == "no such file"
+
+
+async def test_process_error_becomes_a_result_not_an_exception(settings: Settings) -> None:
+    # One failing probe must never abort a whole preflight tier.
+    connection = MagicMock()
+    connection.run = AsyncMock(side_effect=_process_error(exit_status=2, stderr="denied"))
+    transport = _connected_transport(settings, connection)
+
+    result = await transport.run_command(["docker", "version"])
+
+    assert result.exit_status == 2
+    assert result.failure is None
+    assert result.stderr == "denied"
+
+
+async def test_command_timeout_becomes_a_timeout_result(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(side_effect=_timeout_error(stdout="partial"))
+    transport = _connected_transport(settings, connection)
+
+    result = await transport.run_command(["sleep", "600"])
+
+    assert result.failure is CommandFailure.TIMEOUT
+    assert result.exit_status == COMMAND_TIMEOUT_EXIT_STATUS
+    assert result.ok is False
+    assert result.stdout == "partial"
+
+
+async def test_channel_open_error_becomes_a_channel_refused_result(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(side_effect=asyncssh.ChannelOpenError(4, "administratively prohibited"))
+    transport = _connected_transport(settings, connection)
+
+    result = await transport.run_command(["true"])
+
+    assert result.failure is CommandFailure.CHANNEL_REFUSED
+    assert result.exit_status == COMMAND_FAILED_EXIT_STATUS
+
+
+async def test_signalled_process_reports_a_signal_failure(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(return_value=_completed(exit_status=None, exit_signal=("KILL", False, "", "en-US")))
+    transport = _connected_transport(settings, connection)
+
+    result = await transport.run_command(["python", "-c", "pass"])
+
+    assert result.failure is CommandFailure.SIGNALED
+    assert result.ok is False
+
+
+async def test_connection_lost_during_a_command_raises_a_connection_error(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(side_effect=asyncssh.ConnectionLost("connection lost"))
+    transport = _connected_transport(settings, connection)
+
+    with pytest.raises(SshConnectionError) as error:
+        await transport.run_command(["true"])
+
+    assert "connection_lost" in error.value.message
+
+
+async def test_builtin_timeout_during_a_command_raises_a_connection_error(settings: Settings) -> None:
+    connection = MagicMock()
+    connection.run = AsyncMock(side_effect=TimeoutError)
+    transport = _connected_transport(settings, connection)
+
+    with pytest.raises(SshConnectionError) as error:
+        await transport.run_command(["true"])
+
+    assert "timeout" in error.value.message
+
+
+def test_command_result_first_line_skips_blank_lines() -> None:
+    result = CommandResult(argv=("true",), command="true", exit_status=0, stdout="\n  \nDocker 27.3.1\nmore\n")
+
+    assert result.first_line() == "Docker 27.3.1"
+
+
+def test_command_result_first_line_of_empty_output_is_empty() -> None:
+    result = CommandResult(argv=("true",), command="true", exit_status=0)
+
+    assert result.first_line() == ""
+
+
+# --------------------------------------------------------------------------- #
+# Alias resolution before dialing                                             #
+# --------------------------------------------------------------------------- #
+
+
+async def test_connect_rejects_an_unknown_alias_without_dialing(settings: Settings, monkeypatch) -> None:
+    connect = AsyncMock()
+    monkeypatch.setattr(asyncssh, "connect", connect)
+    transport = SshTransport("not-in-config", settings)
+
+    with pytest.raises(SshHostAliasNotFoundError):
+        await transport.connect()
+
+    connect.assert_not_awaited()
+
+
+async def test_connect_rejects_a_wildcard_only_alias(tmp_path: Path, monkeypatch) -> None:
+    # A pattern stanza is not a usable target, so it must not be dialed.
+    config_path = tmp_path / "config"
+    config_path.write_text("Host *\n  User tester\n")
+    settings = Settings(SSH_CONFIG_PATH=config_path, SSH_KNOWN_HOSTS_PATH=tmp_path / "known_hosts")
+    connect = AsyncMock()
+    monkeypatch.setattr(asyncssh, "connect", connect)
+
+    with pytest.raises(SshHostAliasNotFoundError):
+        await SshTransport(ALIAS, settings).connect()
+
+    connect.assert_not_awaited()
+
+
+async def test_connect_is_idempotent(settings: Settings, monkeypatch) -> None:
+    connect = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(asyncssh, "connect", connect)
+    transport = SshTransport(ALIAS, settings)
+
+    await transport.connect()
+    await transport.connect()
+
+    assert connect.await_count == 1
+    await transport.close()
+
+
+async def test_context_manager_connects_and_closes(settings: Settings, monkeypatch) -> None:
+    connection = MagicMock()
+    connection.wait_closed = AsyncMock()
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(return_value=connection))
+
+    async with SshTransport(ALIAS, settings) as transport:
+        assert transport.connected is True
+
+    connection.close.assert_called_once()
+
+
+async def test_connect_reads_the_users_config_and_alias(settings: Settings, monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_connect(*, options, **_kwargs):
+        captured["options"] = options
+        return MagicMock()
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+    transport = SshTransport(ALIAS, settings)
+
+    await transport.connect()
+
+    # asyncssh resolved the alias itself, from the user's own config file.
+    assert captured["options"].host == _HOSTNAME
+    await transport.close()
+
+
+# --------------------------------------------------------------------------- #
+# Host-key classification                                                     #
+# --------------------------------------------------------------------------- #
+#
+# asyncssh raises the same HostKeyNotVerifiable for an unknown host and for a
+# changed key, so the transport records what known_hosts held before verification
+# ran. These tests pin that classification, including its fail-closed default.
+
+
+def _match(trusted: int = 0, ca: int = 0, revoked: int = 0):
+    return ([object()] * trusted, [object()] * ca, [object()] * revoked, [], [], [], [])
+
+
+def _verifying_connect(monkeypatch, match_result) -> None:
+    """Fake ``asyncssh.connect`` that consults the matcher, then rejects the key.
+
+    Mirrors the real handshake order - asyncssh looks the host up in
+    ``known_hosts`` and only then raises ``HostKeyNotVerifiable`` - because the
+    lookup result is the only thing that distinguishes unknown from changed.
+    """
+    monkeypatch.setattr(asyncssh, "match_known_hosts", lambda *_args: match_result)
+
+    async def fake_connect(*, options, **_kwargs):
+        options.known_hosts(_HOSTNAME, "10.0.0.1", 22)
+        raise asyncssh.HostKeyNotVerifiable(f"Host key is not trusted for host {_HOSTNAME}")
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+
+
+async def test_no_known_hosts_entry_is_reported_as_an_unknown_host(settings: Settings, monkeypatch) -> None:
+    _verifying_connect(monkeypatch, _match())
+
+    with pytest.raises(SshHostKeyUnknownError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+async def test_an_existing_known_hosts_entry_is_reported_as_a_mismatch(settings: Settings, monkeypatch) -> None:
+    # An entry existed and verification still failed: the presented key differs
+    # from the accepted one. Telling the user to accept a fingerprint here would
+    # be exactly the wrong advice.
+    _verifying_connect(monkeypatch, _match(trusted=1))
+
+    with pytest.raises(SshHostKeyMismatchError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+async def test_a_revoked_key_is_reported_as_a_mismatch(settings: Settings, monkeypatch) -> None:
+    _verifying_connect(monkeypatch, _match(revoked=1))
+
+    with pytest.raises(SshHostKeyMismatchError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+async def test_a_ca_only_entry_is_reported_as_a_mismatch(settings: Settings, monkeypatch) -> None:
+    _verifying_connect(monkeypatch, _match(ca=1))
+
+    with pytest.raises(SshHostKeyMismatchError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+async def test_the_matcher_state_does_not_leak_between_connects(settings: Settings, monkeypatch) -> None:
+    # A mismatch recorded on one attempt must not make the next attempt - which
+    # never consulted known_hosts - look like a mismatch for that reason.
+    _verifying_connect(monkeypatch, _match(trusted=1))
+    transport = SshTransport(ALIAS, settings)
+    with pytest.raises(SshHostKeyMismatchError):
+        await transport.connect()
+
+    _verifying_connect(monkeypatch, _match())
+
+    with pytest.raises(SshHostKeyUnknownError):
+        await transport.connect()
+
+
+async def test_an_unconsulted_matcher_fails_closed_as_a_mismatch(settings: Settings, monkeypatch) -> None:
+    # asyncssh rejected the key without ever calling the matcher. Ambiguous, so
+    # the more suspicious interpretation wins: never tell a user to accept a
+    # fingerprint for a key that may have changed.
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=asyncssh.HostKeyNotVerifiable("not trusted")))
+
+    with pytest.raises(SshHostKeyMismatchError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+async def test_missing_known_hosts_file_is_treated_as_empty(settings: Settings, monkeypatch) -> None:
+    # A nonexistent known_hosts file would make asyncssh raise FileNotFoundError;
+    # the actionable outcome is "you have never accepted this host".
+    recorded: dict[str, Any] = {}
+
+    def fake_match(source, host, addr, port):
+        recorded["source"] = source
+        return _match()
+
+    monkeypatch.setattr(asyncssh, "match_known_hosts", fake_match)
+    transport = SshTransport(ALIAS, settings)
+
+    transport._match_known_hosts(_HOSTNAME, "10.0.0.1", 22)
+
+    assert recorded["source"] == b""
+
+
+async def test_existing_known_hosts_file_is_passed_by_path(settings: Settings, known_hosts: Path, monkeypatch) -> None:
+    known_hosts.write_text(f"{_HOSTNAME} ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIexample\n")
+    recorded: dict[str, Any] = {}
+
+    def fake_match(source, host, addr, port):
+        recorded["source"] = source
+        return _match(trusted=1)
+
+    monkeypatch.setattr(asyncssh, "match_known_hosts", fake_match)
+    transport = SshTransport(ALIAS, settings)
+
+    transport._match_known_hosts(_HOSTNAME, "10.0.0.1", 22)
+
+    assert recorded["source"] == str(known_hosts)
+
+
+# --------------------------------------------------------------------------- #
+# Connect-failure mapping                                                     #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("error", "expected", "reason_fragment"),
+    [
+        (TimeoutError(), SshConnectionError, "timeout"),
+        (TimeoutError(), SshConnectionError, "timeout"),
+        (asyncssh.ConnectionLost("lost"), SshConnectionError, "connection_lost"),
+        (asyncssh.ProtocolError("bad packet"), SshConnectionError, "protocol_error"),
+        (asyncssh.KeyExchangeFailed("no kex"), SshConnectionError, "protocol_error"),
+        (ConnectionRefusedError(), SshConnectionError, "unreachable"),
+        (socket.gaierror("name resolution failed"), SshConnectionError, "unreachable"),
+        (OSError("network unreachable"), SshConnectionError, "unreachable"),
+        (asyncssh.DisconnectError(2, "protocol error"), SshConnectionError, "protocol_error"),
+    ],
+)
+async def test_map_connect_failures_to_a_connection_error(
+    settings: Settings,
+    monkeypatch,
+    error: Exception,
+    expected: type[SshConnectionError],
+    reason_fragment: str,
+) -> None:
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=error))
+
+    with pytest.raises(expected) as raised:
+        await SshTransport(ALIAS, settings).connect()
+
+    assert reason_fragment in raised.value.message
+
+
+async def test_map_permission_denied_to_an_authentication_error(settings: Settings, monkeypatch) -> None:
+    # No encrypted identity is configured, so this is a plain rejection.
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=asyncssh.PermissionDenied("denied")))
+
+    with pytest.raises(SshAuthenticationError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+async def test_map_permission_denied_with_a_locked_key_to_an_agent_error(
+    encrypted_identity_settings: Settings,
+    monkeypatch,
+) -> None:
+    # A passphrase-protected key with no usable agent arrives from asyncssh as a
+    # plain PermissionDenied, so the actionable cause has to be diagnosed after
+    # the fact - otherwise the user is told to check their key instead of to run
+    # ssh-add. The key here is genuinely encrypted, so the detection is real.
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=asyncssh.PermissionDenied("denied")))
+    monkeypatch.setattr(transport_module, "_agent_has_keys", AsyncMock(return_value=False))
+
+    with pytest.raises(SshAgentRequiredError):
+        await SshTransport(ALIAS, encrypted_identity_settings).connect()
+
+
+async def test_a_locked_key_with_a_loaded_agent_is_an_authentication_error(
+    encrypted_identity_settings: Settings,
+    monkeypatch,
+) -> None:
+    # The agent holds keys, so the passphrase is not the problem: the server
+    # rejected the identity.
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=asyncssh.PermissionDenied("denied")))
+    monkeypatch.setattr(transport_module, "_agent_has_keys", AsyncMock(return_value=True))
+
+    with pytest.raises(SshAuthenticationError):
+        await SshTransport(ALIAS, encrypted_identity_settings).connect()
+
+
+async def test_a_plaintext_key_rejection_is_an_authentication_error(tmp_path: Path, monkeypatch) -> None:
+    # No passphrase involved, so an agent would not help.
+    identity = tmp_path / "id_plain"
+    identity.write_bytes(asyncssh.generate_private_key("ssh-ed25519").export_private_key("openssh"))
+    config_path = tmp_path / "config"
+    config_path.write_text(f"Host {ALIAS}\n  HostName {_HOSTNAME}\n  IdentityFile {identity}\n")
+    settings = Settings(SSH_CONFIG_PATH=config_path, SSH_KNOWN_HOSTS_PATH=tmp_path / "known_hosts")
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=asyncssh.PermissionDenied("denied")))
+
+    with pytest.raises(SshAuthenticationError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        asyncssh.KeyImportError("Passphrase must be specified to import encrypted private keys"),
+        asyncssh.KeyEncryptionError("bad passphrase"),
+    ],
+)
+async def test_map_encrypted_key_load_failures_to_an_agent_error(
+    settings: Settings,
+    monkeypatch,
+    error: Exception,
+) -> None:
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=error))
+
+    with pytest.raises(SshAgentRequiredError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+async def test_a_malformed_identity_file_is_an_authentication_error(tmp_path: Path, monkeypatch) -> None:
+    # asyncssh loads identities while building options, so this fails before the
+    # dial. It must still arrive as an actionable Ssh* error - and not as an agent
+    # error, because ssh-add will never fix a corrupt file.
+    identity = tmp_path / "id_broken"
+    identity.write_text("not-a-real-key")
+    config_path = tmp_path / "config"
+    config_path.write_text(f"Host {ALIAS}\n  HostName {_HOSTNAME}\n  IdentityFile {identity}\n")
+    settings = Settings(SSH_CONFIG_PATH=config_path, SSH_KNOWN_HOSTS_PATH=tmp_path / "known_hosts")
+    connect = AsyncMock()
+    monkeypatch.setattr(asyncssh, "connect", connect)
+
+    with pytest.raises(SshAuthenticationError):
+        await SshTransport(ALIAS, settings).connect()
+
+    connect.assert_not_awaited()
+
+
+async def test_a_missing_identity_file_is_an_authentication_error(tmp_path: Path, monkeypatch) -> None:
+    # A configured IdentityFile that does not exist makes asyncssh raise
+    # FileNotFoundError; an unhandled OSError must not reach the API layer.
+    config_path = tmp_path / "config"
+    config_path.write_text(f"Host {ALIAS}\n  HostName {_HOSTNAME}\n  IdentityFile {tmp_path / 'absent'}\n")
+    settings = Settings(SSH_CONFIG_PATH=config_path, SSH_KNOWN_HOSTS_PATH=tmp_path / "known_hosts")
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock())
+
+    with pytest.raises(SshAuthenticationError) as raised:
+        await SshTransport(ALIAS, settings).connect()
+
+    assert str(tmp_path) not in raised.value.message
+
+
+async def test_map_an_unexpected_exception_to_a_connection_error(settings: Settings, monkeypatch) -> None:
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=RuntimeError("something odd")))
+
+    with pytest.raises(SshConnectionError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+async def test_cancellation_is_not_swallowed(settings: Settings, monkeypatch) -> None:
+    # A cancelled request must cancel, not surface as a server error.
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=asyncio.CancelledError))
+
+    with pytest.raises(asyncio.CancelledError):
+        await SshTransport(ALIAS, settings).connect()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        asyncssh.PermissionDenied(f"Permission denied for key {_IDENTITY_PATH} on {_HOSTNAME}"),
+        asyncssh.ProtocolError(f"Protocol error talking to {_HOSTNAME}"),
+        asyncssh.HostKeyNotVerifiable(f"Host key is not trusted for host {_HOSTNAME}"),
+        OSError(f"[Errno 113] No route to host: {_HOSTNAME}"),
+    ],
+)
+async def test_mapped_errors_never_leak_hostnames_or_key_paths(
+    settings: Settings,
+    monkeypatch,
+    error: Exception,
+) -> None:
+    # A raw SSH error can name the resolved hostname or an identity path, and the
+    # mapped message reaches an API response. The alias is the only host-ish
+    # identifier allowed through, because the user chose it and it is not secret.
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=error))
+
+    with pytest.raises(StudioBaseException) as raised:
+        await SshTransport(ALIAS, settings).connect()
+
+    message = raised.value.message
+    assert _HOSTNAME not in message
+    assert _IDENTITY_PATH not in message
+    assert str(error) not in message
+    assert ALIAS in message
+
+
+async def test_mapped_errors_drop_the_original_exception_chain(settings: Settings, monkeypatch) -> None:
+    # `raise ... from None`: a traceback rendered into a log must not re-expose
+    # the raw text the mapping deliberately dropped.
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=asyncssh.ProtocolError(f"talking to {_HOSTNAME}")))
+
+    with pytest.raises(SshConnectionError) as raised:
+        await SshTransport(ALIAS, settings).connect()
+
+    assert raised.value.__cause__ is None
+
+
+# --------------------------------------------------------------------------- #
+# Bounded concurrency                                                         #
+# --------------------------------------------------------------------------- #
+
+
+async def test_the_per_alias_connection_slot_is_released_on_failure(settings: Settings, monkeypatch) -> None:
+    # A leaked semaphore slot would wedge the alias for the rest of the process,
+    # so every failing path must release it.
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(side_effect=OSError("refused")))
+
+    for _ in range(settings.ssh_max_connections_per_server + 2):
+        with pytest.raises(SshConnectionError):
+            await SshTransport(ALIAS, settings).connect()
+
+
+async def test_concurrent_connections_to_one_alias_are_capped(
+    ssh_config: Path,
+    known_hosts: Path,
+    monkeypatch,
+) -> None:
+    # UI polling plus a status check plus a preflight must not pile connections
+    # onto one server, so the cap is enforced per alias.
+    settings = Settings(
+        SSH_CONFIG_PATH=ssh_config,
+        SSH_KNOWN_HOSTS_PATH=known_hosts,
+        SSH_MAX_CONNECTIONS_PER_SERVER=2,
+        SSH_PREFLIGHT_THROTTLE_S=0.0,
+    )
+    in_flight = 0
+    peak = 0
+
+    async def fake_connect(**_kwargs):
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        # Yield, so a slot is genuinely held while the other tasks get a turn.
+        await asyncio.sleep(0.01)
+        in_flight -= 1
+        connection = MagicMock()
+        connection.wait_closed = AsyncMock()
+        return connection
+
+    monkeypatch.setattr(asyncssh, "connect", fake_connect)
+    transports = [SshTransport(ALIAS, settings) for _ in range(5)]
+
+    async def dial(transport: SshTransport) -> None:
+        await transport.connect()
+        await transport.close()
+
+    await asyncio.gather(*(dial(transport) for transport in transports))
+
+    assert peak <= 2
+
+
+async def test_close_is_safe_without_a_connection(settings: Settings) -> None:
+    transport = SshTransport(ALIAS, settings)
+
+    await transport.close()
+
+    assert transport.connected is False
+
+
+async def test_close_releases_the_slot_even_if_wait_closed_fails(settings: Settings, monkeypatch) -> None:
+    connection = MagicMock()
+    connection.wait_closed = AsyncMock(side_effect=asyncssh.ConnectionLost("already gone"))
+    monkeypatch.setattr(asyncssh, "connect", AsyncMock(return_value=connection))
+    settings_with_room = settings
+
+    for _ in range(settings_with_room.ssh_max_connections_per_server + 2):
+        transport = SshTransport(ALIAS, settings_with_room)
+        await transport.connect()
+        await transport.close()
+
+
+def test_open_transport_returns_an_unconnected_transport(settings: Settings) -> None:
+    transport = open_transport(ALIAS, settings)
+
+    assert isinstance(transport, SshTransport)
+    assert transport.alias == ALIAS
+    assert transport.connected is False

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -2637,7 +2637,7 @@ requires-dist = [
     { name = "aiortc", specifier = ">=1.13.0" },
     { name = "aiosqlite", specifier = "~=0.21" },
     { name = "alembic", specifier = ">=1.16.5" },
-    { name = "asyncssh", specifier = ">=2.14" },
+    { name = "asyncssh", specifier = "~=2.24" },
     { name = "click", specifier = ">=8.3.0" },
     { name = "cv2-enumerate-cameras" },
     { name = "fastapi", extras = ["standard"], specifier = "<1" },

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -267,6 +267,19 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncssh"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/7f/2d79247bacc562104f312d27efe541673aa177feac89de291bd61bca52be/asyncssh-2.24.0.tar.gz", hash = "sha256:4064c590e59ce2e8d82a2f66d35f3120d765828b4df5e3dbfb07b4a8c24686c9", size = 550148, upload-time = "2026-06-27T20:34:44.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/29/908ce0ca5e8cae76662e354a0f08df552d6d221844748b9e5ca06051cc44/asyncssh-2.24.0-py3-none-any.whl", hash = "sha256:9abd46300adcb6d4b73269b34c53cd0d17a138b9a22b5b38008ce7d5808734b7", size = 381237, upload-time = "2026-06-27T20:34:43.198Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2547,6 +2560,7 @@ dependencies = [
     { name = "aiortc" },
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "asyncssh" },
     { name = "click" },
     { name = "cv2-enumerate-cameras" },
     { name = "fastapi", extra = ["standard"] },
@@ -2623,6 +2637,7 @@ requires-dist = [
     { name = "aiortc", specifier = ">=1.13.0" },
     { name = "aiosqlite", specifier = "~=0.21" },
     { name = "alembic", specifier = ">=1.16.5" },
+    { name = "asyncssh", specifier = ">=2.14" },
     { name = "click", specifier = ">=8.3.0" },
     { name = "cv2-enumerate-cameras" },
     { name = "fastapi", extras = ["standard"], specifier = "<1" },


### PR DESCRIPTION
## Purpose
Build the security-critical remote execution boundary before exposing it through an API or job flow.

## What changed

- **`SshTransport`** over `asyncssh`, using the user's `~/.ssh/config` and `known_hosts`. Every command goes through `shlex.join` before the exec channel, so no argument can break out of its position — commands are never interpolated shell strings.
- **Actionable error mapping** for unknown host key, changed host key, passphrase-protected key with no agent, auth failure, and unreachable host. No raw exception text, hostname, or key path reaches the mapped message.
- **`sanitize_output`** strips `Cc`/`Cf` control and bidi-override characters and ESC-introduced sequences, then caps per-line and total length. Remote stdout/stderr is environment-influenced content, not trusted text.

## Two-tier preflight

The split exists so saving a server stays cheap while still being verified:

- **Tier 1** (cheap, save-gating): alias resolution, reachability, auth, host key, Docker, disk, driver, registry reachability via `HEAD`. Never touches an image. GPU occupancy is reported as a **non-blocking** warning — a busy GPU is transient and must not block editing a target.
- **Tier 2** (expensive, explicit): image resolve/pull, signature check, in-container device probe, protocol compatibility. The only path that can pull; Tier 1 never invokes it.

## Design notes

- Host-key verification is `asyncssh` against `known_hosts` — no TOFU, no pinning, no host-key column.
- XPU host detection is two probes (`xpu-smi`, else Intel render nodes); Tier 2's in-container `torch.xpu.is_available()` is authoritative.
- Nothing uses the transport yet; the API that calls it is #926.

---

**Plan:** [PR 3 — SSH transport, validation, and preflight primitives](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md#pr-3--ssh-transport-validation-and-preflight-primitives) · [backend plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-plan.md) · [full PR plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md)
