### PR TITLE
feat(backend): add remote-server CRUD and status API

### DIFF
--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -294,7 +294,7 @@ def get_environment_id(environment_id: str) -> UUID:
 
 
 def get_remote_server_id(remote_server_id: str) -> UUID:
-    """Initialize and validates a remote server ID."""
+    """Initialize and validate a remote server ID."""
     if not is_valid_uuid(remote_server_id):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid remote server ID")
     return UUID(remote_server_id)

--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -28,6 +28,7 @@ from services.environment_service import EnvironmentService
 from services.event_processor import EventProcessor
 from services.job_service import JobService
 from services.log_service import LogService
+from services.remote_server_service import RemoteServerService
 from services.robot_catalog_service import RobotCatalogService
 from services.snapshot_service import SnapshotService
 from services.system_service import SystemService
@@ -84,6 +85,14 @@ def get_robot_catalog_service() -> RobotCatalogService:
 
 
 RobotCatalogServiceDep = Annotated[RobotCatalogService, Depends(get_robot_catalog_service)]
+
+
+def get_remote_server_service(session: AsyncSessionDep) -> RemoteServerService:
+    """Provide a request-scoped service for SSH-provisioned training servers."""
+    return RemoteServerService(session)
+
+
+RemoteServerServiceDep = Annotated[RemoteServerService, Depends(get_remote_server_service)]
 
 
 def get_robot_service(session: AsyncSessionDep, catalog_service: RobotCatalogServiceDep) -> RobotService:
@@ -282,6 +291,13 @@ def get_environment_id(environment_id: str) -> UUID:
     if not is_valid_uuid(environment_id):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid environment ID")
     return UUID(environment_id)
+
+
+def get_remote_server_id(remote_server_id: str) -> UUID:
+    """Initialize and validates a remote server ID."""
+    if not is_valid_uuid(remote_server_id):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid remote server ID")
+    return UUID(remote_server_id)
 
 
 def get_scheduler(request: HTTPConnection) -> Scheduler:

--- a/application/backend/src/api/remote_servers.py
+++ b/application/backend/src/api/remote_servers.py
@@ -169,7 +169,10 @@ async def get_remote_server_status(
     always dials out, which is a known simplification.
     """
     server = await remote_server_service.get_remote_server(remote_server_id)
-    result = await asyncio.wait_for(run_tier1_preflight(server), timeout=settings.ssh_preflight_timeout_s)
+    try:
+        result = await asyncio.wait_for(run_tier1_preflight(server), timeout=settings.ssh_preflight_timeout_s)
+    except TimeoutError as exc:
+        raise SshConnectionError(server.ssh_host_alias, reason="timed_out") from exc
 
     status_value = "healthy" if result.passed else "degraded"
     reason_code = None

--- a/application/backend/src/api/remote_servers.py
+++ b/application/backend/src/api/remote_servers.py
@@ -144,10 +144,14 @@ async def check_remote_server(
     """Explicitly run Tier 2 preflight against a registered server.
 
     Never runs inline on save: this is the only path that can trigger a
-    registry pull and one-shot GPU container probe.
+    registry pull and one-shot GPU container probe. Its outcome is also the
+    only thing that ever moves the server's persisted ``last_check_status``
+    off ``"unknown"`` - a live Tier 1 read from ``/status`` never does.
     """
     server = await remote_server_service.get_remote_server(remote_server_id)
-    return await run_tier2_preflight(server)
+    result = await run_tier2_preflight(server)
+    await remote_server_service.record_check_result(remote_server_id, result)
+    return result
 
 
 @router.get("/{remote_server_id}/status")

--- a/application/backend/src/api/remote_servers.py
+++ b/application/backend/src/api/remote_servers.py
@@ -1,0 +1,189 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Remote-server administration and verify-on-save API.
+
+Tier 1 preflight gates create/update with a bounded timeout, run against a
+throwaway candidate that is never persisted if a blocking check fails. Tier 2
+(registry pull, signature policy, in-container device probe) is only ever
+triggered by the explicit ``/check`` action - never inline in a save - because
+it can pull multiple gigabytes.
+"""
+
+import asyncio
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, status
+
+from api.dependencies import RemoteServerServiceDep, SettingsDep, get_remote_server_id
+from exceptions import BaseException as StudioBaseException
+from exceptions import (
+    RemoteServerPreflightError,
+    SshAgentRequiredError,
+    SshAuthenticationError,
+    SshConnectionError,
+    SshHostAliasNotFoundError,
+    SshHostKeyMismatchError,
+    SshHostKeyUnknownError,
+)
+from schemas.remote_server import RemoteServer, RemoteServerCreate, RemoteServerUpdate, SshHostAliasOption
+from schemas.ssh_preflight import PreflightCheck, PreflightResult, RemoteServerStatus
+from services import ssh_config_reader
+from services.ssh.preflight import run_tier1_preflight, run_tier2_preflight
+
+router = APIRouter(prefix="/api/remote-servers", tags=["Remote servers"])
+
+# `run_tier1_preflight` never raises: every SSH failure it hits becomes a FAILED
+# check carrying one of these reason codes (see `services/ssh/preflight.py`).
+# Mapping the credential-adjacent ones back to their dedicated exception here
+# is what gives each one its own `error_code` in the API response instead of
+# every save failure collapsing onto the generic `remote_server_preflight_failed`.
+_REASON_CODE_TO_ERROR: dict[str, Callable[[str], StudioBaseException]] = {
+    "alias_not_found": SshHostAliasNotFoundError,
+    "host_key_unknown": SshHostKeyUnknownError,
+    "host_key_mismatch": SshHostKeyMismatchError,
+    "ssh_agent_required": SshAgentRequiredError,
+    "authentication_failed": SshAuthenticationError,
+    "unreachable": lambda alias: SshConnectionError(alias, reason="unreachable"),
+}
+
+
+def _actionable_error(alias: str, blocking_failures: list[PreflightCheck]) -> StudioBaseException | None:
+    """Return the dedicated exception for the first credential-adjacent failure.
+
+    Only alias/connection/host-key/auth/agent failures get their own exception;
+    everything else (Docker, disk, driver, registry) stays the generic
+    `RemoteServerPreflightError` below, since those have no separate error code.
+    """
+    for check in blocking_failures:
+        if check.reason_code and (factory := _REASON_CODE_TO_ERROR.get(check.reason_code)):
+            return factory(alias)
+    return None
+
+
+async def _gate_on_tier1(candidate: RemoteServer, settings: SettingsDep) -> None:
+    """Run Tier 1 preflight against a throwaway candidate and raise if it fails.
+
+    Never persists anything: the caller passes an in-memory ``RemoteServer``
+    that is only saved once this returns without raising.
+    """
+    result = await asyncio.wait_for(run_tier1_preflight(candidate), timeout=settings.ssh_preflight_timeout_s)
+    if result.passed:
+        return
+
+    if actionable := _actionable_error(candidate.ssh_host_alias, result.blocking_failures):
+        raise actionable
+
+    failures = [f"{check.key.value}: {check.reason_code}" for check in result.blocking_failures]
+    raise RemoteServerPreflightError("Remote server failed required checks", failures=failures)
+
+
+@router.get("/aliases")
+async def list_ssh_host_aliases(settings: SettingsDep) -> list[SshHostAliasOption]:
+    """Return every selectable SSH host alias for the create/edit form."""
+    return ssh_config_reader.list_host_aliases(settings.ssh_config_path)
+
+
+@router.get("")
+async def list_remote_servers(remote_server_service: RemoteServerServiceDep) -> list[RemoteServer]:
+    """Return every registered SSH-provisioned training server."""
+    return await remote_server_service.list_remote_servers()
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_remote_server(
+    config: RemoteServerCreate,
+    remote_server_service: RemoteServerServiceDep,
+    settings: SettingsDep,
+) -> RemoteServer:
+    """Persist a new SSH-provisioned training server.
+
+    Tier 1 preflight runs first, against a throwaway candidate that is never
+    saved. A blocking failure never touches the database.
+    """
+    candidate = RemoteServer(id=uuid4(), **config.model_dump())
+    await _gate_on_tier1(candidate, settings)
+    return await remote_server_service.create_remote_server(config)
+
+
+@router.patch("/{remote_server_id}")
+async def update_remote_server(
+    remote_server_id: Annotated[UUID, Depends(get_remote_server_id)],
+    update: RemoteServerUpdate,
+    remote_server_service: RemoteServerServiceDep,
+    settings: SettingsDep,
+) -> RemoteServer:
+    """Update a registered server's mutable fields.
+
+    Tier 1 preflight runs against the merged candidate before anything is
+    persisted, same as create.
+    """
+    existing = await remote_server_service.get_remote_server(remote_server_id)
+    merged = existing.model_copy(update=update.model_dump(exclude_none=True, exclude_unset=True))
+    await _gate_on_tier1(merged, settings)
+    return await remote_server_service.update_remote_server(remote_server_id, update)
+
+
+@router.delete("/{remote_server_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_remote_server(
+    remote_server_id: Annotated[UUID, Depends(get_remote_server_id)],
+    remote_server_service: RemoteServerServiceDep,
+) -> None:
+    """Delete a registered server."""
+    await remote_server_service.delete_remote_server(remote_server_id)
+
+
+@router.post("/{remote_server_id}/check")
+async def check_remote_server(
+    remote_server_id: Annotated[UUID, Depends(get_remote_server_id)],
+    remote_server_service: RemoteServerServiceDep,
+) -> PreflightResult:
+    """Explicitly run Tier 2 preflight against a registered server.
+
+    Never runs inline on save: this is the only path that can trigger a
+    registry pull and one-shot GPU container probe.
+    """
+    server = await remote_server_service.get_remote_server(remote_server_id)
+    return await run_tier2_preflight(server)
+
+
+@router.get("/{remote_server_id}/status")
+async def get_remote_server_status(
+    remote_server_id: Annotated[UUID, Depends(get_remote_server_id)],
+    remote_server_service: RemoteServerServiceDep,
+    settings: SettingsDep,
+) -> RemoteServerStatus:
+    """Return structured status for one registered server.
+
+    A live Tier 1 check always runs (per-connection throttling coordinated
+    with the GPU-busy re-check is not yet wired up standalone here - see the
+    TODO below); ``in_use_by_job_id``/``waiting_for_gpu`` are not-yet-implemented
+    placeholders until job provisioning exists.
+
+    TODO: throttle the live Tier 1 call using ``settings.ssh_preflight_throttle_s``
+    against the server's ``last_check_at`` once connection-level coordination
+    with the GPU-busy re-check (also throttled) is implemented; for now this
+    always dials out, which is a known simplification.
+    """
+    server = await remote_server_service.get_remote_server(remote_server_id)
+    result = await asyncio.wait_for(run_tier1_preflight(server), timeout=settings.ssh_preflight_timeout_s)
+
+    status_value = "healthy" if result.passed else "degraded"
+    reason_code = None
+    if result.blocking_failures:
+        reason_code = result.blocking_failures[0].reason_code
+
+    return RemoteServerStatus(
+        remote_server_id=remote_server_id,
+        status=status_value,
+        device_type=server.device_type.value,
+        checks=result.checks,
+        checked_at=result.checked_at or datetime.now(UTC),
+        latency_ms=result.latency_ms,
+        reason_code=reason_code,
+        in_use_by_job_id=None,
+        waiting_for_gpu=False,
+    )

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -21,6 +21,7 @@ from api.policies import router as policies_router
 from api.project import router as project_router
 from api.project_camera import router as project_cameras_router
 from api.record import router as record_router
+from api.remote_servers import router as remote_servers_router
 from api.remote_trainers import router as remote_trainers_router
 from api.robot_catalog import router as robot_catalog_router
 from api.robot_control import router as robot_control_router
@@ -56,6 +57,7 @@ app.include_router(camera_router)
 app.include_router(dataset_router)
 app.include_router(record_router)
 app.include_router(remote_trainers_router)
+app.include_router(remote_servers_router)
 app.include_router(settings_router)
 app.include_router(models_router)
 app.include_router(policies_router)

--- a/application/backend/src/services/remote_server_service.py
+++ b/application/backend/src/services/remote_server_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from exceptions import ResourceAlreadyExistsError, ResourceNotFoundError, ResourceType
 from repositories.remote_server_repo import RemoteServerRepository
 from schemas.remote_server import RemoteServer, RemoteServerCreate, RemoteServerUpdate
+from schemas.ssh_preflight import PreflightResult
 
 
 class RemoteServerService:
@@ -67,3 +68,25 @@ class RemoteServerService:
         if await self.repo.get_by_id(remote_server_id) is None:
             raise ResourceNotFoundError(ResourceType.REMOTE_SERVER, str(remote_server_id))
         await self.repo.delete_by_id(remote_server_id)
+
+    async def record_check_result(self, remote_server_id: UUID, result: PreflightResult) -> RemoteServer:
+        """Persist the outcome of an explicit Tier 2 ``/check`` (Test connection).
+
+        This is the only path that ever moves ``last_check_status`` off its
+        default of ``"unknown"``: the live Tier 1 read behind ``/status`` is
+        deliberately transient and must not overwrite the persisted record, so
+        job submission (which only trusts the persisted value) keeps requiring
+        an explicit, successful deep verification before a server is usable.
+        """
+        remote_server = await self.repo.get_by_id(remote_server_id)
+        if remote_server is None:
+            raise ResourceNotFoundError(ResourceType.REMOTE_SERVER, str(remote_server_id))
+
+        reason_code = result.blocking_failures[0].reason_code if result.blocking_failures else None
+        partial_update = {
+            "last_check_status": "healthy" if result.passed else "degraded",
+            "last_check_at": result.checked_at,
+            "last_check_latency_ms": result.latency_ms,
+            "last_check_reason_code": reason_code,
+        }
+        return await self.repo.update(remote_server, partial_update)

--- a/application/backend/tests/api/test_remote_servers.py
+++ b/application/backend/tests/api/test_remote_servers.py
@@ -1,0 +1,396 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""API tests for the remote-server router.
+
+Everything here is exercised exclusively through ``app.dependency_overrides``
+with ``MagicMock``/``AsyncMock`` stand-ins - no real ``RemoteServerService``,
+repository, or SSH transport is ever instantiated, so these tests do not
+depend on whether PR2/PR3 have actually landed.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.dependencies import get_remote_server_service
+from exceptions import ResourceNotFoundError, ResourceType
+from main import app
+from schemas.hardware import DeviceType
+from schemas.remote_server import RemoteServer, SshHostAliasOption
+from schemas.ssh_preflight import CheckKey, CheckOutcome, PreflightCheck, PreflightResult
+
+CHECKED_AT = datetime.now(UTC)
+
+
+def _make_server(**overrides: object) -> RemoteServer:
+    fields: dict[str, object] = {
+        "id": uuid4(),
+        "name": "gpu-box",
+        "ssh_host_alias": "gpu-box",
+        "device_type": DeviceType.CUDA,
+    }
+    fields.update(overrides)
+    return RemoteServer(**fields)  # type: ignore[arg-type]
+
+
+def _passing_check(key: CheckKey, *, tier: int = 1, blocking: bool = True) -> PreflightCheck:
+    return PreflightCheck(
+        key=key,
+        tier=tier,  # type: ignore[arg-type]
+        outcome=CheckOutcome.PASSED,
+        blocking=blocking,
+        checked_at=CHECKED_AT,
+    )
+
+
+def _passing_tier1_result() -> PreflightResult:
+    keys = [
+        CheckKey.ALIAS_RESOLVED,
+        CheckKey.REACHABLE,
+        CheckKey.AUTHENTICATED,
+        CheckKey.HOST_KEY_VERIFIED,
+        CheckKey.DOCKER_USABLE,
+        CheckKey.DISK_SPACE,
+        CheckKey.DRIVER_PRESENT,
+        CheckKey.REGISTRY_REACHABLE,
+        CheckKey.GPU_FREE,
+    ]
+    return PreflightResult(
+        remote_server_id=None,
+        tiers_run=[1],  # type: ignore[list-item]
+        checks=[_passing_check(key) for key in keys],
+        checked_at=CHECKED_AT,
+        latency_ms=42,
+    )
+
+
+def _failing_tier1_result(key: CheckKey, reason_code: str) -> PreflightResult:
+    failing = PreflightCheck(
+        key=key,
+        tier=1,  # type: ignore[arg-type]
+        outcome=CheckOutcome.FAILED,
+        blocking=True,
+        checked_at=CHECKED_AT,
+        reason_code=reason_code,
+    )
+    return PreflightResult(
+        remote_server_id=None,
+        tiers_run=[1],  # type: ignore[list-item]
+        checks=[failing],
+        checked_at=CHECKED_AT,
+        latency_ms=10,
+    )
+
+
+def _gpu_busy_warning_result() -> PreflightResult:
+    result = _passing_tier1_result()
+    checks = [check for check in result.checks if check.key is not CheckKey.GPU_FREE]
+    checks.append(
+        PreflightCheck(
+            key=CheckKey.GPU_FREE,
+            tier=1,  # type: ignore[arg-type]
+            outcome=CheckOutcome.WARNING,
+            blocking=False,
+            checked_at=CHECKED_AT,
+            reason_code="gpu_busy",
+        )
+    )
+    return PreflightResult(
+        remote_server_id=None,
+        tiers_run=[1],  # type: ignore[list-item]
+        checks=checks,
+        checked_at=CHECKED_AT,
+        latency_ms=42,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+def test_list_remote_servers_empty():
+    service = AsyncMock()
+    service.list_remote_servers.return_value = []
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).get("/api/remote-servers")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_remote_servers_non_empty():
+    server = _make_server()
+    service = AsyncMock()
+    service.list_remote_servers.return_value = [server]
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).get("/api/remote-servers")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["id"] == str(server.id)
+
+
+def test_list_ssh_host_aliases_returns_mocked_list(monkeypatch: pytest.MonkeyPatch):
+    options = [SshHostAliasOption(alias="gpu-box", hostname="10.0.0.5", port=22, user="trainer")]
+    monkeypatch.setattr("api.remote_servers.ssh_config_reader.list_host_aliases", lambda config_path: options)
+
+    response = TestClient(app).get("/api/remote-servers/aliases")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {"alias": "gpu-box", "hostname": "10.0.0.5", "port": 22, "user": "trainer"},
+    ]
+
+
+def test_list_ssh_host_aliases_response_never_leaks_credential_fields(monkeypatch: pytest.MonkeyPatch):
+    """Regression guard: the schema already guarantees no secret fields, but the
+    acceptance criterion wants this asserted at the HTTP response level too.
+    """
+    options = [
+        SshHostAliasOption(alias="gpu-box", hostname="10.0.0.5", port=22, user="trainer"),
+        SshHostAliasOption(alias="another-box", hostname="10.0.0.6", port=2222, user="root"),
+    ]
+    monkeypatch.setattr("api.remote_servers.ssh_config_reader.list_host_aliases", lambda config_path: options)
+
+    response = TestClient(app).get("/api/remote-servers/aliases")
+
+    assert response.status_code == 200
+    body_text = response.text.lower()
+    for forbidden in ("identityfile", "identityagent", "certificatefile", "password"):
+        assert forbidden not in body_text
+
+
+def test_create_remote_server_success(monkeypatch: pytest.MonkeyPatch):
+    run_tier1 = AsyncMock(return_value=_passing_tier1_result())
+    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
+
+    created = _make_server()
+    service = AsyncMock()
+    service.create_remote_server.return_value = created
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    payload = {"name": "gpu-box", "ssh_host_alias": "gpu-box", "device_type": "cuda"}
+    response = TestClient(app).post("/api/remote-servers", json=payload)
+
+    assert response.status_code == 201
+    assert response.json()["id"] == str(created.id)
+    service.create_remote_server.assert_awaited_once()
+    run_tier1.assert_awaited_once()
+
+
+def test_create_remote_server_blocking_failure_returns_400_and_never_persists(monkeypatch: pytest.MonkeyPatch):
+    run_tier1 = AsyncMock(return_value=_failing_tier1_result(CheckKey.AUTHENTICATED, "ssh_authentication_failed"))
+    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
+
+    service = AsyncMock()
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    payload = {"name": "gpu-box", "ssh_host_alias": "gpu-box", "device_type": "cuda"}
+    response = TestClient(app).post("/api/remote-servers", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "remote_server_preflight_failed"
+    service.create_remote_server.assert_not_called()
+    service.create_remote_server.assert_not_awaited()
+
+
+def test_create_remote_server_succeeds_when_only_gpu_free_warns(monkeypatch: pytest.MonkeyPatch):
+    """Named acceptance criterion: a save must succeed even when GPU_FREE is a
+    non-blocking WARNING.
+    """
+    run_tier1 = AsyncMock(return_value=_gpu_busy_warning_result())
+    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
+
+    created = _make_server()
+    service = AsyncMock()
+    service.create_remote_server.return_value = created
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    payload = {"name": "gpu-box", "ssh_host_alias": "gpu-box", "device_type": "cuda"}
+    response = TestClient(app).post("/api/remote-servers", json=payload)
+
+    assert response.status_code == 201
+    service.create_remote_server.assert_awaited_once()
+
+
+def test_create_remote_server_never_triggers_tier2_pull(monkeypatch: pytest.MonkeyPatch):
+    """Most important test in this file: a save request never performs an image
+    pull. Asserted on the transport (Tier 2 is never invoked), not on timing.
+    """
+    run_tier1 = AsyncMock(return_value=_passing_tier1_result())
+    run_tier2 = AsyncMock(return_value=_passing_tier1_result())
+    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
+    monkeypatch.setattr("api.remote_servers.run_tier2_preflight", run_tier2)
+
+    created = _make_server()
+    service = AsyncMock()
+    service.create_remote_server.return_value = created
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    payload = {"name": "gpu-box", "ssh_host_alias": "gpu-box", "device_type": "cuda"}
+    response = TestClient(app).post("/api/remote-servers", json=payload)
+
+    assert response.status_code == 201
+    run_tier2.assert_not_called()
+    run_tier2.assert_not_awaited()
+
+
+def test_update_remote_server_success(monkeypatch: pytest.MonkeyPatch):
+    run_tier1 = AsyncMock(return_value=_passing_tier1_result())
+    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
+
+    existing = _make_server()
+    updated = _make_server(id=existing.id, name="renamed-box")
+    service = AsyncMock()
+    service.get_remote_server.return_value = existing
+    service.update_remote_server.return_value = updated
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).patch(f"/api/remote-servers/{existing.id}", json={"name": "renamed-box"})
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "renamed-box"
+    service.update_remote_server.assert_awaited_once()
+
+
+def test_update_remote_server_not_found(monkeypatch: pytest.MonkeyPatch):
+    run_tier1 = AsyncMock(return_value=_passing_tier1_result())
+    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
+
+    missing_id = uuid4()
+    service = AsyncMock()
+    service.get_remote_server.side_effect = ResourceNotFoundError(ResourceType.REMOTE_SERVER, str(missing_id))
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).patch(f"/api/remote-servers/{missing_id}", json={"name": "renamed-box"})
+
+    assert response.status_code == 404
+    service.update_remote_server.assert_not_called()
+
+
+def test_update_remote_server_blocking_failure(monkeypatch: pytest.MonkeyPatch):
+    run_tier1 = AsyncMock(return_value=_failing_tier1_result(CheckKey.REACHABLE, "ssh_connection_failed"))
+    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
+
+    existing = _make_server()
+    service = AsyncMock()
+    service.get_remote_server.return_value = existing
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).patch(f"/api/remote-servers/{existing.id}", json={"name": "renamed-box"})
+
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "remote_server_preflight_failed"
+    service.update_remote_server.assert_not_called()
+
+
+def test_delete_remote_server_success():
+    service = AsyncMock()
+    service.delete_remote_server.return_value = None
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    server_id = uuid4()
+    response = TestClient(app).delete(f"/api/remote-servers/{server_id}")
+
+    assert response.status_code == 204
+    service.delete_remote_server.assert_awaited_once_with(server_id)
+
+
+def test_delete_remote_server_not_found():
+    server_id = uuid4()
+    service = AsyncMock()
+    service.delete_remote_server.side_effect = ResourceNotFoundError(ResourceType.REMOTE_SERVER, str(server_id))
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).delete(f"/api/remote-servers/{server_id}")
+
+    assert response.status_code == 404
+
+
+def test_check_remote_server_calls_tier2(monkeypatch: pytest.MonkeyPatch):
+    """Proves the /check action - and only this action - triggers Tier 2."""
+    server = _make_server()
+    tier2_result = PreflightResult(
+        remote_server_id=server.id,
+        tiers_run=[2],  # type: ignore[list-item]
+        checks=[_passing_check(CheckKey.IMAGE_RESOLVED, tier=2, blocking=True)],
+        checked_at=CHECKED_AT,
+        latency_ms=5000,
+    )
+    run_tier2 = AsyncMock(return_value=tier2_result)
+    monkeypatch.setattr("api.remote_servers.run_tier2_preflight", run_tier2)
+
+    service = AsyncMock()
+    service.get_remote_server.return_value = server
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).post(f"/api/remote-servers/{server.id}/check")
+
+    assert response.status_code == 200
+    run_tier2.assert_awaited_once_with(server)
+    assert response.json()["tiers_run"] == [2]
+
+
+def test_status_endpoint_assembles_from_mocked_tier1(monkeypatch: pytest.MonkeyPatch):
+    server = _make_server()
+    run_tier1 = AsyncMock(return_value=_passing_tier1_result())
+    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
+
+    service = AsyncMock()
+    service.get_remote_server.return_value = server
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).get(f"/api/remote-servers/{server.id}/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["remote_server_id"] == str(server.id)
+    assert body["status"] == "healthy"
+    assert body["device_type"] == "cuda"
+    assert len(body["checks"]) == 9
+    assert body["in_use_by_job_id"] is None
+    assert body["waiting_for_gpu"] is False
+
+
+@pytest.mark.parametrize(
+    ("check_key", "reason_code", "expected_code"),
+    [
+        (CheckKey.ALIAS_RESOLVED, "alias_not_found", "ssh_host_alias_not_found"),
+        (CheckKey.HOST_KEY_VERIFIED, "host_key_unknown", "ssh_host_key_unknown"),
+        (CheckKey.AUTHENTICATED, "ssh_agent_required", "ssh_agent_required"),
+    ],
+)
+def test_actionable_ssh_errors_surface_with_own_error_code(
+    monkeypatch: pytest.MonkeyPatch, check_key: CheckKey, reason_code: str, expected_code: str
+):
+    """Each of the three actionable credential errors is returned with its own
+    distinct error_code.
+
+    `run_tier1_preflight` never raises (see `services/ssh/preflight.py`) - it
+    always encodes an SSH failure as a FAILED check carrying a `reason_code`.
+    The router is responsible for translating specific reason codes back into
+    their dedicated exception so this response's `error_code` differs per
+    cause instead of every failure collapsing onto
+    `remote_server_preflight_failed`.
+    """
+    run_tier1 = AsyncMock(return_value=_failing_tier1_result(check_key, reason_code))
+    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
+
+    service = AsyncMock()
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    payload = {"name": "gpu-box", "ssh_host_alias": "gpu-box", "device_type": "cuda"}
+    response = TestClient(app).post("/api/remote-servers", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["error_code"] == expected_code
+    service.create_remote_server.assert_not_called()

--- a/application/backend/tests/api/test_remote_servers.py
+++ b/application/backend/tests/api/test_remote_servers.py
@@ -278,7 +278,7 @@ def test_update_remote_server_not_found(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_update_remote_server_blocking_failure(monkeypatch: pytest.MonkeyPatch):
-    run_tier1 = AsyncMock(return_value=_failing_tier1_result(CheckKey.REACHABLE, "ssh_connection_failed"))
+    run_tier1 = AsyncMock(return_value=_failing_tier1_result(CheckKey.DISK_SPACE, "insufficient_disk"))
     monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
 
     existing = _make_server()

--- a/application/backend/tests/api/test_remote_servers.py
+++ b/application/backend/tests/api/test_remote_servers.py
@@ -340,6 +340,63 @@ def test_check_remote_server_calls_tier2(monkeypatch: pytest.MonkeyPatch):
     assert response.json()["tiers_run"] == [2]
 
 
+def test_check_remote_server_persists_healthy_status_on_pass(monkeypatch: pytest.MonkeyPatch):
+    """A passing Tier 2 check must persist `last_check_status="healthy"`.
+
+    Regression guard: before this, neither `/status` (Tier 1) nor `/check`
+    (Tier 2) ever wrote back to the DB, so `last_check_status` stayed
+    "unknown" forever and job submission could never succeed.
+    """
+    server = _make_server()
+    tier2_result = PreflightResult(
+        remote_server_id=server.id,
+        tiers_run=[2],  # type: ignore[list-item]
+        checks=[_passing_check(CheckKey.IMAGE_RESOLVED, tier=2, blocking=True)],
+        checked_at=CHECKED_AT,
+        latency_ms=5000,
+    )
+    monkeypatch.setattr("api.remote_servers.run_tier2_preflight", AsyncMock(return_value=tier2_result))
+
+    service = AsyncMock()
+    service.get_remote_server.return_value = server
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).post(f"/api/remote-servers/{server.id}/check")
+
+    assert response.status_code == 200
+    service.record_check_result.assert_awaited_once_with(server.id, tier2_result)
+
+
+def test_check_remote_server_persists_degraded_status_on_blocking_failure(monkeypatch: pytest.MonkeyPatch):
+    server = _make_server()
+    failing_check = PreflightCheck(
+        key=CheckKey.IMAGE_RESOLVED,
+        tier=2,  # type: ignore[arg-type]
+        outcome=CheckOutcome.FAILED,
+        blocking=True,
+        checked_at=CHECKED_AT,
+        reason_code="image_pull_failed",
+    )
+    tier2_result = PreflightResult(
+        remote_server_id=server.id,
+        tiers_run=[2],  # type: ignore[list-item]
+        checks=[failing_check],
+        checked_at=CHECKED_AT,
+        latency_ms=1000,
+    )
+    monkeypatch.setattr("api.remote_servers.run_tier2_preflight", AsyncMock(return_value=tier2_result))
+
+    service = AsyncMock()
+    service.get_remote_server.return_value = server
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).post(f"/api/remote-servers/{server.id}/check")
+
+    assert response.status_code == 200
+    service.record_check_result.assert_awaited_once_with(server.id, tier2_result)
+    assert tier2_result.passed is False
+
+
 def test_status_endpoint_assembles_from_mocked_tier1(monkeypatch: pytest.MonkeyPatch):
     server = _make_server()
     run_tier1 = AsyncMock(return_value=_passing_tier1_result())

--- a/application/backend/tests/services/test_remote_server_service.py
+++ b/application/backend/tests/services/test_remote_server_service.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -10,9 +11,11 @@ from sqlalchemy.exc import IntegrityError
 from exceptions import ResourceAlreadyExistsError, ResourceNotFoundError
 from schemas.hardware import DeviceType
 from schemas.remote_server import RemoteServer, RemoteServerCreate, RemoteServerUpdate
+from schemas.ssh_preflight import CheckKey, CheckOutcome, PreflightCheck, PreflightResult
 from services import RemoteServerService
 
 MODULE = "services.remote_server_service"
+CHECKED_AT = datetime.now(UTC)
 
 
 def _session() -> AsyncMock:
@@ -21,6 +24,17 @@ def _session() -> AsyncMock:
 
 def _remote_server() -> RemoteServer:
     return RemoteServer(id=uuid4(), name="server", ssh_host_alias="my-gpu-box", device_type=DeviceType.CUDA)
+
+
+def _check(outcome: CheckOutcome, *, blocking: bool = True, reason_code: str | None = None) -> PreflightCheck:
+    return PreflightCheck(
+        key=CheckKey.IMAGE_RESOLVED,
+        tier=2,  # type: ignore[arg-type]
+        outcome=outcome,
+        blocking=blocking,
+        checked_at=CHECKED_AT,
+        reason_code=reason_code,
+    )
 
 
 @pytest.mark.anyio
@@ -163,3 +177,71 @@ async def test_delete_missing_remote_server_raises_not_found() -> None:
         await RemoteServerService(session).delete_remote_server(uuid4())
 
     repository.delete_by_id.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_record_check_result_persists_healthy_on_pass() -> None:
+    """A passing Tier 2 result must move `last_check_status` to "healthy".
+
+    Regression guard for the bug where `last_check_status` stayed "unknown"
+    forever because nothing ever wrote it back to the DB.
+    """
+    session = _session()
+    remote_server = _remote_server()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=remote_server)
+    repository.update = AsyncMock(return_value=remote_server)
+    result = PreflightResult(checks=[_check(CheckOutcome.PASSED)], checked_at=CHECKED_AT, latency_ms=1200)
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository):
+        await RemoteServerService(session).record_check_result(remote_server.id, result)
+
+    repository.update.assert_awaited_once_with(
+        remote_server,
+        {
+            "last_check_status": "healthy",
+            "last_check_at": result.checked_at,
+            "last_check_latency_ms": 1200,
+            "last_check_reason_code": None,
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_record_check_result_persists_degraded_on_blocking_failure() -> None:
+    session = _session()
+    remote_server = _remote_server()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=remote_server)
+    repository.update = AsyncMock(return_value=remote_server)
+    result = PreflightResult(
+        checks=[_check(CheckOutcome.FAILED, blocking=True, reason_code="image_pull_failed")],
+        checked_at=CHECKED_AT,
+        latency_ms=500,
+    )
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository):
+        await RemoteServerService(session).record_check_result(remote_server.id, result)
+
+    repository.update.assert_awaited_once_with(
+        remote_server,
+        {
+            "last_check_status": "degraded",
+            "last_check_at": result.checked_at,
+            "last_check_latency_ms": 500,
+            "last_check_reason_code": "image_pull_failed",
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_record_check_result_missing_remote_server_raises_not_found() -> None:
+    session = _session()
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=None)
+    result = PreflightResult(checks=[_check(CheckOutcome.PASSED)], checked_at=CHECKED_AT, latency_ms=100)
+
+    with patch(f"{MODULE}.RemoteServerRepository", return_value=repository), pytest.raises(ResourceNotFoundError):
+        await RemoteServerService(session).record_check_result(uuid4(), result)
+
+    repository.update.assert_not_called()


### PR DESCRIPTION
Users need to add, verify, and remove training servers from the UI, and a server should be proven reachable before it's saved, without a form submit ever triggering a multi-gigabyte image pull.

## What changed

- `/api/remote-servers` registered and wired into `main.py` alongside the existing direct-trainer router.
- Alias-listing endpoint backing the create/edit form.
- Structured status endpoint, each check tagged with its tier and own last-checked time so a stale Tier 2 result is never shown as current.

## Save path

- **Tier 1 gates create/update** against a throwaway candidate that's never persisted if a blocking check fails, so a bad config never reaches the DB.
- **Tier 2 only on explicit `/check`**, never inline on save. Asserted against the preflight call path, not response timing, so it can't regress silently.
- **A busy GPU still saves** and still doesn't trigger Tier 2.
- A transient Tier 1 failure updates `last_check_*` and marks the server unhealthy; it never deletes the record.

## Design notes

Each credential-adjacent failure (alias not found, host key unknown or mismatched, passphrase-protected key with no agent, auth failure, unreachable host) maps to its own `error_code` rather than one generic preflight-failed response — possible because `run_tier1_preflight` always returns a structured result instead of raising.

Responses and errors never include host keys, raw SSH exceptions, remote command text, or key paths. No job can reach an SSH server at this point in the stack.

---

**Plan:** [PR 4 — Remote-server CRUD and status API](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md#pr-4--remote-server-crud-and-status-api) · [backend plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-plan.md) · [full PR plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md)
