### PR TITLE
fix: reset selected episodes after delete

### DIFF
--- a/application/ui/src/features/datasets/episodes/use-episodes.ts
+++ b/application/ui/src/features/datasets/episodes/use-episodes.ts
@@ -29,7 +29,7 @@ export const useDeleteEpisodeQuery = (dataset_id: string) => {
     });
 
     const deleteEpisodes = (episodeIndices: number[]) => {
-        mutation.mutate({
+        return mutation.mutateAsync({
             params: {
                 path: {
                     dataset_id,

--- a/application/ui/src/routes/datasets/dataset-viewer.tsx
+++ b/application/ui/src/routes/datasets/dataset-viewer.tsx
@@ -20,6 +20,7 @@ import { useQuery } from '@tanstack/react-query';
 import { SchemaEpisode } from '../../api/openapi-spec';
 import { useDeleteEpisodeQuery } from '../../features/datasets/episodes/use-episodes';
 import { paths } from '../../router';
+import { pluralize } from '../../utils';
 import { ReactComponent as EmptyIllustration } from './../../assets/illustration.svg';
 import { useDataset } from './dataset-provider';
 import { EpisodeList } from './episode-list';
@@ -125,7 +126,7 @@ export const DatasetViewer = () => {
                                 isPrimaryActionDisabled={isPending}
                             >
                                 Are you sure you want to delete {selectedEpisodes.length} selected{' '}
-                                {selectedEpisodes.length === 1 ? 'episode' : 'episodes'}?
+                                {pluralize(selectedEpisodes.length, 'episode', 'episodes')}?
                             </AlertDialog>
                         </DialogTrigger>
                     </Flex>

--- a/application/ui/src/routes/datasets/dataset-viewer.tsx
+++ b/application/ui/src/routes/datasets/dataset-viewer.tsx
@@ -113,9 +113,11 @@ export const DatasetViewer = () => {
                                 <Delete fill='white' />
                             </ActionButton>
                             <AlertDialog
-                                onPrimaryAction={() => {
+                                onPrimaryAction={async () => {
+                                    const deletePromise = deleteEpisodes(selectedEpisodes);
                                     setSelectedEpisodes([]);
-                                    deleteEpisodes(selectedEpisodes);
+
+                                    await deletePromise;
                                 }}
                                 title='Delete episodes'
                                 variant='warning'

--- a/application/ui/src/routes/datasets/dataset-viewer.tsx
+++ b/application/ui/src/routes/datasets/dataset-viewer.tsx
@@ -68,7 +68,7 @@ export const DatasetViewer = () => {
             <Flex margin={'size-200'} direction={'column'} flex>
                 <IllustratedMessage>
                     <EmptyIllustration />
-                    <Content> Currently there are episodes. </Content>
+                    <Content>Currently there are no episodes.</Content>
                     <Text>It&apos;s time to begin recording a dataset. </Text>
                     <Heading>No episodes yet</Heading>
                     <View margin={'size-100'}>

--- a/application/ui/src/routes/datasets/dataset-viewer.tsx
+++ b/application/ui/src/routes/datasets/dataset-viewer.tsx
@@ -113,12 +113,17 @@ export const DatasetViewer = () => {
                                 <Delete fill='white' />
                             </ActionButton>
                             <AlertDialog
-                                onPrimaryAction={() => deleteEpisodes(selectedEpisodes)}
+                                onPrimaryAction={() => {
+                                    setSelectedEpisodes([]);
+                                    deleteEpisodes(selectedEpisodes);
+                                }}
                                 title='Delete episodes'
                                 variant='warning'
                                 primaryActionLabel='Delete'
+                                isPrimaryActionDisabled={isPending}
                             >
-                                Are you sure you want to delete the selected episodes?
+                                Are you sure you want to delete {selectedEpisodes.length} selected{' '}
+                                {selectedEpisodes.length === 1 ? 'episode' : 'episodes'}?
                             </AlertDialog>
                         </DialogTrigger>
                     </Flex>

--- a/application/ui/src/utils.ts
+++ b/application/ui/src/utils.ts
@@ -8,3 +8,8 @@ export const toMMSS = (timeInSeconds: number): string => {
     const seconds = Math.floor(timeInSeconds % 60);
     return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
 };
+
+const pluralRules = new Intl.PluralRules('en');
+
+export const pluralize = (count: number, singular: string, plural: string): string =>
+    pluralRules.select(count) === 'one' ? singular : plural;


### PR DESCRIPTION
Fixes #916 and improves general UX when deleting episodes from a dataset:
- clarify how many episodes will get deleted
- fix typo in empty episodes
- reset selected episodes after deleting them, and wait for deletion to finish

The last item is important as episodes are referenced by episode index, so not resetting this meant that the user might accidentally delete other episodes if they click delete twice.