### PR TITLE
fix(ui): preserve video offsets while seeking

### DIFF
--- a/application/ui/src/features/datasets/episodes/episode-video-cell.component.tsx
+++ b/application/ui/src/features/datasets/episodes/episode-video-cell.component.tsx
@@ -39,13 +39,15 @@ export const EpisodeVideoCell = ({
 
     useEffect(() => {
         const video = videoRef.current;
-        if (video && player.isSeeking) {
+        const start = episodeVideo.start;
+
+        if (video && player.isSeeking && Number.isFinite(start)) {
             const interval = setInterval(() => {
-                video.currentTime = player.timeRef.current;
+                video.currentTime = player.timeRef.current + start;
             }, 1000 / 60);
             return () => clearInterval(interval);
         }
-    }, [player, videoRef]);
+    }, [player, episodeVideo.start]);
 
     const { containerRef, width, height } = useFittedMediaSize(
         videoRef.current?.videoWidth,

--- a/application/ui/src/features/datasets/episodes/use-player.ts
+++ b/application/ui/src/features/datasets/episodes/use-player.ts
@@ -49,6 +49,8 @@ export const usePlayer = (episode: SchemaEpisode): Player => {
     const seek = (newTime: number) => {
         setTimeSynced(newTime);
         setState(PlayState.Seeking);
+
+        requestAnimationFrame(() => setState(PlayState.Paused));
     };
 
     useEffect(() => {


### PR DESCRIPTION
Previously if the user has a dataset with multiple cameras and selected say episode 20 then seeking in the timeline would make it that the UI shows the first episode in all but the first episode. So if you'd have 3 cameras then the 2nd and 3rd would show the first episode of the dataset.

Playing the episodes was working though.

The reason for this bug is that internally multiple episodes are stored as a single video file. Viewing say the second episode in a dataset means you open the first video in the dataset and play it with an offset (equal to the length of the first episode).