### PR TITLE
ci: Split docker builds across runner types

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -82,7 +82,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        device: [cpu, xpu, cuda]
+        include:
+          # CPU and XPU build on GitHub-hosted runners
+          - device: cpu
+            runner: ubuntu-latest
+          - device: xpu
+            runner: ubuntu-latest
+          # CUDA usually needs more disk space
+          - device: cuda
+            runner: [self-hosted, linux, x64]
 
     steps:
       - *harden-runner

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -73,7 +73,7 @@ jobs:
     name: Build (${{ matrix.device }})
     needs: check-paths
     if: needs.check-paths.outputs.run_workflow == 'true'
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read # Checkout code
       packages: write # Push/pull registry build cache on GHCR
@@ -85,10 +85,10 @@ jobs:
         include:
           # CPU and XPU build on GitHub-hosted runners
           - device: cpu
-            runner: ubuntu-latest
+            runner: [ubuntu-latest]
           - device: xpu
-            runner: ubuntu-latest
-          # CUDA usually needs more disk space
+            runner: [ubuntu-latest]
+          # CUDA needs GPU hardware for the smoke test
           - device: cuda
             runner: [self-hosted, linux, x64]
 


### PR DESCRIPTION
## Description

Build CPU, XPU based docker images at GH provided runners in order to speed up merge queue

## Related Issues

One step forward to resolve #931 
