### PR TITLE
Expand ~ in TRAINER_STORAGE_DIR

### DIFF
--- a/application/backend/src/trainer/settings.py
+++ b/application/backend/src/trainer/settings.py
@@ -6,7 +6,7 @@
 from functools import lru_cache
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -24,6 +24,20 @@ class TrainerSettings(BaseSettings):
     storage_dir: Path = Field(
         default=Path("~/.local/share/physicalai-trainer").expanduser(), alias="TRAINER_STORAGE_DIR"
     )
+
+    @field_validator("storage_dir", mode="before")
+    @classmethod
+    def expand_storage_dir(cls, value: Path | str) -> Path:
+        """Expand user-provided storage directories like ~/.local/share.
+
+        Field(default=...expanduser()) only expands the *default* value;
+        a value actually supplied via TRAINER_STORAGE_DIR (env var or
+        .env file) bypasses that and is parsed into a Path as-is, so a
+        literal "~" segment was never expanded. Matches the equivalent
+        validator on the studio Settings.storage_dir field.
+        """
+        return Path(value).expanduser()
+
     # Concurrency cap for the queue worker. Defaults to a single GPU job.
     max_concurrent_jobs: int = Field(default=1, ge=1, le=8, alias="TRAINER_MAX_CONCURRENT_JOBS")
 

--- a/application/backend/tests/trainer/test_settings.py
+++ b/application/backend/tests/trainer/test_settings.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for trainer service settings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from trainer.settings import TrainerSettings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_default_storage_dir_is_expanded() -> None:
+    settings = TrainerSettings()
+
+    assert "~" not in str(settings.storage_dir)
+    assert settings.storage_dir.is_absolute()
+
+
+def test_storage_dir_override_expands_user(monkeypatch, tmp_path: Path) -> None:
+    """
+    Regression test: TRAINER_STORAGE_DIR=~/... previously reflected as a
+    literal "~" path segment (Field(default=...expanduser()) only expands
+    the default, not a value actually supplied via the env var/.env file),
+    so downstream directories derived from it (datasets_dir, models_dir,
+    etc.) never resolved to the real home directory.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    settings = TrainerSettings(TRAINER_STORAGE_DIR="~/custom-trainer-storage")
+
+    assert settings.storage_dir == tmp_path / "custom-trainer-storage"
+    assert "~" not in str(settings.storage_dir)
+
+
+def test_storage_dir_override_absolute_path_unaffected(tmp_path: Path) -> None:
+    custom = tmp_path / "already-absolute"
+
+    settings = TrainerSettings(TRAINER_STORAGE_DIR=str(custom))
+
+    assert settings.storage_dir == custom
+
+
+def test_datasets_dir_derives_from_expanded_storage_dir(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    settings = TrainerSettings(TRAINER_STORAGE_DIR="~/custom-trainer-storage")
+
+    assert settings.datasets_dir == tmp_path / "custom-trainer-storage" / "datasets"


### PR DESCRIPTION
Closes #941.

`TrainerSettings.storage_dir` used `Field(default=Path("~/.local/share/physicalai-trainer").expanduser(), alias="TRAINER_STORAGE_DIR")`. `Field(default=...)` only expands the *default* value -- a value actually supplied via `TRAINER_STORAGE_DIR` (env var or `.env` file) bypasses the default entirely and is parsed into a `Path` as-is, so a literal `~` segment was never expanded. Every directory derived from `storage_dir` (`datasets_dir`, `models_dir`, `archives_dir`, `db_path`) inherited the unexpanded path, so files written under the real home directory couldn't be found there -- matching the issue's reported symptom exactly.

The studio's `Settings.storage_dir` field already solves this with a `field_validator(mode="before")` that expands every incoming value, not just the default. This PR adds the same validator to `TrainerSettings`, matching the existing pattern for consistency.

**Testing**

Added `application/backend/tests/trainer/test_settings.py`:
- `test_default_storage_dir_is_expanded` -- default still expands correctly.
- `test_storage_dir_override_expands_user` -- regression test for this issue; `TRAINER_STORAGE_DIR=~/custom-trainer-storage` now expands to the real home directory (previously reflected as a literal `PosixPath('~/custom-trainer-storage')`).
- `test_storage_dir_override_absolute_path_unaffected` -- already-absolute overrides are untouched.
- `test_datasets_dir_derives_from_expanded_storage_dir` -- derived paths correctly use the expanded value.

All 4 pass with the fix; reverting the validator makes 2 of the 4 fail with the literal-tilde symptom described in the issue. `ruff check` is clean on both changed files.