### PR TITLE
fix: Remote training/training improvements

### DIFF
--- a/application/backend/src/services/remote_trainer_service.py
+++ b/application/backend/src/services/remote_trainer_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime
 from time import perf_counter
 from uuid import UUID, uuid4
@@ -20,6 +21,14 @@ from schemas.remote_trainer import (
 
 _HEALTH_CHECK_TIMEOUT_S = 5.0
 
+# RemoteTrainerService is instantiated fresh per request (see
+# api.dependencies.get_remote_trainer_service), so an instance-level cache
+# can't prevent concurrent requests for the same trainer (multiple browser
+# tabs/components polling at once) from each issuing their own /health,
+# /devices, /storage round trip. Coalesce those into one in-flight probe per
+# trainer, shared across requests via this module-level table.
+_inflight_checks: dict[UUID, asyncio.Task[RemoteTrainerHealth]] = {}
+
 
 class RemoteTrainerService:
     """Manage global direct remote trainer endpoint configurations."""
@@ -40,8 +49,29 @@ class RemoteTrainerService:
         return remote_trainer
 
     async def check_remote_trainer(self, remote_trainer_id: UUID) -> RemoteTrainerHealth:
-        """Check a configured trainer's liveness and available compute devices."""
+        """Check a configured trainer's liveness and available compute devices.
+
+        Concurrent callers (multiple browser tabs, or the trainers table and a
+        training dialog both polling the same trainer) share one in-flight
+        probe instead of each triggering their own /health, /devices,
+        /storage round trip against the trainer.
+        """
         remote_trainer = await self.get_remote_trainer(remote_trainer_id)
+        task = _inflight_checks.get(remote_trainer_id)
+        if task is None:
+            task = asyncio.ensure_future(self._probe_remote_trainer(remote_trainer_id, remote_trainer))
+            _inflight_checks[remote_trainer_id] = task
+
+            def _clear_inflight(done: asyncio.Task[RemoteTrainerHealth], trainer_id: UUID = remote_trainer_id) -> None:
+                if _inflight_checks.get(trainer_id) is done:
+                    del _inflight_checks[trainer_id]
+
+            task.add_done_callback(_clear_inflight)
+        return await task
+
+    @staticmethod
+    async def _probe_remote_trainer(remote_trainer_id: UUID, remote_trainer: RemoteTrainer) -> RemoteTrainerHealth:
+        """Probe a trainer's /health, /devices, /storage once and build its health report."""
         checked_at = datetime.now(UTC)
         started = perf_counter()
         base_url = str(remote_trainer.url).rstrip("/")
@@ -69,7 +99,7 @@ class RemoteTrainerService:
                         devices = [
                             device for device in validated_devices if device.type in {DeviceType.XPU, DeviceType.CUDA}
                         ]
-                        storage = await self._fetch_storage(client, base_url)
+                        storage = await RemoteTrainerService._fetch_storage(client, base_url)
         except httpx.TimeoutException:
             status, reason_code = "unreachable", "timeout"
         except httpx.HTTPStatusError:

--- a/application/backend/src/services/training_backends/base.py
+++ b/application/backend/src/services/training_backends/base.py
@@ -62,7 +62,11 @@ class TrainingContext:
     ``on_remote_job_id`` is awaited once a fresh remote job id is known so the
     caller can persist it for restart recovery. ``should_suspend`` distinguishes
     an application shutdown (leave the remote job running) from a user
-    cancellation (cancel the remote job).
+    cancellation (cancel the remote job). ``should_cancel_job`` reports whether
+    *this specific job* was canceled by the user, independent of a concurrent
+    application shutdown; a backend must check it before ``should_suspend`` so
+    a user cancellation that happens to overlap with shutdown still cancels
+    the remote job instead of being left running for reattach.
     """
 
     job: Job
@@ -77,6 +81,7 @@ class TrainingContext:
     remote_job_id: UUID | None = None
     on_remote_job_id: Callable[[UUID], Awaitable[None]] | None = None
     should_suspend: Callable[[], bool] = field(default=lambda: False)
+    should_cancel_job: Callable[[], bool] = field(default=lambda: False)
 
 
 @runtime_checkable

--- a/application/backend/src/services/training_backends/remote.py
+++ b/application/backend/src/services/training_backends/remote.py
@@ -500,11 +500,14 @@ class RemoteTrainingBackend:
             message=state.get("message"),
             extra_info=extra_info,
         )
-        if extra_info is not None:
-            line = render_progress_log(extra_info)
-            if line is not None and line != self._last_progress_log:
-                self._log.info(line)
-                self._last_progress_log = line
+        line = render_progress_log(extra_info) if extra_info else None
+        if line is None:
+            message = state.get("message")
+            if isinstance(message, str) and message:
+                line = message
+        if line is not None and line != self._last_progress_log:
+            self._log.info(line)
+            self._last_progress_log = line
 
         if status in _TERMINAL_STATES:
             if status == "completed":

--- a/application/backend/src/services/training_backends/remote.py
+++ b/application/backend/src/services/training_backends/remote.py
@@ -663,7 +663,17 @@ class RemoteTrainingBackend:
         archive.extract_to(output_dir, min_free_bytes=min_free_bytes)
 
     async def _handle_stop_request(self, context: TrainingContext, remote_job_id: uuid.UUID) -> None:
-        """Suspend on shutdown; cancel the remote job for a user stop request."""
+        """Cancel on a user stop request; suspend on shutdown.
+
+        Checked in this order because ``should_stop`` is a combined signal (user
+        cancel OR app shutdown): a user cancellation must win even when a backend
+        shutdown happens to be in flight at the same time, otherwise the job the
+        user explicitly stopped is left running on the trainer and gets silently
+        reattached to on the next startup.
+        """
+        if context.should_cancel_job():
+            await self._cancel(remote_job_id)
+            raise TrainingCanceledError("Training canceled")
         if context.should_suspend():
             raise TrainingSuspendedError("Studio shutting down; leaving remote training job running for reattach")
         await self._cancel(remote_job_id)

--- a/application/backend/src/trainer/runner.py
+++ b/application/backend/src/trainer/runner.py
@@ -55,8 +55,7 @@ class TrainerRunner:
         finally:
             self._cleanup_uploaded_dataset(job_id)
 
-        report(100, "Archiving model", None)
-        return self._archive_model(job_id, model_dir)
+        return self._archive_model(job_id, model_dir, report=report)
 
     @staticmethod
     def _cleanup_uploaded_dataset(job_id: str) -> None:
@@ -112,12 +111,25 @@ class TrainerRunner:
             raise JobCanceledError(msg)
 
     @staticmethod
-    def _archive_model(job_id: str, model_dir: Path) -> Path:
+    def _archive_model(job_id: str, model_dir: Path, *, report: ProgressFn) -> Path:
+        """Zip the model directory, reporting progress as each file is added.
+
+        Uses ``ZIP_STORED`` (no compression) rather than ``ZIP_DEFLATED``:
+        checkpoints and exported weights (float32/bf16 tensors, ONNX/OpenVINO
+        artifacts) barely compress, so DEFLATE burns single-threaded CPU time
+        for negligible size savings — for a large multi-backend export (e.g. a
+        VLA policy exporting torch + ONNX + OpenVINO) that can turn a
+        multi-minute step into tens of minutes with no visible progress.
+        """
         archives_dir = get_settings().archives_dir
         archives_dir.mkdir(parents=True, exist_ok=True)
         archive_path = archives_dir / f"{job_id}.zip"
-        with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
-            for path in model_dir.rglob("*"):
-                if path.is_file():
-                    archive.write(path, arcname=path.relative_to(model_dir))
+
+        files = [path for path in model_dir.rglob("*") if path.is_file()]
+        total = len(files) or 1
+        with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_STORED) as archive:
+            for index, path in enumerate(files, start=1):
+                archive.write(path, arcname=path.relative_to(model_dir))
+                report(100, f"Archiving model ({index}/{total})", None)
+
         return archive_path

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -207,6 +207,7 @@ class TrainingWorker(BaseProcessWorker):
                 remote_job_id=payload.remote_job_id,
                 on_remote_job_id=lambda remote_job_id: self._persist_remote_job_id(job, payload, remote_job_id),
                 should_suspend=self.should_stop,
+                should_cancel_job=lambda: bool(self.job_interrupt_flags.get(str(job.id), False)),
             )
 
             backend = get_training_backend(payload)

--- a/application/backend/tests/services/test_remote_trainer_health.py
+++ b/application/backend/tests/services/test_remote_trainer_health.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Self
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -132,3 +133,47 @@ async def test_check_remote_trainer_reports_malformed_devices_as_degraded() -> N
 
     assert result.status == "degraded"
     assert result.reason_code == "invalid_devices_response"
+
+
+@pytest.mark.anyio
+async def test_check_remote_trainer_coalesces_concurrent_calls() -> None:
+    """Two callers checking the same trainer at once must trigger only one probe."""
+    trainer = _trainer()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    class _SlowClient(_Client):
+        async def get(self, _url: str) -> _Response:
+            nonlocal call_count
+            if _url.endswith("/health"):
+                call_count += 1
+                started.set()
+                await release.wait()
+            return await super().get(_url)
+
+    client = _SlowClient(
+        [
+            _Response({"status": "healthy"}),
+            _Response([{"type": "cuda", "name": "NVIDIA A100", "memory": None, "index": 0}]),
+            _Response({"total_bytes": 1, "free_bytes": 1}),
+        ]
+    )
+
+    with (
+        patch.object(RemoteTrainerService, "get_remote_trainer", new=AsyncMock(return_value=trainer)),
+        patch(f"{MODULE}.httpx.AsyncClient", return_value=client) as async_client,
+    ):
+        service_a = RemoteTrainerService(MagicMock())
+        service_b = RemoteTrainerService(MagicMock())
+
+        task_a = asyncio.create_task(service_a.check_remote_trainer(trainer.id))
+        await started.wait()
+        task_b = asyncio.create_task(service_b.check_remote_trainer(trainer.id))
+        release.set()
+
+        result_a, result_b = await asyncio.gather(task_a, task_b)
+
+    assert call_count == 1
+    assert async_client.call_count == 1
+    assert result_a == result_b

--- a/application/backend/tests/services/test_remote_training_backend.py
+++ b/application/backend/tests/services/test_remote_training_backend.py
@@ -211,7 +211,13 @@ def _settings() -> MagicMock:
     return settings
 
 
-def _context(tmp_path: Path, *, should_stop: bool = False, remote_job_id: UUID | None = None) -> TrainingContext:
+def _context(
+    tmp_path: Path,
+    *,
+    should_stop: bool = False,
+    remote_job_id: UUID | None = None,
+    should_cancel_job: bool = False,
+) -> TrainingContext:
     snap = tmp_path / "snap"
     snap.mkdir()
     # A file in the snapshot dir gives the ZIP archive real bytes to stream.
@@ -241,6 +247,7 @@ def _context(tmp_path: Path, *, should_stop: bool = False, remote_job_id: UUID |
         progress=MagicMock(),
         should_stop=lambda: should_stop,
         remote_job_id=remote_job_id,
+        should_cancel_job=lambda: should_cancel_job,
     )
 
 
@@ -888,8 +895,38 @@ class TestModelDownloadCancellation:
 
         assert controller.cancelled is False
 
+    @pytest.mark.anyio
+    async def test_user_cancel_racing_shutdown_still_cancels_remote_job(self, tmp_path):
+        """A user cancel that overlaps a concurrent app shutdown must still cancel, not suspend.
 
-class TestSnapshotUploadHeartbeat:
+        Regression guard: stopping a job and then stopping the backend "soon
+        after" can make ``should_suspend`` true (app shutting down) at the same
+        moment the user's own interrupt made ``should_stop`` true. Suspend must
+        not win here, or the "canceled" job is left running on the trainer and
+        gets silently reattached to on the next startup.
+        """
+        from services.training_backends.base import TrainingCanceledError
+
+        settings = _settings()
+        context = _context(tmp_path, should_stop=True, should_cancel_job=True)
+        # A shutdown is *also* in flight at the same moment, but the user's own
+        # cancel of this specific job must take priority.
+        context.should_suspend = lambda: True
+        controller = _Controller(states=[])
+        controller.artifact_chunks = [b"a" * 500, b"b" * 500]
+        controller.artifact_headers = {"content-length": "1000"}
+        stream_timeout = httpx.Timeout(5.0)
+
+        with (
+            patch(f"{REMOTE}.get_settings", return_value=settings),
+            patch(f"{REMOTE}.httpx.AsyncClient", lambda **kw: _FakeClient(controller, **kw)),
+        ):
+            backend = _backend(settings)
+            with pytest.raises(TrainingCanceledError):
+                await backend._stream_archive(context, controller.remote_job_id, tmp_path / "model.zip", stream_timeout)
+
+        assert controller.cancelled is True
+
     """The HTTP upload loop emits throttled byte heartbeats for large snapshots."""
 
     @pytest.mark.anyio

--- a/application/backend/tests/services/test_training_log_format.py
+++ b/application/backend/tests/services/test_training_log_format.py
@@ -139,6 +139,52 @@ def test_apply_state_mirrors_validation_fields_to_job_log() -> None:
     bound_logger.info.assert_called_once_with("Validation progress: batch=1, val/loss_step=0.3")
 
 
+def test_apply_state_falls_back_to_plain_message_when_not_cadence() -> None:
+    """Export/archiving progress carries only a message; it must still be logged.
+
+    Otherwise these long-running steps leave a silent gap in the job log
+    between the last training/validation line and job completion.
+    """
+    context = MagicMock()
+    state = {
+        "status": "running",
+        "progress": 99,
+        "message": "Exporting to onnx format",
+        "extra_info": {},
+    }
+    backend = _backend()
+    with patch.object(backend, "_log") as bound_logger:
+        completed = backend._apply_state(context, state)
+    assert completed is False
+    bound_logger.info.assert_called_once_with("Exporting to onnx format")
+
+
+def test_apply_state_falls_back_to_plain_message_with_no_extra_info() -> None:
+    """Archiving progress reports a message with no extra_info at all."""
+    context = MagicMock()
+    state = {
+        "status": "running",
+        "progress": 100,
+        "message": "Archiving model (3/10)",
+        "extra_info": None,
+    }
+    backend = _backend()
+    with patch.object(backend, "_log") as bound_logger:
+        backend._apply_state(context, state)
+    bound_logger.info.assert_called_once_with("Archiving model (3/10)")
+
+
+def test_apply_state_dedupes_repeated_plain_messages() -> None:
+    """Re-emitted identical messages (e.g. slow trainer polling) log only once."""
+    context = MagicMock()
+    state = {"status": "running", "progress": 99, "message": "Training model", "extra_info": {}}
+    backend = _backend()
+    with patch.object(backend, "_log") as bound_logger:
+        backend._apply_state(context, dict(state))
+        backend._apply_state(context, dict(state))
+    bound_logger.info.assert_called_once_with("Training model")
+
+
 def test_apply_state_suppresses_duplicate_progress_lines() -> None:
     """Re-emitted identical progress (e.g. during export) is logged only once."""
     context = MagicMock()

--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -6,7 +6,7 @@
 import inspect
 import logging
 import tempfile
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from os import PathLike
 from pathlib import Path
@@ -46,28 +46,43 @@ DATASET_STATS_KEY = "dataset_stats"
 # Their warnings and errors still matter, so only INFO and below is suppressed.
 _VERBOSE_ONNX_EXPORT_LOGGERS = ("onnxscript", "onnx_ir")
 
+# openvino.convert_model() probes a string/Path input against several PyTorch
+# loaders (torch.jit.load, then torch.export.load) before falling back to its
+# ONNX frontend. When the input is actually a plain ONNX file (our via_onnx
+# OpenVINO export path), the torch.export.load() probe always fails and torch
+# logs it at WARNING with a full traceback (exc_info=True), even though the
+# RuntimeError is caught internally by both torch and OpenVINO and is harmless.
+_ONNX_PROBE_NOISE_LOGGERS = ("torch.export",)
+
 
 @contextmanager
-def _quiet_onnx_export_logs() -> Generator[None, None, None]:
-    """Raise the ONNX exporter loggers to WARNING for the duration of the block.
+def _quiet_loggers(names: Iterable[str], level: int = logging.WARNING) -> Generator[None, None, None]:
+    """Raise the given loggers to `level` for the duration of the block.
 
     Usable as either a context manager or a decorator. Loggers that already sit
-    at WARNING or above (for example because the caller configured them
+    at `level` or above (for example because the caller configured them
     explicitly) are left untouched, and every level is restored on exit even if
-    the export raises.
+    the block raises.
     """
     restore: list[tuple[logging.Logger, int]] = []
-    for name in _VERBOSE_ONNX_EXPORT_LOGGERS:
-        onnx_logger = logging.getLogger(name)
-        if onnx_logger.getEffectiveLevel() >= logging.WARNING:
+    for name in names:
+        target_logger = logging.getLogger(name)
+        if target_logger.getEffectiveLevel() >= level:
             continue
-        restore.append((onnx_logger, onnx_logger.level))
-        onnx_logger.setLevel(logging.WARNING)
+        restore.append((target_logger, target_logger.level))
+        target_logger.setLevel(level)
     try:
         yield
     finally:
-        for onnx_logger, level in restore:
-            onnx_logger.setLevel(level)
+        for target_logger, restored_level in restore:
+            target_logger.setLevel(restored_level)
+
+
+@contextmanager
+def _quiet_onnx_export_logs() -> Generator[None, None, None]:
+    """Raise the ONNX exporter loggers to WARNING for the duration of the block."""
+    with _quiet_loggers(_VERBOSE_ONNX_EXPORT_LOGGERS):
+        yield
 
 
 class ExportablePolicyMixin:
@@ -480,11 +495,12 @@ class ExportablePolicyMixin:
                         arg_name=arg_name,
                         **extra_export_kwargs,
                     )
-                    ov_model = openvino.convert_model(
-                        tmp.name,
-                        example_input={arg_name: input_sample},
-                        input=input_shapes,
-                    )
+                    with _quiet_loggers(_ONNX_PROBE_NOISE_LOGGERS, level=logging.ERROR):
+                        ov_model = openvino.convert_model(
+                            tmp.name,
+                            example_input={arg_name: input_sample},
+                            input=input_shapes,
+                        )
             else:
                 ov_model = openvino.convert_model(
                     self.model,


### PR DESCRIPTION
## Description

This PR contains several smaller fixes:

- Suppresses harmless runtime error caught during export of pi05 model `RuntimeError: PytorchStreamReader failed reading zip archive: failed finding central directory. This is an internal miniz error. If you are seeing this error, there is a high likelihood that your checkpoint file is corrupted. This can happen if the checkpoint was not saved properly, was transferred incorrectly, or the file was modified after saving.`
- Consolidate health check probes in the backend. The UI can fire multiple concurrent checks from independent hooks.
- Do not compress model zips. This takes tens of minutes for pi05 models while the compression is basically 0 for model files. Using no compressions cuts this whole process down to less than a minute. 
- Fix a race where stopping a remote training job right before stopping the backend could raise TrainingSuspendedError instead of TrainingCanceledError, leaving the remote job running and causing it to be silently reattached to on the next backend startup.
- Add extra logs for exporting/archiving of models 
