### PR TITLE
ci: Use cleanup images v0.1.1

### DIFF
--- a/.github/workflows/cleanup-old-app-images.yml
+++ b/.github/workflows/cleanup-old-app-images.yml
@@ -56,7 +56,7 @@ jobs:
           egress-policy: audit
 
       - name: Cleanup old container images
-        uses: open-edge-platform/geti-ci/actions/cleanup-images@287abbfdced5c02904ab2f39a0fe944cd402c36f # cleanup-images/v0.1.0
+        uses: open-edge-platform/geti-ci/actions/cleanup-images@164479fa1091ae69e1fa7c2be65eaecdf7f3cf66 # cleanup-images/v0.1.1
         with:
           packages: |
             physical-ai-studio-cpu

--- a/.github/workflows/cleanup-old-app-images.yml
+++ b/.github/workflows/cleanup-old-app-images.yml
@@ -65,4 +65,5 @@ jobs:
             physicalai-trainer-xpu
             physicalai-trainer-cuda
           min-versions-to-keep: ${{ github.event_name == 'workflow_dispatch' && inputs.min_versions_to_keep || 10 }}
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+          # Scheduled runs delete for real; manual dispatch previews by default.
+          dry-run: ${{ github.event_name != 'schedule' && inputs.dry_run && 'true' || 'false' }}


### PR DESCRIPTION
## Description

Addressing the issue with deleting untagged child images which belong to protected tags like vX.Y.XrcN

Use updated cleanup-images v0.1.1 action from geti-ci. Explicitly run deletion of images in real (non dry run) mode when scheduled.