### PR TITLE
fix: harden identification of so101

### DIFF
--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -282,3 +282,19 @@ class SharedRobotTransportError(BaseException):
             error_code="robot_transport_error",
             http_status=http.HTTPStatus.BAD_REQUEST,
         )
+
+
+class RobotIdentifyError(BaseException):
+    """Raised when visually identifying a robot fails during joint motion."""
+
+    def __init__(
+        self,
+        message: str = (
+            "Robot identify failed: a joint could not be moved safely. Power-cycle the robot and try again."
+        ),
+    ) -> None:
+        super().__init__(
+            message=message,
+            error_code="robot_identify_error",
+            http_status=http.HTTPStatus.BAD_REQUEST,
+        )

--- a/application/backend/src/robots/catalog/so101.py
+++ b/application/backend/src/robots/catalog/so101.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
-from uuid import UUID
 
 from loguru import logger
 from physicalai.robot import SO101
 from physicalai.robot.so101 import SO101Calibration, SO101JointCalibration
 from physicalai.robot.so101.constants import TICKS_PER_REVOLUTION
-from physicalai_studio_plugin import RobotAdapterOptions, RobotAsset, RobotCatalogDefinition
+from physicalai_studio_plugin import RobotAdapterOptions, RobotAsset, RobotCatalogDefinition, RobotProbe
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from exceptions import RobotIdentifyError
@@ -22,8 +20,6 @@ SO101Types = Literal["SO101_Follower", "SO101_Leader"]
 
 if TYPE_CHECKING:
     from physicalai_studio_plugin import CatalogRobot, CatalogRobotFactory, PortScanner
-
-    from schemas.robot import Robot
 
 
 class SO101RobotPayload(BaseModel):
@@ -121,13 +117,6 @@ async def _build_so101_driver(robot: CatalogRobot[SO101RobotPayload], factory: C
     )
 
 
-def serial_port_from_so101(robot: SO101Robot) -> SerialPortInfo:
-    """Build a serial identity from an SO101 robot configuration."""
-    connection_string = robot.payload.connection_string or None
-    serial_number = robot.payload.serial_number or None
-    return SerialPortInfo(connection_string=connection_string, serial_number=serial_number)
-
-
 def _resolve_serial_port(discovered: list[SerialPortInfo], target: SerialPortInfo) -> str | None:
     if target.serial_number is not None:
         for serial_port in discovered:
@@ -161,16 +150,14 @@ async def find_so101_port(
 _IDENTIFY_WIGGLE = 0.08
 
 
-def _identify_so101_motion(connection_string: str, joint: str) -> None:
-    """Move ``joint`` a small way and back to identify the robot.
+def identify_so101_robot_visually(connection_string: str) -> None:
+    """Move the gripper a small way and back to identify the robot.
 
-    Drives through the physicalai ``SO101`` driver in raw-ticks (uncalibrated)
-    mode, which applies the gripper torque/current/overload protection
-    registers on connect. Torque is disabled before disconnecting so the arm
-    relaxes afterwards.
+    Uses the physicalai ``SO101`` driver in raw-ticks (uncalibrated) mode, so no
+    calibration file is required. The gripper is only moved a small fraction of
+    its travel, never to a stop, so the STS3215 servos cannot trip overload.
     """
-    if joint not in SO101.JOINT_ORDER:
-        raise ValueError(f"Unknown SO101 joint: {joint!r}")
+    joint = "gripper"
     joint_index = SO101.JOINT_ORDER.index(joint)
 
     driver = SO101.uncalibrated(port=connection_string, role="follower")
@@ -183,7 +170,11 @@ def _identify_so101_motion(connection_string: str, joint: str) -> None:
 
         step = TICKS_PER_REVOLUTION * _IDENTIFY_WIGGLE
         lo, hi = 0.0, float(TICKS_PER_REVOLUTION - 1)
-        targets = (min(max(current + step, lo), hi), min(max(current - step, lo), hi), current)
+        targets = (
+            min(max(current + step, lo), hi),
+            min(max(current - step, lo), hi),
+            current,
+        )
 
         for target in targets:
             action = observation.joint_positions.copy()
@@ -203,34 +194,7 @@ def _identify_so101_motion(connection_string: str, joint: str) -> None:
         driver.disconnect()
 
 
-async def identify_so101_robot_visually(
-    manager: PortScanner,
-    robot: Robot,
-    joint: str | None = None,
-) -> None:
-    """Identify the robot by moving the joint a small way and back to its start.
-
-    Uses the physicalai ``SO101`` driver in raw-ticks (uncalibrated) mode, so no
-    calibration file is required. The joint is only moved a small fraction of
-    its travel, never to a stop, so the STS3215 servos cannot trip overload.
-    """
-    if not isinstance(robot.payload, SO101RobotPayload):
-        raise ValueError(f"Trying to identify unsupported robot: {robot.type}")
-
-    if joint is None:
-        joint = "gripper"
-
-    connection_string = await find_so101_port(manager, serial_port_from_so101(robot))
-
-    if connection_string is None:
-        if robot.payload.serial_number:
-            raise ValueError(f"Could not find the serial port for serial number {robot.payload.serial_number}")
-        raise ValueError("Could not resolve a serial port from connection_string")
-
-    await asyncio.to_thread(_identify_so101_motion, connection_string, joint)
-
-
-class SO101Probe:
+class SO101Probe(RobotProbe[SO101RobotPayload]):
     """Probe for SO101 robots — serial port discovery + joint identification."""
 
     async def discover(self, manager: PortScanner) -> list[SerialPortInfo]:
@@ -241,21 +205,22 @@ class SO101Probe:
         self,
         payload: SO101RobotPayload,
         manager: PortScanner | None,
-        joint: str | None = None,
+        joint: str | None = None,  # noqa: ARG002 - identification always uses the gripper
     ) -> None:
         if manager is None:
             raise ValueError("PortScanner required for SO101 identification")
 
-        now = datetime.now()
-        robot = SO101Robot(
-            id=UUID(int=0),
-            name="",
-            type="SO101_Follower",
-            payload=payload,
-            created_at=now,
-            updated_at=now,
+        serial_port = SerialPortInfo(
+            connection_string=payload.connection_string or None,
+            serial_number=payload.serial_number or None,
         )
-        await identify_so101_robot_visually(manager, robot, joint)
+        connection_string = await find_so101_port(manager, serial_port)
+        if connection_string is None:
+            if payload.serial_number:
+                raise ValueError(f"Could not find the serial port for serial number {payload.serial_number}")
+            raise ValueError("Could not resolve a serial port from connection_string")
+
+        await asyncio.to_thread(identify_so101_robot_visually, connection_string)
 
     async def is_online(self, payload: SO101RobotPayload, manager: PortScanner | None = None) -> bool:
         serial_port = SerialPortInfo(

--- a/application/backend/src/robots/catalog/so101.py
+++ b/application/backend/src/robots/catalog/so101.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -8,9 +10,11 @@ from uuid import UUID
 from loguru import logger
 from physicalai.robot import SO101
 from physicalai.robot.so101 import SO101Calibration, SO101JointCalibration
+from physicalai.robot.so101.constants import TICKS_PER_REVOLUTION
 from physicalai_studio_plugin import RobotAdapterOptions, RobotAsset, RobotCatalogDefinition
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from exceptions import RobotIdentifyError
 from schemas import SerialPortInfo
 from schemas.robot_type import BaseRobot
 
@@ -20,14 +24,6 @@ if TYPE_CHECKING:
     from physicalai_studio_plugin import CatalogRobot, CatalogRobotFactory, PortScanner
 
     from schemas.robot import Robot
-
-
-class SO101CalibrationValue(BaseModel):
-    id: int
-    drive_mode: int
-    homing_offset: int
-    range_min: int
-    range_max: int
 
 
 class SO101RobotPayload(BaseModel):
@@ -158,16 +154,66 @@ async def find_so101_port(
     return _resolve_serial_port(manager.robots, serial_port)
 
 
+# Relative wiggle (fraction of the full encoder) moved around the current
+# position. Uncalibrated mode has no calibrated range, so identification only
+# moves a small amount relative to where the joint already is, keeping it clear
+# of the physical stops so it cannot stall and trip overload protection.
+_IDENTIFY_WIGGLE = 0.08
+
+
+def _identify_so101_motion(connection_string: str, joint: str) -> None:
+    """Move ``joint`` a small way and back to identify the robot.
+
+    Drives through the physicalai ``SO101`` driver in raw-ticks (uncalibrated)
+    mode, which applies the gripper torque/current/overload protection
+    registers on connect. Torque is disabled before disconnecting so the arm
+    relaxes afterwards.
+    """
+    if joint not in SO101.JOINT_ORDER:
+        raise ValueError(f"Unknown SO101 joint: {joint!r}")
+    joint_index = SO101.JOINT_ORDER.index(joint)
+
+    driver = SO101.uncalibrated(port=connection_string, role="follower")
+    driver.torque_on_disconnect = False
+    # Port open / permission failures keep the standard serial error mapping.
+    driver.connect()
+    try:
+        observation = driver.get_observation()
+        current = float(observation.joint_positions[joint_index])
+
+        step = TICKS_PER_REVOLUTION * _IDENTIFY_WIGGLE
+        lo, hi = 0.0, float(TICKS_PER_REVOLUTION - 1)
+        targets = (min(max(current + step, lo), hi), min(max(current - step, lo), hi), current)
+
+        for target in targets:
+            action = observation.joint_positions.copy()
+            action[joint_index] = target
+            driver.send_action(action)
+            time.sleep(1.0)
+            # A servo that trips overload protection stops responding to sync
+            # reads, so this surfaces immediately with a clear error.
+            driver.get_observation()
+    except ConnectionError as exc:
+        raise RobotIdentifyError(
+            f"Robot identify failed: {joint} stopped responding during motion. "
+            "The servo may have tripped overload protection. Power-cycle the robot and try again."
+        ) from exc
+    finally:
+        driver.set_torque(enabled=False)
+        driver.disconnect()
+
+
 async def identify_so101_robot_visually(
     manager: PortScanner,
     robot: Robot,
     joint: str | None = None,
 ) -> None:
-    """Identify the robot by moving the joint from current to min to max to initial position."""
-    import asyncio
+    """Identify the robot by moving the joint a small way and back to its start.
 
-    from lerobot.robots.so_follower import SOFollower, SOFollowerRobotConfig
-
+    Uses the physicalai ``SO101`` driver in raw-ticks (uncalibrated) mode, so no
+    calibration file is required. The joint is only moved a small fraction of
+    its travel, never to a stop, so the STS3215 servos cannot trip overload.
+    """
     if not isinstance(robot.payload, SO101RobotPayload):
         raise ValueError(f"Trying to identify unsupported robot: {robot.type}")
 
@@ -180,21 +226,8 @@ async def identify_so101_robot_visually(
         if robot.payload.serial_number:
             raise ValueError(f"Could not find the serial port for serial number {robot.payload.serial_number}")
         raise ValueError("Could not resolve a serial port from connection_string")
-    connection = SOFollower(SOFollowerRobotConfig(port=connection_string))
-    connection.bus.connect()
 
-    PRESENT_POSITION_KEY = "Present_Position"
-    GOAL_POSITION_KEY = "Goal_Position"
-
-    current_position = connection.bus.sync_read(PRESENT_POSITION_KEY, normalize=False)
-    gripper_calibration = connection.bus.read_calibration()[joint]
-    connection.bus.write(GOAL_POSITION_KEY, joint, gripper_calibration.range_min, normalize=False)
-    await asyncio.sleep(1)
-    connection.bus.write(GOAL_POSITION_KEY, joint, gripper_calibration.range_max, normalize=False)
-    await asyncio.sleep(1)
-    connection.bus.write(GOAL_POSITION_KEY, joint, current_position[joint], normalize=False)
-    await asyncio.sleep(1)
-    connection.bus.disconnect()
+    await asyncio.to_thread(_identify_so101_motion, connection_string, joint)
 
 
 class SO101Probe:

--- a/application/backend/tests/api/test_hardware.py
+++ b/application/backend/tests/api/test_hardware.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -128,27 +128,23 @@ class TestHardwareApi:
         robot_manager.find_robots.assert_awaited_once()
 
     def test_identify_so101_uses_robot_manager_dependency(self):
-        robot_manager = _StubRobotManager([])
+        robot_manager = _StubRobotManager([SerialPortInfo(connection_string="/dev/ttyUSB0", serial_number=None)])
         app.dependency_overrides[get_robot_manager_service] = lambda: robot_manager
 
         try:
             client = TestClient(app)
-            with patch("robots.catalog.so101.identify_so101_robot_visually", new_callable=AsyncMock) as identify:
+            with patch("robots.catalog.so101.identify_so101_robot_visually", new_callable=Mock) as identify:
                 response = client.post(
                     "/api/robots/catalog/SO101_Follower/identify",
-                    params={"joint": "gripper"},
                     json={"connection_string": "/dev/ttyUSB0", "serial_number": ""},
                 )
         finally:
             app.dependency_overrides.clear()
 
         assert response.status_code == 200, response.text
-        identify.assert_awaited_once()
-        manager_arg, robot_arg, joint_arg = identify.await_args.args
-        assert manager_arg is robot_manager
-        assert robot_arg.type == "SO101_Follower"
-        assert robot_arg.payload.connection_string == "/dev/ttyUSB0"
-        assert joint_arg == "gripper"
+        identify.assert_called_once()
+        (connection_string,) = identify.call_args.args
+        assert connection_string == "/dev/ttyUSB0"
 
     def test_identify_trossen_calls_trossen_identifier(self):
         robot_manager = _StubRobotManager([])

--- a/application/backend/tests/robots/test_so101_identify.py
+++ b/application/backend/tests/robots/test_so101_identify.py
@@ -1,0 +1,242 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the SO-101 visual identification routine.
+
+``identify_so101_robot_visually`` drives the physicalai ``SO101`` driver in
+raw-ticks (uncalibrated) mode and wiggles the joint a small amount around its
+current position. The critical regression this guards is driving a joint to a
+physical stop, which can stall an STS3215 servo into overload protection.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import numpy as np
+import pytest
+
+import robots.catalog.so101 as so101_module
+from exceptions import RobotIdentifyError
+from robots.catalog.so101 import SO101Robot, SO101RobotPayload, _identify_so101_motion, identify_so101_robot_visually
+from schemas import SerialPortInfo
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+JOINT_NAMES = ("shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper")
+PORT = "/dev/ttyACM0"
+SERIAL_NUMBER = "SO101-2026-0001"
+
+
+class _FakeDriver:
+    """Stands in for physicalai's SO101 driver."""
+
+    JOINT_ORDER = list(JOINT_NAMES)
+    instances: list[_FakeDriver] = []
+    default_start: np.ndarray = np.zeros(6, dtype=np.float32)
+    default_observation_failure: Exception | None = None
+
+    def __init__(
+        self,
+        *,
+        port: str | None = None,
+        role: str | None = None,
+        unit: str | None = None,
+    ) -> None:
+        self.port = port
+        self.role = role
+        self.unit = unit
+        self.current_position = _FakeDriver.default_start.copy()
+        self._observation_failure = _FakeDriver.default_observation_failure
+        self.actions: list[np.ndarray] = []
+        self._torque_on_disconnect = True
+        self.torque_commands: list[bool] = []
+        self.connected = False
+        self.disconnected = False
+        _FakeDriver.instances.append(self)
+
+    @classmethod
+    def uncalibrated(
+        cls,
+        port: str,
+        baudrate: int = 1_000_000,
+        role: str = "follower",
+        unit: str = "ticks",
+    ) -> _FakeDriver:
+        return cls(port=port, role=role, unit=unit)
+
+    @property
+    def torque_on_disconnect(self) -> bool:
+        return self._torque_on_disconnect
+
+    @torque_on_disconnect.setter
+    def torque_on_disconnect(self, value: bool) -> None:
+        self._torque_on_disconnect = value
+
+    def connect(self) -> None:
+        self.connected = True
+
+    def get_observation(self) -> SimpleNamespace:
+        if self._observation_failure is not None:
+            raise self._observation_failure
+        return SimpleNamespace(joint_positions=self.current_position.copy())
+
+    def send_action(self, action: np.ndarray) -> None:
+        self.actions.append(action.copy())
+        self.current_position = action.copy()
+
+    def set_torque(self, *, enabled: bool) -> None:
+        self.torque_commands.append(enabled)
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+
+class _FakePortScanner:
+    def __init__(self, robots: list[SerialPortInfo] | None = None) -> None:
+        self.robots = (
+            [SerialPortInfo(connection_string=PORT, serial_number=SERIAL_NUMBER)] if robots is None else robots
+        )
+
+    async def find_robots(self) -> list[SerialPortInfo]:
+        return self.robots
+
+
+def _robot() -> SO101Robot:
+    now = datetime.now()
+    return SO101Robot(
+        id=UUID(int=0),
+        name="",
+        type="SO101_Follower",
+        payload=SO101RobotPayload(connection_string="", serial_number=SERIAL_NUMBER),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_fake_drivers() -> Generator[None, None, None]:
+    _FakeDriver.instances.clear()
+    _FakeDriver.default_start = np.zeros(6, dtype=np.float32)
+    _FakeDriver.default_observation_failure = None
+    yield
+    _FakeDriver.instances.clear()
+    _FakeDriver.default_start = np.zeros(6, dtype=np.float32)
+    _FakeDriver.default_observation_failure = None
+
+
+def _last_driver() -> _FakeDriver:
+    return _FakeDriver.instances[-1]
+
+
+# ---------------------------------------------------------------------------
+# Motion
+# ---------------------------------------------------------------------------
+
+
+def test_identify_so101_motion_uses_uncalibrated_driver_with_safe_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
+
+    start = np.zeros(6, dtype=np.float32)
+    start[5] = 2048.0
+    _FakeDriver.default_start = start
+
+    _identify_so101_motion(PORT, "gripper")
+
+    driver = _last_driver()
+    assert driver.unit == "ticks"
+    assert driver.role == "follower"
+    assert driver.connected
+    assert driver.disconnected
+    assert driver.torque_on_disconnect is False
+    assert driver.torque_commands == [False]
+    assert len(driver.actions) == 3
+
+    gripper_goals = [float(action[5]) for action in driver.actions]
+    assert all(0.0 <= goal <= 4095.0 for goal in gripper_goals)
+    assert gripper_goals[-1] == 2048.0
+
+
+def test_identify_so101_motion_lets_connect_errors_propagate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingDriver(_FakeDriver):
+        def connect(self) -> None:
+            raise ConnectionError(f"Failed to open serial port {PORT}")
+
+    monkeypatch.setattr(so101_module, "SO101", _FailingDriver)
+
+    # Port open / permission failures keep the standard serial error mapping
+    # instead of the identify (power-cycle) error.
+    with pytest.raises(ConnectionError, match="Failed to open serial port"):
+        _identify_so101_motion(PORT, "gripper")
+
+    # physicalai cleans up the port itself when connect fails; torque is never
+    # touched because the motion never started.
+    assert not _last_driver().disconnected
+    assert _last_driver().torque_commands == []
+
+
+def test_identify_so101_motion_wraps_overload_as_robot_identify_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
+    _FakeDriver.default_start = np.array([0, 0, 0, 0, 0, 2048.0], dtype=np.float32)
+    _FakeDriver.default_observation_failure = ConnectionError("Servo 'gripper' (ID 6) data not available in sync read")
+
+    with pytest.raises(RobotIdentifyError, match="overload"):
+        _identify_so101_motion(PORT, "gripper")
+
+    driver = _last_driver()
+    assert driver.disconnected
+    assert driver.torque_commands == [False]
+
+
+def test_identify_so101_motion_rejects_unknown_joint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
+
+    with pytest.raises(ValueError, match="Unknown SO101 joint"):
+        _identify_so101_motion(PORT, "bogus")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end identify
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identify_so101_robot_visually_drives_via_uncalibrated_driver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
+
+    start = np.zeros(6, dtype=np.float32)
+    start[5] = 2048.0
+    _FakeDriver.default_start = start
+
+    await identify_so101_robot_visually(_FakePortScanner(), _robot())
+
+    driver = _last_driver()
+    assert driver.unit == "ticks"
+    assert driver.role == "follower"
+    gripper_goals = [float(action[5]) for action in driver.actions]
+    assert all(0.0 <= goal <= 4095.0 for goal in gripper_goals)
+    assert gripper_goals[-1] == 2048.0
+    assert driver.disconnected
+    assert driver.torque_commands == [False]
+
+
+@pytest.mark.asyncio
+async def test_identify_so101_robot_visually_raises_when_port_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
+
+    with pytest.raises(ValueError, match="serial port"):
+        await identify_so101_robot_visually(_FakePortScanner(robots=[]), _robot())

--- a/application/backend/tests/robots/test_so101_identify.py
+++ b/application/backend/tests/robots/test_so101_identify.py
@@ -4,24 +4,22 @@
 """Tests for the SO-101 visual identification routine.
 
 ``identify_so101_robot_visually`` drives the physicalai ``SO101`` driver in
-raw-ticks (uncalibrated) mode and wiggles the joint a small amount around its
+raw-ticks (uncalibrated) mode and wiggles the gripper a small amount around its
 current position. The critical regression this guards is driving a joint to a
 physical stop, which can stall an STS3215 servo into overload protection.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
-from uuid import UUID
 
 import numpy as np
 import pytest
 
 import robots.catalog.so101 as so101_module
 from exceptions import RobotIdentifyError
-from robots.catalog.so101 import SO101Robot, SO101RobotPayload, _identify_so101_motion, identify_so101_robot_visually
+from robots.catalog.so101 import SO101Probe, SO101RobotPayload
 from schemas import SerialPortInfo
 
 if TYPE_CHECKING:
@@ -106,16 +104,8 @@ class _FakePortScanner:
         return self.robots
 
 
-def _robot() -> SO101Robot:
-    now = datetime.now()
-    return SO101Robot(
-        id=UUID(int=0),
-        name="",
-        type="SO101_Follower",
-        payload=SO101RobotPayload(connection_string="", serial_number=SERIAL_NUMBER),
-        created_at=now,
-        updated_at=now,
-    )
+def _payload() -> SO101RobotPayload:
+    return SO101RobotPayload(connection_string="", serial_number=SERIAL_NUMBER)
 
 
 @pytest.fixture(autouse=True)
@@ -133,21 +123,15 @@ def _last_driver() -> _FakeDriver:
     return _FakeDriver.instances[-1]
 
 
-# ---------------------------------------------------------------------------
-# Motion
-# ---------------------------------------------------------------------------
-
-
-def test_identify_so101_motion_uses_uncalibrated_driver_with_safe_targets(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+@pytest.mark.asyncio
+async def test_identify_uses_uncalibrated_driver_with_safe_targets(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
 
     start = np.zeros(6, dtype=np.float32)
     start[5] = 2048.0
     _FakeDriver.default_start = start
 
-    _identify_so101_motion(PORT, "gripper")
+    await SO101Probe().identify(_payload(), _FakePortScanner())
 
     driver = _last_driver()
     assert driver.unit == "ticks"
@@ -163,9 +147,8 @@ def test_identify_so101_motion_uses_uncalibrated_driver_with_safe_targets(
     assert gripper_goals[-1] == 2048.0
 
 
-def test_identify_so101_motion_lets_connect_errors_propagate(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+@pytest.mark.asyncio
+async def test_identify_lets_connect_errors_propagate(monkeypatch: pytest.MonkeyPatch) -> None:
     class _FailingDriver(_FakeDriver):
         def connect(self) -> None:
             raise ConnectionError(f"Failed to open serial port {PORT}")
@@ -175,7 +158,7 @@ def test_identify_so101_motion_lets_connect_errors_propagate(
     # Port open / permission failures keep the standard serial error mapping
     # instead of the identify (power-cycle) error.
     with pytest.raises(ConnectionError, match="Failed to open serial port"):
-        _identify_so101_motion(PORT, "gripper")
+        await SO101Probe().identify(_payload(), _FakePortScanner())
 
     # physicalai cleans up the port itself when connect fails; torque is never
     # touched because the motion never started.
@@ -183,60 +166,23 @@ def test_identify_so101_motion_lets_connect_errors_propagate(
     assert _last_driver().torque_commands == []
 
 
-def test_identify_so101_motion_wraps_overload_as_robot_identify_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+@pytest.mark.asyncio
+async def test_identify_wraps_overload_as_robot_identify_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
     _FakeDriver.default_start = np.array([0, 0, 0, 0, 0, 2048.0], dtype=np.float32)
     _FakeDriver.default_observation_failure = ConnectionError("Servo 'gripper' (ID 6) data not available in sync read")
 
     with pytest.raises(RobotIdentifyError, match="overload"):
-        _identify_so101_motion(PORT, "gripper")
+        await SO101Probe().identify(_payload(), _FakePortScanner())
 
     driver = _last_driver()
     assert driver.disconnected
     assert driver.torque_commands == [False]
 
 
-def test_identify_so101_motion_rejects_unknown_joint(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
-
-    with pytest.raises(ValueError, match="Unknown SO101 joint"):
-        _identify_so101_motion(PORT, "bogus")
-
-
-# ---------------------------------------------------------------------------
-# End-to-end identify
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
-async def test_identify_so101_robot_visually_drives_via_uncalibrated_driver(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
-
-    start = np.zeros(6, dtype=np.float32)
-    start[5] = 2048.0
-    _FakeDriver.default_start = start
-
-    await identify_so101_robot_visually(_FakePortScanner(), _robot())
-
-    driver = _last_driver()
-    assert driver.unit == "ticks"
-    assert driver.role == "follower"
-    gripper_goals = [float(action[5]) for action in driver.actions]
-    assert all(0.0 <= goal <= 4095.0 for goal in gripper_goals)
-    assert gripper_goals[-1] == 2048.0
-    assert driver.disconnected
-    assert driver.torque_commands == [False]
-
-
-@pytest.mark.asyncio
-async def test_identify_so101_robot_visually_raises_when_port_not_found(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_identify_raises_when_port_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(so101_module, "SO101", _FakeDriver)
 
     with pytest.raises(ValueError, match="serial port"):
-        await identify_so101_robot_visually(_FakePortScanner(robots=[]), _robot())
+        await SO101Probe().identify(_payload(), _FakePortScanner(robots=[]))

--- a/application/ui/src/api/errors.test.ts
+++ b/application/ui/src/api/errors.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { getApiErrorMessage, isResourceInUseError, isSerialPermissionDeniedError } from './errors';
+
+describe('isSerialPermissionDeniedError', () => {
+    it('matches the serial_permission_denied code', () => {
+        expect(
+            isSerialPermissionDeniedError({
+                error_code: 'serial_permission_denied',
+                message: 'Permission denied while opening the serial device.',
+                http_status: 403,
+            })
+        ).toBe(true);
+    });
+
+    it('matches case-insensitively', () => {
+        expect(isSerialPermissionDeniedError({ error_code: 'SERIAL_PERMISSION_DENIED' })).toBe(true);
+    });
+
+    it('returns false for non-object, missing, or non-string error codes', () => {
+        expect(isSerialPermissionDeniedError(null)).toBe(false);
+        expect(isSerialPermissionDeniedError('serial_permission_denied')).toBe(false);
+        expect(isSerialPermissionDeniedError({})).toBe(false);
+        expect(isSerialPermissionDeniedError({ error_code: 403 })).toBe(false);
+        expect(isSerialPermissionDeniedError({ error_code: 'robot_identify_error' })).toBe(false);
+    });
+});
+
+describe('isResourceInUseError', () => {
+    it('matches _in_use codes case-insensitively', () => {
+        expect(isResourceInUseError({ error_code: 'robot_in_use' })).toBe(true);
+        expect(isResourceInUseError({ error_code: 'ROBOT_IN_USE' })).toBe(true);
+        expect(isResourceInUseError({ error_code: 'robot_identify_error' })).toBe(false);
+    });
+});
+
+describe('getApiErrorMessage', () => {
+    it('returns the message when present', () => {
+        expect(getApiErrorMessage({ error_code: 'robot_identify_error', message: 'Identify failed.' })).toBe(
+            'Identify failed.'
+        );
+    });
+
+    it('returns undefined when the message is absent or not a string', () => {
+        expect(getApiErrorMessage({})).toBeUndefined();
+        expect(getApiErrorMessage({ message: 42 })).toBeUndefined();
+        expect(getApiErrorMessage(null)).toBeUndefined();
+    });
+});

--- a/application/ui/src/api/errors.ts
+++ b/application/ui/src/api/errors.ts
@@ -33,8 +33,8 @@ export const isResourceInUseError = (error: unknown): boolean =>
 export const isSerialPermissionDeniedError = (error: unknown): boolean =>
     typeof error === 'object' &&
     error !== null &&
-    'error_code' in error &&
-    (error as Record<string, unknown>).error_code === 'serial_permission_denied';
+    typeof (error as Record<string, unknown>).error_code === 'string' &&
+    (error as Record<string, string>).error_code.toLowerCase() === 'serial_permission_denied';
 
 interface ApiErrorBody {
     error_code?: string;

--- a/application/ui/src/api/errors.ts
+++ b/application/ui/src/api/errors.ts
@@ -24,6 +24,18 @@ export const isResourceInUseError = (error: unknown): boolean =>
     typeof (error as Record<string, unknown>).error_code === 'string' &&
     (error as Record<string, string>).error_code.toLowerCase().endsWith('_in_use');
 
+/**
+ * Returns true when the API error was a serial port permission failure (HTTP 403).
+ *
+ * The backend returns `{ error_code: "serial_permission_denied", ... }` when the
+ * process cannot open the robot's serial device (e.g. missing `dialout` access).
+ */
+export const isSerialPermissionDeniedError = (error: unknown): boolean =>
+    typeof error === 'object' &&
+    error !== null &&
+    'error_code' in error &&
+    (error as Record<string, unknown>).error_code === 'serial_permission_denied';
+
 interface ApiErrorBody {
     error_code?: string;
     message?: string;

--- a/application/ui/src/features/robots/robot-form/catalog/so101.test.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.test.tsx
@@ -1,0 +1,78 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { http } from '../../../../api/utils';
+import { server } from '../../../../msw-node-setup';
+import { render } from '../../../../test-utils/render';
+import { RobotFormProvider } from '../provider';
+import { SO101FormFields } from './so101';
+
+const IDENTIFY_PATH = '/api/robots/catalog/{robot_type}/identify';
+const DISCOVER_PATH = '/api/robots/catalog/{robot_type}/discover';
+
+const IDENTIFY_OVERLOAD_MESSAGE =
+    'Robot identify failed: gripper stopped responding during motion. The servo may have tripped overload protection. Power-cycle the robot and try again.';
+
+const renderSo101Form = () =>
+    render(
+        <RobotFormProvider>
+            <SO101FormFields />
+        </RobotFormProvider>
+    );
+
+const clickIdentify = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(await screen.findByRole('button', { name: 'Identify' }));
+};
+
+describe('SO101FormFields identify errors', () => {
+    it('renders the actual identify error instead of Permission Denied', async () => {
+        server.use(
+            http.get(DISCOVER_PATH, () => HttpResponse.json([])),
+            http.post(IDENTIFY_PATH, () =>
+                HttpResponse.json(
+                    {
+                        error_code: 'robot_identify_error',
+                        message: IDENTIFY_OVERLOAD_MESSAGE,
+                        http_status: 400,
+                    },
+                    { status: 400 }
+                )
+            )
+        );
+
+        const user = userEvent.setup();
+        renderSo101Form();
+
+        await clickIdentify(user);
+
+        expect(await screen.findByText('Identify Failed')).toBeInTheDocument();
+        expect(screen.getByText(/Power-cycle the robot and try again/)).toBeInTheDocument();
+        expect(screen.queryByText('Permission Denied')).not.toBeInTheDocument();
+    });
+
+    it('renders Permission Denied guidance for serial permission failures', async () => {
+        server.use(
+            http.get(DISCOVER_PATH, () => HttpResponse.json([])),
+            http.post(IDENTIFY_PATH, () =>
+                HttpResponse.json(
+                    {
+                        error_code: 'serial_permission_denied',
+                        message: 'Permission denied while opening the serial device.',
+                        http_status: 403,
+                    },
+                    { status: 403 }
+                )
+            )
+        );
+
+        const user = userEvent.setup();
+        renderSo101Form();
+
+        await clickIdentify(user);
+
+        expect(await screen.findByText('Permission Denied')).toBeInTheDocument();
+        expect(screen.queryByText('Identify Failed')).not.toBeInTheDocument();
+    });
+});

--- a/application/ui/src/features/robots/robot-form/catalog/so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.tsx
@@ -1,8 +1,10 @@
 import { Flex, Item, Picker, Text } from '@geti-ui/ui';
 
+import { getApiErrorMessage, isSerialPermissionDeniedError } from '../../../../api/errors';
 import type { SchemaSo101RobotPayload } from '../../../../api/openapi-spec';
 import { useCatalogIdentifyMutation, useDiscoverRobotsQuery } from '../../robot-catalog.hooks';
 import type { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
+import { InlineAlert } from '../../setup-wizard/shared/inline-alert';
 import { PermissionDeniedError } from '../../setup-wizard/so101/diagnostics-step-error';
 import { useRobotFormFields } from '../provider';
 import { IdentifyRobot, RefreshRobotsButton } from './actions';
@@ -122,7 +124,24 @@ export const SO101FormFields = () => {
                 </Flex>
             </Flex>
 
-            {identifyMutation.isError && <PermissionDeniedError port={formData.payload.connection_string} />}
+            {identifyMutation.isError && (
+                <IdentifyError error={identifyMutation.error} port={formData.payload.connection_string} />
+            )}
         </>
+    );
+};
+
+const IdentifyError = ({ error, port }: { error: unknown; port: string | null }) => {
+    if (isSerialPermissionDeniedError(error)) {
+        return <PermissionDeniedError port={port} />;
+    }
+
+    return (
+        <InlineAlert variant='error'>
+            <strong>Identify Failed</strong>
+            <br />
+            {getApiErrorMessage(error) ??
+                'The robot could not be identified. Make sure it is powered on and not already in use, then try again.'}
+        </InlineAlert>
     );
 };


### PR DESCRIPTION
- Minimize the "wiggle" the gripper does so we avoid moving the gripper beyond its reach
- Only use physicalai drivers to connect and identify the so101 robot.
- Improve error handling in UI giving more concrete error messages

Fixes #955