### PR TITLE
feat: Expose `created_at` in the projects response

### DIFF
--- a/application/backend/src/repositories/mappers/project_mapper.py
+++ b/application/backend/src/repositories/mappers/project_mapper.py
@@ -25,6 +25,7 @@ class ProjectMapper(IBaseMapper):
                 "id": model.id,
                 "name": model.name,
                 "updated_at": model.updated_at,
+                "created_at": model.created_at,
                 "datasets": [DatasetMapper.from_schema(dataset) for dataset in model.datasets],
             }
         )

--- a/application/backend/src/schemas/project.py
+++ b/application/backend/src/schemas/project.py
@@ -8,7 +8,7 @@ from schemas.base import BaseIDNameModel
 
 class Project(BaseIDNameModel):
     updated_at: datetime | None = Field(None)
-    created_at: datetime = Field()
+    created_at: datetime | None = Field(None)
     datasets: list[Dataset] = Field([], description="Datasets")
     model_config = {
         "json_schema_extra": {

--- a/application/backend/src/schemas/project.py
+++ b/application/backend/src/schemas/project.py
@@ -8,6 +8,7 @@ from schemas.base import BaseIDNameModel
 
 class Project(BaseIDNameModel):
     updated_at: datetime | None = Field(None)
+    created_at: datetime = Field()
     datasets: list[Dataset] = Field([], description="Datasets")
     model_config = {
         "json_schema_extra": {
@@ -15,6 +16,7 @@ class Project(BaseIDNameModel):
                 "id": "7b073838-99d3-42ff-9018-4e901eb047fc",
                 "name": "SO101 Teleoperation",
                 "updated_at": "2021-06-29T16:24:30.928000+00:00",
+                "created_at": "2021-06-29T16:24:30.928000+00:00",
                 "datasets": [
                     {
                         "id": "fec4a691-76ee-4f66-8dea-aad3110e16d6",

--- a/application/ui/src/features/projects/list/projects.tsx
+++ b/application/ui/src/features/projects/list/projects.tsx
@@ -41,8 +41,8 @@ const ProjectsList = ({ projects }: ProjectsListProps) => {
 
     const sortedProjects = useMemo(() => {
         return filteredProjects.toSorted((projectA, projectB) => {
-            const projectUpdatedAtA = projectA.updated_at ? new Date(projectA.updated_at) : new Date(0);
-            const projectUpdatedAtB = projectB.updated_at ? new Date(projectB.updated_at) : new Date(0);
+            const projectUpdatedAtA = projectA.created_at ? new Date(projectA.created_at) : new Date(0);
+            const projectUpdatedAtB = projectB.created_at ? new Date(projectB.created_at) : new Date(0);
 
             return sortDirection === 'desc'
                 ? projectUpdatedAtB.getTime() - projectUpdatedAtA.getTime()

--- a/application/ui/src/features/projects/list/projects.tsx
+++ b/application/ui/src/features/projects/list/projects.tsx
@@ -41,12 +41,12 @@ const ProjectsList = ({ projects }: ProjectsListProps) => {
 
     const sortedProjects = useMemo(() => {
         return filteredProjects.toSorted((projectA, projectB) => {
-            const projectUpdatedAtA = projectA.created_at ? new Date(projectA.created_at) : new Date(0);
+            const projectCreatedAtA = projectA.created_at ? new Date(projectA.created_at) : new Date(0);
             const projectUpdatedAtB = projectB.created_at ? new Date(projectB.created_at) : new Date(0);
 
             return sortDirection === 'desc'
-                ? projectUpdatedAtB.getTime() - projectUpdatedAtA.getTime()
-                : projectUpdatedAtA.getTime() - projectUpdatedAtB.getTime();
+                ? projectUpdatedAtB.getTime() - projectCreatedAtA.getTime()
+                : projectCreatedAtA.getTime() - projectUpdatedAtB.getTime();
         });
     }, [filteredProjects, sortDirection]);
 


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->

ATM UI uses `updated_at` when sorting projects by `Newest first` or `Oldest first`. With this change UI uses `created_at`.

## Related Issues

<!-- Fixes #123 -->
