### PR TITLE
feat(runtime): make the session a discoverable runtime owner

### DIFF
--- a/application/backend/.env.example
+++ b/application/backend/.env.example
@@ -19,6 +19,12 @@ ENVIRONMENT=dev
 # the Studio UI/API. Client timeouts are configured in the `trainer` group of
 # settings.json, not via environment variables.
 
+# Runtime sessions
+# Seconds a detached session keeps holding the arm after the last client
+# disconnects. A page refresh reconnects well under 5s; 45 leaves headroom
+# for a slow reload while still bounding an abandoned arm to under a minute.
+# RUNTIME_IDLE_TIMEOUT_S=45.0
+
 # Server
 HOST=0.0.0.0
 PORT=7860

--- a/application/backend/src/api/record.py
+++ b/application/backend/src/api/record.py
@@ -7,6 +7,8 @@ from fastapi.responses import Response
 from loguru import logger
 
 from api.dependencies import ModelRegistryDep, RecordingLockedCamerasDep, RobotClientFactoryDep, SchedulerDep
+from exceptions import RuntimeSessionBusyError
+from runtime.owner import runtime_session_holder
 from schemas import Dataset, InferenceDevice, Model
 from schemas.environment import EnvironmentWithRelations
 from workers.robot_control_worker import RobotControlWorker
@@ -14,10 +16,43 @@ from workers.robot_control_worker import RobotControlWorker
 router = APIRouter(prefix="/api/record")
 
 
+async def _refuse_if_runtime_holds_follower(websocket: WebSocket, environment: EnvironmentWithRelations) -> bool:
+    """Send an error frame when a runtime session already holds this follower."""
+    follower_id = environment.robots[0].robot.id
+    holder = await asyncio.to_thread(runtime_session_holder, follower_id)
+    if holder is None:
+        return False
+    error = RuntimeSessionBusyError(
+        robot_name=environment.robots[0].robot.name,
+        pid=holder.get("pid") if isinstance(holder.get("pid"), int) else None,
+    )
+    await websocket.send_json(
+        {
+            "event": "error",
+            "message": error.message,
+            "error_code": error.error_code,
+        }
+    )
+    return True
+
+
 @router.get("/robot_control/ws", tags=["WebSocket"], summary="Robot Control (WebSocket)", status_code=426)
 async def robot_control_websocket_openapi() -> Response:
     """This endpoint requires a WebSocket connection. Use `wss://` to connect."""
     return Response(status_code=426)
+
+
+async def _load_environment_unless_held(
+    websocket: WebSocket,
+    process: RobotControlWorker,
+    environment: EnvironmentWithRelations,
+    locked_camera_fingerprints: set[str],
+) -> None:
+    if await _refuse_if_runtime_holds_follower(websocket, environment):
+        return
+    locked_camera_fingerprints.clear()
+    locked_camera_fingerprints.update(camera.fingerprint for camera in environment.cameras)
+    process.load_environment(environment)
 
 
 async def handle_incoming(
@@ -32,10 +67,12 @@ async def handle_incoming(
             payload = data.get("data", {})
             match data["event"]:
                 case "load_environment":
-                    environment = EnvironmentWithRelations.model_validate(payload["environment"])
-                    locked_camera_fingerprints.clear()
-                    locked_camera_fingerprints.update(camera.fingerprint for camera in environment.cameras)
-                    process.load_environment(environment)
+                    await _load_environment_unless_held(
+                        websocket,
+                        process,
+                        EnvironmentWithRelations.model_validate(payload["environment"]),
+                        locked_camera_fingerprints,
+                    )
                 case "load_model":
                     process.load_model(
                         Model.model_validate(payload["model"]),

--- a/application/backend/src/api/robot_control.py
+++ b/application/backend/src/api/robot_control.py
@@ -86,7 +86,9 @@ async def handle_incoming(websocket: WebSocket, client: RuntimeSessionClient) ->
                 continue
             client.apply(command)
     except WebSocketDisconnect:
-        pass
+        # Browser close / refresh is a detach. The child stays up until an
+        # explicit disconnect event or idle timeout.
+        logger.debug("Robot control websocket closed; detaching from the runtime session")
 
 
 async def start_runtime_session(

--- a/application/backend/src/api/robot_control.py
+++ b/application/backend/src/api/robot_control.py
@@ -10,12 +10,12 @@ from fastapi.websockets import WebSocketDisconnect
 from loguru import logger
 from pydantic import ValidationError
 
-from api.dependencies import RobotClientFactoryDep, get_project_id, get_robot_id, get_robot_service
+from api.dependencies import RobotClientFactoryDep, SettingsDep, get_project_id, get_robot_id, get_robot_service
 from exceptions import BaseException as AppBaseException
 from exceptions import RobotPluginUnavailableError
 from runtime.config_builder import build_runtime_config
 from runtime.contract import DisconnectCommand, SetFollowerSourceCommand
-from runtime.hosts.process_host import RuntimeProcessHost
+from runtime.owner import RuntimeSessionOwner
 from runtime.transport.client import RuntimeProcessError, RuntimeSessionClient
 from runtime.transport.ids import runtime_session_name
 from schemas.robot import ReadableRobot, UnavailableRobot
@@ -34,12 +34,6 @@ def _websocket_error_payload(exc: Exception) -> dict[str, str]:
     }
 
 
-@router.get("/ws", tags=["WebSocket"], summary="Robot control (WebSocket)", status_code=426)
-async def robot_websocket_openapi(project_id: UUID) -> Response:  # noqa: ARG001
-    """This endpoint requires a WebSocket connection. Use `wss://` to connect."""
-    return Response(status_code=426)
-
-
 def _ensure_robot_available(robot: ReadableRobot) -> None:
     if isinstance(robot, UnavailableRobot):
         raise RobotPluginUnavailableError(robot.name, robot.type)
@@ -48,7 +42,7 @@ def _ensure_robot_available(robot: ReadableRobot) -> None:
 async def handle_outgoing(
     websocket: WebSocket,
     client: RuntimeSessionClient,
-    host: RuntimeProcessHost,
+    owner: RuntimeSessionOwner,
 ) -> None:
     """Send all runtime events from one task so websocket writes cannot overlap."""
     process_dead_since: float | None = None
@@ -59,11 +53,11 @@ async def handle_outgoing(
             except queue.Empty:
                 if client.error is not None:
                     raise client.error
-                if not host.is_alive():
-                    if client.shutdown_received or host.exited_cleanly:
+                if not owner.is_alive():
+                    if client.shutdown_received or owner.exited_cleanly():
                         return
-                    if host.error is not None:
-                        raise host.error
+                    if owner.error is not None:
+                        raise owner.error
                     process_dead_since = process_dead_since or time.monotonic()
                     if time.monotonic() - process_dead_since >= 0.2:
                         raise RuntimeProcessError("Runtime session process stopped unexpectedly")
@@ -79,6 +73,9 @@ async def handle_incoming(websocket: WebSocket, client: RuntimeSessionClient) ->
     try:
         while True:
             message = await websocket.receive_json("text")
+            if message.get("event") == "disconnect":
+                client.apply(DisconnectCommand())
+                return
             if message.get("event") != "set_follower_source":
                 continue
             payload = message.get("data", {})
@@ -89,14 +86,19 @@ async def handle_incoming(websocket: WebSocket, client: RuntimeSessionClient) ->
                 continue
             client.apply(command)
     except WebSocketDisconnect:
-        client.apply(DisconnectCommand())
+        pass
 
 
-async def start_runtime_session(client: RuntimeSessionClient, host: RuntimeProcessHost) -> None:
-    """Spawn, then wait for transport and hardware readiness, off the event loop."""
-    await asyncio.to_thread(host.start)
-    await asyncio.to_thread(client.connect, process=host)
-    await asyncio.to_thread(client.wait_until_ready, host)
+async def start_runtime_session(client: RuntimeSessionClient, owner: RuntimeSessionOwner) -> None:
+    """Attach or spawn, then wait for hardware readiness, off the event loop."""
+    await asyncio.to_thread(owner.connect)
+    await asyncio.to_thread(client.wait_until_ready, owner)
+
+
+@router.get("/ws", tags=["WebSocket"], summary="Robot control (WebSocket)", status_code=426)
+async def robot_websocket_openapi(project_id: UUID) -> Response:  # noqa: ARG001
+    """This endpoint requires a WebSocket connection. Use `wss://` to connect."""
+    return Response(status_code=426)
 
 
 @router.websocket("/ws")
@@ -104,24 +106,25 @@ async def robot_websocket(  # noqa: PLR0912, PLR0915
     project_id: Annotated[UUID, Depends(get_project_id)],
     robot_service: Annotated[RobotService, Depends(get_robot_service)],
     robot_client_factory: RobotClientFactoryDep,
+    settings: SettingsDep,
     websocket: WebSocket,
     fps: int = 30,
 ) -> None:
     """Stream follower state and accept hold/teleop mode changes."""
     await websocket.accept()
-    host: RuntimeProcessHost | None = None
+    owner: RuntimeSessionOwner | None = None
     client: RuntimeSessionClient | None = None
     incoming_task: asyncio.Task[None] | None = None
     outgoing_task: asyncio.Task[None] | None = None
     startup_task: asyncio.Task[None] | None = None
     try:
-        settings = await websocket.receive_json("text")
-        follower_id = get_robot_id(settings["follower_id"])
+        handshake = await websocket.receive_json("text")
+        follower_id = get_robot_id(handshake["follower_id"])
         follower = await robot_service.get_robot_by_id(project_id, follower_id)
         _ensure_robot_available(follower)
         leader = None
-        if settings.get("leader_id") is not None:
-            leader_id = get_robot_id(settings["leader_id"])
+        if handshake.get("leader_id") is not None:
+            leader_id = get_robot_id(handshake["leader_id"])
             leader = await robot_service.get_robot_by_id(project_id, leader_id)
             _ensure_robot_available(leader)
 
@@ -135,26 +138,29 @@ async def robot_websocket(  # noqa: PLR0912, PLR0915
         session_name = runtime_session_name(follower.id)
         client = RuntimeSessionClient(session_name)
         await asyncio.to_thread(client.open)
-        host = RuntimeProcessHost(
-            session_name,
-            document,
+        owner = RuntimeSessionOwner(
+            client,
+            session_name=session_name,
+            document=document,
             follower_name=follower.name,
             leader_name=None if leader is None else leader.name,
+            idle_timeout_s=settings.runtime_idle_timeout_s,
         )
         incoming_task = asyncio.create_task(handle_incoming(websocket, client))
-        startup_task = asyncio.create_task(start_runtime_session(client, host))
+        startup_task = asyncio.create_task(start_runtime_session(client, owner))
         done, _ = await asyncio.wait(
             {incoming_task, startup_task},
             return_when=asyncio.FIRST_COMPLETED,
         )
         if incoming_task in done:
             incoming_task.result()
-            await asyncio.to_thread(host.stop)
+            if owner.spawned:
+                await asyncio.to_thread(owner.stop)
             await asyncio.gather(startup_task, return_exceptions=True)
             return
         startup_task.result()
 
-        outgoing_task = asyncio.create_task(handle_outgoing(websocket, client, host))
+        outgoing_task = asyncio.create_task(handle_outgoing(websocket, client, owner))
         done, pending = await asyncio.wait(
             {incoming_task, outgoing_task},
             return_when=asyncio.FIRST_COMPLETED,
@@ -181,9 +187,5 @@ async def robot_websocket(  # noqa: PLR0912, PLR0915
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
-        if client is not None:
-            client.apply(DisconnectCommand())
-        if host is not None:
-            await asyncio.to_thread(host.stop)
         if client is not None:
             client.close()

--- a/application/backend/src/api/robot_control.py
+++ b/application/backend/src/api/robot_control.py
@@ -89,9 +89,15 @@ async def handle_incoming(websocket: WebSocket, client: RuntimeSessionClient) ->
         pass
 
 
-async def start_runtime_session(client: RuntimeSessionClient, owner: RuntimeSessionOwner) -> None:
-    """Attach or spawn, then wait for hardware readiness, off the event loop."""
-    await asyncio.to_thread(owner.connect)
+async def start_runtime_session(
+    client: RuntimeSessionClient, owner: RuntimeSessionOwner, *, replace: bool = False
+) -> None:
+    """Attach or spawn, then wait for hardware readiness, off the event loop.
+
+    ``replace`` stops any live session for this follower before spawning with
+    the handshake's current recipe.
+    """
+    await asyncio.to_thread(owner.connect, replace=replace)
     await asyncio.to_thread(client.wait_until_ready, owner)
 
 
@@ -102,7 +108,7 @@ async def robot_websocket_openapi(project_id: UUID) -> Response:  # noqa: ARG001
 
 
 @router.websocket("/ws")
-async def robot_websocket(  # noqa: PLR0912, PLR0915
+async def robot_websocket(  # noqa: PLR0915
     project_id: Annotated[UUID, Depends(get_project_id)],
     robot_service: Annotated[RobotService, Depends(get_robot_service)],
     robot_client_factory: RobotClientFactoryDep,
@@ -147,20 +153,20 @@ async def robot_websocket(  # noqa: PLR0912, PLR0915
             idle_timeout_s=settings.runtime_idle_timeout_s,
         )
         incoming_task = asyncio.create_task(handle_incoming(websocket, client))
-        startup_task = asyncio.create_task(start_runtime_session(client, owner))
+        startup_task = asyncio.create_task(
+            start_runtime_session(client, owner, replace=handshake.get("restart") is True)
+        )
         done, _ = await asyncio.wait(
             {incoming_task, startup_task},
             return_when=asyncio.FIRST_COMPLETED,
         )
         if incoming_task in done:
             incoming_task.result()
-            # Stop a spawn we still own, including one that has not yet set
-            # ``spawned``. Never stop an attached session another client may be using.
-            if owner.host is not None:
-                await asyncio.to_thread(owner.stop)
+            # Interrupt a spawn that is not yet discoverable. Once /metadata is
+            # up this close is a detach — same as after startup.
+            await asyncio.to_thread(owner.stop_abandoned_spawn)
             await asyncio.gather(startup_task, return_exceptions=True)
-            if owner.host is not None:
-                await asyncio.to_thread(owner.stop)
+            await asyncio.to_thread(owner.stop_abandoned_spawn)
             return
         startup_task.result()
 

--- a/application/backend/src/api/robot_control.py
+++ b/application/backend/src/api/robot_control.py
@@ -154,9 +154,13 @@ async def robot_websocket(  # noqa: PLR0912, PLR0915
         )
         if incoming_task in done:
             incoming_task.result()
-            if owner.spawned:
+            # Stop a spawn we still own, including one that has not yet set
+            # ``spawned``. Never stop an attached session another client may be using.
+            if owner.host is not None:
                 await asyncio.to_thread(owner.stop)
             await asyncio.gather(startup_task, return_exceptions=True)
+            if owner.host is not None:
+                await asyncio.to_thread(owner.stop)
             return
         startup_task.result()
 

--- a/application/backend/src/api/robot_control.py
+++ b/application/backend/src/api/robot_control.py
@@ -166,7 +166,6 @@ async def robot_websocket(  # noqa: PLR0915
             # up this close is a detach — same as after startup.
             await asyncio.to_thread(owner.stop_abandoned_spawn)
             await asyncio.gather(startup_task, return_exceptions=True)
-            await asyncio.to_thread(owner.stop_abandoned_spawn)
             return
         startup_task.result()
 

--- a/application/backend/src/api/robots.py
+++ b/application/backend/src/api/robots.py
@@ -1,9 +1,12 @@
+import asyncio
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
 
 from api.dependencies import get_project_id, get_robot_id, get_robot_service
+from exceptions import RuntimeSessionBusyError
+from runtime.owner import runtime_session_holder
 from schemas.robot import (
     ReadableRobot,
     Robot,
@@ -79,4 +82,9 @@ async def delete_project_robot(
     robot_service: Annotated[RobotService, Depends(get_robot_service)],
 ) -> None:
     """Delete a robot."""
+    robot = await robot_service.get_robot_by_id(project_id, robot_id)
+    holder = await asyncio.to_thread(runtime_session_holder, robot_id)
+    if holder is not None:
+        pid = holder.get("pid")
+        raise RuntimeSessionBusyError(robot_name=robot.name, pid=pid if isinstance(pid, int) else None)
     await robot_service.delete_robot(project_id, robot_id)

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -27,10 +27,11 @@ class BaseException(Exception):
     :param http_status: int default http status code to return to user
     """
 
-    def __init__(self, message: str, error_code: str, http_status: int) -> None:
+    def __init__(self, message: str, error_code: str, http_status: int, *, phase: str | None = None) -> None:
         self.message = message
         self.error_code = error_code
         self.http_status = http_status
+        self.phase = phase
         super().__init__(message)
 
 
@@ -224,7 +225,24 @@ class RecordingLockError(BaseException):
         super().__init__(
             message=message,
             error_code="recording_locked",
-            http_status=423,
+            http_status=http.HTTPStatus.LOCKED,
+        )
+
+
+class RuntimeSessionBusyError(BaseException):
+    """Raised when a live runtime session already holds the robot being asked for."""
+
+    def __init__(self, *, robot_name: str | None = None, pid: int | None = None) -> None:
+        subject = f"Robot {robot_name!r} is" if robot_name else "This robot is"
+        holder = f" (pid {pid})" if pid is not None else ""
+        message = (
+            f"{subject} already in use by a running session{holder}. "
+            "Stop that session, or wait for it to disconnect, then try again."
+        )
+        super().__init__(
+            message=message,
+            error_code="runtime_session_busy",
+            http_status=http.HTTPStatus.LOCKED,
         )
 
 

--- a/application/backend/src/runtime/config_builder.py
+++ b/application/backend/src/runtime/config_builder.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import TYPE_CHECKING, Any, cast
 
 from physicalai.capture import ColorMode, SharedCamera
@@ -103,6 +105,12 @@ async def build_runtime_config(
     document = Config("physicalai.runtime.RobotRuntime", init_args).to_dict()
     validate_config(document)
     return cast("dict[str, Any]", document)
+
+
+def runtime_config_digest(document: dict[str, Any]) -> str:
+    """Identify one rig configuration, so a client cannot attach to a different one."""
+    canonical = json.dumps(document, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
 
 
 def runtime_config_change_me(document: dict[str, Any]) -> list[str]:

--- a/application/backend/src/runtime/hosts/process_host.py
+++ b/application/backend/src/runtime/hosts/process_host.py
@@ -26,12 +26,14 @@ class RuntimeProcessHost:
         *,
         follower_name: str | None = None,
         leader_name: str | None = None,
+        idle_timeout_s: float = 45.0,
         start_timeout: float = _DEFAULT_START_TIMEOUT,
     ) -> None:
         self._session_name = name
         self._document = document
         self._follower_name = follower_name
         self._leader_name = leader_name
+        self._idle_timeout_s = idle_timeout_s
         self._start_timeout = start_timeout
         self._proc: subprocess.Popen[str] | None = None
         self._error: AppBaseException | None = None
@@ -61,7 +63,7 @@ class RuntimeProcessHost:
                 "document": self._document,
                 "follower_name": self._follower_name,
                 "leader_name": self._leader_name,
-                "parent_pid": os.getpid(),
+                "idle_timeout_s": self._idle_timeout_s,
             }
         )
         with self._lock:
@@ -208,12 +210,15 @@ class RuntimeProcessHost:
             payload = json.loads(line.removeprefix("ERROR:"))
             message = payload["msg"]
             error_code = payload["error_code"]
+            phase = payload.get("phase")
             if not isinstance(message, str) or not isinstance(error_code, str):
                 raise TypeError("msg and error_code must be strings")
+            if phase is not None and not isinstance(phase, str):
+                raise TypeError("phase must be a string")
         except (json.JSONDecodeError, KeyError, TypeError) as exc:
             raise AppBaseException(
                 message=f"Runtime session worker returned a malformed startup error: {line!r}",
                 error_code="robot_connection_failed",
                 http_status=500,
             ) from exc
-        return AppBaseException(message=message, error_code=error_code, http_status=500)
+        return AppBaseException(message=message, error_code=error_code, http_status=500, phase=phase)

--- a/application/backend/src/runtime/hosts/session_worker.py
+++ b/application/backend/src/runtime/hosts/session_worker.py
@@ -9,29 +9,72 @@ import os
 import signal
 import sys
 import threading
+import time
 import traceback
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from loguru import logger
 
 from core.logging import setup_logging
 from exceptions import BaseException as AppBaseException
-from runtime.contract import ErrorEvent
+from exceptions import RuntimeSessionBusyError
+from runtime.config_builder import runtime_config_digest
+from runtime.contract import ErrorEvent, LifecycleData, LifecycleEvent, SetFollowerSourceCommand
 from runtime.session import RuntimeSession
+from runtime.transport.lock import SessionNameLock, live_session_pid
 from runtime.transport.server import RuntimeZenohServer
 
 if TYPE_CHECKING:
     from types import FrameType
 
-_WATCHDOG_INTERVAL_S = 0.1
+_IDLE_POLL_INTERVAL_S = 0.1
 
 
-def _watch_parent(parent_pid: int, stop: threading.Event) -> None:
-    """Stop when B1's spawning API exits; B2 replaces this with subscriber presence."""
-    while not stop.wait(_WATCHDOG_INTERVAL_S):
-        if os.getppid() != parent_pid:
-            logger.warning("Parent process {} exited; stopping the runtime session", parent_pid)
+def _watch_subscribers(
+    server: RuntimeZenohServer,
+    session: RuntimeSession,
+    idle_timeout_s: float,
+    stop: threading.Event,
+) -> None:
+    """Force hold when the last subscriber leaves, then idle-exit.
+
+    Started only after wait_for_client() returned, so a subscriber has already
+    matched at least once. Losing every subscriber is the worst abandonment
+    state — an arm following a leader with nobody watching — so the session
+    latches a target before the countdown starts.
+    """
+    subscribers_present = True
+    idle_since: float | None = None
+
+    while not stop.wait(_IDLE_POLL_INTERVAL_S):
+        if server.has_matching_subscribers():
+            subscribers_present = True
+            idle_since = None
+            continue
+        if subscribers_present:
+            subscribers_present = False
+            logger.warning("Runtime session lost its last subscriber; switching follower to hold")
+            try:
+                session.apply(SetFollowerSourceCommand(follower_source="hold"))
+            except Exception:
+                logger.exception("Failed to switch runtime session to hold after losing subscribers")
+        now = time.monotonic()
+        if idle_since is None:
+            idle_since = now
+        elif now - idle_since > idle_timeout_s:
+            if server.has_matching_subscribers():
+                # A client attached on the deadline. Without this re-check they
+                # would lose the session and pay a full hardware reconnect.
+                idle_since = None
+                continue
+            logger.info("Runtime session idle for {}s; shutting down", idle_timeout_s)
+            server.emit(LifecycleEvent(data=LifecycleData(event="shutdown", reason="idle_timeout")))
+            # Setting stop ends session.run(...), which returns through
+            # session.teardown() in main(). B4 extends that teardown with
+            # RecordingMutation.teardown so an idle exit during recording
+            # still saves the episode.
             stop.set()
             return
 
@@ -122,6 +165,78 @@ def _teardown(
     return failed
 
 
+@dataclass(frozen=True, slots=True)
+class _StartupPayload:
+    session_name: str
+    document: dict[str, Any]
+    follower_name: str | None
+    leader_name: str | None
+    idle_timeout_s: float
+
+
+def _parse_startup_payload(raw: str) -> _StartupPayload:
+    payload = json.loads(raw)
+    session_name = payload["session_name"]
+    document = payload["document"]
+    follower_name = payload.get("follower_name")
+    leader_name = payload.get("leader_name")
+    idle_timeout_s = payload["idle_timeout_s"]
+    if (
+        not isinstance(session_name, str)
+        or not isinstance(document, dict)
+        or isinstance(idle_timeout_s, bool)
+        or not isinstance(idle_timeout_s, int | float)
+        or (follower_name is not None and not isinstance(follower_name, str))
+        or (leader_name is not None and not isinstance(leader_name, str))
+    ):
+        raise TypeError("Runtime session startup payload has invalid field types")
+    return _StartupPayload(session_name, document, follower_name, leader_name, float(idle_timeout_s))
+
+
+def _open_locked_session(
+    payload: _StartupPayload,
+    stop: threading.Event,
+    loop: asyncio.AbstractEventLoop,
+    phase: list[str],
+) -> tuple[SessionNameLock, RuntimeZenohServer, RuntimeSession]:
+    """Take the name lock, declare endpoints, and set the session up.
+
+    ``phase`` is a one-element list so the handshake can report where startup
+    failed after this function raises.
+    """
+    lock = SessionNameLock(payload.session_name)
+    phase[0] = "name_lock_contention"
+    if not lock.acquire():
+        raise RuntimeSessionBusyError(robot_name=payload.follower_name, pid=live_session_pid(payload.session_name))
+
+    instance_id = uuid4().hex
+    server = RuntimeZenohServer(payload.session_name, instance_id=instance_id)
+    server.update_metadata(
+        config_digest=runtime_config_digest(payload.document),
+        pid=os.getpid(),
+        started_at=time.time(),
+        idle_timeout_s=payload.idle_timeout_s,
+    )
+    session = RuntimeSession(
+        payload.document,
+        event_sink=server,
+        follower_name=payload.follower_name,
+        leader_name=payload.leader_name,
+    )
+    phase[0] = "endpoint_collision"
+    server.open(session.apply)
+    server.wait_for_client()
+    threading.Thread(
+        target=_watch_subscribers,
+        args=(server, session, payload.idle_timeout_s, stop),
+        name="runtime-subscriber-watch",
+        daemon=True,
+    ).start()
+    phase[0] = "setup_failed"
+    loop.run_until_complete(session.setup())
+    return lock, server, session
+
+
 def main() -> int:
     """Run one runtime session configured by JSON stdin and acknowledged on stdout."""
     raw = sys.stdin.read()
@@ -132,61 +247,42 @@ def main() -> int:
     saved_fd = suppress_stdout()
     server: RuntimeZenohServer | None = None
     session: RuntimeSession | None = None
-    phase = "invalid_config"
+    lock: SessionNameLock | None = None
+    phase = ["invalid_config"]
 
     try:
-        payload = json.loads(raw)
-        session_name = payload["session_name"]
-        document = payload["document"]
-        follower_name = payload.get("follower_name")
-        leader_name = payload.get("leader_name")
-        parent_pid = payload["parent_pid"]
-        if not isinstance(session_name, str) or not isinstance(document, dict) or not isinstance(parent_pid, int):
-            raise TypeError("Runtime session startup payload has invalid field types")
+        try:
+            payload = _parse_startup_payload(raw)
+            setup_logging()
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            signal.signal(signal.SIGTERM, lambda signum, frame: _stop_on_sigterm(signum, frame, stop))
+            lock, server, session = _open_locked_session(payload, stop, loop, phase)
+        except Exception as exc:
+            restore_stdout(saved_fd)
+            signal_error(exc, phase=phase[0])
+            _teardown(loop, session, server, report_errors=False)
+            return 1
 
-        setup_logging()
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, lambda signum, frame: _stop_on_sigterm(signum, frame, stop))
-        threading.Thread(
-            target=_watch_parent,
-            args=(parent_pid, stop),
-            name="runtime-parent-watchdog",
-            daemon=True,
-        ).start()
-
-        instance_id = uuid4().hex
-        server = RuntimeZenohServer(session_name, instance_id=instance_id)
-        session = RuntimeSession(
-            document,
-            event_sink=server,
-            follower_name=follower_name,
-            leader_name=leader_name,
-        )
-        phase = "endpoint_collision"
-        server.open(session.apply)
-        server.wait_for_client()
-        phase = "setup_failed"
-        loop.run_until_complete(session.setup())
-    except Exception as exc:
         restore_stdout(saved_fd)
-        signal_error(exc, phase=phase)
-        _teardown(loop, session, server, report_errors=False)
-        return 1
+        signal_ready()
 
-    restore_stdout(saved_fd)
-    signal_ready()
-
-    completed = False
-    try:
-        session.run(stop)
-        completed = True
-    except Exception as exc:
-        logger.exception("Runtime session failed")
-        _publish_fatal(server, exc)
+        completed = False
+        try:
+            # session.run() returns through session.teardown() below. B4 extends
+            # that teardown with RecordingMutation.teardown so an idle exit
+            # during recording still saves the episode.
+            session.run(stop)
+            completed = True
+        except Exception as exc:
+            logger.exception("Runtime session failed")
+            _publish_fatal(server, exc)
+        finally:
+            if _teardown(loop, session, server, report_errors=True):
+                completed = False
+        return 0 if completed else 1
     finally:
-        if _teardown(loop, session, server, report_errors=True):
-            completed = False
-    return 0 if completed else 1
+        if lock is not None:
+            lock.release()
 
 
 if __name__ == "__main__":

--- a/application/backend/src/runtime/hosts/session_worker.py
+++ b/application/backend/src/runtime/hosts/session_worker.py
@@ -226,14 +226,14 @@ def _open_locked_session(
     phase[0] = "endpoint_collision"
     server.open(session.apply)
     server.wait_for_client()
+    phase[0] = "setup_failed"
+    loop.run_until_complete(session.setup())
     threading.Thread(
         target=_watch_subscribers,
         args=(server, session, payload.idle_timeout_s, stop),
         name="runtime-subscriber-watch",
         daemon=True,
     ).start()
-    phase[0] = "setup_failed"
-    loop.run_until_complete(session.setup())
     return lock, server, session
 
 

--- a/application/backend/src/runtime/owner.py
+++ b/application/backend/src/runtime/owner.py
@@ -134,7 +134,7 @@ class RuntimeSessionOwner:
             self._attach_to(metadata)
             return
 
-        host = RuntimeProcessHost(
+        self._host = RuntimeProcessHost(
             self._session_name,
             self._document,
             follower_name=self._follower_name,
@@ -142,8 +142,9 @@ class RuntimeSessionOwner:
             idle_timeout_s=self._idle_timeout_s,
         )
         try:
-            host.start()
+            self._host.start()
         except AppBaseException as exc:
+            self._host = None
             if getattr(exc, "phase", None) != "name_lock_contention":
                 raise
             metadata = self._client.probe_with_retry(_RACE_RETRY_TIMEOUT)
@@ -152,7 +153,6 @@ class RuntimeSessionOwner:
             self._attach_to(metadata)
             return
 
-        self._host = host
         try:
             metadata = self._wait_for_spawned_metadata(_RACE_RETRY_TIMEOUT)
             if metadata is None:
@@ -163,7 +163,7 @@ class RuntimeSessionOwner:
                 )
             self._attach_to(metadata)
         except Exception:
-            host.stop()
+            self.stop()
             self._host = None
             raise
         self._spawned = True

--- a/application/backend/src/runtime/owner.py
+++ b/application/backend/src/runtime/owner.py
@@ -1,0 +1,204 @@
+"""Parent-side policy: probe, attach or spawn, and resolve the spawn race."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from exceptions import BaseException as AppBaseException
+from exceptions import RuntimeSessionBusyError
+from runtime.config_builder import runtime_config_digest
+from runtime.hosts.process_host import RuntimeProcessHost
+from runtime.transport.codec import decode_metadata
+from runtime.transport.ids import metadata_key, runtime_session_name
+from runtime.transport.lock import live_session_pid
+from runtime.transport.session import open_session
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from runtime.transport.client import RuntimeSessionClient
+
+_PROBE_TIMEOUT = 1.0
+_RACE_RETRY_TIMEOUT = 5.0
+
+
+def probe_session_metadata(session_name: str, timeout: float = _PROBE_TIMEOUT) -> dict[str, Any] | None:
+    """Query ``/metadata`` once without declaring telemetry subscribers.
+
+    Used by discovery (deletion guards, the record-path check) so a miss does
+    not reset a session's idle countdown.
+    """
+    session = open_session(session_name, listen=False)
+    try:
+        replies = session.get(metadata_key(session_name), timeout=timeout)
+        for reply in replies:
+            sample = reply.ok
+            if sample is not None:
+                return decode_metadata(sample.payload.to_bytes())
+    except Exception:
+        logger.debug("Runtime metadata probe failed for {}", session_name, exc_info=True)
+    finally:
+        session.close()
+    return None
+
+
+def runtime_session_holder(follower_id: UUID | str, *, timeout: float = _PROBE_TIMEOUT) -> dict[str, Any] | None:
+    """Return metadata for a live session driving this follower, or ``None``.
+
+    Reads the on-disk lock registry first — a miss is the common case and must
+    not open a Zenoh session — and only probes ``/metadata`` on a hit.
+    """
+    name = runtime_session_name(follower_id)
+    if live_session_pid(name) is None:
+        return None
+    return probe_session_metadata(name, timeout=timeout)
+
+
+class RuntimeSessionOwner:
+    """Attach to a live runtime session, or spawn one if none answers."""
+
+    def __init__(
+        self,
+        client: RuntimeSessionClient,
+        *,
+        session_name: str,
+        document: dict[str, Any],
+        follower_name: str | None,
+        leader_name: str | None,
+        idle_timeout_s: float,
+    ) -> None:
+        self._client = client
+        self._session_name = session_name
+        self._document = document
+        self._follower_name = follower_name
+        self._leader_name = leader_name
+        self._idle_timeout_s = idle_timeout_s
+        self._host: RuntimeProcessHost | None = None
+        self._metadata: dict[str, Any] | None = None
+        self._spawned = False
+
+    @property
+    def spawned(self) -> bool:
+        """Whether this owner started the child, rather than attaching to one."""
+        return self._spawned
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Session metadata adopted during ``connect``."""
+        if self._metadata is None:
+            raise RuntimeError("Runtime session owner is not connected")
+        return self._metadata
+
+    @property
+    def host(self) -> RuntimeProcessHost | None:
+        """The spawned child handle, or ``None`` when this owner attached."""
+        return self._host
+
+    @property
+    def error(self) -> AppBaseException | None:
+        """A startup failure reported by a child this owner spawned."""
+        return None if self._host is None else self._host.error
+
+    def is_alive(self) -> bool:
+        """Return whether the session process is still running."""
+        if self._spawned:
+            return self._host is not None and self._host.is_alive()
+        pid = None if self._metadata is None else self._metadata.get("pid")
+        if not isinstance(pid, int) or pid <= 0:
+            return False
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        return True
+
+    def exited_cleanly(self) -> bool:
+        """Return whether the session ended through a clean shutdown path."""
+        if self._spawned:
+            return self._host is not None and self._host.exited_cleanly
+        return self._client.shutdown_received
+
+    def stop(self) -> None:
+        """Terminate the child. Only meaningful for a session this owner spawned."""
+        if self._host is not None:
+            self._host.stop()
+
+    def connect(self) -> None:
+        """Attach to a live session, or spawn one. Blocking."""
+        metadata = self._client.probe()
+        if metadata is not None:
+            self._attach_to(metadata)
+            return
+
+        host = RuntimeProcessHost(
+            self._session_name,
+            self._document,
+            follower_name=self._follower_name,
+            leader_name=self._leader_name,
+            idle_timeout_s=self._idle_timeout_s,
+        )
+        try:
+            host.start()
+        except AppBaseException as exc:
+            if getattr(exc, "phase", None) != "name_lock_contention":
+                raise
+            metadata = self._client.probe_with_retry(_RACE_RETRY_TIMEOUT)
+            if metadata is None:
+                raise
+            self._attach_to(metadata)
+            return
+
+        self._host = host
+        try:
+            metadata = self._wait_for_spawned_metadata(_RACE_RETRY_TIMEOUT)
+            if metadata is None:
+                raise AppBaseException(
+                    message=f"Runtime session {self._session_name} reported READY but its metadata is unreachable.",
+                    error_code="robot_connection_failed",
+                    http_status=500,
+                )
+            self._attach_to(metadata)
+        except Exception:
+            host.stop()
+            self._host = None
+            raise
+        self._spawned = True
+
+    def _wait_for_spawned_metadata(self, timeout: float) -> dict[str, Any] | None:
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            if self._host is not None and not self._host.is_alive():
+                if self._host.error is not None:
+                    raise self._host.error
+                raise AppBaseException(
+                    message="Runtime session stopped before answering metadata",
+                    error_code="robot_connection_failed",
+                    http_status=500,
+                )
+            metadata = self._client.probe(timeout=min(1.0, remaining))
+            if metadata is not None:
+                return metadata
+            time.sleep(min(0.05, remaining))
+
+    def _attach_to(self, metadata: dict[str, Any]) -> None:
+        self._reject_if_different_rig(metadata)
+        self._client.attach(metadata)
+        self._metadata = metadata
+
+    def _reject_if_different_rig(self, metadata: dict[str, Any]) -> None:
+        expected = runtime_config_digest(self._document)
+        actual = metadata.get("config_digest")
+        if actual == expected:
+            return
+        pid = metadata.get("pid")
+        raise RuntimeSessionBusyError(
+            robot_name=self._follower_name,
+            pid=pid if isinstance(pid, int) else None,
+        )

--- a/application/backend/src/runtime/owner.py
+++ b/application/backend/src/runtime/owner.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
+import signal
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -24,6 +26,7 @@ if TYPE_CHECKING:
 
 _PROBE_TIMEOUT = 1.0
 _RACE_RETRY_TIMEOUT = 5.0
+_STOP_TIMEOUT = 5.0
 
 
 def probe_session_metadata(session_name: str, timeout: float = _PROBE_TIMEOUT) -> dict[str, Any] | None:
@@ -50,12 +53,67 @@ def runtime_session_holder(follower_id: UUID | str, *, timeout: float = _PROBE_T
     """Return metadata for a live session driving this follower, or ``None``.
 
     Reads the on-disk lock registry first — a miss is the common case and must
-    not open a Zenoh session — and only probes ``/metadata`` on a hit.
+    not open a Zenoh session — and only probes ``/metadata`` on a hit. A live
+    lock with a metadata miss is still treated as held: the worker may have
+    the flock and the arm before ``/metadata`` answers, and a probe timeout
+    must not look like an idle robot.
     """
     name = runtime_session_name(follower_id)
-    if live_session_pid(name) is None:
+    pid = live_session_pid(name)
+    if pid is None:
         return None
-    return probe_session_metadata(name, timeout=timeout)
+    metadata = probe_session_metadata(name, timeout=timeout)
+    if metadata is not None:
+        return metadata
+    logger.warning(
+        "Runtime session {} holds the lock (pid {}) but metadata did not answer",
+        name,
+        pid,
+    )
+    return {"pid": pid}
+
+
+def stop_runtime_session(session_name: str, *, timeout: float = _STOP_TIMEOUT) -> None:
+    """Terminate the live session for ``session_name``, if any. Blocking.
+
+    Sends SIGTERM to the lock holder, waits for the name lock to drop, then
+    SIGKILL. Does not attach as a subscriber, so a winding-down session is
+    not kept alive by the stop itself.
+    """
+    pid = live_session_pid(session_name)
+    if pid is None:
+        metadata = probe_session_metadata(session_name, timeout=min(1.0, timeout))
+        raw = None if metadata is None else metadata.get("pid")
+        pid = raw if isinstance(raw, int) and raw > 0 else None
+    if pid is None:
+        return
+
+    logger.info("Stopping runtime session {} (pid {})", session_name, pid)
+    _signal_pid(pid, signal.SIGTERM)
+    if _wait_until_session_gone(session_name, pid, timeout):
+        return
+
+    logger.warning("Runtime session {} (pid {}) did not stop within {}s, killing", session_name, pid, timeout)
+    _signal_pid(pid, signal.SIGKILL)
+    _wait_until_session_gone(session_name, pid, 1.0)
+
+
+def _signal_pid(pid: int, sig: signal.Signals) -> None:
+    with contextlib.suppress(OSError):
+        os.kill(pid, sig)
+
+
+def _wait_until_session_gone(session_name: str, pid: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if live_session_pid(session_name) is None:
+            return True
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return True
+        time.sleep(0.05)
+    return live_session_pid(session_name) is None
 
 
 class RuntimeSessionOwner:
@@ -127,9 +185,29 @@ class RuntimeSessionOwner:
         if self._host is not None:
             self._host.stop()
 
-    def connect(self) -> None:
-        """Attach to a live session, or spawn one. Blocking."""
-        metadata = self._client.probe()
+    def stop_abandoned_spawn(self) -> None:
+        """Stop a child this owner started that other clients cannot attach to yet.
+
+        A websocket close after ``/metadata`` is up is a detach: another client
+        may already be attached, and a refresh must be able to rejoin. Only an
+        in-flight spawn that has not published metadata is private to this owner.
+        """
+        if self._host is None or self._spawned or self._metadata is not None:
+            return
+        if self._client.probe(timeout=_PROBE_TIMEOUT) is not None:
+            return
+        self.stop()
+
+    def connect(self, *, replace: bool = False) -> None:
+        """Attach to a live session, or spawn one. Blocking.
+
+        When ``replace`` is true, any live session for this name is stopped
+        first and this owner always tries to spawn with its current document.
+        """
+        if replace:
+            stop_runtime_session(self._session_name)
+
+        metadata = None if replace else self._client.probe()
         if metadata is not None:
             self._attach_to(metadata)
             return
@@ -153,6 +231,7 @@ class RuntimeSessionOwner:
             self._attach_to(metadata)
             return
 
+        self._spawned = True
         try:
             metadata = self._wait_for_spawned_metadata(_RACE_RETRY_TIMEOUT)
             if metadata is None:
@@ -165,8 +244,8 @@ class RuntimeSessionOwner:
         except Exception:
             self.stop()
             self._host = None
+            self._spawned = False
             raise
-        self._spawned = True
 
     def _wait_for_spawned_metadata(self, timeout: float) -> dict[str, Any] | None:
         deadline = time.monotonic() + timeout

--- a/application/backend/src/runtime/transport/client.py
+++ b/application/backend/src/runtime/transport/client.py
@@ -58,6 +58,45 @@ class RuntimeSessionClient:
             encoding=zenoh.Encoding("application/msgpack"),
         )
 
+    def probe(self, timeout: float = 1.0) -> dict[str, Any] | None:
+        """Query metadata once. No retry and no client state change."""
+        if self._session is None:
+            raise RuntimeError("Runtime session client is not open")
+        try:
+            replies = self._session.get(metadata_key(self._name), timeout=timeout)
+            for reply in replies:
+                sample = reply.ok
+                if sample is None:
+                    continue
+                metadata = decode_metadata(sample.payload.to_bytes())
+                if self._instance_id is not None and metadata.get("instance_id") != self._instance_id:
+                    continue
+                return metadata
+        except Exception:
+            logger.debug("Runtime metadata query failed for {}", self._name, exc_info=True)
+        return None
+
+    def probe_with_retry(self, timeout: float) -> dict[str, Any] | None:
+        """Poll ``probe`` until metadata answers or the deadline elapses."""
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            metadata = self.probe(timeout=min(1.0, remaining))
+            if metadata is not None:
+                return metadata
+            time.sleep(min(0.05, remaining))
+
+    def attach(self, metadata: dict[str, Any]) -> None:
+        """Adopt the session generation id and flush any command buffered before it."""
+        instance_id = metadata.get("instance_id")
+        if instance_id is not None and (not isinstance(instance_id, str) or not instance_id):
+            raise RuntimeError("Runtime session metadata instance_id must be a string")
+        self._instance_id = instance_id
+        self._metadata_ready.set()
+        self._flush_pending_command()
+
     def connect(self, timeout: float = 10.0, *, process: Any = None) -> dict[str, Any]:
         """Wait for metadata before allowing any command publication."""
         if self._session is None:
@@ -74,22 +113,10 @@ class RuntimeSessionClient:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise TimeoutError(f"Runtime session {self._name} did not answer metadata")
-            try:
-                replies = self._session.get(metadata_key(self._name), timeout=min(1.0, remaining))
-                for reply in replies:
-                    sample = reply.ok
-                    if sample is None:
-                        continue
-                    metadata = decode_metadata(sample.payload.to_bytes())
-                    if self._instance_id is None:
-                        self._instance_id = metadata["instance_id"]
-                    elif metadata.get("instance_id") != self._instance_id:
-                        continue
-                    self._metadata_ready.set()
-                    self._flush_pending_command()
-                    return metadata
-            except Exception:
-                logger.debug("Runtime metadata query failed for {}", self._name, exc_info=True)
+            metadata = self.probe(timeout=min(1.0, remaining))
+            if metadata is not None:
+                self.attach(metadata)
+                return metadata
             time.sleep(min(0.05, remaining))
 
     def apply(self, command: Command) -> None:
@@ -151,9 +178,15 @@ class RuntimeSessionClient:
             except Exception:
                 logger.debug("Failed to undeclare runtime subscriber", exc_info=True)
         if self._command_pub is not None:
-            self._command_pub.undeclare()
+            try:
+                self._command_pub.undeclare()
+            except Exception:
+                logger.debug("Failed to undeclare runtime command publisher", exc_info=True)
         if self._session is not None:
-            self._session.close()
+            try:
+                self._session.close()
+            except Exception:
+                logger.debug("Failed to close runtime Zenoh session", exc_info=True)
 
     def _flush_pending_command(self) -> None:
         with self._lock:

--- a/application/backend/src/runtime/transport/lock.py
+++ b/application/backend/src/runtime/transport/lock.py
@@ -1,0 +1,204 @@
+"""Host-local exclusivity lock for Studio runtime sessions.
+
+Same mechanism as physicalai's robot name lock — a non-blocking ``flock`` on a
+user-private file, released by the kernel even on ``SIGKILL`` — in a separate
+directory so the two namespaces cannot collide on disk. The identity is the
+``rt-<follower uuid>`` session name, never the robot's own SharedRobot name.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import tempfile
+import time
+from pathlib import Path
+from typing import Self
+
+from runtime.transport.ids import validate_session_name
+
+SESSION_LOCK_KIND = "rt-name"
+
+
+def _lock_dir() -> Path:
+    """Return the user-scoped Studio runtime-lock directory, creating it if needed.
+
+    Prefers ``$XDG_RUNTIME_DIR/physicalai-studio/runtime-locks``. When that
+    variable is unset (some containers), falls back to
+    ``<tempdir>/physicalai-studio-<uid>/runtime-locks``.
+
+    Raises:
+        RuntimeError: If the resulting directory is not private or is not
+            owned by the current user.
+    """
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        lock_dir = Path(runtime_dir) / "physicalai-studio" / "runtime-locks"
+    else:
+        lock_dir = Path(tempfile.gettempdir()) / f"physicalai-studio-{os.getuid()}" / "runtime-locks"
+
+    lock_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+    lock_dir_stat = lock_dir.stat()
+    if not stat.S_ISDIR(lock_dir_stat.st_mode) or lock_dir_stat.st_uid != os.getuid() or lock_dir_stat.st_mode & 0o077:
+        raise RuntimeError(f"runtime lock directory must be private and owned by this user: {lock_dir}")
+    return lock_dir
+
+
+def session_lock_path(identity: str) -> Path:
+    """Return the lock-file path for one runtime session identity.
+
+    Hashing keeps filesystem-unsafe characters out of the filename and keeps
+    this namespace distinct from physicalai's robot locks even when the raw
+    identity strings happen to match.
+    """
+    digest = hashlib.sha256(f"{SESSION_LOCK_KIND}:{identity}".encode()).hexdigest()
+    return _lock_dir() / f"{digest}.lock"
+
+
+def _read_live_diagnostics(path: Path) -> dict[str, object] | None:
+    """Parse and liveness-check one lock file.
+
+    Lock files are never deleted, so a well-formed file is not enough: the
+    recorded pid must still exist and the flock must still be held.
+    """
+    try:
+        diagnostics = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(diagnostics, dict) or diagnostics.get("kind") != SESSION_LOCK_KIND:
+        return None
+
+    pid = diagnostics.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    try:
+        # Signal 0 sends nothing; the kernel only checks that the pid exists
+        # and is signalable. Valid here because the trust model is a single host.
+        os.kill(pid, 0)
+    except OSError:
+        return None
+
+    try:
+        fd = os.open(path, os.O_RDWR)
+    except OSError:
+        return None
+    held = False
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        held = True
+    finally:
+        os.close(fd)
+    return diagnostics if held else None
+
+
+def registered_session_names() -> list[str]:
+    """Return session names whose lock file records a live, currently held flock.
+
+    Files are retained after release, so both the pid check and the flock
+    check are required. The result is only a set of candidates: callers still
+    confirm liveness through the session's metadata queryable.
+    """
+    names: set[str] = set()
+    for path in _lock_dir().glob("*.lock"):
+        diagnostics = _read_live_diagnostics(path)
+        if diagnostics is None:
+            continue
+        identity = diagnostics.get("identity")
+        if isinstance(identity, str):
+            names.add(identity)
+    return sorted(names)
+
+
+def live_session_pid(name: str) -> int | None:
+    """Return the holder's pid for a live session, or ``None``.
+
+    This is the cheap first half of the deletion guard: a filesystem read that
+    misses without opening a Zenoh session.
+    """
+    diagnostics = _read_live_diagnostics(session_lock_path(name))
+    if diagnostics is None or diagnostics.get("identity") != name:
+        return None
+    pid = diagnostics.get("pid")
+    return pid if isinstance(pid, int) else None
+
+
+class SessionNameLock:
+    """Exclusive, non-blocking advisory lock on one runtime session name.
+
+    Held for the child's lifetime and released on process exit even after a
+    crash (``flock`` locks die with the file descriptor). Lock files are
+    never deleted on release — the kernel lock, not file existence,
+    determines ownership.
+    """
+
+    def __init__(self, identity: str) -> None:
+        self._identity = validate_session_name(identity)
+        self._path = session_lock_path(self._identity)
+        self._fd: int | None = None
+
+    @property
+    def path(self) -> Path:
+        """The lock-file path."""
+        return self._path
+
+    @property
+    def identity(self) -> str:
+        """The runtime session name this lock guards."""
+        return self._identity
+
+    def acquire(self) -> bool:
+        """Try to acquire the lock without blocking.
+
+        Returns:
+            True if this process now holds the lock, False if another
+            process already holds it.
+        """
+        if self._fd is not None:
+            return True
+        fd = os.open(self._path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(fd)
+            return False
+        diagnostics = {
+            "kind": SESSION_LOCK_KIND,
+            "identity": self._identity,
+            "pid": os.getpid(),
+            "created_at": time.time(),
+        }
+        os.ftruncate(fd, 0)
+        os.write(fd, json.dumps(diagnostics).encode())
+        self._fd = fd
+        return True
+
+    def release(self) -> None:
+        """Release the lock. No-op when not held."""
+        fd = self._fd
+        if fd is None:
+            return
+        self._fd = None
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+    def __enter__(self) -> Self:
+        """Acquire on entry.
+
+        Raises:
+            RuntimeError: If the lock is already held by another process.
+        """
+        if not self.acquire():
+            raise RuntimeError(f"runtime session lock already held: {self._identity}")
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Release on exit."""
+        self.release()

--- a/application/backend/src/runtime/transport/server.py
+++ b/application/backend/src/runtime/transport/server.py
@@ -108,6 +108,11 @@ class RuntimeZenohServer:
 
         self._metadata_queryable = self._session.declare_queryable(metadata_key(self._name), answer_metadata)
 
+    def has_matching_subscribers(self) -> bool:
+        """Return whether at least one client is subscribed to session state."""
+        publisher = self._publishers.get(StateEvent)
+        return publisher is not None and bool(publisher.matching_status.matching)
+
     def emit(self, event: RuntimeEvent, *, fatal: bool = False) -> None:
         """Publish an event without allowing transport failure to stop the robot loop."""
         with self._metadata_lock:

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -204,6 +204,15 @@ class Settings(BaseSettings):
         """Expand `~` so the default resolves to the running user's SSH config."""
         return Path(value).expanduser()
 
+    # Runtime sessions
+    # Seconds a session keeps running with no client attached before it exits by
+    # itself. A websocket reconnect after a page refresh completes well under 5s,
+    # so 45 leaves roughly nine times the headroom for a slow reload or a brief
+    # network drop; at the other end it bounds an abandoned, torque-holding arm to
+    # under a minute. Labs on flaky networks want it longer, an unattended rig
+    # wants it shorter.
+    runtime_idle_timeout_s: float = Field(default=45.0, alias="RUNTIME_IDLE_TIMEOUT_S")
+
     # Server
     host: str = Field(default="0.0.0.0", alias="HOST")  # noqa: S104 # nosec B104
     port: int = Field(default=7860, alias="PORT")

--- a/application/backend/tests/api/test_record.py
+++ b/application/backend/tests/api/test_record.py
@@ -8,11 +8,15 @@ from schemas import InferenceBackend, InferenceDevice, Model
 class FakeWebSocket:
     def __init__(self, messages: list[dict]) -> None:
         self._messages = messages
+        self.sent: list[dict] = []
 
     async def receive_json(self, _: str) -> dict:
         if not self._messages:
             raise RuntimeError("No more messages")
         return self._messages.pop(0)
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
 
 
 def test_handle_incoming_load_model_requires_inference_device(test_model) -> None:
@@ -36,4 +40,36 @@ def test_handle_incoming_load_model_requires_inference_device(test_model) -> Non
         Model.model_validate(test_model.model_dump(mode="json")),
         InferenceDevice(backend=InferenceBackend.OPENVINO, device="GPU"),
     )
+    process.disconnect.assert_called_once()
+
+
+def test_record_path_refuses_a_held_follower(test_environment, monkeypatch) -> None:
+    process = MagicMock()
+    monkeypatch.setattr(
+        "api.record.runtime_session_holder",
+        lambda follower_id, timeout=1.0: {"pid": 41273},
+    )
+    websocket = FakeWebSocket(
+        [
+            {
+                "event": "load_environment",
+                "data": {"environment": test_environment.model_dump(mode="json")},
+            },
+            {"event": "disconnect", "data": {}},
+        ]
+    )
+
+    asyncio.run(handle_incoming(websocket, process, set()))
+
+    process.load_environment.assert_not_called()
+    assert websocket.sent == [
+        {
+            "event": "error",
+            "message": (
+                "Robot 'Khaos' is already in use by a running session (pid 41273). "
+                "Stop that session, or wait for it to disconnect, then try again."
+            ),
+            "error_code": "runtime_session_busy",
+        }
+    ]
     process.disconnect.assert_called_once()

--- a/application/backend/tests/api/test_robot_control_errors.py
+++ b/application/backend/tests/api/test_robot_control_errors.py
@@ -93,5 +93,15 @@ def test_start_runtime_session_keeps_process_failure_checks() -> None:
 
     asyncio.run(start_runtime_session(client, owner))
 
-    owner.connect.assert_called_once_with()
+    owner.connect.assert_called_once_with(replace=False)
+    client.wait_until_ready.assert_called_once_with(owner)
+
+
+def test_start_runtime_session_forwards_replace() -> None:
+    client = MagicMock()
+    owner = MagicMock()
+
+    asyncio.run(start_runtime_session(client, owner, replace=True))
+
+    owner.connect.assert_called_once_with(replace=True)
     client.wait_until_ready.assert_called_once_with(owner)

--- a/application/backend/tests/api/test_robot_control_errors.py
+++ b/application/backend/tests/api/test_robot_control_errors.py
@@ -43,6 +43,7 @@ def test_handle_incoming_applies_a_valid_set_follower_source_command() -> None:
     asyncio.run(handle_incoming(websocket, session))
 
     session.apply.assert_any_call(SetFollowerSourceCommand(follower_source="teleop"))
+    session.apply.assert_called_once()
 
 
 def test_handle_incoming_drops_malformed_follower_source_without_crashing() -> None:
@@ -63,17 +64,23 @@ def test_handle_incoming_drops_malformed_follower_source_without_crashing() -> N
 
     asyncio.run(handle_incoming(websocket, session))
 
-    # Only the valid, later command was applied (the malformed ones were dropped),
-    # followed by the disconnect once the fake websocket runs out of messages.
     assert session.apply.call_args_list == [
         call(SetFollowerSourceCommand(follower_source="hold")),
-        call(DisconnectCommand()),
     ]
 
 
-def test_handle_incoming_applies_disconnect_on_websocket_disconnect() -> None:
+def test_handle_incoming_does_not_disconnect_on_websocket_close() -> None:
     session = MagicMock()
     websocket = FakeWebSocket([])
+
+    asyncio.run(handle_incoming(websocket, session))
+
+    session.apply.assert_not_called()
+
+
+def test_handle_incoming_applies_an_explicit_disconnect() -> None:
+    session = MagicMock()
+    websocket = FakeWebSocket([{"event": "disconnect"}])
 
     asyncio.run(handle_incoming(websocket, session))
 
@@ -82,10 +89,9 @@ def test_handle_incoming_applies_disconnect_on_websocket_disconnect() -> None:
 
 def test_start_runtime_session_keeps_process_failure_checks() -> None:
     client = MagicMock()
-    host = MagicMock()
+    owner = MagicMock()
 
-    asyncio.run(start_runtime_session(client, host))
+    asyncio.run(start_runtime_session(client, owner))
 
-    host.start.assert_called_once_with()
-    client.connect.assert_called_once_with(process=host)
-    client.wait_until_ready.assert_called_once_with(host)
+    owner.connect.assert_called_once_with()
+    client.wait_until_ready.assert_called_once_with(owner)

--- a/application/backend/tests/api/test_runtime_owner_api.py
+++ b/application/backend/tests/api/test_runtime_owner_api.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.dependencies import get_robot_service
+from main import app
+
+
+class _StubRobot:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _StubRobotService:
+    def __init__(self, robot: _StubRobot) -> None:
+        self.robot = robot
+        self.deleted: list[UUID] = []
+
+    async def get_robot_by_id(self, project_id: UUID, robot_id: UUID) -> _StubRobot:
+        return self.robot
+
+    async def delete_robot(self, project_id: UUID, robot_id: UUID) -> None:
+        self.deleted.append(robot_id)
+
+
+def _client(service: _StubRobotService) -> TestClient:
+    app.dependency_overrides[get_robot_service] = lambda: service
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def isolate_runtime_locks(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    xdg = tmp_path / "xdg-runtime"
+    xdg.mkdir(mode=0o700)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+    yield
+    app.dependency_overrides.clear()
+
+
+def test_deleting_a_held_robot_returns_423(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _StubRobotService(_StubRobot("left arm"))
+    monkeypatch.setattr("api.robots.runtime_session_holder", lambda follower_id, timeout=1.0: {"pid": 41273})
+    project_id = uuid4()
+    robot_id = uuid4()
+
+    response = _client(service).delete(f"/api/projects/{project_id}/robots/{robot_id}")
+
+    assert response.status_code == 423
+    body = response.json()
+    assert body["error_code"] == "runtime_session_busy"
+    assert "left arm" in body["message"]
+    assert "41273" in body["message"]
+    assert service.deleted == []
+
+
+def test_deleting_an_unheld_robot_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _StubRobotService(_StubRobot("idle arm"))
+    probe = MagicMock()
+    monkeypatch.setattr("runtime.owner.probe_session_metadata", probe)
+    project_id = uuid4()
+    robot_id = uuid4()
+
+    response = _client(service).delete(f"/api/projects/{project_id}/robots/{robot_id}")
+
+    assert response.status_code == 204
+    assert service.deleted == [robot_id]
+    probe.assert_not_called()

--- a/application/backend/tests/api/test_runtime_owner_api.py
+++ b/application/backend/tests/api/test_runtime_owner_api.py
@@ -57,6 +57,24 @@ def test_deleting_a_held_robot_returns_423(monkeypatch: pytest.MonkeyPatch) -> N
     assert service.deleted == []
 
 
+def test_deleting_a_robot_whose_lock_is_live_without_metadata_returns_423(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _StubRobotService(_StubRobot("left arm"))
+    monkeypatch.setattr("runtime.owner.live_session_pid", lambda name: 41273)
+    monkeypatch.setattr("runtime.owner.probe_session_metadata", lambda *args, **kwargs: None)
+    project_id = uuid4()
+    robot_id = uuid4()
+
+    response = _client(service).delete(f"/api/projects/{project_id}/robots/{robot_id}")
+
+    assert response.status_code == 423
+    body = response.json()
+    assert body["error_code"] == "runtime_session_busy"
+    assert "41273" in body["message"]
+    assert service.deleted == []
+
+
 def test_deleting_an_unheld_robot_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
     service = _StubRobotService(_StubRobot("idle arm"))
     probe = MagicMock()

--- a/application/backend/tests/runtime/conftest.py
+++ b/application/backend/tests/runtime/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_runtime_locks(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep session lock files out of the developer's XDG runtime directory."""
+    xdg = tmp_path / "xdg-runtime"
+    xdg.mkdir(mode=0o700)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))

--- a/application/backend/tests/runtime/test_config_builder.py
+++ b/application/backend/tests/runtime/test_config_builder.py
@@ -9,7 +9,7 @@ from physicalai.config import to_yaml, validate_config
 from physicalai.runtime import RobotRuntime
 
 from robots.robot_client_factory import RobotClientFactory
-from runtime.config_builder import build_runtime_config, runtime_config_change_me
+from runtime.config_builder import build_runtime_config, runtime_config_change_me, runtime_config_digest
 from schemas import SerialPortInfo
 from schemas.project_camera import CameraAdapter
 from schemas.robot import RobotAdapter
@@ -134,3 +134,21 @@ async def test_export_keeps_the_stored_port_when_the_robot_is_absent(mocker: Any
     port = document["init_args"]["robot"]["init_args"]["robot"]["init_args"]["port"]
     assert port == "/dev/ttyACM0"
     assert runtime_config_change_me(document) == ["/dev/ttyACM0"]
+
+
+def test_runtime_config_digest_changes_when_the_rig_changes() -> None:
+    document = {
+        "class_path": "physicalai.runtime.RobotRuntime",
+        "init_args": {"fps": 30.0, "cameras": {}},
+    }
+    same = {
+        "init_args": {"cameras": {}, "fps": 30.0},
+        "class_path": "physicalai.runtime.RobotRuntime",
+    }
+    different = {
+        "class_path": "physicalai.runtime.RobotRuntime",
+        "init_args": {"fps": 15.0, "cameras": {}},
+    }
+
+    assert runtime_config_digest(document) == runtime_config_digest(same)
+    assert runtime_config_digest(document) != runtime_config_digest(different)

--- a/application/backend/tests/runtime/test_owner.py
+++ b/application/backend/tests/runtime/test_owner.py
@@ -7,13 +7,15 @@ import queue
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
 
 from exceptions import RuntimeSessionBusyError
+from runtime.config_builder import runtime_config_digest
 from runtime.contract import DisconnectCommand, SetFollowerSourceCommand, StateEvent
-from runtime.owner import RuntimeSessionOwner, probe_session_metadata, runtime_session_holder
+from runtime.owner import RuntimeSessionOwner, probe_session_metadata, runtime_session_holder, stop_runtime_session
 from runtime.transport.client import RuntimeSessionClient
 from runtime.transport.ids import runtime_session_name
 from runtime.transport.lock import SessionNameLock, live_session_pid, registered_session_names, session_lock_path
@@ -168,6 +170,86 @@ def test_attaching_with_a_different_rig_is_refused() -> None:
         _stop_session(owner, client)
 
 
+def test_replace_stops_the_existing_session_and_spawns_with_the_new_rig() -> None:
+    name = _name()
+    owner, client = _connect_owner(name, _document(), follower_name="left arm")
+    original_pid = owner.metadata["pid"]
+    try:
+        different = _document()
+        different["init_args"]["fps"] = 15.0
+        second_client = RuntimeSessionClient(name)
+        second_client.open()
+        second_owner = RuntimeSessionOwner(
+            second_client,
+            session_name=name,
+            document=different,
+            follower_name="left arm",
+            leader_name=None,
+            idle_timeout_s=30.0,
+        )
+        try:
+            second_owner.connect(replace=True)
+            second_client.wait_until_ready(second_owner, timeout=5)
+            assert second_owner.spawned is True
+            assert second_owner.metadata["pid"] != original_pid
+            assert second_owner.metadata["config_digest"] == runtime_config_digest(different)
+            assert not owner.is_alive()
+        finally:
+            _stop_session(second_owner, second_client)
+    finally:
+        if owner.is_alive():
+            owner.stop()
+        client.close()
+
+
+def test_replace_spawns_even_when_the_rig_matches() -> None:
+    name = _name()
+    document = _document()
+    owner, client = _connect_owner(name, document)
+    original_pid = owner.metadata["pid"]
+    try:
+        second_client = RuntimeSessionClient(name)
+        second_client.open()
+        second_owner = RuntimeSessionOwner(
+            second_client,
+            session_name=name,
+            document=document,
+            follower_name="follower",
+            leader_name=None,
+            idle_timeout_s=30.0,
+        )
+        try:
+            second_owner.connect(replace=True)
+            second_client.wait_until_ready(second_owner, timeout=5)
+            assert second_owner.spawned is True
+            assert second_owner.metadata["pid"] != original_pid
+        finally:
+            _stop_session(second_owner, second_client)
+    finally:
+        if owner.is_alive():
+            owner.stop()
+        client.close()
+
+
+def test_stop_runtime_session_is_a_noop_when_nothing_is_running() -> None:
+    stop_runtime_session(_name())
+
+
+def test_stop_runtime_session_terminates_a_live_child() -> None:
+    name = _name()
+    owner, client = _connect_owner(name, _document())
+    try:
+        stop_runtime_session(name)
+        deadline = time.monotonic() + 3
+        while owner.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert not owner.is_alive()
+        assert live_session_pid(name) is None
+    finally:
+        owner.stop()
+        client.close()
+
+
 def test_losing_the_last_subscriber_switches_to_hold() -> None:
     name = _name()
     document = _document_with_leader()
@@ -303,3 +385,67 @@ def test_probe_session_metadata_is_reachable_after_lock_hit() -> None:
         assert probe_session_metadata(name) is not None
     finally:
         _stop_session(owner, client)
+
+
+def test_holder_treats_a_lock_without_metadata_as_held(monkeypatch: pytest.MonkeyPatch) -> None:
+    follower_id = uuid4()
+    name = runtime_session_name(follower_id)
+    monkeypatch.setattr("runtime.owner.live_session_pid", lambda session_name: 41273 if session_name == name else None)
+    monkeypatch.setattr("runtime.owner.probe_session_metadata", lambda *args, **kwargs: None)
+
+    holder = runtime_session_holder(follower_id)
+
+    assert holder == {"pid": 41273}
+
+
+def _owner_with_mock_client(name: str | None = None) -> tuple[RuntimeSessionOwner, Any]:
+    client = MagicMock()
+    owner = RuntimeSessionOwner(
+        client,
+        session_name=name or _name(),
+        document=_document(),
+        follower_name="follower",
+        leader_name=None,
+        idle_timeout_s=30.0,
+    )
+    return owner, client
+
+
+def test_abandoned_spawn_is_stopped_before_metadata_answers() -> None:
+    owner, client = _owner_with_mock_client()
+    host = MagicMock()
+    owner._host = host
+    client.probe.return_value = None
+
+    owner.stop_abandoned_spawn()
+
+    host.stop.assert_called_once()
+
+
+def test_abandoned_spawn_is_not_stopped_once_metadata_answers() -> None:
+    owner, client = _owner_with_mock_client()
+    host = MagicMock()
+    owner._host = host
+    client.probe.return_value = {"pid": 41273}
+
+    owner.stop_abandoned_spawn()
+
+    host.stop.assert_not_called()
+
+
+def test_abandoned_spawn_is_not_stopped_after_the_child_is_ready() -> None:
+    owner, client = _owner_with_mock_client()
+    host = MagicMock()
+    owner._host = host
+    owner._spawned = True
+
+    owner.stop_abandoned_spawn()
+
+    host.stop.assert_not_called()
+    client.probe.assert_not_called()
+
+
+def test_attached_owner_does_not_stop_on_abandon() -> None:
+    owner, _client = _owner_with_mock_client()
+
+    owner.stop_abandoned_spawn()

--- a/application/backend/tests/runtime/test_owner.py
+++ b/application/backend/tests/runtime/test_owner.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import http
+import json
+import os
+import queue
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from exceptions import RuntimeSessionBusyError
+from runtime.contract import DisconnectCommand, SetFollowerSourceCommand, StateEvent
+from runtime.owner import RuntimeSessionOwner, probe_session_metadata, runtime_session_holder
+from runtime.transport.client import RuntimeSessionClient
+from runtime.transport.ids import runtime_session_name
+from runtime.transport.lock import SessionNameLock, live_session_pid, registered_session_names, session_lock_path
+from tests.runtime.test_session import _document, _document_with_leader
+
+
+def _name() -> str:
+    return runtime_session_name(uuid4())
+
+
+def _connect_owner(
+    name: str,
+    document: dict[str, Any],
+    *,
+    idle_timeout_s: float = 30.0,
+    follower_name: str | None = "follower",
+    leader_name: str | None = None,
+) -> tuple[RuntimeSessionOwner, RuntimeSessionClient]:
+    client = RuntimeSessionClient(name)
+    client.open()
+    owner = RuntimeSessionOwner(
+        client,
+        session_name=name,
+        document=document,
+        follower_name=follower_name,
+        leader_name=leader_name,
+        idle_timeout_s=idle_timeout_s,
+    )
+    try:
+        owner.connect()
+        client.wait_until_ready(owner, timeout=5)
+    except Exception:
+        owner.stop()
+        client.close()
+        raise
+    return owner, client
+
+
+def _stop_session(owner: RuntimeSessionOwner, *clients: RuntimeSessionClient) -> None:
+    if clients:
+        clients[0].apply(DisconnectCommand())
+    deadline = time.monotonic() + 3
+    while owner.is_alive() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    owner.stop()
+    for client in clients:
+        client.close()
+
+
+def _drain_until_source(client: RuntimeSessionClient, source: str, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            event = client.get_nowait()
+        except queue.Empty:
+            time.sleep(0.01)
+            continue
+        if isinstance(event, StateEvent) and event.data.follower_source == source:
+            return
+    pytest.fail(f"Did not observe follower_source={source!r}")
+
+
+def _follower_source(metadata: dict[str, Any]) -> str | None:
+    state = metadata.get("state")
+    if not isinstance(state, dict):
+        return None
+    data = state.get("data")
+    if not isinstance(data, dict):
+        return None
+    source = data.get("follower_source")
+    return source if isinstance(source, str) else None
+
+
+def _missing_pid() -> int:
+    for candidate in range(2**22, 2**22 + 10_000):
+        try:
+            os.kill(candidate, 0)
+        except OSError:
+            return candidate
+    raise RuntimeError("Could not find an unused pid")
+
+
+def test_second_client_attaches_to_the_running_session() -> None:
+    name = _name()
+    document = _document()
+    first_owner, first_client = _connect_owner(name, document)
+    try:
+        second_owner, second_client = _connect_owner(name, document)
+        try:
+            assert first_owner.spawned is True
+            assert second_owner.spawned is False
+            assert first_owner.metadata["pid"] == second_owner.metadata["pid"]
+            assert first_owner.host is not None
+            assert first_owner.host.is_alive()
+            assert second_owner.host is None
+        finally:
+            second_client.close()
+    finally:
+        _stop_session(first_owner, first_client)
+
+
+def test_losing_the_spawn_race_attaches_to_the_winner() -> None:
+    name = _name()
+    document = _document()
+
+    def connect() -> tuple[RuntimeSessionOwner, RuntimeSessionClient]:
+        return _connect_owner(name, document)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = [future.result(timeout=30) for future in (pool.submit(connect), pool.submit(connect))]
+
+    owners = [owner for owner, _ in results]
+    clients = [client for _, client in results]
+    try:
+        pids = {owner.metadata["pid"] for owner in owners}
+        assert len(pids) == 1
+        assert sum(owner.spawned for owner in owners) <= 1
+        assert any(not owner.spawned for owner in owners)
+    finally:
+        _stop_session(owners[0], *clients)
+        for owner in owners[1:]:
+            owner.stop()
+
+
+def test_attaching_with_a_different_rig_is_refused() -> None:
+    name = _name()
+    owner, client = _connect_owner(name, _document(), follower_name="left arm")
+    try:
+        different = _document()
+        different["init_args"]["fps"] = 15.0
+        second_client = RuntimeSessionClient(name)
+        second_client.open()
+        second_owner = RuntimeSessionOwner(
+            second_client,
+            session_name=name,
+            document=different,
+            follower_name="left arm",
+            leader_name=None,
+            idle_timeout_s=30.0,
+        )
+        try:
+            with pytest.raises(RuntimeSessionBusyError) as exc_info:
+                second_owner.connect()
+            assert int(exc_info.value.http_status) == http.HTTPStatus.LOCKED
+            assert exc_info.value.error_code == "runtime_session_busy"
+            assert "left arm" in exc_info.value.message
+            assert str(owner.metadata["pid"]) in exc_info.value.message
+        finally:
+            second_owner.stop()
+            second_client.close()
+    finally:
+        _stop_session(owner, client)
+
+
+def test_losing_the_last_subscriber_switches_to_hold() -> None:
+    name = _name()
+    document = _document_with_leader()
+    owner, client = _connect_owner(name, document, idle_timeout_s=5.0, leader_name="leader")
+    try:
+        client.apply(SetFollowerSourceCommand(follower_source="teleop"))
+        _drain_until_source(client, "teleop")
+        client.close()
+        time.sleep(0.4)
+
+        second_owner, second_client = _connect_owner(name, document, idle_timeout_s=5.0, leader_name="leader")
+        try:
+            assert second_owner.spawned is False
+            assert _follower_source(second_owner.metadata) == "hold"
+        finally:
+            _stop_session(second_owner, second_client)
+    finally:
+        if owner.is_alive():
+            owner.stop()
+
+
+def test_session_exits_when_no_client_is_attached() -> None:
+    name = _name()
+    owner, client = _connect_owner(name, _document(), idle_timeout_s=1.0)
+    try:
+        client.close()
+        deadline = time.monotonic() + 5
+        while owner.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert not owner.is_alive()
+    finally:
+        owner.stop()
+
+
+def test_a_client_attaching_on_the_idle_deadline_keeps_the_session() -> None:
+    name = _name()
+    owner, client = _connect_owner(name, _document(), idle_timeout_s=1.5)
+    try:
+        client.close()
+        time.sleep(1.2)
+        second_owner, second_client = _connect_owner(name, _document(), idle_timeout_s=1.5)
+        try:
+            time.sleep(1.0)
+            assert second_owner.is_alive()
+            assert second_owner.metadata["pid"] == owner.metadata["pid"]
+        finally:
+            _stop_session(second_owner, second_client)
+    finally:
+        if owner.is_alive():
+            owner.stop()
+
+
+def test_a_new_client_reattaches_after_every_client_goes_away() -> None:
+    name = _name()
+    document = _document()
+    owner, client = _connect_owner(name, document, idle_timeout_s=5.0)
+    original_pid = owner.metadata["pid"]
+    try:
+        client.close()
+        time.sleep(0.2)
+        second_owner, second_client = _connect_owner(name, document, idle_timeout_s=5.0)
+        try:
+            assert second_owner.spawned is False
+            assert second_owner.metadata["pid"] == original_pid
+            events: list[object] = []
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                try:
+                    events.append(second_client.get_nowait())
+                except queue.Empty:
+                    time.sleep(0.01)
+                if any(isinstance(event, StateEvent) for event in events):
+                    break
+            assert any(isinstance(event, StateEvent) and event.data.connected for event in events)
+        finally:
+            _stop_session(second_owner, second_client)
+    finally:
+        if owner.is_alive():
+            owner.stop()
+
+
+def test_dead_pid_is_not_reported_as_a_holder() -> None:
+    name = _name()
+    path = session_lock_path(name)
+    path.write_text(
+        json.dumps(
+            {
+                "kind": "rt-name",
+                "identity": name,
+                "pid": _missing_pid(),
+                "created_at": time.time(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert name not in registered_session_names()
+    assert live_session_pid(name) is None
+
+
+def test_released_lock_is_not_reported_as_a_holder() -> None:
+    name = _name()
+    lock = SessionNameLock(name)
+    assert lock.acquire()
+    assert name in registered_session_names()
+    lock.release()
+
+    assert lock.path.exists()
+    assert name not in registered_session_names()
+    assert live_session_pid(name) is None
+
+
+def test_holder_does_not_probe_when_the_lock_is_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def _probe(session_name: str, timeout: float = 1.0) -> dict[str, Any] | None:
+        calls.append(session_name)
+        return {"pid": 1}
+
+    monkeypatch.setattr("runtime.owner.probe_session_metadata", _probe)
+    assert runtime_session_holder(uuid4()) is None
+    assert calls == []
+
+
+def test_probe_session_metadata_is_reachable_after_lock_hit() -> None:
+    name = _name()
+    owner, client = _connect_owner(name, _document())
+    try:
+        follower_id = UUID(name.removeprefix("rt-"))
+        holder = runtime_session_holder(follower_id)
+        assert holder is not None
+        assert holder["pid"] == owner.metadata["pid"]
+        assert probe_session_metadata(name) is not None
+    finally:
+        _stop_session(owner, client)

--- a/application/backend/tests/runtime/test_process_host.py
+++ b/application/backend/tests/runtime/test_process_host.py
@@ -5,7 +5,6 @@ import json
 import os
 import queue
 import socket
-import threading
 import time
 from typing import Any
 from uuid import UUID
@@ -17,7 +16,6 @@ from api.robot_control import handle_outgoing
 from exceptions import BaseException as AppBaseException
 from exceptions import RobotDeviceAlreadyOwnedError
 from runtime.contract import DisconnectCommand, SetFollowerSourceCommand, StateEvent
-from runtime.hosts import session_worker
 from runtime.hosts.process_host import RuntimeProcessHost
 from runtime.transport.client import RuntimeProcessError, RuntimeSessionClient
 from runtime.transport.ids import derive_endpoint_port, runtime_session_name
@@ -113,7 +111,7 @@ def test_killed_process_is_observable_without_waiting_indefinitely() -> None:
         assert not host.is_alive()
         assert not client.shutdown_received
         with pytest.raises(RuntimeProcessError, match="stopped unexpectedly"):
-            asyncio.run(asyncio.wait_for(handle_outgoing(_FakeWebSocket(), client, host), timeout=2))
+            asyncio.run(asyncio.wait_for(handle_outgoing(_FakeWebSocket(), client, _HostAsOwner(host)), timeout=2))
     finally:
         _stop_host(host, client)
 
@@ -134,24 +132,6 @@ def test_process_host_propagates_setup_error() -> None:
     finally:
         host.stop()
         client.close()
-
-
-def test_second_spawn_does_not_attach_to_or_disconnect_existing_session() -> None:
-    name = runtime_session_name(UUID("233f3b26-e411-4772-94aa-8580f7d44de2"))
-    first_host, first_client = _start_host(name, _document())
-    try:
-        second_host = RuntimeProcessHost(name, _document())
-        try:
-            with pytest.raises(AppBaseException) as exc_info:
-                second_host.start()
-            assert exc_info.value.error_code == RobotDeviceAlreadyOwnedError().error_code
-        finally:
-            second_host.stop()
-
-        assert first_host.is_alive()
-        assert first_host.error is None
-    finally:
-        _stop_host(first_host, first_client)
 
 
 def test_listener_bind_failure_reaches_parent_as_robot_ownership_error() -> None:
@@ -211,7 +191,7 @@ def test_spawn_payload_survives_json() -> None:
         "document": _document_with_leader(),
         "follower_name": "follower",
         "leader_name": "leader",
-        "parent_pid": os.getpid(),
+        "idle_timeout_s": 45.0,
     }
 
     assert json.loads(json.dumps(payload)) == payload
@@ -227,14 +207,6 @@ def test_child_runs_in_its_own_process_group() -> None:
         _stop_host(host, client)
 
 
-def test_parent_watchdog_stops_the_session_when_the_parent_pid_changes() -> None:
-    stop = threading.Event()
-
-    session_worker._watch_parent(parent_pid=os.getpid(), stop=stop)
-
-    assert stop.is_set()
-
-
 def test_stop_before_start_terminates_the_spawned_worker() -> None:
     name = runtime_session_name(UUID("15e54f25-b877-412a-9a40-8efc3f932b82"))
     host = RuntimeProcessHost(name, _document())
@@ -244,6 +216,21 @@ def test_stop_before_start_terminates_the_spawned_worker() -> None:
     host.join(timeout=2)
 
     assert not host.is_alive()
+
+
+class _HostAsOwner:
+    def __init__(self, host: RuntimeProcessHost) -> None:
+        self._host = host
+
+    def is_alive(self) -> bool:
+        return self._host.is_alive()
+
+    def exited_cleanly(self) -> bool:
+        return self._host.exited_cleanly
+
+    @property
+    def error(self) -> AppBaseException | None:
+        return self._host.error
 
 
 class _FakeWebSocket:

--- a/application/ui/src/api/errors.ts
+++ b/application/ui/src/api/errors.ts
@@ -36,6 +36,18 @@ export const isSerialPermissionDeniedError = (error: unknown): boolean =>
     typeof (error as Record<string, unknown>).error_code === 'string' &&
     (error as Record<string, string>).error_code.toLowerCase() === 'serial_permission_denied';
 
+/**
+ * Returns true when a live runtime session holds the robot (HTTP 423).
+ *
+ * Expected when deleting a robot that is still being driven, or when connecting
+ * with a different rig (leader, fps) than the session that already owns it.
+ */
+export const isRuntimeSessionBusyError = (error: unknown): boolean =>
+    typeof error === 'object' &&
+    error !== null &&
+    'error_code' in error &&
+    (error as Record<string, unknown>).error_code === 'runtime_session_busy';
+
 interface ApiErrorBody {
     error_code?: string;
     message?: string;
@@ -60,6 +72,7 @@ export const getApiErrorMessage = (error: unknown): string | undefined => {
 export const getRobotConnectionErrorTitle = (errorCode: string | null): string => {
     switch (errorCode) {
         case 'robot_device_already_owned':
+        case 'runtime_session_busy':
             return 'Robot already in use';
         case 'robot_name_conflict':
             return 'Robot name conflict';

--- a/application/ui/src/features/robots/controller/joint-controls.tsx
+++ b/application/ui/src/features/robots/controller/joint-controls.tsx
@@ -82,12 +82,13 @@ const useRobotJointsState = (): {
     error: string | null;
     errorCode: string | null;
     disconnect: () => void;
+    restart: () => void;
 } => {
     const robot = useRobot();
     const modelJoints = useModelJoints();
 
     const { project_id, robot_id } = useRobotId();
-    const { joints, error, errorCode, disconnect } = useJointState(project_id, robot_id);
+    const { joints, error, errorCode, disconnect, restart } = useJointState(project_id, robot_id);
     useSynchronizeModelJoints(joints, robot.type);
 
     return {
@@ -101,22 +102,23 @@ const useRobotJointsState = (): {
         error,
         errorCode,
         disconnect,
+        restart,
     };
 };
 
 const EnabledJointControls = ({
     isExpanded,
-    onDisconnectReady,
+    onSessionReady,
 }: {
     isExpanded: boolean;
-    onDisconnectReady: (disconnect: (() => void) | null) => void;
+    onSessionReady: (session: { disconnect: () => void; restart: () => void } | null) => void;
 }) => {
-    const { joints, error, errorCode, disconnect } = useRobotJointsState();
+    const { joints, error, errorCode, disconnect, restart } = useRobotJointsState();
 
     useEffect(() => {
-        onDisconnectReady(disconnect);
-        return () => onDisconnectReady(null);
-    }, [disconnect, onDisconnectReady]);
+        onSessionReady({ disconnect, restart });
+        return () => onSessionReady(null);
+    }, [disconnect, restart, onSessionReady]);
 
     if (error) {
         return (
@@ -153,14 +155,14 @@ export const JointControls = ({
     setIsConnected: Dispatch<SetStateAction<boolean>>;
 }) => {
     const [isExpanded, setIsExpanded] = useState(true);
-    const disconnectRef = useRef<(() => void) | null>(null);
-    const onDisconnectReady = useCallback((disconnect: (() => void) | null) => {
-        disconnectRef.current = disconnect;
+    const sessionRef = useRef<{ disconnect: () => void; restart: () => void } | null>(null);
+    const onSessionReady = useCallback((session: { disconnect: () => void; restart: () => void } | null) => {
+        sessionRef.current = session;
     }, []);
 
     const onConnectChange = (connected: boolean) => {
         if (!connected) {
-            disconnectRef.current?.();
+            sessionRef.current?.disconnect();
         }
         setIsConnected(connected);
     };
@@ -194,12 +196,17 @@ export const JointControls = ({
                         </Heading>
                     </ActionButton>
 
-                    <Switch isSelected={isConnected} onChange={onConnectChange}>
-                        Connect
-                    </Switch>
+                    <Flex alignItems='center' gap='size-150'>
+                        {isConnected && (
+                            <ActionButton onPress={() => sessionRef.current?.restart()}>Restart session</ActionButton>
+                        )}
+                        <Switch isSelected={isConnected} onChange={onConnectChange}>
+                            Connect
+                        </Switch>
+                    </Flex>
                 </Flex>
                 {isConnected ? (
-                    <EnabledJointControls isExpanded={isExpanded} onDisconnectReady={onDisconnectReady} />
+                    <EnabledJointControls isExpanded={isExpanded} onSessionReady={onSessionReady} />
                 ) : (
                     <DisabledJointsControls isExpanded={isExpanded} />
                 )}

--- a/application/ui/src/features/robots/controller/joint-controls.tsx
+++ b/application/ui/src/features/robots/controller/joint-controls.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
 
 import { ActionButton, Flex, Grid, Heading, minmax, repeat, Slider, Switch, View } from '@geti-ui/ui';
 import { ChevronDownSmallLight } from '@geti-ui/ui/icons';
@@ -77,12 +77,17 @@ const useModelJoints = (): JointsState => {
 };
 
 // Combine the joint range of the urdf model with actual joint state from robot
-const useRobotJointsState = (): { joints: JointsState; error: string | null; errorCode: string | null } => {
+const useRobotJointsState = (): {
+    joints: JointsState;
+    error: string | null;
+    errorCode: string | null;
+    disconnect: () => void;
+} => {
     const robot = useRobot();
     const modelJoints = useModelJoints();
 
     const { project_id, robot_id } = useRobotId();
-    const { joints, error, errorCode } = useJointState(project_id, robot_id);
+    const { joints, error, errorCode, disconnect } = useJointState(project_id, robot_id);
     useSynchronizeModelJoints(joints, robot.type);
 
     return {
@@ -95,11 +100,23 @@ const useRobotJointsState = (): { joints: JointsState; error: string | null; err
         }),
         error,
         errorCode,
+        disconnect,
     };
 };
 
-const EnabledJointControls = ({ isExpanded }: { isExpanded: boolean }) => {
-    const { joints, error, errorCode } = useRobotJointsState();
+const EnabledJointControls = ({
+    isExpanded,
+    onDisconnectReady,
+}: {
+    isExpanded: boolean;
+    onDisconnectReady: (disconnect: (() => void) | null) => void;
+}) => {
+    const { joints, error, errorCode, disconnect } = useRobotJointsState();
+
+    useEffect(() => {
+        onDisconnectReady(disconnect);
+        return () => onDisconnectReady(null);
+    }, [disconnect, onDisconnectReady]);
 
     if (error) {
         return (
@@ -136,6 +153,17 @@ export const JointControls = ({
     setIsConnected: Dispatch<SetStateAction<boolean>>;
 }) => {
     const [isExpanded, setIsExpanded] = useState(true);
+    const disconnectRef = useRef<(() => void) | null>(null);
+    const onDisconnectReady = useCallback((disconnect: (() => void) | null) => {
+        disconnectRef.current = disconnect;
+    }, []);
+
+    const onConnectChange = (connected: boolean) => {
+        if (!connected) {
+            disconnectRef.current?.();
+        }
+        setIsConnected(connected);
+    };
 
     return (
         <View
@@ -166,12 +194,12 @@ export const JointControls = ({
                         </Heading>
                     </ActionButton>
 
-                    <Switch isSelected={isConnected} onChange={setIsConnected}>
+                    <Switch isSelected={isConnected} onChange={onConnectChange}>
                         Connect
                     </Switch>
                 </Flex>
                 {isConnected ? (
-                    <EnabledJointControls isExpanded={isExpanded} />
+                    <EnabledJointControls isExpanded={isExpanded} onDisconnectReady={onDisconnectReady} />
                 ) : (
                     <DisabledJointsControls isExpanded={isExpanded} />
                 )}

--- a/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
+++ b/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
@@ -1,4 +1,4 @@
-import { Flex, ProgressCircle, Switch, View } from '@geti-ui/ui';
+import { Button, Flex, ProgressCircle, Switch, View } from '@geti-ui/ui';
 
 import { $api } from '../../../../api/client';
 import { getRobotConnectionErrorTitle } from '../../../../api/errors';
@@ -19,7 +19,7 @@ const AvailableRobotCell = ({
     leaderId?: string;
 }) => {
     const { project_id } = useProjectId();
-    const { joints, state, error, errorCode, warning, setFollowerSource } = useJointState(
+    const { joints, state, error, errorCode, warning, setFollowerSource, restart } = useJointState(
         project_id,
         followerId,
         leaderId
@@ -31,12 +31,24 @@ const AvailableRobotCell = ({
     if (error) {
         return (
             <View width='100%' height='100%' padding='size-200'>
-                <Flex width='100%' height='100%' justifyContent='center' alignItems='center'>
+                <Flex
+                    width='100%'
+                    height='100%'
+                    justifyContent='center'
+                    alignItems='center'
+                    direction='column'
+                    gap='size-100'
+                >
                     <InlineAlert variant='error'>
                         <strong>{getRobotConnectionErrorTitle(errorCode)}</strong>
                         <br />
                         {error}
                     </InlineAlert>
+                    {errorCode === 'runtime_session_busy' && (
+                        <Button variant='primary' onPress={restart}>
+                            Restart session
+                        </Button>
+                    )}
                 </Flex>
             </View>
         );
@@ -65,13 +77,18 @@ const AvailableRobotCell = ({
                     <InlineAlert variant='warning'>{warning}</InlineAlert>
                 </View>
             )}
-            {leaderId !== undefined && (
-                <View position={'absolute'} right={0} top={0}>
-                    <Switch isSelected={isTeleoperating} onChange={(b) => setFollowerSource(b ? 'teleop' : 'hold')}>
-                        Teleoperate
-                    </Switch>
-                </View>
-            )}
+            <View position={'absolute'} right={0} top={0} padding='size-100'>
+                <Flex gap='size-100' alignItems='center'>
+                    <Button variant='secondary' onPress={restart}>
+                        Restart session
+                    </Button>
+                    {leaderId !== undefined && (
+                        <Switch isSelected={isTeleoperating} onChange={(b) => setFollowerSource(b ? 'teleop' : 'hold')}>
+                            Teleoperate
+                        </Switch>
+                    )}
+                </Flex>
+            </View>
         </View>
     );
 };

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -5,7 +5,7 @@ import { clsx } from 'clsx';
 import { NavLink } from 'react-router';
 
 import { $api } from '../../api/client';
-import { getApiErrorMessage, isResourceInUseError } from '../../api/errors';
+import { getApiErrorMessage, isResourceInUseError, isRuntimeSessionBusyError } from '../../api/errors';
 import { paths } from '../../router';
 import { useProjectId } from '../projects/use-project';
 import RobotArm from './../../assets/robot-arm.webp';
@@ -58,7 +58,7 @@ const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
                             { params: { path: { project_id, robot_id: robot.id } } },
                             {
                                 onError: (error) => {
-                                    if (isResourceInUseError(error)) {
+                                    if (isResourceInUseError(error) || isRuntimeSessionBusyError(error)) {
                                         toast.info(
                                             getApiErrorMessage(error) ?? 'This robot is in use and cannot be deleted.'
                                         );

--- a/application/ui/src/features/robots/use-joint-state.ts
+++ b/application/ui/src/features/robots/use-joint-state.ts
@@ -136,5 +136,18 @@ export const useJointState = (project_id: string, follower_id: string, leader_id
         });
     };
 
-    return { joints, socket, state, error, errorCode, warning, setFollowerSource: setFollowerSourceRequest };
+    const disconnect = () => {
+        socket.sendJsonMessage({ event: 'disconnect' });
+    };
+
+    return {
+        joints,
+        socket,
+        state,
+        error,
+        errorCode,
+        warning,
+        setFollowerSource: setFollowerSourceRequest,
+        disconnect,
+    };
 };

--- a/application/ui/src/features/robots/use-joint-state.ts
+++ b/application/ui/src/features/robots/use-joint-state.ts
@@ -60,7 +60,10 @@ export const useJointState = (project_id: string, follower_id: string, leader_id
     const [error, setError] = useState<string | null>(null);
     const [errorCode, setErrorCode] = useState<string | null>(null);
     const [warning, setWarning] = useState<string | null>(null);
+    const [socketEnabled, setSocketEnabled] = useState(true);
     const hasFatalError = useRef(false);
+    const restartRequested = useRef(false);
+    const socketEnabledRef = useRef(true);
 
     const handleMessage = useCallback((event: WebSocketEventMap['message']) => {
         try {
@@ -106,28 +109,42 @@ export const useJointState = (project_id: string, follower_id: string, leader_id
             reconnectAttempts: 5,
             reconnectInterval: 3000,
             onOpen: () => {
+                socketEnabledRef.current = true;
                 if (hasFatalError.current) {
                     return;
                 }
                 setError(null);
                 setErrorCode(null);
                 setWarning(null);
+                const shouldRestart = restartRequested.current;
+                restartRequested.current = false;
                 socket.sendJsonMessage({
                     follower_id,
                     leader_id,
+                    ...(shouldRestart ? { restart: true } : {}),
                 });
             },
             onMessage: handleMessage,
             onError: (wsError) => console.error('WebSocket error:', wsError),
             onClose: (event) => {
+                if (!socketEnabledRef.current || restartRequested.current) {
+                    return;
+                }
                 if (!hasFatalError.current && event.code !== 1000) {
                     hasFatalError.current = true;
                     setError(`Connection closed unexpectedly (code ${event.code})`);
                     setErrorCode('connection_closed');
                 }
             },
-        }
+        },
+        socketEnabled
     );
+
+    useEffect(() => {
+        if (!socketEnabled) {
+            setSocketEnabled(true);
+        }
+    }, [socketEnabled]);
 
     const setFollowerSourceRequest = (value: FollowerSource) => {
         socket.sendJsonMessage({
@@ -140,6 +157,15 @@ export const useJointState = (project_id: string, follower_id: string, leader_id
         socket.sendJsonMessage({ event: 'disconnect' });
     };
 
+    const restart = useCallback(() => {
+        hasFatalError.current = false;
+        restartRequested.current = true;
+        socketEnabledRef.current = false;
+        setError(null);
+        setErrorCode(null);
+        setSocketEnabled(false);
+    }, []);
+
     return {
         joints,
         socket,
@@ -149,5 +175,6 @@ export const useJointState = (project_id: string, follower_id: string, leader_id
         warning,
         setFollowerSource: setFollowerSourceRequest,
         disconnect,
+        restart,
     };
 };


### PR DESCRIPTION
## Why

#952 moved teleop into a detached child over Zenoh. Closing the browser still killed that child, and a second client (refresh, new tab, API restart) could not find it. This PR makes the child a discoverable owner so the session can outlive the UI and re-attach afterwards.

## What this adds over #952

- A host-local name lock on `rt-<follower uuid>`.
- Attach-or-spawn: a second client joins the running session instead of starting another.
- Losing the last subscriber switches to hold (torque on). The child exits after `RUNTIME_IDLE_TIMEOUT_S` (default 45s).
- Closing the browser detaches. An explicit disconnect still stops the child immediately.
- Deleting a held robot returns HTTP 423.
- Session restart from the UI.

Record still works. If a runtime session already holds the follower, starting a recording on that robot is refused so the two paths do not fight for the serial port. The reverse is still open: a runtime session can start while a record session is already driving the arm (to be addressed in B4).

## What's next

- **B3** — policy inference and model loading on the same owner.
- **B4** — recording on the runtime session (delete `RobotControlWorker`, close the reverse exclusivity gap, camera claim registry).

Stacked on #952. Do not merge to `main` until that PR lands.

## Tested scenarios

- [ ] Refresh reattaches to the same child (hold)
- [ ] API restart reattaches
- [x] Idle exit after `RUNTIME_IDLE_TIMEOUT_S`
- [x] Two tabs, one child; closing one does not kill the other
- [ ] Delete a held robot → 423
- [ ] Record while a runtime session holds the follower → error frame

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>