### PR TITLE
feat: enable ipcam under feature flag

### DIFF
--- a/application/backend/src/schemas/project_camera.py
+++ b/application/backend/src/schemas/project_camera.py
@@ -44,9 +44,7 @@ class USBCameraPayload(BaseModel):
 class IPCameraPayload(BaseModel):
     """Configuration for IPCameraCapture."""
 
-    stream_url: str = Field(..., description="RTSP or HTTP stream URL")
-    username: str | None = Field(None, description="Camera login username")
-    password: str | None = Field(None, description="Camera login password")
+    url: str = Field(..., description="RTSP or HTTP stream URL")
     width: int | None = Field(None, ge=160, le=4096, description="Frame width in pixels (if supported)")
     height: int | None = Field(None, ge=120, le=2160, description="Frame height in pixels (if supported)")
     fps: int = Field(25, ge=1, le=60, description="Expected frame rate")
@@ -131,9 +129,7 @@ class IPCamera(BaseCamera):
                 "fingerprint": "rtsp://192.168.1.100:554/stream1",
                 "hardware_name": None,
                 "payload": {
-                    "stream_url": "rtsp://192.168.1.100:554/stream1",
-                    "username": "admin",
-                    "password": "<rtsp-password>",
+                    "url": "rtsp://192.168.1.100:554/stream1",
                 },
             }
         }

--- a/application/backend/src/utils/camera_factory.py
+++ b/application/backend/src/utils/camera_factory.py
@@ -14,24 +14,27 @@ from physicalai.capture import CameraType, ColorMode, SharedCamera
 if TYPE_CHECKING:
     from schemas.project_camera import Camera
 
-MIGRATED_DRIVERS: frozenset[str] = frozenset({"usb_camera", "realsense", "basler"})
+MIGRATED_DRIVERS: frozenset[str] = frozenset({"usb_camera", "realsense", "basler", "ipcam"})
 
 DRIVER_KEY_MAP: dict[str, str] = {
     "uvc": "usb_camera",
     "realsense": "realsense",
     "basler": "basler",
+    "ipcam": "ipcam",
 }
 
 _DRIVER_TO_CAMERA_TYPE: dict[str, CameraType] = {
     "usb_camera": CameraType.UVC,
     "realsense": CameraType.REALSENSE,
     "basler": CameraType.BASLER,
+    "ipcam": CameraType.IP,
 }
 
 _DRIVER_TO_CLASS_PATH: dict[str, str] = {
     "usb_camera": "physicalai.capture.UVCCamera",
     "realsense": "physicalai.capture.RealSenseCamera",
     "basler": "physicalai.capture.BaslerCamera",
+    "ipcam": "physicalai.capture.IPCamera",
 }
 
 # Per-driver kwargs that are safe to pass through to the nested camera recipe.
@@ -39,6 +42,7 @@ _ALLOWED_KWARGS: dict[str, frozenset[str]] = {
     "usb_camera": frozenset({"width", "height", "fps"}),
     "realsense": frozenset({"width", "height", "fps"}),
     "basler": frozenset({"width", "height", "fps"}),
+    "ipcam": frozenset({"width", "height", "fps", "url"}),
 }
 
 
@@ -55,7 +59,7 @@ def _camera_component_config(config: Camera) -> dict[str, Any]:
         if fingerprint.startswith("/dev/video") and ":" in fingerprint:
             fingerprint = fingerprint.split(":")[0]
         init_args["device"] = fingerprint
-    else:
+    elif config.driver != "ipcam":
         init_args["serial_number"] = config.fingerprint
 
     return {"class_path": class_path, "init_args": init_args}

--- a/application/ui/src/config/feature-flags.ts
+++ b/application/ui/src/config/feature-flags.ts
@@ -10,7 +10,7 @@
  *   setFeatureFlag('someFlag')         // clear override, use build default
  */
 
-type FeatureFlagName = never;
+type FeatureFlagName = 'ipcam';
 
 const STORAGE_KEY_PREFIX = 'physicalai:featureFlags:';
 
@@ -49,7 +49,11 @@ void resolveFlag;
  *       return resolveFlag('someFlag', envValue);
  *   },
  */
-export const featureFlags = {};
+export const featureFlags = {
+    get ipCamera(): boolean {
+        return resolveFlag('ipcam', typeof process !== 'undefined' ? process.env.PUBLIC_ENABLE_IP_CAM : undefined);
+    },
+};
 
 /**
  * Overrides a feature flag at runtime via `localStorage`, without needing a

--- a/application/ui/src/features/robots/camera-form/drivers/ipcam.tsx
+++ b/application/ui/src/features/robots/camera-form/drivers/ipcam.tsx
@@ -12,7 +12,7 @@ export const initialIpCamState: DriverFormSchema<'ipcam'> = {
         fps: 30,
         width: 640,
         height: 480,
-        stream_url: '',
+        url: '',
     },
 };
 
@@ -23,7 +23,7 @@ export const validateIpCam = (formData: DriverFormSchema<'ipcam'>): formData is 
         !!formData.payload?.width &&
         !!formData.payload?.height &&
         !!formData.payload?.fps &&
-        !!formData.payload?.stream_url
+        !!formData.payload?.url
     );
 };
 
@@ -40,7 +40,7 @@ export const IpCamFormFields = () => {
                 value={formData.fingerprint ?? ''}
                 onChange={(url) => {
                     updateField('fingerprint', url);
-                    updatePayload({ stream_url: url });
+                    updatePayload({ url });
                 }}
             />
         </Flex>

--- a/application/ui/src/features/robots/camera-form/form.tsx
+++ b/application/ui/src/features/robots/camera-form/form.tsx
@@ -4,6 +4,7 @@ import { Button, Divider, Flex, Heading, Icon, View } from '@geti-ui/ui';
 import { ChevronLeft } from '@geti-ui/ui/icons';
 
 import { RadioDisclosure } from '../../../components/radio-disclosure-group/radio-disclosure-group';
+import { featureFlags } from '../../../config/feature-flags';
 import { useProjectId } from '../../../features/projects/use-project';
 import { paths } from '../../../router';
 import { CameraIcon } from './camera-icon';
@@ -84,7 +85,7 @@ const CameraFormFields = () => {
             value: 'ipcam' as const,
             icon: <CameraIcon type='ipcam' width={'24px'} />,
             content: <IpCamFormFields />,
-            visible: false, // Disable IP cameras until tested
+            visible: featureFlags.ipCamera,
         },
     ].filter((item) => item.visible);
 


### PR DESCRIPTION
Support for IP camera was added to physicalai in
https://github.com/openvinotoolkit/physicalai/pull/230

In Studio we already build this support based on our previous camera library, however the UI was hidden and the payload schema was not compatible with the changes from physicalai.
We now re-enable IP cameras, but only when enabling its feature flag. This way we can start doing some experiments with this (for instance using ip cameras to stream camera feeds from simultation software like mujoco or isaac sim).
Enable it in the UI by running,
```typescript
setFeatureFlag('ipcam', true)
```

The username and password that we previously stored are removed from the payload so that we don't need to add any extra security details to this.

<img width="2048" height="1200" alt="192 168 2 118_3000_projects_22e1cbf2-f740-49e6-a5d4-ba9c2e31d390_cameras_009e0166-41f8-4df3-b706-b83985649d2d_edit" src="https://github.com/user-attachments/assets/64dad9b5-0743-4a2a-9321-b1095128fa96" />
