### PR TITLE
feat(robots): stream joints without a runtime session

### DIFF
--- a/application/backend/src/api/robot_observations.py
+++ b/application/backend/src/api/robot_observations.py
@@ -1,0 +1,123 @@
+"""Read-only joint observation stream.
+
+The robot detail page displays live joint positions and never sends actions.
+Attaching a ``SharedRobot`` subscriber is enough: it joins the existing owner
+when a runtime session is already driving the arm, and it never takes an
+``rt-`` session lock.
+"""
+
+import asyncio
+from typing import Annotated
+from uuid import UUID
+
+import anyio
+from fastapi import APIRouter, Depends, Query, WebSocket, status
+from fastapi.responses import Response
+from fastapi.websockets import WebSocketDisconnect
+from loguru import logger
+from physicalai.robot import RobotError, SharedRobot
+
+from api.dependencies import RobotClientFactoryDep, get_project_id, get_robot_id, get_robot_service
+from exceptions import BaseException as AppBaseException
+from robots.shared_robot_errors import translate_robot_error
+from runtime.contract import ErrorEvent, ObservationEvent
+from runtime.features import observation_to_dict
+from services import RobotService
+from workers.base import run_at_frequency
+
+router = APIRouter(prefix="/api/projects/{project_id}/robots", tags=["Project Robots"])
+
+
+def _error_payload(exc: BaseException) -> dict[str, str]:
+    if isinstance(exc, AppBaseException):
+        return ErrorEvent(message=exc.message, error_code=exc.error_code).model_dump()
+    return ErrorEvent(
+        message=str(exc) or "Failed to connect to the robot.",
+        error_code="robot_connection_failed",
+    ).model_dump()
+
+
+async def _send_error_and_close(websocket: WebSocket, exc: BaseException) -> None:
+    if isinstance(exc, AppBaseException):
+        logger.warning("Robot observation websocket error: {} ({})", exc.message, exc.error_code)
+    else:
+        logger.exception("Unexpected error in robot observation websocket: {}", exc)
+    try:
+        await websocket.send_json(_error_payload(exc))
+        await websocket.close(code=status.WS_1011_INTERNAL_ERROR)
+    except Exception as close_exc:
+        logger.error("Could not close observation websocket after exception: {}", close_exc)
+
+
+async def _disconnect(shared_robot: SharedRobot | None) -> None:
+    if shared_robot is None:
+        return
+    # Shield so a cancelled websocket task still drops the subscriber. Starlette
+    # cancels the ASGI task on client close; an unshielded await in ``finally``
+    # would skip disconnect and leak the SharedRobot attach.
+    with anyio.CancelScope(shield=True):
+        try:
+            await asyncio.to_thread(shared_robot.disconnect)
+        except Exception as exc:
+            logger.warning("SharedRobot disconnect failed: {}", exc)
+
+
+async def _stream_joint_observations(websocket: WebSocket, shared_robot: SharedRobot, fps: int) -> None:
+    """Emit observation frames at ``fps``, with one connected-state after the first read."""
+    sent_ready = False
+    while True:
+        async with run_at_frequency(fps):
+            observation = await asyncio.to_thread(shared_robot.get_observation)
+            data = observation_to_dict(
+                shared_robot.joint_names,
+                observation,
+                include_velocities=False,
+            )
+            if not sent_ready:
+                await websocket.send_json({"event": "state", "data": {"connected": True}})
+                sent_ready = True
+            await websocket.send_json(ObservationEvent(data=data).model_dump(mode="json"))
+
+
+@router.get(
+    "/{robot_id}/observations/ws",
+    tags=["WebSocket"],
+    summary="Robot joint observations (WebSocket)",
+    status_code=426,
+)
+async def robot_observations_websocket_openapi(
+    project_id: UUID,  # noqa: ARG001
+    robot_id: UUID,  # noqa: ARG001
+    fps: Annotated[int, Query(ge=1, description="Display rate in frames per second")] = 30,  # noqa: ARG001
+) -> Response:
+    """This endpoint requires a WebSocket connection. Use `wss://` to connect."""
+    return Response(status_code=426)
+
+
+@router.websocket("/{robot_id}/observations/ws")
+async def robot_observations_websocket(
+    websocket: WebSocket,
+    project_id: Annotated[UUID, Depends(get_project_id)],
+    robot_id: Annotated[UUID, Depends(get_robot_id)],
+    robot_service: Annotated[RobotService, Depends(get_robot_service)],
+    robot_client_factory: RobotClientFactoryDep,
+    fps: Annotated[int, Query(ge=1)] = 30,
+) -> None:
+    """Stream named joint positions from a read-only SharedRobot attach."""
+    await websocket.accept()
+    shared_robot: SharedRobot | None = None
+    robot_name: str | None = None
+    try:
+        robot = await robot_service.get_robot_by_id(project_id, robot_id)
+        robot_name = robot.name
+        shared_robot, _definition = await robot_client_factory.build_shared_robot(robot)
+        await asyncio.to_thread(shared_robot.connect)
+        await _stream_joint_observations(websocket, shared_robot, fps)
+    except WebSocketDisconnect:
+        pass
+    except RobotError as exc:
+        await _send_error_and_close(websocket, translate_robot_error(exc, robot_name=robot_name))
+    except Exception as exc:
+        await _send_error_and_close(websocket, exc)
+    finally:
+        await _disconnect(shared_robot)

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -25,6 +25,7 @@ from api.remote_servers import router as remote_servers_router
 from api.remote_trainers import router as remote_trainers_router
 from api.robot_catalog import router as robot_catalog_router
 from api.robot_control import router as robot_control_router
+from api.robot_observations import router as robot_observations_router
 from api.robot_setup import router as robot_setup_router
 from api.robots import router as project_robots_router
 from api.settings import router as settings_router
@@ -51,6 +52,7 @@ app.include_router(robot_catalog_router)
 app.include_router(project_cameras_router)
 app.include_router(robot_setup_router)
 app.include_router(robot_control_router)
+app.include_router(robot_observations_router)
 app.include_router(project_environments_router)
 app.include_router(hardware_router)
 app.include_router(camera_router)

--- a/application/backend/tests/api/test_dependencies.py
+++ b/application/backend/tests/api/test_dependencies.py
@@ -14,6 +14,7 @@ from api.dependencies import (
 )
 from api.record import robot_control_websocket
 from api.robot_control import robot_websocket
+from api.robot_observations import robot_observations_websocket
 from robots.robot_client_factory import RobotClientFactory
 from services.job_service import JobService
 from services.robot_catalog_service import RobotCatalogService
@@ -78,3 +79,7 @@ def test_record_websocket_depends_on_robot_client_factory() -> None:
 
 def test_teleoperation_websocket_depends_on_robot_client_factory() -> None:
     assert get_robot_client_factory in _dependency_calls(robot_websocket)
+
+
+def test_observation_websocket_depends_on_robot_client_factory() -> None:
+    assert get_robot_client_factory in _dependency_calls(robot_observations_websocket)

--- a/application/backend/tests/api/test_robot_observations.py
+++ b/application/backend/tests/api/test_robot_observations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 from uuid import UUID, uuid4
 
@@ -12,6 +13,9 @@ from physicalai.robot import RobotDeviceAlreadyOwned
 from api.dependencies import get_robot_client_factory, get_robot_service
 from main import app
 from runtime.features import feature_names
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 PROJECT_ID = uuid4()
 ROBOT_ID = uuid4()
@@ -90,7 +94,7 @@ def factory(mock_robot_client_factory, shared_robot: FakeSharedRobot):
 
 
 @pytest.fixture
-def client(factory) -> TestClient:
+def client(factory) -> Iterator[TestClient]:
     app.dependency_overrides[get_robot_service] = lambda: _StubRobotService(_StubRobot())
     app.dependency_overrides[get_robot_client_factory] = lambda: factory
     try:

--- a/application/backend/tests/api/test_robot_observations.py
+++ b/application/backend/tests/api/test_robot_observations.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+from physicalai.robot import RobotDeviceAlreadyOwned
+
+from api.dependencies import get_robot_client_factory, get_robot_service
+from main import app
+from runtime.features import feature_names
+
+PROJECT_ID = uuid4()
+ROBOT_ID = uuid4()
+JOINT_NAMES = ["shoulder_pan", "shoulder_lift"]
+
+
+@dataclass
+class FakeObservation:
+    joint_positions: np.ndarray
+    timestamp: float = 1.0
+    sensor_data: dict | None = None
+    images: dict | None = None
+
+
+@dataclass
+class FakeSharedRobot:
+    joint_names: list[str]
+    observation: FakeObservation
+    connect_error: Exception | None = None
+    connect_calls: int = 0
+    disconnect_calls: int = 0
+    _connected: bool = field(default=False, init=False)
+
+    def connect(self) -> None:
+        self.connect_calls += 1
+        if self.connect_error is not None:
+            raise self.connect_error
+        self._connected = True
+
+    def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self._connected = False
+
+    def get_observation(self) -> FakeObservation:
+        return self.observation
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+
+class _StubRobot:
+    def __init__(self, robot_id: UUID = ROBOT_ID) -> None:
+        self.id = robot_id
+        self.name = "Khaos"
+
+
+class _StubRobotService:
+    def __init__(self, robot: _StubRobot) -> None:
+        self.robot = robot
+
+    async def get_robot_by_id(self, project_id: UUID, robot_id: UUID) -> _StubRobot:
+        assert project_id == PROJECT_ID
+        assert robot_id == self.robot.id
+        return self.robot
+
+
+def _url(*, fps: int | None = 30) -> str:
+    path = f"/api/projects/{PROJECT_ID}/robots/{ROBOT_ID}/observations/ws"
+    if fps is None:
+        return path
+    return f"{path}?fps={fps}"
+
+
+@pytest.fixture
+def shared_robot() -> FakeSharedRobot:
+    return FakeSharedRobot(
+        joint_names=list(JOINT_NAMES),
+        observation=FakeObservation(joint_positions=np.array([12.3, 0.0])),
+    )
+
+
+@pytest.fixture
+def factory(mock_robot_client_factory, shared_robot: FakeSharedRobot):
+    mock_robot_client_factory.build_shared_robot = AsyncMock(return_value=(shared_robot, object()))
+    return mock_robot_client_factory
+
+
+@pytest.fixture
+def client(factory) -> TestClient:
+    app.dependency_overrides[get_robot_service] = lambda: _StubRobotService(_StubRobot())
+    app.dependency_overrides[get_robot_client_factory] = lambda: factory
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_http_get_is_a_websocket_upgrade_stub(client: TestClient) -> None:
+    response = client.get(_url())
+
+    assert response.status_code == 426
+
+
+def test_stream_emits_named_joint_features(client: TestClient, factory, shared_robot: FakeSharedRobot) -> None:
+    messages: list[dict] = []
+
+    with client.websocket_connect(_url()) as websocket:
+        while len(messages) < 2:
+            messages.append(websocket.receive_json())
+
+    events = {message["event"]: message for message in messages}
+    expected_keys = feature_names(JOINT_NAMES, include_velocities=False)
+
+    assert events["state"] == {"event": "state", "data": {"connected": True}}
+    assert events["observation"]["event"] == "observation"
+    assert list(events["observation"]["data"]) == expected_keys
+    assert events["observation"]["data"] == {"shoulder_pan.pos": 12.3, "shoulder_lift.pos": 0.0}
+    factory.build.assert_not_called()
+    factory.build_shared_robot.assert_called_once()
+    assert shared_robot.connect_calls == 1
+
+
+def test_stream_reports_connect_failure_as_an_error_frame(client: TestClient, shared_robot: FakeSharedRobot) -> None:
+    shared_robot.connect_error = RobotDeviceAlreadyOwned(
+        "ignored",
+        phase="device_lock_contention",
+        device_ids=("serial:ttyACM0",),
+    )
+
+    with client.websocket_connect(_url()) as websocket:
+        payload = websocket.receive_json()
+
+    assert payload["event"] == "error"
+    assert payload["error_code"] == "robot_device_already_owned"
+    assert "serial:ttyACM0" in payload["message"]
+    assert shared_robot.disconnect_calls == 1
+
+
+def test_stream_disconnects_the_shared_robot_on_close(client: TestClient, shared_robot: FakeSharedRobot) -> None:
+    with client.websocket_connect(_url()) as websocket:
+        websocket.receive_json()
+
+    assert shared_robot.disconnect_calls == 1
+
+
+def test_stream_does_not_create_a_runtime_session(client: TestClient) -> None:
+    # Patch both the definition and the name bound in the owner: an in-process
+    # import of RuntimeProcessHost would otherwise miss the source-module patch.
+    with (
+        patch("runtime.transport.lock.SessionNameLock") as lock_cls,
+        patch("runtime.hosts.process_host.RuntimeProcessHost") as host_src,
+        patch("runtime.owner.RuntimeProcessHost") as host_bound,
+        patch("runtime.owner.RuntimeSessionOwner") as owner_cls,
+        client.websocket_connect(_url()) as websocket,
+    ):
+        websocket.receive_json()
+
+    lock_cls.assert_not_called()
+    host_src.assert_not_called()
+    host_bound.assert_not_called()
+    owner_cls.assert_not_called()

--- a/application/ui/src/features/robots/controller/joint-controls.tsx
+++ b/application/ui/src/features/robots/controller/joint-controls.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 
 import { ActionButton, Flex, Grid, Heading, minmax, repeat, Slider, Switch, View } from '@geti-ui/ui';
 import { ChevronDownSmallLight } from '@geti-ui/ui/icons';
@@ -7,8 +7,9 @@ import { radToDeg } from 'three/src/math/MathUtils.js';
 import { getRobotConnectionErrorTitle } from '../../../api/errors';
 import { useLoadModelQuery } from '../robot-models-context';
 import { InlineAlert } from '../setup-wizard/shared/inline-alert';
-import { useJointState, useSynchronizeModelJoints } from '../use-joint-state';
+import { useSynchronizeModelJoints } from '../use-joint-state';
 import { useRobot, useRobotId } from '../use-robot';
+import { useRobotObservations } from '../use-robot-observations';
 
 type JointState = {
     name: string;
@@ -81,14 +82,12 @@ const useRobotJointsState = (): {
     joints: JointsState;
     error: string | null;
     errorCode: string | null;
-    disconnect: () => void;
-    restart: () => void;
 } => {
     const robot = useRobot();
     const modelJoints = useModelJoints();
 
     const { project_id, robot_id } = useRobotId();
-    const { joints, error, errorCode, disconnect, restart } = useJointState(project_id, robot_id);
+    const { joints, error, errorCode } = useRobotObservations(project_id, robot_id);
     useSynchronizeModelJoints(joints, robot.type);
 
     return {
@@ -101,24 +100,11 @@ const useRobotJointsState = (): {
         }),
         error,
         errorCode,
-        disconnect,
-        restart,
     };
 };
 
-const EnabledJointControls = ({
-    isExpanded,
-    onSessionReady,
-}: {
-    isExpanded: boolean;
-    onSessionReady: (session: { disconnect: () => void; restart: () => void } | null) => void;
-}) => {
-    const { joints, error, errorCode, disconnect, restart } = useRobotJointsState();
-
-    useEffect(() => {
-        onSessionReady({ disconnect, restart });
-        return () => onSessionReady(null);
-    }, [disconnect, restart, onSessionReady]);
+const EnabledJointControls = ({ isExpanded }: { isExpanded: boolean }) => {
+    const { joints, error, errorCode } = useRobotJointsState();
 
     if (error) {
         return (
@@ -155,17 +141,6 @@ export const JointControls = ({
     setIsConnected: Dispatch<SetStateAction<boolean>>;
 }) => {
     const [isExpanded, setIsExpanded] = useState(true);
-    const sessionRef = useRef<{ disconnect: () => void; restart: () => void } | null>(null);
-    const onSessionReady = useCallback((session: { disconnect: () => void; restart: () => void } | null) => {
-        sessionRef.current = session;
-    }, []);
-
-    const onConnectChange = (connected: boolean) => {
-        if (!connected) {
-            sessionRef.current?.disconnect();
-        }
-        setIsConnected(connected);
-    };
 
     return (
         <View
@@ -196,17 +171,12 @@ export const JointControls = ({
                         </Heading>
                     </ActionButton>
 
-                    <Flex alignItems='center' gap='size-150'>
-                        {isConnected && (
-                            <ActionButton onPress={() => sessionRef.current?.restart()}>Restart session</ActionButton>
-                        )}
-                        <Switch isSelected={isConnected} onChange={onConnectChange}>
-                            Connect
-                        </Switch>
-                    </Flex>
+                    <Switch isSelected={isConnected} onChange={setIsConnected}>
+                        Connect
+                    </Switch>
                 </Flex>
                 {isConnected ? (
-                    <EnabledJointControls isExpanded={isExpanded} onSessionReady={onSessionReady} />
+                    <EnabledJointControls isExpanded={isExpanded} />
                 ) : (
                     <DisabledJointsControls isExpanded={isExpanded} />
                 )}

--- a/application/ui/src/features/robots/use-robot-observations.test.ts
+++ b/application/ui/src/features/robots/use-robot-observations.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseRobotObservationMessage } from './use-robot-observations';
+
+describe('parseRobotObservationMessage', () => {
+    it('turns an observation frame into joint state', () => {
+        expect(
+            parseRobotObservationMessage({
+                event: 'observation',
+                data: { 'shoulder_pan.pos': 12.3, 'gripper.pos': 0 },
+            })
+        ).toEqual({
+            type: 'observation',
+            joints: [
+                { name: 'shoulder_pan.pos', value: 12.3 },
+                { name: 'gripper.pos', value: 0 },
+            ],
+        });
+    });
+
+    it('ignores unknown events', () => {
+        expect(parseRobotObservationMessage({ event: 'lifecycle', data: {} })).toEqual({ type: 'ignored' });
+        expect(parseRobotObservationMessage(null)).toEqual({ type: 'ignored' });
+        expect(parseRobotObservationMessage('observation')).toEqual({ type: 'ignored' });
+    });
+
+    it('reads an error frame', () => {
+        expect(
+            parseRobotObservationMessage({
+                event: 'error',
+                message: 'Device serial:ttyACM0 is already in use by another session.',
+                error_code: 'robot_device_already_owned',
+            })
+        ).toEqual({
+            type: 'error',
+            message: 'Device serial:ttyACM0 is already in use by another session.',
+            errorCode: 'robot_device_already_owned',
+        });
+    });
+
+    it('treats a connected state frame as readiness, not joint data', () => {
+        expect(parseRobotObservationMessage({ event: 'state', data: { connected: true } })).toEqual({ type: 'state' });
+    });
+});

--- a/application/ui/src/features/robots/use-robot-observations.ts
+++ b/application/ui/src/features/robots/use-robot-observations.ts
@@ -1,0 +1,108 @@
+import { useCallback, useRef, useState } from 'react';
+
+import useWebSocket from 'react-use-websocket';
+
+import { fetchClient } from '../../api/client';
+
+interface JointState {
+    name: string;
+    value: number;
+}
+
+export type JointsState = Array<JointState>;
+
+const getNewJointState = (newJoints: Record<string, number>): JointsState => {
+    return Object.keys(newJoints).map((joint_name) => {
+        return {
+            name: joint_name,
+            value: Number(newJoints[joint_name]),
+        };
+    });
+};
+
+export type ParsedRobotObservationMessage =
+    | { type: 'observation'; joints: JointsState }
+    | { type: 'state' }
+    | { type: 'error'; message: string; errorCode: string }
+    | { type: 'ignored' };
+
+export const parseRobotObservationMessage = (payload: unknown): ParsedRobotObservationMessage => {
+    if (typeof payload !== 'object' || payload === null || !('event' in payload)) {
+        return { type: 'ignored' };
+    }
+
+    const message = payload as { event?: unknown; data?: unknown; message?: unknown; error_code?: unknown };
+
+    if (message.event === 'observation') {
+        if (typeof message.data !== 'object' || message.data === null) {
+            return { type: 'ignored' };
+        }
+        return { type: 'observation', joints: getNewJointState(message.data as Record<string, number>) };
+    }
+
+    if (message.event === 'state') {
+        return { type: 'state' };
+    }
+
+    if (message.event === 'error') {
+        return {
+            type: 'error',
+            message: typeof message.message === 'string' ? message.message : 'Failed to connect to the robot.',
+            errorCode: typeof message.error_code === 'string' ? message.error_code : 'robot_connection_failed',
+        };
+    }
+
+    return { type: 'ignored' };
+};
+
+// Compose from the typed robot path; the observations socket is not in OpenAPI yet.
+const observationSocketUrl = (project_id: string, robot_id: string): string =>
+    `${fetchClient.PATH('/api/projects/{project_id}/robots/{robot_id}', {
+        params: { path: { project_id, robot_id } },
+    })}/observations/ws`;
+
+export const useRobotObservations = (project_id: string, robot_id: string) => {
+    const [joints, setJoints] = useState<JointsState>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [errorCode, setErrorCode] = useState<string | null>(null);
+    const hasErrorFrame = useRef(false);
+
+    const handleMessage = useCallback((event: WebSocketEventMap['message']) => {
+        try {
+            const parsed = parseRobotObservationMessage(JSON.parse(event.data));
+            if (parsed.type === 'observation') {
+                setJoints(parsed.joints);
+            } else if (parsed.type === 'state') {
+                hasErrorFrame.current = false;
+                setError(null);
+                setErrorCode(null);
+            } else if (parsed.type === 'error') {
+                hasErrorFrame.current = true;
+                setError(parsed.message);
+                setErrorCode(parsed.errorCode);
+            }
+        } catch (parseError) {
+            console.error('Failed to parse WebSocket message:', parseError);
+        }
+    }, []);
+
+    useWebSocket(observationSocketUrl(project_id, robot_id), {
+        queryParams: {
+            fps: 30,
+        },
+        share: true,
+        shouldReconnect: () => true,
+        reconnectAttempts: 5,
+        reconnectInterval: 3000,
+        onMessage: handleMessage,
+        onError: (wsError) => console.error('WebSocket error:', wsError),
+        onClose: (event) => {
+            if (event.code !== 1000 && !hasErrorFrame.current) {
+                setError(`Connection closed unexpectedly (code ${event.code})`);
+                setErrorCode('connection_closed');
+            }
+        },
+    });
+
+    return { joints, error, errorCode };
+};


### PR DESCRIPTION
## Why

The robot detail page spawned a full `rt-` session to display numbers it never writes. It collided with the environment form. Opening both on the same arm produced HTTP 423 for two pages that are not in conflict.

## What this adds over #971

- A read-only websocket at `/api/projects/{project_id}/robots/{robot_id}/observations/ws`.
- It attaches a `SharedRobot` subscriber (the same owner a live session already uses) and streams named `<joint>.pos` features. No `RobotRuntime`, no `SessionNameLock`, no `session_worker`.
- The detail page Connect switch opens that socket. Restart is gone from this page; it stays on the environment form, which still uses `useJointState`.

A read-only attach to avoid `423` error: `SharedRobot` is multi-subscriber by design.

## What's next

- **B3a** — cameras on the session, identity split so only environment-derived surfaces mint `rt-` sessions.
- **B3b** — policy inference; delete the model-worker stack.
- **B4** — recording on the runtime session (delete `RobotControlWorker`).

Stacked on #971. Do not merge to `main` until that PR lands.

## Stack

```
main
 └── #938 teleop
      └── #952 zenoh transport
           └── #967 runtime owner
                └── #971 physicalai bump
                     └── this PR (max/runtime-6-robot-observations)
```

## Tested scenarios

- [x] Connect on the robot detail page
- [x] Teleop still works
- [x] Detail page + environment form on the same robot at once: both work

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
