### PR TITLE
fix(ui): allow deleting canceled jobs and refresh list on delete

### DIFF
--- a/application/backend/src/api/job.py
+++ b/application/backend/src/api/job.py
@@ -46,7 +46,7 @@ async def delete_job(
     job_id: Annotated[UUID, Depends(get_job_id)],
     job_service: Annotated[JobService, Depends(get_job_service)],
 ) -> None:
-    """Delete a job. Only allows deleting failed jobs"""
+    """Delete a job. Only allows deleting failed or canceled jobs"""
     await job_service.delete_job(job_id)
 
 

--- a/application/ui/src/routes/models/index.delete-job.test.tsx
+++ b/application/ui/src/routes/models/index.delete-job.test.tsx
@@ -13,19 +13,37 @@ const jobId = 'f1b3f8f0-1c1a-4b1a-9c1a-1c1a1c1a1c1a';
 
 // `Index` opens a live WebSocket for job updates. jsdom has no server to
 // connect to, so stub out `WebSocket` with a minimal no-op implementation
-// that never attempts a real network connection.
+// that never attempts a real network connection. Matches the constructor
+// signature of the real WebSocket so `react-use-websocket` can instantiate
+// it safely, and is stubbed/restored per-test so it can't leak into other
+// test files.
 class FakeWebSocket extends EventTarget {
     static readonly CONNECTING = 0;
     static readonly OPEN = 1;
     static readonly CLOSING = 2;
     static readonly CLOSED = 3;
     readyState = FakeWebSocket.OPEN;
+
+    constructor(
+        public url: string | URL,
+        public protocols?: string | string[]
+    ) {
+        super();
+    }
+
     close() {
         this.readyState = FakeWebSocket.CLOSED;
     }
     send() {}
 }
-vi.stubGlobal('WebSocket', FakeWebSocket);
+
+beforeEach(() => {
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
 
 let jobs: SchemaTrainJob[];
 

--- a/application/ui/src/routes/models/index.delete-job.test.tsx
+++ b/application/ui/src/routes/models/index.delete-job.test.tsx
@@ -1,0 +1,83 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse } from 'msw';
+
+import { http } from '../../api/utils';
+import { server } from '../../msw-node-setup';
+import { render } from '../../test-utils/render';
+import { Index } from './index';
+import { SchemaTrainJob } from './train-model-dialog';
+
+const projectId = 'b8b28d4f-e78f-48ad-afb8-03d060178a3c';
+const jobId = 'f1b3f8f0-1c1a-4b1a-9c1a-1c1a1c1a1c1a';
+
+// `Index` opens a live WebSocket for job updates. jsdom has no server to
+// connect to, so stub out `WebSocket` with a minimal no-op implementation
+// that never attempts a real network connection.
+class FakeWebSocket extends EventTarget {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    readyState = FakeWebSocket.OPEN;
+    close() {
+        this.readyState = FakeWebSocket.CLOSED;
+    }
+    send() {}
+}
+vi.stubGlobal('WebSocket', FakeWebSocket);
+
+let jobs: SchemaTrainJob[];
+
+const baseJob: SchemaTrainJob = {
+    id: jobId,
+    project_id: projectId,
+    type: 'training',
+    status: 'canceled',
+    progress: 42,
+    message: 'Cancelled by user',
+    start_time: '2026-08-01T00:00:00Z',
+    end_time: '2026-08-01T00:05:00Z',
+    created_at: '2026-08-01T00:00:00Z',
+    extra_info: {},
+    payload: {
+        training_target: 'local',
+        model_name: 'Cancelled model',
+        policy: 'act',
+        dataset_id: 'd1',
+    },
+} as unknown as SchemaTrainJob;
+
+const mockRoutes = () => {
+    jobs = [baseJob];
+
+    server.use(
+        http.get('/api/projects/{project_id}/models', () => HttpResponse.json([])),
+        http.get('/api/jobs', () => HttpResponse.json(jobs)),
+        http.delete('/api/jobs/{job_id}', () => {
+            jobs = jobs.filter((job) => job.id !== jobId);
+            return HttpResponse.json(null);
+        })
+    );
+};
+
+describe('Index - deleting a canceled training job', () => {
+    it('removes the job row from the list once deletion succeeds, without a page refresh', async () => {
+        const user = userEvent.setup();
+        mockRoutes();
+
+        render(<Index />, {
+            route: `/projects/${projectId}/models`,
+            path: '/projects/:project_id/models',
+        });
+
+        expect(await screen.findByText('Cancelled model')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Job options' }));
+        await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+        await waitFor(() => {
+            expect(screen.queryByText('Cancelled model')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/application/ui/src/routes/models/job-table.component.test.tsx
+++ b/application/ui/src/routes/models/job-table.component.test.tsx
@@ -1,0 +1,47 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render } from '../../test-utils/render';
+import { TrainingRow } from './job-table.component';
+import { SchemaTrainJob } from './train-model-dialog';
+
+const baseJob: SchemaTrainJob = {
+    id: 'f1b3f8f0-1c1a-4b1a-9c1a-1c1a1c1a1c1a',
+    status: 'failed',
+    progress: 0,
+    message: '',
+    start_time: null,
+    end_time: null,
+    extra_info: {},
+    payload: {
+        training_target: 'local',
+        model_name: 'Test model',
+        policy: 'act',
+    },
+} as unknown as SchemaTrainJob;
+
+const renderRow = (job: SchemaTrainJob) =>
+    render(<TrainingRow trainJob={job} onInterrupt={() => undefined} onViewLogs={() => undefined} />, {
+        route: '/projects/p1/models',
+        path: '/projects/:project_id/models',
+    });
+
+describe('JobMenu delete option', () => {
+    it.each(['failed', 'canceled'] as const)('is enabled when job status is %s', async (status) => {
+        const user = userEvent.setup();
+        renderRow({ ...baseJob, status });
+
+        await user.click(screen.getByRole('button', { name: 'Job options' }));
+
+        expect(screen.getByRole('menuitem', { name: 'Delete' })).not.toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it.each(['running', 'completed', 'pending'] as const)('is disabled when job status is %s', async (status) => {
+        const user = userEvent.setup();
+        renderRow({ ...baseJob, status });
+
+        await user.click(screen.getByRole('button', { name: 'Job options' }));
+
+        expect(screen.getByRole('menuitem', { name: 'Delete' })).toHaveAttribute('aria-disabled', 'true');
+    });
+});

--- a/application/ui/src/routes/models/job-table.component.tsx
+++ b/application/ui/src/routes/models/job-table.component.tsx
@@ -14,9 +14,11 @@ import {
     View,
 } from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { $api } from '../../api/client';
 import { ElapsedDuration } from '../../components/elapsed-duration.component';
+import { notify } from '../../components/notification/notification.component';
 import { CollapsableRow } from './collapsable-row.component';
 import { GRID_COLUMNS } from './constants';
 import { JobRowContent } from './job-row-content.component';
@@ -92,9 +94,20 @@ const TrainJobStatus = ({ job }: { job: SchemaTrainJob }) => {
 };
 
 const JobMenu = ({ trainJob, onViewLogs }: { trainJob: SchemaTrainJob; onViewLogs: () => void }) => {
+    const queryClient = useQueryClient();
     const deleteJobMutation = $api.useMutation('delete', '/api/jobs/{job_id}', {
         meta: {
             invalidates: [['get', '/api/jobs']],
+        },
+        onSuccess: () => {
+            // Remove the job from the cache immediately instead of waiting on the
+            // fire-and-forget invalidation refetch, so the row disappears right away.
+            queryClient.setQueryData<SchemaTrainJob[]>(['get', '/api/jobs'], (old = []) =>
+                old.filter((job) => job.id !== trainJob.id)
+            );
+        },
+        onError: () => {
+            notify('error', `Failed to delete ${trainJob.payload.model_name}`);
         },
     });
     const onAction = (key: Key) => {
@@ -109,7 +122,8 @@ const JobMenu = ({ trainJob, onViewLogs }: { trainJob: SchemaTrainJob; onViewLog
         }
     };
 
-    const disabledKeys = trainJob.status === 'failed' ? [] : ['delete'];
+    const isDeletable = trainJob.status === 'failed' || trainJob.status === 'canceled';
+    const disabledKeys = isDeletable ? [] : ['delete'];
 
     return (
         <MenuTrigger>


### PR DESCRIPTION
## Summary

Fixes #732, https://github.com/open-edge-platform/physical-ai-studio/issues/980: cancelled training jobs could not be deleted from the UI.

## Changes

- Enable the **Delete** menu option for jobs with status `canceled`, not just
  `failed`. The backend (`JobService.delete_job`) already allowed deleting
  both statuses; the frontend menu was stricter than the API.
- Remove the deleted job from the `GET /api/jobs` query cache immediately on
  a successful delete, instead of relying solely on a fire-and-forget
  invalidation refetch. This makes the row disappear right away without
  needing a page refresh.
- Surface a notification if the delete request fails, instead of failing
  silently.
- Fix a stale docstring on `DELETE /api/jobs/{job_id}` that said "Only allows
  deleting failed jobs".

