### PR TITLE
feat(runtime): hold cameras on the session and split identity

### DIFF
--- a/application/backend/src/api/environments.py
+++ b/application/backend/src/api/environments.py
@@ -7,7 +7,7 @@ from fastapi.responses import Response
 from physicalai.config import to_yaml
 
 from api.dependencies import RobotClientFactoryDep, get_environment_id, get_environment_service, get_project_id
-from runtime.config_builder import build_runtime_config, runtime_config_change_me
+from runtime.config_builder import RUNTIME_FPS, build_runtime_config, runtime_config_change_me
 from schemas.environment import Environment, EnvironmentWithRelations, TeleoperatorRobotWithRobot
 from services.environment_service import EnvironmentService
 
@@ -65,8 +65,8 @@ async def get_runtime_config(
             follower=relation.robot,
             leader=relation.tele_operator.robot,
             cameras=environment.cameras,
-            fps=30,
             robot_factory=robot_client_factory,
+            fps=RUNTIME_FPS,
             # The rig this describes does not have to be attached to export it.
             allow_stored_port=True,
         )

--- a/application/backend/src/api/runtime_ws.py
+++ b/application/backend/src/api/runtime_ws.py
@@ -1,27 +1,42 @@
+from __future__ import annotations
+
 import asyncio
 import queue
 import time
-from typing import Annotated
-from uuid import UUID
+from typing import TYPE_CHECKING, Annotated, Any
+from uuid import UUID  # noqa: TC003  # FastAPI evaluates websocket annotations at runtime
 
 from fastapi import APIRouter, Depends, WebSocket, status
+from fastapi.exceptions import HTTPException
 from fastapi.responses import Response
 from fastapi.websockets import WebSocketDisconnect
 from loguru import logger
 from pydantic import ValidationError
 
-from api.dependencies import RobotClientFactoryDep, SettingsDep, get_project_id, get_robot_id, get_robot_service
+from api.dependencies import (
+    ProjectCameraServiceDep,
+    RobotClientFactoryDep,
+    SettingsDep,
+    get_camera_id,
+    get_project_id,
+    get_robot_id,
+    get_robot_service,
+)
 from exceptions import BaseException as AppBaseException
 from exceptions import RobotPluginUnavailableError
-from runtime.config_builder import build_runtime_config
+from runtime.config_builder import RUNTIME_FPS, build_runtime_config
 from runtime.contract import DisconnectCommand, SetFollowerSourceCommand
 from runtime.owner import RuntimeSessionOwner
 from runtime.transport.client import RuntimeProcessError, RuntimeSessionClient
 from runtime.transport.ids import runtime_session_name
 from schemas.robot import ReadableRobot, UnavailableRobot
-from services import RobotService
+from services import ProjectCameraService, RobotService
 
-router = APIRouter(prefix="/api/projects/{project_id}/robots", tags=["Project Robots"])
+if TYPE_CHECKING:
+    from schemas.project_camera import Camera
+    from schemas.robot import Robot
+
+router = APIRouter(prefix="/api/projects/{project_id}/runtime", tags=["Runtime"])
 
 
 def _websocket_error_payload(exc: Exception) -> dict[str, str]:
@@ -103,20 +118,47 @@ async def start_runtime_session(
     await asyncio.to_thread(client.wait_until_ready, owner)
 
 
-@router.get("/ws", tags=["WebSocket"], summary="Robot control (WebSocket)", status_code=426)
-async def robot_websocket_openapi(project_id: UUID) -> Response:  # noqa: ARG001
+async def _devices_from_handshake(
+    handshake: dict[str, Any],
+    project_id: UUID,
+    robot_service: RobotService,
+    camera_service: ProjectCameraService,
+) -> tuple[Robot, Robot | None, list[Camera]]:
+    """Resolve handshake ids against the project so a client cannot name another project's devices."""
+    follower_id = get_robot_id(handshake["follower_id"])
+    follower = await robot_service.get_robot_by_id(project_id, follower_id)
+    _ensure_robot_available(follower)
+    leader = None
+    if handshake.get("leader_id") is not None:
+        leader_id = get_robot_id(handshake["leader_id"])
+        leader = await robot_service.get_robot_by_id(project_id, leader_id)
+        _ensure_robot_available(leader)
+
+    raw_camera_ids = handshake.get("camera_ids") or []
+    if not isinstance(raw_camera_ids, list):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="camera_ids must be a list")
+    cameras: list[Camera] = []
+    for raw in raw_camera_ids:
+        if not isinstance(raw, str):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid camera ID")
+        cameras.append(await camera_service.get_camera_by_id(project_id, get_camera_id(raw)))
+    return follower, leader, cameras
+
+
+@router.get("/ws", tags=["WebSocket"], summary="Runtime session (WebSocket)", status_code=426)
+async def runtime_websocket_openapi(project_id: UUID) -> Response:  # noqa: ARG001
     """This endpoint requires a WebSocket connection. Use `wss://` to connect."""
     return Response(status_code=426)
 
 
 @router.websocket("/ws")
-async def robot_websocket(  # noqa: PLR0915
+async def runtime_websocket(
     project_id: Annotated[UUID, Depends(get_project_id)],
     robot_service: Annotated[RobotService, Depends(get_robot_service)],
+    camera_service: ProjectCameraServiceDep,
     robot_client_factory: RobotClientFactoryDep,
     settings: SettingsDep,
     websocket: WebSocket,
-    fps: int = 30,
 ) -> None:
     """Stream follower state and accept hold/teleop mode changes."""
     await websocket.accept()
@@ -127,20 +169,12 @@ async def robot_websocket(  # noqa: PLR0915
     startup_task: asyncio.Task[None] | None = None
     try:
         handshake = await websocket.receive_json("text")
-        follower_id = get_robot_id(handshake["follower_id"])
-        follower = await robot_service.get_robot_by_id(project_id, follower_id)
-        _ensure_robot_available(follower)
-        leader = None
-        if handshake.get("leader_id") is not None:
-            leader_id = get_robot_id(handshake["leader_id"])
-            leader = await robot_service.get_robot_by_id(project_id, leader_id)
-            _ensure_robot_available(leader)
-
+        follower, leader, cameras = await _devices_from_handshake(handshake, project_id, robot_service, camera_service)
         document = await build_runtime_config(
             follower=follower,
             leader=leader,
-            cameras=[],
-            fps=fps,
+            cameras=cameras,
+            fps=RUNTIME_FPS,
             robot_factory=robot_client_factory,
         )
         session_name = runtime_session_name(follower.id)
@@ -185,9 +219,9 @@ async def robot_websocket(  # noqa: PLR0915
         pass
     except Exception as exc:
         if isinstance(exc, AppBaseException):
-            logger.warning("Robot websocket error: {} ({})", exc.message, exc.error_code)
+            logger.warning("Runtime websocket error: {} ({})", exc.message, exc.error_code)
         else:
-            logger.exception("Unexpected error in robot websocket: {}", exc)
+            logger.exception("Unexpected error in runtime websocket: {}", exc)
         try:
             await websocket.send_json(_websocket_error_payload(exc))
             await websocket.close(code=status.WS_1011_INTERNAL_ERROR)

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -24,10 +24,10 @@ from api.record import router as record_router
 from api.remote_servers import router as remote_servers_router
 from api.remote_trainers import router as remote_trainers_router
 from api.robot_catalog import router as robot_catalog_router
-from api.robot_control import router as robot_control_router
 from api.robot_observations import router as robot_observations_router
 from api.robot_setup import router as robot_setup_router
 from api.robots import router as project_robots_router
+from api.runtime_ws import router as runtime_ws_router
 from api.settings import router as settings_router
 from api.system import system_router
 from api.webui import SPAStaticFiles
@@ -51,7 +51,7 @@ app.include_router(project_robots_router)
 app.include_router(robot_catalog_router)
 app.include_router(project_cameras_router)
 app.include_router(robot_setup_router)
-app.include_router(robot_control_router)
+app.include_router(runtime_ws_router)
 app.include_router(robot_observations_router)
 app.include_router(project_environments_router)
 app.include_router(hardware_router)

--- a/application/backend/src/runtime/config_builder.py
+++ b/application/backend/src/runtime/config_builder.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     from schemas.project_camera import Camera
     from schemas.robot import Robot
 
+RUNTIME_FPS = 30.0
+
 
 class _StoredPortFallback:
     """Export-only port finder: keeps the registered port when a robot is absent.
@@ -57,9 +59,15 @@ def _shared_camera_config(camera: Camera) -> dict[str, Any]:
     if fingerprint.startswith("/dev/video") and ":" in fingerprint:
         fingerprint = fingerprint.split(":")[0]
     device = resolve_camera_device(fingerprint) if camera.driver == "usb_camera" else None
+    # Never reconfigure another session's publisher (overwrite_settings=False).
+    # Refuse frames at a resolution this environment did not declare rather
+    # than silently reading the wrong size: that is a wrong answer, not a
+    # degraded one. See runtime-process-context.md#cameras-connect-strictly.
     shared_camera = SharedCamera(
         camera=build_camera_config(camera, device=device),
         color_mode=ColorMode.RGB,
+        validate_on_connect=True,
+        overwrite_settings=False,
     )
     return to_config(shared_camera).to_dict()
 
@@ -69,8 +77,8 @@ async def build_runtime_config(
     follower: Robot,
     leader: Robot | None,
     cameras: list[Camera],
-    fps: float,
     robot_factory: RobotClientFactory,
+    fps: float = RUNTIME_FPS,
     allow_stored_port: bool = False,
 ) -> dict[str, Any]:
     """Assemble one physicalai runtime recipe from Studio database rows.
@@ -107,10 +115,28 @@ async def build_runtime_config(
     return cast("dict[str, Any]", document)
 
 
-def runtime_config_digest(document: dict[str, Any]) -> str:
-    """Identify one rig configuration, so a client cannot attach to a different one."""
-    canonical = json.dumps(document, sort_keys=True, separators=(",", ":"))
+def runtime_identity_digest(document: dict[str, Any]) -> str:
+    """Identify the hardware a session is driving, so a client cannot attach to a different rig.
+
+    Covers the robot recipe, the leader recipe and fps — everything that
+    physically determines what the arm does. Cameras are deliberately excluded:
+    they are read-only observation, a client that needs more can restart the
+    session, and including them would make every camera edit in the environment
+    form look like a rig change. See runtime-process-context.md#decisions.
+    """
+    init_args = document["init_args"]
+    identity = {
+        "robot": init_args["robot"],
+        "action_source": init_args.get("action_source"),
+        "fps": init_args["fps"],
+    }
+    canonical = json.dumps(identity, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def runtime_camera_keys(document: dict[str, Any]) -> list[str]:
+    """Return the sorted camera feature keys this document declares."""
+    return sorted(document["init_args"].get("cameras", {}))
 
 
 def runtime_config_change_me(document: dict[str, Any]) -> list[str]:

--- a/application/backend/src/runtime/hosts/session_worker.py
+++ b/application/backend/src/runtime/hosts/session_worker.py
@@ -20,7 +20,7 @@ from loguru import logger
 from core.logging import setup_logging
 from exceptions import BaseException as AppBaseException
 from exceptions import RuntimeSessionBusyError
-from runtime.config_builder import runtime_config_digest
+from runtime.config_builder import runtime_camera_keys, runtime_identity_digest
 from runtime.contract import ErrorEvent, LifecycleData, LifecycleEvent, SetFollowerSourceCommand
 from runtime.session import RuntimeSession
 from runtime.transport.lock import SessionNameLock, live_session_pid
@@ -212,7 +212,8 @@ def _open_locked_session(
     instance_id = uuid4().hex
     server = RuntimeZenohServer(payload.session_name, instance_id=instance_id)
     server.update_metadata(
-        config_digest=runtime_config_digest(payload.document),
+        identity_digest=runtime_identity_digest(payload.document),
+        camera_keys=runtime_camera_keys(payload.document),
         pid=os.getpid(),
         started_at=time.time(),
         idle_timeout_s=payload.idle_timeout_s,

--- a/application/backend/src/runtime/owner.py
+++ b/application/backend/src/runtime/owner.py
@@ -12,7 +12,7 @@ from loguru import logger
 
 from exceptions import BaseException as AppBaseException
 from exceptions import RuntimeSessionBusyError
-from runtime.config_builder import runtime_config_digest
+from runtime.config_builder import runtime_camera_keys, runtime_identity_digest
 from runtime.hosts.process_host import RuntimeProcessHost
 from runtime.transport.codec import decode_metadata
 from runtime.transport.ids import metadata_key, runtime_session_name
@@ -209,8 +209,18 @@ class RuntimeSessionOwner:
 
         metadata = None if replace else self._client.probe()
         if metadata is not None:
-            self._attach_to(metadata)
-            return
+            # Identity first: a client asking for a different arm must get 423,
+            # not a silent takeover because it also happens to need more cameras.
+            self._reject_if_different_rig(metadata)
+            if self._needs_more_cameras(metadata):
+                logger.info(
+                    "Runtime session {} is missing cameras this client needs; restarting",
+                    self._session_name,
+                )
+                stop_runtime_session(self._session_name)
+            else:
+                self._attach_to(metadata)
+                return
 
         self._host = RuntimeProcessHost(
             self._session_name,
@@ -272,12 +282,23 @@ class RuntimeSessionOwner:
         self._metadata = metadata
 
     def _reject_if_different_rig(self, metadata: dict[str, Any]) -> None:
-        expected = runtime_config_digest(self._document)
-        actual = metadata.get("config_digest")
-        if actual == expected:
+        expected = runtime_identity_digest(self._document)
+        if metadata.get("identity_digest") == expected:
             return
         pid = metadata.get("pid")
         raise RuntimeSessionBusyError(
             robot_name=self._follower_name,
             pid=pid if isinstance(pid, int) else None,
         )
+
+    def _needs_more_cameras(self, metadata: dict[str, Any]) -> bool:
+        """Whether the running session lacks a camera this client needs.
+
+        Cameras are outside the session identity, so a session started by a client
+        that needed none — the environment form preview — is a valid attach target
+        for its own identity but cannot serve a client that has to read frames.
+        Restarting is correct rather than rude: the displaced client reattaches to
+        the superset, because its identity still matches.
+        """
+        running = set(metadata.get("camera_keys") or [])
+        return not set(runtime_camera_keys(self._document)).issubset(running)

--- a/application/backend/src/runtime/owner.py
+++ b/application/backend/src/runtime/owner.py
@@ -207,55 +207,50 @@ class RuntimeSessionOwner:
         if replace:
             stop_runtime_session(self._session_name)
 
-        metadata = None if replace else self._client.probe()
-        if metadata is not None:
-            # Identity first: a client asking for a different arm must get 423,
-            # not a silent takeover because it also happens to need more cameras.
-            self._reject_if_different_rig(metadata)
-            if self._needs_more_cameras(metadata):
-                logger.info(
-                    "Runtime session {} is missing cameras this client needs; restarting",
-                    self._session_name,
-                )
-                stop_runtime_session(self._session_name)
-            else:
-                self._attach_to(metadata)
+        skip_probe = replace
+        while True:
+            metadata = None if skip_probe else self._client.probe()
+            skip_probe = False
+            if metadata is not None and self._try_attach(metadata):
                 return
 
-        self._host = RuntimeProcessHost(
-            self._session_name,
-            self._document,
-            follower_name=self._follower_name,
-            leader_name=self._leader_name,
-            idle_timeout_s=self._idle_timeout_s,
-        )
-        try:
-            self._host.start()
-        except AppBaseException as exc:
-            self._host = None
-            if getattr(exc, "phase", None) != "name_lock_contention":
-                raise
-            metadata = self._client.probe_with_retry(_RACE_RETRY_TIMEOUT)
-            if metadata is None:
-                raise
-            self._attach_to(metadata)
-            return
+            self._host = RuntimeProcessHost(
+                self._session_name,
+                self._document,
+                follower_name=self._follower_name,
+                leader_name=self._leader_name,
+                idle_timeout_s=self._idle_timeout_s,
+            )
+            try:
+                self._host.start()
+            except AppBaseException as exc:
+                self._host = None
+                if getattr(exc, "phase", None) != "name_lock_contention":
+                    raise
+                # The winner may not have published metadata yet.
+                metadata = self._client.probe_with_retry(_RACE_RETRY_TIMEOUT)
+                if metadata is None:
+                    raise
+                if self._try_attach(metadata):
+                    return
+                continue
 
-        self._spawned = True
-        try:
-            metadata = self._wait_for_spawned_metadata(_RACE_RETRY_TIMEOUT)
-            if metadata is None:
-                raise AppBaseException(
-                    message=f"Runtime session {self._session_name} reported READY but its metadata is unreachable.",
-                    error_code="robot_connection_failed",
-                    http_status=500,
-                )
-            self._attach_to(metadata)
-        except Exception:
-            self.stop()
-            self._host = None
-            self._spawned = False
-            raise
+            self._spawned = True
+            try:
+                metadata = self._wait_for_spawned_metadata(_RACE_RETRY_TIMEOUT)
+                if metadata is None:
+                    raise AppBaseException(
+                        message=f"Runtime session {self._session_name} reported READY but its metadata is unreachable.",
+                        error_code="robot_connection_failed",
+                        http_status=500,
+                    )
+                self._attach_to(metadata)
+            except Exception:
+                self.stop()
+                self._host = None
+                self._spawned = False
+                raise
+            return
 
     def _wait_for_spawned_metadata(self, timeout: float) -> dict[str, Any] | None:
         deadline = time.monotonic() + timeout
@@ -275,6 +270,27 @@ class RuntimeSessionOwner:
             if metadata is not None:
                 return metadata
             time.sleep(min(0.05, remaining))
+
+    def _try_attach(self, metadata: dict[str, Any]) -> bool:
+        """Attach to ``metadata`` if it can serve this client.
+
+        Returns True after attaching. Returns False after stopping a session
+        that matches identity but lacks cameras this client needs, so the
+        caller can spawn. Raises RuntimeSessionBusyError on an identity mismatch.
+
+        Identity is checked first: a client asking for a different arm must get
+        423, not a silent takeover because it also happens to need more cameras.
+        """
+        self._reject_if_different_rig(metadata)
+        if self._needs_more_cameras(metadata):
+            logger.info(
+                "Runtime session {} is missing cameras this client needs; restarting",
+                self._session_name,
+            )
+            stop_runtime_session(self._session_name)
+            return False
+        self._attach_to(metadata)
+        return True
 
     def _attach_to(self, metadata: dict[str, Any]) -> None:
         self._reject_if_different_rig(metadata)

--- a/application/backend/src/runtime/session.py
+++ b/application/backend/src/runtime/session.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from loguru import logger
 from physicalai.config import Config
@@ -16,10 +16,22 @@ from runtime.callbacks.stream import StreamCallback
 from runtime.contract import DisconnectCommand, InMemoryCommandMailbox
 
 if TYPE_CHECKING:
+    from physicalai.capture import Camera
     from physicalai.robot.interface import Robot
     from physicalai.runtime import StopSignal
 
     from runtime.contract import Command, EventSink
+
+
+class _Connectable(Protocol):
+    def connect(self) -> None: ...
+    def disconnect(self) -> None: ...
+
+
+def _is_connected(device: object) -> bool:
+    """Return connection state for a robot (method) or camera (property)."""
+    connected = getattr(device, "is_connected", False)
+    return bool(connected() if callable(connected) else connected)
 
 
 class RuntimeSession:
@@ -41,6 +53,7 @@ class RuntimeSession:
         self.ready = threading.Event()
         self._follower: Robot | None = None
         self._leader: Robot | None = None
+        self._cameras: dict[str, Camera] = {}
         self._action_source: StudioActionSource | None = None
         self._stream_callback: StreamCallback | None = None
         self._runtime: RobotRuntime | None = None
@@ -56,6 +69,11 @@ class RuntimeSession:
             leader_config = source_args.get("leader") if isinstance(source_args, dict) else None
             if isinstance(leader_config, dict):
                 self._leader = cast("Robot", Config.from_dict(leader_config).instantiate())
+
+        self._cameras = {
+            key: cast("Camera", Config.from_dict(config).instantiate())
+            for key, config in init_args.get("cameras", {}).items()
+        }
 
         self._action_source = StudioActionSource(
             follower=self._follower,
@@ -78,7 +96,7 @@ class RuntimeSession:
         self._runtime = RobotRuntime(
             robot=self._follower,
             action_source=self._action_source,
-            cameras={},
+            cameras=self._cameras,
             fps=float(self._document["init_args"]["fps"]),
             callbacks=[self._stream_callback],
         )
@@ -102,7 +120,7 @@ class RuntimeSession:
         try:
             if self._disconnect_requested or stop_signal.is_set():
                 return
-            self._preconnect_robots()
+            self._preconnect_devices()
             if self._disconnect_requested or stop_signal.is_set():
                 return
             # Do not use ``with runtime``: the session alone owns device teardown.
@@ -118,6 +136,12 @@ class RuntimeSession:
 
     async def teardown(self) -> None:
         # Device lifetime belongs to the session, not to a disposable runtime view.
+        # Cameras first so a wedged publisher cannot strand the arm connected.
+        for key, camera in self._cameras.items():
+            try:
+                camera.disconnect()
+            except Exception as exc:
+                logger.warning("Camera {} disconnect failed: {}", key, exc)
         if self._leader is not None:
             try:
                 self._leader.disconnect()
@@ -129,25 +153,26 @@ class RuntimeSession:
             except Exception as exc:
                 logger.warning("Follower disconnect failed: {}", exc)
 
-    def _preconnect_robots(self) -> None:
-        """Connect robots in parallel to reduce session startup time."""
+    def _preconnect_devices(self) -> None:
+        """Connect robots and cameras in parallel to reduce session startup time."""
         if self._follower is None:
             raise RuntimeError("Follower robot is not set up")
-        robots = [self._follower]
+        devices: list[_Connectable] = [self._follower]
         if self._leader is not None:
-            robots.append(self._leader)
-        with ThreadPoolExecutor(max_workers=len(robots)) as executor:
-            futures = {executor.submit(robot.connect): robot for robot in robots}
+            devices.append(self._leader)
+        devices.extend(self._cameras.values())
+        with ThreadPoolExecutor(max_workers=len(devices)) as executor:
+            futures = {executor.submit(device.connect): device for device in devices}
             try:
                 for future in as_completed(futures):
                     future.result()
             except Exception as exc:
-                logger.error("Robot parallel connect failed: {}", exc)
+                logger.error("Device parallel connect failed: {}", exc)
                 for future in futures:
                     future.cancel()
-                for robot in robots:
-                    if robot.is_connected():
-                        logger.error("Disconnecting robot {} after connect failure", robot)
+                for device in devices:
+                    if _is_connected(device):
+                        logger.error("Disconnecting device {} after connect failure", device)
                         with contextlib.suppress(Exception):
-                            robot.disconnect()
+                            device.disconnect()
                 raise

--- a/application/backend/src/runtime/transport/client.py
+++ b/application/backend/src/runtime/transport/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import queue
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -89,11 +90,21 @@ class RuntimeSessionClient:
             time.sleep(min(0.05, remaining))
 
     def attach(self, metadata: dict[str, Any]) -> None:
-        """Adopt the session generation id and flush any command buffered before it."""
+        """Adopt one session generation and drop any state from a previous one."""
         instance_id = metadata.get("instance_id")
         if instance_id is not None and (not isinstance(instance_id, str) or not instance_id):
             raise RuntimeError("Runtime session metadata instance_id must be a string")
         self._instance_id = instance_id
+        with self._state_lock:
+            self._hardware_ready.clear()
+            self._last_state = None
+            self.error = None
+            self._shutdown_received.clear()
+        while True:
+            try:
+                self._events.get_nowait()
+            except queue.Empty:
+                break
         self._metadata_ready.set()
         self._flush_pending_command()
 
@@ -197,6 +208,8 @@ class RuntimeSessionClient:
     def _receive_event(self, sample: Any) -> None:
         try:
             event, fatal, instance_id = decode_event(sample.payload.to_bytes())
+            if not self._metadata_ready.is_set():
+                return
             if self._instance_id is not None and instance_id != self._instance_id:
                 logger.warning("Rejected runtime event for a different instance")
                 return

--- a/application/backend/tests/api/test_dependencies.py
+++ b/application/backend/tests/api/test_dependencies.py
@@ -5,6 +5,7 @@ from fastapi.dependencies.utils import get_dependant
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.dependencies import (
+    get_camera_service,
     get_dataset_service,
     get_job_service,
     get_log_service,
@@ -13,8 +14,8 @@ from api.dependencies import (
     get_robot_client_factory,
 )
 from api.record import robot_control_websocket
-from api.robot_control import robot_websocket
 from api.robot_observations import robot_observations_websocket
+from api.runtime_ws import runtime_websocket
 from robots.robot_client_factory import RobotClientFactory
 from services.job_service import JobService
 from services.robot_catalog_service import RobotCatalogService
@@ -77,8 +78,9 @@ def test_record_websocket_depends_on_robot_client_factory() -> None:
     assert get_robot_client_factory in _dependency_calls(robot_control_websocket)
 
 
-def test_teleoperation_websocket_depends_on_robot_client_factory() -> None:
-    assert get_robot_client_factory in _dependency_calls(robot_websocket)
+def test_runtime_websocket_depends_on_robot_client_factory() -> None:
+    assert get_robot_client_factory in _dependency_calls(runtime_websocket)
+    assert get_camera_service in _dependency_calls(runtime_websocket)
 
 
 def test_observation_websocket_depends_on_robot_client_factory() -> None:

--- a/application/backend/tests/api/test_robot_control_errors.py
+++ b/application/backend/tests/api/test_robot_control_errors.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, call
 
 from fastapi.websockets import WebSocketDisconnect
 
-from api.robot_control import _websocket_error_payload, handle_incoming, start_runtime_session
+from api.runtime_ws import _websocket_error_payload, handle_incoming, start_runtime_session
 from exceptions import RobotDeviceAlreadyOwnedError
 from runtime.contract import DisconnectCommand, SetFollowerSourceCommand
 

--- a/application/backend/tests/api/test_runtime_ws.py
+++ b/application/backend/tests/api/test_runtime_ws.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 from uuid import UUID, uuid4
 
@@ -9,6 +10,9 @@ from fastapi.testclient import TestClient
 from api.dependencies import get_camera_service, get_robot_client_factory, get_robot_service
 from exceptions import ResourceNotFoundError, ResourceType
 from main import app
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 PROJECT_ID = uuid4()
 ROBOT_ID = uuid4()
@@ -43,7 +47,7 @@ def camera_service() -> _StubCameraService:
 
 
 @pytest.fixture
-def client(mock_robot_client_factory, camera_service: _StubCameraService) -> TestClient:
+def client(mock_robot_client_factory, camera_service: _StubCameraService) -> Iterator[TestClient]:
     app.dependency_overrides[get_robot_service] = lambda: _StubRobotService()
     app.dependency_overrides[get_camera_service] = lambda: camera_service
     app.dependency_overrides[get_robot_client_factory] = lambda: mock_robot_client_factory

--- a/application/backend/tests/api/test_runtime_ws.py
+++ b/application/backend/tests/api/test_runtime_ws.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.dependencies import get_camera_service, get_robot_client_factory, get_robot_service
+from exceptions import ResourceNotFoundError, ResourceType
+from main import app
+
+PROJECT_ID = uuid4()
+ROBOT_ID = uuid4()
+FOREIGN_CAMERA_ID = uuid4()
+
+
+class _StubRobot:
+    def __init__(self) -> None:
+        self.id = ROBOT_ID
+        self.name = "Khaos"
+
+
+class _StubRobotService:
+    async def get_robot_by_id(self, project_id: UUID, robot_id: UUID) -> _StubRobot:
+        assert project_id == PROJECT_ID
+        assert robot_id == ROBOT_ID
+        return _StubRobot()
+
+
+class _StubCameraService:
+    def __init__(self) -> None:
+        self.lookups: list[tuple[UUID, UUID]] = []
+
+    async def get_camera_by_id(self, project_id: UUID, camera_id: UUID) -> None:
+        self.lookups.append((project_id, camera_id))
+        raise ResourceNotFoundError(ResourceType.CAMERA, str(camera_id))
+
+
+@pytest.fixture
+def camera_service() -> _StubCameraService:
+    return _StubCameraService()
+
+
+@pytest.fixture
+def client(mock_robot_client_factory, camera_service: _StubCameraService) -> TestClient:
+    app.dependency_overrides[get_robot_service] = lambda: _StubRobotService()
+    app.dependency_overrides[get_camera_service] = lambda: camera_service
+    app.dependency_overrides[get_robot_client_factory] = lambda: mock_robot_client_factory
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_runtime_ws_handshake_resolves_cameras_against_the_project(
+    client: TestClient, camera_service: _StubCameraService
+) -> None:
+    url = f"/api/projects/{PROJECT_ID}/runtime/ws"
+
+    with (
+        patch("api.runtime_ws.RuntimeSessionOwner") as owner_cls,
+        patch("api.runtime_ws.build_runtime_config") as build,
+        client.websocket_connect(url) as websocket,
+    ):
+        websocket.send_json(
+            {
+                "follower_id": str(ROBOT_ID),
+                "camera_ids": [str(FOREIGN_CAMERA_ID)],
+            }
+        )
+        payload = websocket.receive_json()
+
+    assert payload["event"] == "error"
+    assert payload["error_code"] == "Camera_not_found"
+    assert camera_service.lookups == [(PROJECT_ID, FOREIGN_CAMERA_ID)]
+    build.assert_not_called()
+    owner_cls.assert_not_called()

--- a/application/backend/tests/runtime/fakes.py
+++ b/application/backend/tests/runtime/fakes.py
@@ -5,9 +5,12 @@ import time
 from dataclasses import dataclass
 
 import numpy as np
+from physicalai.capture import Frame
 
 _connect_tracker = {"depth": 0, "max_depth": 0}
 _connect_depth_lock = threading.Lock()
+_disconnect_order: list[str] = []
+_disconnect_lock = threading.Lock()
 
 
 def reset_connect_tracking() -> None:
@@ -19,6 +22,37 @@ def reset_connect_tracking() -> None:
 def max_concurrent_connects() -> int:
     with _connect_depth_lock:
         return int(_connect_tracker["max_depth"])
+
+
+def reset_disconnect_tracking() -> None:
+    with _disconnect_lock:
+        _disconnect_order.clear()
+
+
+def recorded_disconnects() -> list[str]:
+    with _disconnect_lock:
+        return list(_disconnect_order)
+
+
+def _track_connect(delay: float, error: str | None) -> None:
+    with _connect_depth_lock:
+        _connect_tracker["depth"] += 1
+        _connect_tracker["max_depth"] = max(_connect_tracker["max_depth"], _connect_tracker["depth"])
+    try:
+        if delay > 0:
+            time.sleep(delay)
+        if error is not None:
+            raise ConnectionError(error)
+    finally:
+        with _connect_depth_lock:
+            _connect_tracker["depth"] -= 1
+
+
+def _track_disconnect(name: str, error: str | None) -> None:
+    with _disconnect_lock:
+        _disconnect_order.append(name)
+    if error is not None:
+        raise ConnectionError(error)
 
 
 @dataclass
@@ -45,6 +79,7 @@ class FakeRobot:
         connect_error: str | None = None,
         observation_error: str | None = None,
         connect_delay: float = 0.0,
+        disconnect_error: str | None = None,
         name: str = "fake_robot",
     ) -> None:
         if observations is None:
@@ -59,24 +94,16 @@ class FakeRobot:
         self._connect_error = connect_error
         self._observation_error = observation_error
         self._connect_delay = connect_delay
+        self._disconnect_error = disconnect_error
         self.name = name
         self.sent_actions: list[np.ndarray] = []
 
     def connect(self) -> None:
-        with _connect_depth_lock:
-            _connect_tracker["depth"] += 1
-            _connect_tracker["max_depth"] = max(_connect_tracker["max_depth"], _connect_tracker["depth"])
-        try:
-            if self._connect_delay > 0:
-                time.sleep(self._connect_delay)
-            if self._connect_error is not None:
-                raise ConnectionError(self._connect_error)
-            self._connected = True
-        finally:
-            with _connect_depth_lock:
-                _connect_tracker["depth"] -= 1
+        _track_connect(self._connect_delay, self._connect_error)
+        self._connected = True
 
     def disconnect(self) -> None:
+        _track_disconnect(self.name, self._disconnect_error)
         self._connected = False
 
     def get_observation(self) -> FakeObservation:
@@ -99,3 +126,46 @@ class FakeRobot:
     @property
     def device_ids(self) -> tuple[str, ...]:
         return ()
+
+
+class FakeCamera:
+    """Stand-in for SharedCamera that participates in session connect/teardown."""
+
+    def __init__(
+        self,
+        *,
+        name: str = "fake_camera",
+        connect_error: str | None = None,
+        disconnect_error: str | None = None,
+        connect_delay: float = 0.0,
+        width: int = 8,
+        height: int = 8,
+    ) -> None:
+        self.name = name
+        self._connect_error = connect_error
+        self._disconnect_error = disconnect_error
+        self._connect_delay = connect_delay
+        self._width = width
+        self._height = height
+        self._connected = False
+        self._sequence = 0
+
+    def connect(self, timeout: float = 5.0) -> None:
+        _track_connect(self._connect_delay, self._connect_error)
+        self._connected = True
+
+    def disconnect(self) -> None:
+        _track_disconnect(self.name, self._disconnect_error)
+        self._connected = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def read_latest(self) -> Frame:
+        self._sequence += 1
+        return Frame(
+            data=np.zeros((self._height, self._width, 3), dtype=np.uint8),
+            timestamp=time.monotonic(),
+            sequence=self._sequence,
+        )

--- a/application/backend/tests/runtime/test_config_builder.py
+++ b/application/backend/tests/runtime/test_config_builder.py
@@ -9,7 +9,13 @@ from physicalai.config import to_yaml, validate_config
 from physicalai.runtime import RobotRuntime
 
 from robots.robot_client_factory import RobotClientFactory
-from runtime.config_builder import build_runtime_config, runtime_config_change_me, runtime_config_digest
+from runtime.config_builder import (
+    RUNTIME_FPS,
+    build_runtime_config,
+    runtime_camera_keys,
+    runtime_config_change_me,
+    runtime_identity_digest,
+)
 from schemas import SerialPortInfo
 from schemas.project_camera import CameraAdapter
 from schemas.robot import RobotAdapter
@@ -55,12 +61,12 @@ def _robot(role: str) -> Any:
     )
 
 
-def _camera() -> Any:
+def _camera(*, name: str = "Overhead Camera") -> Any:
     return CameraAdapter.validate_python(
         {
             "id": str(uuid4()),
             "driver": "usb_camera",
-            "name": "Overhead Camera",
+            "name": name,
             "fingerprint": "/dev/video0:0",
             "hardware_name": "Camera",
             "payload": {"width": 640, "height": 480, "fps": 30},
@@ -136,19 +142,69 @@ async def test_export_keeps_the_stored_port_when_the_robot_is_absent(mocker: Any
     assert runtime_config_change_me(document) == ["/dev/ttyACM0"]
 
 
-def test_runtime_config_digest_changes_when_the_rig_changes() -> None:
-    document = {
-        "class_path": "physicalai.runtime.RobotRuntime",
-        "init_args": {"fps": 30.0, "cameras": {}},
+def _identity_document(
+    *,
+    fps: float = 30.0,
+    cameras: dict[str, object] | None = None,
+    leader: bool = False,
+) -> dict[str, Any]:
+    init_args: dict[str, Any] = {
+        "robot": {"class_path": "tests.runtime.fakes.FakeRobot", "init_args": {"name": "follower"}},
+        "cameras": cameras or {},
+        "fps": fps,
     }
-    same = {
-        "init_args": {"cameras": {}, "fps": 30.0},
-        "class_path": "physicalai.runtime.RobotRuntime",
-    }
-    different = {
-        "class_path": "physicalai.runtime.RobotRuntime",
-        "init_args": {"fps": 15.0, "cameras": {}},
-    }
+    if leader:
+        init_args["action_source"] = {
+            "class_path": "physicalai.runtime.TeleopSource",
+            "init_args": {
+                "leader": {"class_path": "tests.runtime.fakes.FakeRobot", "init_args": {"name": "leader"}},
+            },
+        }
+    return {"class_path": "physicalai.runtime.RobotRuntime", "init_args": init_args}
 
-    assert runtime_config_digest(document) == runtime_config_digest(same)
-    assert runtime_config_digest(document) != runtime_config_digest(different)
+
+def test_identity_digest_ignores_cameras() -> None:
+    without_cameras = _identity_document()
+    with_cameras = _identity_document(cameras={"overhead camera": {"class_path": "unused"}})
+
+    assert runtime_identity_digest(without_cameras) == runtime_identity_digest(with_cameras)
+
+
+def test_identity_digest_changes_with_the_leader() -> None:
+    follower_only = _identity_document()
+    with_leader = _identity_document(leader=True)
+
+    assert runtime_identity_digest(follower_only) != runtime_identity_digest(with_leader)
+
+
+def test_identity_digest_changes_with_fps() -> None:
+    at_default = _identity_document(fps=RUNTIME_FPS)
+    at_half = _identity_document(fps=15.0)
+
+    assert runtime_identity_digest(at_default) != runtime_identity_digest(at_half)
+
+
+async def test_camera_keys_are_sorted_sanitized_names(mocker: Any) -> None:
+    _stub_device_paths(mocker)
+    document = await build_runtime_config(
+        follower=_robot("follower"),
+        leader=None,
+        cameras=[_camera(name="Zebra Cam"), _camera(name="Alpha/Cam")],
+        robot_factory=_robot_factory(),
+    )
+
+    assert runtime_camera_keys(document) == ["alpha_cam", "zebra cam"]
+
+
+async def test_cameras_validate_on_connect_and_never_overwrite(mocker: Any) -> None:
+    _stub_device_paths(mocker)
+    document = await build_runtime_config(
+        follower=_robot("follower"),
+        leader=None,
+        cameras=[_camera()],
+        robot_factory=_robot_factory(),
+    )
+
+    shared_camera = document["init_args"]["cameras"]["overhead camera"]["init_args"]
+    assert shared_camera["validate_on_connect"] is True
+    assert shared_camera["overwrite_settings"] is False

--- a/application/backend/tests/runtime/test_owner.py
+++ b/application/backend/tests/runtime/test_owner.py
@@ -12,6 +12,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from exceptions import BaseException as AppBaseException
 from exceptions import RuntimeSessionBusyError
 from runtime.config_builder import runtime_identity_digest
 from runtime.contract import DisconnectCommand, SetFollowerSourceCommand, StateEvent
@@ -138,6 +139,117 @@ def test_losing_the_spawn_race_attaches_to_the_winner() -> None:
         _stop_session(owners[0], *clients)
         for owner in owners[1:]:
             owner.stop()
+
+
+def test_losing_the_spawn_race_attaches_when_the_winner_has_the_cameras(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    name = _name()
+    document = _document_with_cameras("front")
+    client = MagicMock()
+    owner = RuntimeSessionOwner(
+        client,
+        session_name=name,
+        document=document,
+        follower_name="follower",
+        leader_name=None,
+        idle_timeout_s=30.0,
+    )
+    winner_metadata = {
+        "identity_digest": runtime_identity_digest(document),
+        "camera_keys": ["front"],
+        "pid": 41273,
+        "instance_id": "winner",
+    }
+    client.probe.return_value = None
+    client.probe_with_retry.return_value = winner_metadata
+    contention = AppBaseException(
+        message="lock held",
+        error_code="runtime_session_busy",
+        http_status=http.HTTPStatus.LOCKED,
+        phase="name_lock_contention",
+    )
+    host = MagicMock()
+    host.start.side_effect = contention
+    monkeypatch.setattr("runtime.owner.RuntimeProcessHost", lambda *_args, **_kwargs: host)
+    stop = MagicMock()
+    monkeypatch.setattr("runtime.owner.stop_runtime_session", stop)
+
+    owner.connect()
+
+    stop.assert_not_called()
+    assert owner.spawned is False
+    client.attach.assert_called_once_with(winner_metadata)
+    assert owner.metadata == winner_metadata
+
+
+def test_losing_the_spawn_race_restarts_when_the_winner_lacks_cameras(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    name = _name()
+    document = _document_with_cameras("front")
+    client = MagicMock()
+    owner = RuntimeSessionOwner(
+        client,
+        session_name=name,
+        document=document,
+        follower_name="follower",
+        leader_name=None,
+        idle_timeout_s=30.0,
+    )
+    winner_metadata = {
+        "identity_digest": runtime_identity_digest(document),
+        "camera_keys": [],
+        "pid": 41273,
+        "instance_id": "winner",
+    }
+    spawned_metadata = {
+        "identity_digest": runtime_identity_digest(document),
+        "camera_keys": ["front"],
+        "pid": 41274,
+        "instance_id": "ours",
+    }
+    probe_calls = {"n": 0}
+
+    def probe(*_args: Any, **_kwargs: Any) -> dict[str, Any] | None:
+        probe_calls["n"] += 1
+        if probe_calls["n"] <= 2:
+            return None
+        return spawned_metadata
+
+    client.probe.side_effect = probe
+    client.probe_with_retry.return_value = winner_metadata
+    contention = AppBaseException(
+        message="lock held",
+        error_code="runtime_session_busy",
+        http_status=http.HTTPStatus.LOCKED,
+        phase="name_lock_contention",
+    )
+    hosts: list[MagicMock] = []
+
+    def fake_host(*_args: Any, **_kwargs: Any) -> MagicMock:
+        host = MagicMock()
+        if not hosts:
+            host.start.side_effect = contention
+        else:
+            host.start.return_value = None
+            host.is_alive.return_value = True
+        hosts.append(host)
+        return host
+
+    monkeypatch.setattr("runtime.owner.RuntimeProcessHost", fake_host)
+    stop = MagicMock()
+    monkeypatch.setattr("runtime.owner.stop_runtime_session", stop)
+
+    owner.connect()
+
+    stop.assert_called_once_with(name)
+    assert len(hosts) == 2
+    hosts[1].start.assert_called_once()
+    assert owner.spawned is True
+    client.attach.assert_called_once_with(spawned_metadata)
+    assert owner.metadata == spawned_metadata
+    client.probe_with_retry.assert_called_once()
 
 
 def test_attaching_with_a_different_rig_is_refused() -> None:

--- a/application/backend/tests/runtime/test_owner.py
+++ b/application/backend/tests/runtime/test_owner.py
@@ -13,13 +13,13 @@ from uuid import UUID, uuid4
 import pytest
 
 from exceptions import RuntimeSessionBusyError
-from runtime.config_builder import runtime_config_digest
+from runtime.config_builder import runtime_identity_digest
 from runtime.contract import DisconnectCommand, SetFollowerSourceCommand, StateEvent
 from runtime.owner import RuntimeSessionOwner, probe_session_metadata, runtime_session_holder, stop_runtime_session
 from runtime.transport.client import RuntimeSessionClient
 from runtime.transport.ids import runtime_session_name
 from runtime.transport.lock import SessionNameLock, live_session_pid, registered_session_names, session_lock_path
-from tests.runtime.test_session import _document, _document_with_leader
+from tests.runtime.test_session import _document, _document_with_cameras, _document_with_leader
 
 
 def _name() -> str:
@@ -192,7 +192,8 @@ def test_replace_stops_the_existing_session_and_spawns_with_the_new_rig() -> Non
             second_client.wait_until_ready(second_owner, timeout=5)
             assert second_owner.spawned is True
             assert second_owner.metadata["pid"] != original_pid
-            assert second_owner.metadata["config_digest"] == runtime_config_digest(different)
+            assert second_owner.metadata["identity_digest"] == runtime_identity_digest(different)
+            assert second_owner.metadata["camera_keys"] == []
             assert not owner.is_alive()
         finally:
             _stop_session(second_owner, second_client)
@@ -449,3 +450,71 @@ def test_attached_owner_does_not_stop_on_abandon() -> None:
     owner, _client = _owner_with_mock_client()
 
     owner.stop_abandoned_spawn()
+
+
+def test_attaching_with_extra_cameras_is_allowed() -> None:
+    name = _name()
+    running = _document_with_cameras("front", "wrist")
+    owner, client = _connect_owner(name, running)
+    try:
+        subset = _document_with_cameras("front")
+        second_owner, second_client = _connect_owner(name, subset)
+        try:
+            assert second_owner.spawned is False
+            assert second_owner.metadata["pid"] == owner.metadata["pid"]
+            assert second_owner.metadata["camera_keys"] == ["front", "wrist"]
+            assert second_owner.metadata["identity_digest"] == runtime_identity_digest(subset)
+        finally:
+            second_client.close()
+    finally:
+        _stop_session(owner, client)
+
+
+def test_a_client_needing_more_cameras_restarts_the_session() -> None:
+    name = _name()
+    owner, client = _connect_owner(name, _document())
+    original_pid = owner.metadata["pid"]
+    try:
+        needing_cameras = _document_with_cameras("front")
+        second_owner, second_client = _connect_owner(name, needing_cameras)
+        try:
+            assert second_owner.spawned is True
+            assert second_owner.metadata["pid"] != original_pid
+            assert second_owner.metadata["camera_keys"] == ["front"]
+            assert not owner.is_alive()
+            assert live_session_pid(name) == second_owner.metadata["pid"]
+        finally:
+            _stop_session(second_owner, second_client)
+    finally:
+        if owner.is_alive():
+            owner.stop()
+        client.close()
+
+
+def test_a_client_needing_a_different_robot_is_refused_before_the_camera_check() -> None:
+    name = _name()
+    owner, client = _connect_owner(name, _document(), follower_name="left arm")
+    try:
+        different = _document_with_cameras("front", name="other-follower")
+        second_client = RuntimeSessionClient(name)
+        second_client.open()
+        second_owner = RuntimeSessionOwner(
+            second_client,
+            session_name=name,
+            document=different,
+            follower_name="left arm",
+            leader_name=None,
+            idle_timeout_s=30.0,
+        )
+        try:
+            with pytest.raises(RuntimeSessionBusyError) as exc_info:
+                second_owner.connect()
+            assert int(exc_info.value.http_status) == http.HTTPStatus.LOCKED
+            assert not second_owner.spawned
+            assert owner.is_alive()
+            assert live_session_pid(name) == owner.metadata["pid"]
+        finally:
+            second_owner.stop()
+            second_client.close()
+    finally:
+        _stop_session(owner, client)

--- a/application/backend/tests/runtime/test_process_host.py
+++ b/application/backend/tests/runtime/test_process_host.py
@@ -12,7 +12,7 @@ from uuid import UUID
 import pytest
 from physicalai.config import Config
 
-from api.robot_control import handle_outgoing
+from api.runtime_ws import handle_outgoing
 from exceptions import BaseException as AppBaseException
 from exceptions import RobotDeviceAlreadyOwnedError
 from runtime.contract import DisconnectCommand, SetFollowerSourceCommand, StateEvent

--- a/application/backend/tests/runtime/test_session.py
+++ b/application/backend/tests/runtime/test_session.py
@@ -35,6 +35,19 @@ def _document(*, connect_error: str | None = None, **follower_kwargs: Any) -> di
     ).to_dict()
 
 
+def _camera_config(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "class_path": "tests.runtime.fakes.FakeCamera",
+        "init_args": kwargs,
+    }
+
+
+def _document_with_cameras(*names: str, **follower_kwargs: Any) -> dict:
+    document = _document(**follower_kwargs)
+    document["init_args"]["cameras"] = {name: _camera_config(name=name) for name in names}
+    return document
+
+
 def _document_with_leader(*, leader_kwargs: dict[str, Any] | None = None, **follower_kwargs: Any) -> dict:
     document = _document(**follower_kwargs)
     document["init_args"]["action_source"] = {
@@ -99,7 +112,7 @@ async def test_preconnect_runs_follower_and_leader_connects_in_parallel() -> Non
     )
     await session.setup()
 
-    session._preconnect_robots()
+    session._preconnect_devices()
 
     assert session._follower is not None
     assert session._leader is not None
@@ -119,7 +132,7 @@ async def test_preconnect_disconnects_robots_when_one_connect_fails() -> None:
     await session.setup()
 
     with pytest.raises(ConnectionError, match="leader connect failed"):
-        session._preconnect_robots()
+        session._preconnect_devices()
 
     assert session._follower is not None
     assert session._leader is not None

--- a/application/backend/tests/runtime/test_session_cameras.py
+++ b/application/backend/tests/runtime/test_session_cameras.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+from runtime.contract import QueueEventSink
+from runtime.session import RuntimeSession
+from tests.runtime.fakes import (
+    max_concurrent_connects,
+    recorded_disconnects,
+    reset_connect_tracking,
+    reset_disconnect_tracking,
+)
+from tests.runtime.test_session import _camera_config, _document_with_cameras, _document_with_leader
+
+
+def _document_with_leader_and_cameras(
+    *names: str,
+    leader_kwargs: dict[str, Any] | None = None,
+    camera_kwargs: dict[str, dict[str, Any]] | None = None,
+    **follower_kwargs: Any,
+) -> dict[str, Any]:
+    document = _document_with_leader(leader_kwargs=leader_kwargs, **follower_kwargs)
+    per_camera = camera_kwargs or {}
+    cameras: dict[str, dict[str, Any]] = {}
+    for key in names:
+        init_args = dict(per_camera.get(key, {}))
+        init_args["name"] = key
+        cameras[key] = _camera_config(**init_args)
+    document["init_args"]["cameras"] = cameras
+    return document
+
+
+async def test_session_instantiates_cameras_from_the_document() -> None:
+    document = _document_with_cameras("front", "wrist")
+    session = RuntimeSession(document, event_sink=QueueEventSink())
+    await session.setup()
+    runtime = session.build_runtime()
+
+    assert list(runtime.cameras) == ["front", "wrist"]
+    assert session._cameras["front"] is runtime.cameras["front"]
+    assert session._cameras["wrist"] is runtime.cameras["wrist"]
+
+
+async def test_devices_connect_in_parallel() -> None:
+    reset_connect_tracking()
+    delay = 0.05
+    session = RuntimeSession(
+        _document_with_leader_and_cameras(
+            "front",
+            connect_delay=delay,
+            name="follower",
+            leader_kwargs={"connect_delay": delay, "name": "leader"},
+            camera_kwargs={"front": {"connect_delay": delay, "name": "front"}},
+        ),
+        event_sink=QueueEventSink(),
+    )
+    await session.setup()
+
+    started = time.perf_counter()
+    session._preconnect_devices()
+    elapsed = time.perf_counter() - started
+
+    assert session._follower is not None
+    assert session._leader is not None
+    assert session._follower.is_connected()
+    assert session._leader.is_connected()
+    assert session._cameras["front"].is_connected
+    assert max_concurrent_connects() == 3
+    assert elapsed < delay * 2.5
+
+
+async def test_a_failing_camera_rolls_back_every_connected_device() -> None:
+    session = RuntimeSession(
+        _document_with_leader_and_cameras(
+            "front",
+            name="follower",
+            leader_kwargs={"name": "leader"},
+            camera_kwargs={"front": {"connect_error": "camera connect failed", "name": "front"}},
+        ),
+        event_sink=QueueEventSink(),
+    )
+    await session.setup()
+
+    with pytest.raises(ConnectionError, match="camera connect failed"):
+        session._preconnect_devices()
+
+    assert session._follower is not None
+    assert session._leader is not None
+    assert not session._follower.is_connected()
+    assert not session._leader.is_connected()
+    assert not session._cameras["front"].is_connected
+
+
+async def test_teardown_disconnects_cameras_then_robots() -> None:
+    reset_disconnect_tracking()
+    session = RuntimeSession(
+        _document_with_leader_and_cameras(
+            "front",
+            "wrist",
+            name="follower",
+            leader_kwargs={"name": "leader"},
+            camera_kwargs={
+                "front": {"name": "front", "disconnect_error": "front disconnect failed"},
+                "wrist": {"name": "wrist"},
+            },
+        ),
+        event_sink=QueueEventSink(),
+    )
+    await session.setup()
+    session._preconnect_devices()
+
+    await session.teardown()
+
+    assert recorded_disconnects() == ["front", "wrist", "leader", "follower"]
+    assert session._follower is not None
+    assert session._leader is not None
+    assert not session._follower.is_connected()
+    assert not session._leader.is_connected()
+    assert not session._cameras["wrist"].is_connected

--- a/application/backend/tests/runtime/test_transport.py
+++ b/application/backend/tests/runtime/test_transport.py
@@ -9,7 +9,7 @@ from uuid import UUID
 import pytest
 import zenoh
 
-from runtime.contract import Command, SaveEpisodeCommand, SetFollowerSourceCommand, StateData, StateEvent
+from runtime.contract import Command, ErrorEvent, SaveEpisodeCommand, SetFollowerSourceCommand, StateData, StateEvent
 from runtime.transport.client import RuntimeProcessError, RuntimeSessionClient
 from runtime.transport.codec import encode_event
 from runtime.transport.ids import (
@@ -311,6 +311,7 @@ def test_event_from_replaced_instance_is_rejected() -> None:
         runtime_session_name(UUID("c66b74d9-cea7-4ac0-94f8-39f86898589a")),
         instance_id="old-instance",
     )
+    client._metadata_ready.set()
     sample = type(
         "Sample",
         (),
@@ -334,7 +335,7 @@ def test_event_from_replaced_instance_is_rejected() -> None:
         client.get_nowait()
 
 
-def test_event_before_metadata_adoption_is_accepted() -> None:
+def test_event_before_metadata_adoption_is_ignored() -> None:
     client = RuntimeSessionClient(runtime_session_name(UUID("77df4e92-bbd8-46c8-9ca1-640ce0fe79f4")))
     event = StateEvent(data=StateData(connected=True, follower_source="hold"))
     sample = type(
@@ -351,4 +352,55 @@ def test_event_before_metadata_adoption_is_accepted() -> None:
 
     client._receive_event(sample)
 
-    assert client.get_nowait() == event
+    with pytest.raises(queue.Empty):
+        client.get_nowait()
+    assert not client._hardware_ready.is_set()
+
+
+def _event_sample(event: StateEvent | ErrorEvent, *, instance_id: str, fatal: bool = False) -> object:
+    return type(
+        "Sample",
+        (),
+        {
+            "payload": type(
+                "Payload",
+                (),
+                {"to_bytes": lambda self: encode_event(event, fatal=fatal, instance_id=instance_id)},
+            )()
+        },
+    )()
+
+
+def test_attach_clears_stale_ready_from_a_pre_attach_event() -> None:
+    client = RuntimeSessionClient(runtime_session_name(UUID("0c1a2b3d-4e5f-6789-abcd-ef0123456789")))
+    client.attach({"instance_id": "old"})
+    client._receive_event(
+        _event_sample(StateEvent(data=StateData(connected=True, follower_source="hold")), instance_id="old")
+    )
+    assert client._hardware_ready.is_set()
+
+    client.attach({"instance_id": "new"})
+
+    assert not client._hardware_ready.is_set()
+    with pytest.raises(queue.Empty):
+        client.get_nowait()
+
+
+def test_attach_clears_a_fatal_error_from_a_pre_attach_event() -> None:
+    client = RuntimeSessionClient(runtime_session_name(UUID("1d2e3f40-5162-7384-95a6-b7c8d9e0f123")))
+    client.attach({"instance_id": "old"})
+    client._receive_event(
+        _event_sample(
+            ErrorEvent(message="old process died", error_code="robot_connection_failed"),
+            instance_id="old",
+            fatal=True,
+        )
+    )
+    assert client.error is not None
+
+    client.attach({"instance_id": "new"})
+
+    assert client.error is None
+    process = type("AliveProcess", (), {"is_alive": lambda self: True, "error": None})()
+    with pytest.raises(TimeoutError, match="did not become ready"):
+        client.wait_until_ready(process, timeout=0.1)

--- a/application/ui/src/api/client.test.ts
+++ b/application/ui/src/api/client.test.ts
@@ -128,12 +128,12 @@ describe('fetchClient.PATH', () => {
             expect(fetchClient.PATH('/api/record/robot_control/ws')).toBe('/api/record/robot_control/ws');
         });
 
-        it('resolves /api/projects/{project_id}/robots/ws with params', () => {
+        it('resolves /api/projects/{project_id}/runtime/ws with params', () => {
             expect(
-                fetchClient.PATH('/api/projects/{project_id}/robots/ws', {
+                fetchClient.PATH('/api/projects/{project_id}/runtime/ws', {
                     params: { path: { project_id: 'p1' } },
                 })
-            ).toBe('/api/projects/p1/robots/ws');
+            ).toBe('/api/projects/p1/runtime/ws');
         });
 
         it('throws when robot WebSocket path params are missing', () => {

--- a/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
+++ b/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
@@ -116,12 +116,7 @@ export const RobotCell = ({
 
     return (
         <RobotModelsProvider>
-            <AvailableRobotCell
-                robot={robot}
-                followerId={follower_id}
-                leaderId={leader_id}
-                cameraIds={camera_ids}
-            />
+            <AvailableRobotCell robot={robot} followerId={follower_id} leaderId={leader_id} cameraIds={camera_ids} />
         </RobotModelsProvider>
     );
 };

--- a/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
+++ b/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
@@ -13,16 +13,19 @@ const AvailableRobotCell = ({
     robot,
     followerId,
     leaderId,
+    cameraIds,
 }: {
     robot: AvailableSchemaRobot;
     followerId: string;
     leaderId?: string;
+    cameraIds: string[];
 }) => {
     const { project_id } = useProjectId();
     const { joints, state, error, errorCode, warning, setFollowerSource, restart } = useJointState(
         project_id,
         followerId,
-        leaderId
+        leaderId,
+        cameraIds
     );
     useSynchronizeModelJoints(joints, robot.type);
 
@@ -93,7 +96,15 @@ const AvailableRobotCell = ({
     );
 };
 
-export const RobotCell = ({ follower_id, leader_id }: { follower_id: string; leader_id?: string }) => {
+export const RobotCell = ({
+    follower_id,
+    leader_id,
+    camera_ids,
+}: {
+    follower_id: string;
+    leader_id?: string;
+    camera_ids: string[];
+}) => {
     const { project_id } = useProjectId();
 
     const { data: robot } = $api.useSuspenseQuery('get', '/api/projects/{project_id}/robots/{robot_id}', {
@@ -105,7 +116,12 @@ export const RobotCell = ({ follower_id, leader_id }: { follower_id: string; lea
 
     return (
         <RobotModelsProvider>
-            <AvailableRobotCell robot={robot} followerId={follower_id} leaderId={leader_id} />
+            <AvailableRobotCell
+                robot={robot}
+                followerId={follower_id}
+                leaderId={leader_id}
+                cameraIds={camera_ids}
+            />
         </RobotModelsProvider>
     );
 };

--- a/application/ui/src/features/robots/environment-form/preview.tsx
+++ b/application/ui/src/features/robots/environment-form/preview.tsx
@@ -31,8 +31,21 @@ const EmptyPreview = () => {
 };
 
 const components = {
-    follower: (props: IDockviewPanelProps<{ title: string; follower_id: string; leader_id: string | undefined }>) => {
-        return <RobotCell follower_id={props.params.follower_id} leader_id={props.params.leader_id} />;
+    follower: (
+        props: IDockviewPanelProps<{
+            title: string;
+            follower_id: string;
+            leader_id: string | undefined;
+            camera_ids: string[];
+        }>
+    ) => {
+        return (
+            <RobotCell
+                follower_id={props.params.follower_id}
+                leader_id={props.params.leader_id}
+                camera_ids={props.params.camera_ids}
+            />
+        );
     },
     camera: (props: IDockviewPanelProps<{ camera_id: string }>) => {
         return <CameraCell camera_id={props.params.camera_id} />;
@@ -45,7 +58,8 @@ const components = {
 const buildDockviewPanels = (
     api: DockviewReadyEvent['api'],
     environment: EnvironmentFormState,
-    cameraNameMap: Record<string, string>
+    cameraNameMap: Record<string, string>,
+    cameraIds: string[]
 ) => {
     if (environment === null) {
         return api;
@@ -82,6 +96,7 @@ const buildDockviewPanels = (
                     title: 'Follower',
                     follower_id: robot.robot_id,
                     leader_id: teleoperator_id,
+                    camera_ids: cameraIds,
                 },
                 title: 'Follower',
                 component: 'follower',
@@ -124,8 +139,10 @@ const ActualPreview = () => {
         return map;
     }, [camerasQuery.data]);
 
+    const cameraIds = useMemo(() => environment.cameras.map(({ camera_id }) => camera_id), [environment.cameras]);
+
     const onReady = (event: DockviewReadyEvent): void => {
-        api.current = buildDockviewPanels(event.api, environment, cameraNameMap);
+        api.current = buildDockviewPanels(event.api, environment, cameraNameMap, cameraIds);
     };
 
     useEffect(() => {
@@ -133,8 +150,8 @@ const ActualPreview = () => {
             return;
         }
 
-        buildDockviewPanels(api.current, environment, cameraNameMap);
-    }, [environment, cameraNameMap]);
+        buildDockviewPanels(api.current, environment, cameraNameMap, cameraIds);
+    }, [environment, cameraNameMap, cameraIds]);
 
     return <DockviewReact onReady={onReady} components={components} theme={physicalAiTheme} />;
 };

--- a/application/ui/src/features/robots/environment-form/preview.tsx
+++ b/application/ui/src/features/robots/environment-form/preview.tsx
@@ -89,6 +89,10 @@ const buildDockviewPanels = (
     environment.robots.forEach((robot) => {
         const teleoperator_id = robot.teleoperator.type === 'robot' ? robot.teleoperator.robot_id : undefined;
         panels.add(robot.robot_id);
+        // Existing follower panels keep the camera_ids they were created with.
+        // Adding a camera here must not restart the live preview; session cameras
+        // are not what this preview displays. A later client that needs the new
+        // cameras (record) restarts from the owner.
         if (!api.panels.some((panel) => panel.id === robot.robot_id)) {
             api.addPanel({
                 id: robot.robot_id,

--- a/application/ui/src/features/robots/use-joint-state.test.ts
+++ b/application/ui/src/features/robots/use-joint-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isRecoverableRobotControlError } from './use-joint-state';
+import { isRecoverableRobotControlError, runtimeSocketUrl } from './use-joint-state';
 
 describe('isRecoverableRobotControlError', () => {
     it('classifies a leader connection loss as recoverable', () => {
@@ -10,5 +10,15 @@ describe('isRecoverableRobotControlError', () => {
     it('keeps session connection failures fatal', () => {
         expect(isRecoverableRobotControlError('robot_connection_failed')).toBe(false);
         expect(isRecoverableRobotControlError(undefined)).toBe(false);
+    });
+});
+
+describe('runtimeSocketUrl', () => {
+    it('uses a distinct URL per follower so share:true does not collide', () => {
+        const left = runtimeSocketUrl('project-1', 'follower-left');
+        const right = runtimeSocketUrl('project-1', 'follower-right');
+        expect(left).toContain('follower-left');
+        expect(right).toContain('follower-right');
+        expect(left).not.toBe(right);
     });
 });

--- a/application/ui/src/features/robots/use-joint-state.ts
+++ b/application/ui/src/features/robots/use-joint-state.ts
@@ -53,10 +53,11 @@ interface RobotControlState {
 }
 
 // Compose from a typed project path so this does not depend on regenerating OpenAPI.
-const runtimeSocketUrl = (project_id: string): string =>
+// follower_id must be in the URL: react-use-websocket share:true keys by URL.
+export const runtimeSocketUrl = (project_id: string, follower_id: string): string =>
     `${fetchClient.PATH('/api/projects/{project_id}', {
         params: { path: { project_id } },
-    })}/runtime/ws`;
+    })}/runtime/ws?follower_id=${encodeURIComponent(follower_id)}`;
 
 export const useJointState = (
     project_id: string,
@@ -109,7 +110,7 @@ export const useJointState = (
     }, []);
 
     const socket = useWebSocket(
-        runtimeSocketUrl(project_id),
+        runtimeSocketUrl(project_id, follower_id),
         {
             share: true,
             shouldReconnect: () => !hasFatalError.current,

--- a/application/ui/src/features/robots/use-joint-state.ts
+++ b/application/ui/src/features/robots/use-joint-state.ts
@@ -42,6 +42,7 @@ export const useSynchronizeModelJoints = (joints: JointsState, robotType: Schema
 export type FollowerSource = 'hold' | 'teleop' | 'policy';
 
 const RECOVERABLE_ERROR_CODES = new Set(['leader_connection_lost']);
+const EMPTY_CAMERA_IDS: string[] = [];
 
 export const isRecoverableRobotControlError = (errorCode: unknown): errorCode is string =>
     typeof errorCode === 'string' && RECOVERABLE_ERROR_CODES.has(errorCode);
@@ -51,7 +52,18 @@ interface RobotControlState {
     follower_source: FollowerSource;
 }
 
-export const useJointState = (project_id: string, follower_id: string, leader_id?: string) => {
+// Compose from a typed project path so this does not depend on regenerating OpenAPI.
+const runtimeSocketUrl = (project_id: string): string =>
+    `${fetchClient.PATH('/api/projects/{project_id}', {
+        params: { path: { project_id } },
+    })}/runtime/ws`;
+
+export const useJointState = (
+    project_id: string,
+    follower_id: string,
+    leader_id?: string,
+    camera_ids: string[] = EMPTY_CAMERA_IDS
+) => {
     const [joints, setJoints] = useState<JointsState>([]);
     const [state, setState] = useState<RobotControlState>({
         connected: false,
@@ -97,13 +109,8 @@ export const useJointState = (project_id: string, follower_id: string, leader_id
     }, []);
 
     const socket = useWebSocket(
-        fetchClient.PATH('/api/projects/{project_id}/robots/ws', {
-            params: { path: { project_id } },
-        }),
+        runtimeSocketUrl(project_id),
         {
-            queryParams: {
-                fps: 30,
-            },
             share: true,
             shouldReconnect: () => !hasFatalError.current,
             reconnectAttempts: 5,
@@ -121,6 +128,7 @@ export const useJointState = (project_id: string, follower_id: string, leader_id
                 socket.sendJsonMessage({
                     follower_id,
                     leader_id,
+                    camera_ids,
                     ...(shouldRestart ? { restart: true } : {}),
                 });
             },


### PR DESCRIPTION
## Why

The runtime session held no cameras, and any camera-set change looked like a different session (HTTP 423). The environment form and a later record client could not share a child: one needed frames, the other did not. Next phase PRs (inference and recoding) need those frames on the session before they can use them.

## What this adds over #976

- One control websocket: `/api/projects/{project_id}/runtime/ws`. The old `/robots/ws` route is gone.
- Handshake carries `follower_id`, optional `leader_id`, and optional `camera_ids`, all resolved against the project.
- Session identity is robot + leader + fps. Camera keys live in `/metadata` separately. A client that needs more cameras restarts the session; a subset attaches.
- The child instantiates, connects, and tears down the document's cameras (`validate_on_connect=True`, `overwrite_settings=False`).
- The environment form sends those camera ids on the handshake. Adding a camera does not restart the live preview.
- The socket URL includes `follower_id` so two follower panels do not share one handshake. Restart clients ignore events until they attach to the new generation.

## What's next

- **B3b** — policy inference; delete the model-worker stack.
- **B4** — recording on the runtime session (delete `RobotControlWorker`, camera claim registry).

Stacked on #976. Do not merge to `main` until that PR lands.

## Stack

```
main
 └── #938 teleop
      └── #952 zenoh transport
           └── #967 runtime owner
                └── #971 physicalai bump
                     └── #976 robot observations
                          └── this PR (max/runtime-7-session-cameras)
```

## Limits

- Editing a camera's resolution under a live session is ignored until the next connect. Will be address at a later stage
- A camera restart displaces whoever was attached; they rejoin the superset.

## Tested scenarios

- [x] Teleoperate from the environment form with cameras in the environment
- [x] Add a camera while the preview is live: robot panel keeps streaming
- [x] Refresh the environment form: reattaches to the same child
- [x] Client needing extra cameras restarts; subset attaches
- [x] Camera publisher at the wrong resolution fails connect (does not silently read)
- [ ] Change the leader → 423 and Restart works

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>