### PR TITLE
fix(training): Keep best checkpoint instead of last

### DIFF
--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -142,11 +142,14 @@ def run_training_job(
 ) -> None:
     """Train one policy end to end: fit, checkpoint, and export.
 
-    On success ``output_dir`` holds the best checkpoint (:data:`CHECKPOINT_NAME`,
-    written by the ``ModelCheckpoint`` callback during ``fit`` — this function
-    does not save a checkpoint of its own, so it never overwrites that best
-    checkpoint with the final-epoch weights), the Lightning CSV logs, and an
-    :data:`EXPORTS_DIRNAME` directory per successful export backend.
+    On success ``output_dir`` holds a checkpoint (:data:`CHECKPOINT_NAME`),
+    the Lightning CSV logs, and an :data:`EXPORTS_DIRNAME` directory per
+    successful export backend. That checkpoint is normally the best epoch,
+    written by the ``ModelCheckpoint`` callback during ``fit``; this function
+    only saves a checkpoint of its own as a fallback when the callback did
+    not produce one (e.g. the monitored metric never logged), so it never
+    overwrites a best checkpoint with the final-epoch weights (see
+    :func:`_ensure_checkpoint_exists`).
 
     Cancellation is cooperative. ``should_stop`` is polled throughout training
     via :class:`~physicalai.train.callbacks.ProgressReportingCallback`; when it
@@ -197,7 +200,13 @@ def run_training_job(
     trainer = Trainer(
         logger=CSVLogger(cache_dir.parent, name=cache_dir.stem),
         callbacks=[
-            ModelCheckpoint(dirpath=cache_dir, filename="model", save_top_k=1, monitor="val/loss", mode="min"),
+            ModelCheckpoint(
+                dirpath=cache_dir,
+                filename=Path(CHECKPOINT_NAME).stem,
+                save_top_k=1,
+                monitor="val/loss",
+                mode="min",
+            ),
             ProgressReportingCallback(report=report, should_stop=should_stop),
         ],
         accelerator=accelerator,
@@ -215,6 +224,7 @@ def run_training_job(
         logger.info("Training canceled; skipping checkpoint and export")
         return
 
+    _ensure_checkpoint_exists(trainer, cache_dir)
     _publish(cache_dir, output_dir)
 
     export_policy = _export_policy(spec, policy, output_dir)
@@ -249,6 +259,22 @@ def _load_policy_from_checkpoint(spec: TrainingJobSpec, checkpoint: Path) -> Pol
         compile_mode = getattr(policy.config, "compile_mode", "default")
         policy.forward = torch.compile(policy.forward, mode=compile_mode)  # type: ignore[method-assign]
     return policy
+
+
+def _ensure_checkpoint_exists(trainer: Any, cache_dir: Path) -> None:
+    """Save a final checkpoint only if the ``ModelCheckpoint`` callback did not already write one.
+
+    The callback is the preferred source of :data:`CHECKPOINT_NAME`: it tracks
+    the best monitored epoch, not just the last one. But it only saves when
+    its monitored metric was actually logged (e.g. a run with no validation
+    split never logs ``val/loss``), so this is a fallback for that case —
+    saving the trainer's current (final-epoch) weights — rather than a second
+    source of truth that could overwrite the callback's best checkpoint.
+    """
+    checkpoint = cache_dir / CHECKPOINT_NAME
+    if not checkpoint.is_file():
+        logger.warning("ModelCheckpoint callback did not write a checkpoint; saving final weights instead")
+        trainer.save_checkpoint(checkpoint)
 
 
 def _publish(cache_dir: Path, output_dir: Path) -> None:

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -142,8 +142,10 @@ def run_training_job(
 ) -> None:
     """Train one policy end to end: fit, checkpoint, and export.
 
-    On success ``output_dir`` holds the final checkpoint
-    (:data:`CHECKPOINT_NAME`), the Lightning CSV logs, and an
+    On success ``output_dir`` holds the best checkpoint (:data:`CHECKPOINT_NAME`,
+    written by the ``ModelCheckpoint`` callback during ``fit`` — this function
+    does not save a checkpoint of its own, so it never overwrites that best
+    checkpoint with the final-epoch weights), the Lightning CSV logs, and an
     :data:`EXPORTS_DIRNAME` directory per successful export backend.
 
     Cancellation is cooperative. ``should_stop`` is polled throughout training
@@ -213,7 +215,6 @@ def run_training_job(
         logger.info("Training canceled; skipping checkpoint and export")
         return
 
-    trainer.save_checkpoint(cache_dir / CHECKPOINT_NAME)
     _publish(cache_dir, output_dir)
 
     export_policy = _export_policy(spec, policy, output_dir)

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -143,10 +143,9 @@ def run_training_job(
     """Train one policy end to end: fit, checkpoint, and export.
 
     On success ``output_dir`` holds the best checkpoint (:data:`CHECKPOINT_NAME`,
-    written by the ``ModelCheckpoint`` callback during ``fit`` — this function
-    does not save a checkpoint of its own, so it never overwrites that best
-    checkpoint with the final-epoch weights), the Lightning CSV logs, and an
-    :data:`EXPORTS_DIRNAME` directory per successful export backend.
+    written by the ``ModelCheckpoint`` callback during ``fit``, the Lightning 
+    CSV logs, and an :data:`EXPORTS_DIRNAME` directory per successful export 
+    backend.
 
     Cancellation is cooperative. ``should_stop`` is polled throughout training
     via :class:`~physicalai.train.callbacks.ProgressReportingCallback`; when it

--- a/application/backend/tests/training/test_job.py
+++ b/application/backend/tests/training/test_job.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import gc
 import weakref
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,9 +23,6 @@ from pydantic import ValidationError
 
 from training import TrainingJobSpec
 from training.job import CHECKPOINT_NAME, EXPORTS_DIRNAME, PRETRAINED_BASE_CHECKPOINTS, build_policy, run_training_job
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 JOB = "training.job"
 
@@ -144,22 +141,41 @@ def _run(
     policy: object | None = None,
     should_stop: bool = False,
     report: MagicMock | None = None,
+    write_checkpoint: bool = True,
 ) -> MagicMock:
     """Run a job with the datamodule and Lightning trainer mocked out.
+
+    ``Trainer`` is mocked, so its real ``ModelCheckpoint`` callback never runs
+    and never writes a checkpoint on its own; ``write_checkpoint`` simulates
+    that side effect of a successful ``fit`` so callers don't have to.
+    ``trainer.save_checkpoint`` is wired to write the file too, so tests that
+    exercise the fallback (``write_checkpoint=False``) still end up with a
+    real checkpoint on disk once the runner calls it.
 
     Returns:
         The patched ``Trainer`` class, so tests can assert how it was configured.
     """
+    cache_dir = tmp_path / "cache" / "job"
+
+    def fake_fit(*_args: object, **_kwargs: object) -> None:
+        if write_checkpoint:
+            (cache_dir / CHECKPOINT_NAME).write_text("checkpoint")
+
+    def fake_save_checkpoint(path: str | Path, *_args: object, **_kwargs: object) -> None:
+        Path(path).write_text("checkpoint")
+
     with (
         patch("physicalai.data.LeRobotDataModule"),
         patch(f"{JOB}.build_policy", return_value=policy if policy is not None else MagicMock()),
         patch("physicalai.train.trainer.Trainer") as trainer_class,
     ):
+        trainer_class.return_value.fit.side_effect = fake_fit
+        trainer_class.return_value.save_checkpoint.side_effect = fake_save_checkpoint
         run_training_job(
             spec,
             dataset_root=tmp_path / "snapshot",
             output_dir=tmp_path / "model",
-            cache_dir=tmp_path / "cache" / "job",
+            cache_dir=cache_dir,
             report=report or MagicMock(),
             should_stop=lambda: should_stop,
         )
@@ -194,17 +210,19 @@ class TestRunTrainingJob:
 
     def test_dataset_is_loaded_from_the_local_root(self, tmp_path: Path) -> None:
         spec = TrainingJobSpec(policy="act", batch_size=16, num_workers=2, val_split=0.25)
+        cache_dir = tmp_path / "cache" / "job"
 
         with (
             patch("physicalai.data.LeRobotDataModule") as datamodule,
             patch(f"{JOB}.build_policy"),
-            patch("physicalai.train.trainer.Trainer"),
+            patch("physicalai.train.trainer.Trainer") as trainer_class,
         ):
+            trainer_class.return_value.fit.side_effect = lambda *a, **k: (cache_dir / CHECKPOINT_NAME).write_text("x")
             run_training_job(
                 spec,
                 dataset_root=tmp_path / "snapshot",
                 output_dir=tmp_path / "model",
-                cache_dir=tmp_path / "cache" / "job",
+                cache_dir=cache_dir,
                 report=MagicMock(),
                 should_stop=lambda: False,
             )
@@ -220,7 +238,29 @@ class TestRunTrainingJob:
         trainer = trainer_class.return_value
         trainer.save_checkpoint.assert_not_called()
         assert (tmp_path / "model").is_dir()
+        assert (tmp_path / "model" / CHECKPOINT_NAME).is_file()
         assert not (tmp_path / "cache" / "job").exists()
+
+    def test_a_model_checkpoint_callback_is_configured_to_keep_the_best_epoch(self, tmp_path: Path) -> None:
+        """The callback is the sole source of the published checkpoint; assert it stays configured that way."""
+        from lightning.pytorch.callbacks import ModelCheckpoint
+
+        trainer_class = _run(TrainingJobSpec(policy="act"), tmp_path)
+
+        callbacks = trainer_class.call_args.kwargs["callbacks"]
+        checkpoint_callbacks = [c for c in callbacks if isinstance(c, ModelCheckpoint)]
+        assert len(checkpoint_callbacks) == 1
+        callback = checkpoint_callbacks[0]
+        assert callback.dirpath == str(tmp_path / "cache" / "job")
+        assert (callback.monitor, callback.mode, callback.save_top_k) == ("val/loss", "min", 1)
+
+    def test_missing_checkpoint_from_the_callback_falls_back_to_an_explicit_save(self, tmp_path: Path) -> None:
+        """A run with nothing for the callback to monitor (e.g. no validation split) still gets a checkpoint."""
+        trainer_class = _run(TrainingJobSpec(policy="act"), tmp_path, write_checkpoint=False)
+
+        trainer = trainer_class.return_value
+        trainer.save_checkpoint.assert_called_once_with(tmp_path / "cache" / "job" / CHECKPOINT_NAME)
+        assert (tmp_path / "model" / CHECKPOINT_NAME).is_file()
 
     def test_completed_run_replaces_an_existing_model_directory(self, tmp_path: Path) -> None:
         """Retraining into the same directory must not merge with the old model."""
@@ -281,6 +321,7 @@ class TestRunTrainingJob:
         cycle is left in place instead of explicitly detached before export.
         """
         policy = _ExportablePolicy([ExportBackend.TORCH])
+        cache_dir = tmp_path / "cache" / "job"
 
         with (
             patch("physicalai.data.LeRobotDataModule") as datamodule_class,
@@ -289,7 +330,9 @@ class TestRunTrainingJob:
         ):
             trainer_instance = trainer_class.return_value
             datamodule_instance = datamodule_class.return_value
-            # Simulate what Lightning's real `trainer.fit(policy, datamodule)` wires up.
+            # Simulate what Lightning's real `trainer.fit(policy, datamodule)` wires up,
+            # including writing the checkpoint via the ModelCheckpoint callback.
+            trainer_instance.fit.side_effect = lambda *a, **k: (cache_dir / CHECKPOINT_NAME).write_text("x")
             policy._trainer = trainer_instance
             trainer_instance.datamodule = datamodule_instance
             trainer_instance.strategy._lightning_module = policy
@@ -301,7 +344,7 @@ class TestRunTrainingJob:
                 TrainingJobSpec(policy="act"),
                 dataset_root=tmp_path / "snapshot",
                 output_dir=tmp_path / "model",
-                cache_dir=tmp_path / "cache" / "job",
+                cache_dir=cache_dir,
                 report=MagicMock(),
                 should_stop=lambda: False,
             )

--- a/application/backend/tests/training/test_job.py
+++ b/application/backend/tests/training/test_job.py
@@ -214,10 +214,11 @@ class TestRunTrainingJob:
         assert (kwargs["train_batch_size"], kwargs["num_workers"], kwargs["val_split"]) == (16, 2, 0.25)
 
     def test_completed_run_publishes_the_cache_as_the_model_directory(self, tmp_path: Path) -> None:
+        """The final checkpoint comes solely from the ModelCheckpoint callback, not an explicit save."""
         trainer_class = _run(TrainingJobSpec(policy="act"), tmp_path)
 
         trainer = trainer_class.return_value
-        trainer.save_checkpoint.assert_called_once_with(tmp_path / "cache" / "job" / CHECKPOINT_NAME)
+        trainer.save_checkpoint.assert_not_called()
         assert (tmp_path / "model").is_dir()
         assert not (tmp_path / "cache" / "job").exists()
 


### PR DESCRIPTION
## Description

Checkpoints were saved in 2 ways; by the ModelCheckpoint callback and at the end of training an additional checkpoint was saved. Both saved a checkpoint by the same name so the final end of training save always overwrote the best kept checkpoint. This PR now relies on the callback to save a checkpoint and only if the callback did not produce a checkpoint will then save one at the end of training.
