### PR TITLE
feat(backend): SSH Docker provisioning service

### DIFF
--- a/.github/workflows/trainer-images.yml
+++ b/.github/workflows/trainer-images.yml
@@ -109,6 +109,7 @@ jobs:
         run: |
           echo "version=$(tr -d '[:space:]' < application/VERSION)" >> "$GITHUB_OUTPUT"
           echo "created=$(date --utc --iso-8601=seconds)" >> "$GITHUB_OUTPUT"
+          echo "library-version=$(grep -m1 '^version = ' library/pyproject.toml | sed -E 's/version = "(.*)"/\1/')" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -140,6 +141,7 @@ jobs:
             BUILD_DATE=${{ steps.build-metadata.outputs.created }}
             APPLICATION_VERSION=${{ steps.build-metadata.outputs.version }}
             TRAINER_API_PROTOCOL_VERSION=${{ env.TRAINER_API_PROTOCOL_VERSION }}
+            PHYSICALAI_TRAIN_VERSION=${{ steps.build-metadata.outputs.library-version }}
 
       - name: Smoke-test trainer image
         env:
@@ -147,6 +149,7 @@ jobs:
           DEVICE: ${{ matrix.device }}
           VERSION: ${{ steps.build-metadata.outputs.version }}
           BUILD_DATE: ${{ steps.build-metadata.outputs.created }}
+          LIBRARY_VERSION: ${{ steps.build-metadata.outputs.library-version }}
         run: |
           container_name="physicalai-trainer-${DEVICE}-smoke"
           cleanup() { docker rm -f "$container_name" >/dev/null 2>&1 || true; }
@@ -155,6 +158,10 @@ jobs:
           test "$(docker image inspect "$IMAGE" --format '{{.Config.User}}')" = "trainer"
           test "$(docker image inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')" = '["physicalai-trainer"]'
           test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.open-edge-platform.physicalai.trainer.api-protocol"}}')" = "1"
+          # `services.ssh.docker_ops.resolve_protocol_image` reads this label
+          # pre-pull, before `/health` is ever reachable: it must carry the
+          # real installed version, not the Dockerfile's `unknown` default.
+          test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.open-edge-platform.physicalai.trainer.library-version"}}')" = "$LIBRARY_VERSION"
           ! docker run --rm --entrypoint sh "$IMAGE" -c 'test -e /app/application/backend -o -e /app/application/ui -o -e /var/run/docker.sock'
 
           docker run -d --name "$container_name" -p 127.0.0.1::8001 "$IMAGE"
@@ -169,8 +176,9 @@ jobs:
 
           # Read the installed library version from the image itself so this
           # check never drifts from what /health actually reports.
-          library_version="$(docker run --rm --entrypoint python "$IMAGE" -c 'from importlib.metadata import version; print(version("physicalai-train"))')"
-          LIBRARY_VERSION="$library_version" python -c 'import json, os; health = json.load(open("health.json")); assert health == {"status": "healthy", "protocol_version": 1, "device_type": os.environ["DEVICE"], "build_revision": os.environ["GITHUB_SHA"], "build_date": os.environ["BUILD_DATE"], "application_version": os.environ["VERSION"], "library_version": os.environ["LIBRARY_VERSION"]}'
+          reported_version="$(docker run --rm --entrypoint python "$IMAGE" -c 'from importlib.metadata import version; print(version("physicalai-train"))')"
+          test "$reported_version" = "$LIBRARY_VERSION"
+          LIBRARY_VERSION="$reported_version" python -c 'import json, os; health = json.load(open("health.json")); assert health == {"status": "healthy", "protocol_version": 1, "device_type": os.environ["DEVICE"], "build_revision": os.environ["GITHUB_SHA"], "build_date": os.environ["BUILD_DATE"], "application_version": os.environ["VERSION"], "library_version": os.environ["LIBRARY_VERSION"]}'
 
   publish:
     name: Publish, attest, scan, and sign (${{ matrix.device }})
@@ -229,6 +237,7 @@ jobs:
           echo "version=$(tr -d '[:space:]' < application/VERSION)" >> "$GITHUB_OUTPUT"
           echo "short-sha=$(echo "$GITHUB_SHA" | head -c 8)" >> "$GITHUB_OUTPUT"
           echo "created=$(date --utc --iso-8601=seconds)" >> "$GITHUB_OUTPUT"
+          echo "library-version=$(grep -m1 '^version = ' library/pyproject.toml | sed -E 's/version = "(.*)"/\1/')" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Container Registry
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
@@ -268,11 +277,13 @@ jobs:
             BUILD_DATE=${{ steps.build-metadata.outputs.created }}
             APPLICATION_VERSION=${{ steps.build-metadata.outputs.version }}
             TRAINER_API_PROTOCOL_VERSION=${{ env.TRAINER_API_PROTOCOL_VERSION }}
+            PHYSICALAI_TRAIN_VERSION=${{ steps.build-metadata.outputs.library-version }}
 
       - name: Verify required image metadata and attestations
         env:
           IMAGE: ${{ env.IMAGE_REGISTRY }}/physicalai-trainer-${{ matrix.device }}@${{ steps.build.outputs.digest }}
           VERSION: ${{ steps.build-metadata.outputs.version }}
+          LIBRARY_VERSION: ${{ steps.build-metadata.outputs.library-version }}
         run: |
           docker buildx imagetools inspect "$IMAGE" --format '{{json .Image}}' > image.json
           docker buildx imagetools inspect "$IMAGE" --format '{{json .Provenance}}' > provenance.json
@@ -296,6 +307,7 @@ jobs:
               "org.open-edge-platform.physicalai.trainer.api-protocol": os.environ[
                   "TRAINER_API_PROTOCOL_VERSION"
               ],
+              "org.open-edge-platform.physicalai.trainer.library-version": os.environ["LIBRARY_VERSION"],
           }
           for config in configs:
               labels = config.get("config", {}).get("Labels") or {}

--- a/.github/workflows/trainer-images.yml
+++ b/.github/workflows/trainer-images.yml
@@ -166,7 +166,11 @@ jobs:
             sleep 2
           done
           test -s health.json
-          python -c 'import json, os; health = json.load(open("health.json")); assert health == {"status": "healthy", "protocol_version": 1, "device_type": os.environ["DEVICE"], "build_revision": os.environ["GITHUB_SHA"], "build_date": os.environ["BUILD_DATE"], "application_version": os.environ["VERSION"]}'
+
+          # Read the installed library version from the image itself so this
+          # check never drifts from what /health actually reports.
+          library_version="$(docker run --rm --entrypoint python "$IMAGE" -c 'from importlib.metadata import version; print(version("physicalai-train"))')"
+          LIBRARY_VERSION="$library_version" python -c 'import json, os; health = json.load(open("health.json")); assert health == {"status": "healthy", "protocol_version": 1, "device_type": os.environ["DEVICE"], "build_revision": os.environ["GITHUB_SHA"], "build_date": os.environ["BUILD_DATE"], "application_version": os.environ["VERSION"], "library_version": os.environ["LIBRARY_VERSION"]}'
 
   publish:
     name: Publish, attest, scan, and sign (${{ matrix.device }})

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "psutil~=7.2",
   "physicalai-studio-plugin",
   "asyncssh~=2.24",
+  "packaging>=24.0",
 ]
 
 [project.scripts]

--- a/application/backend/src/core/backend_instance.py
+++ b/application/backend/src/core/backend_instance.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable identity for this Studio installation, used to own SSH-provisioned containers.
+
+Remote servers are global: two Studio installations can legitimately target the
+same host, and a container's management labels alone cannot distinguish "mine,
+now orphaned" from "a different, still-active installation's job". A container
+is also labeled with the *owning* installation's id, generated once and
+persisted to disk so it survives process restarts (the orphan sweep runs after
+every restart) but is never shared between installations, e.g. by copying a
+database between machines - copying the data directory copies this file too,
+which is exactly the "same installation" case the orphan sweep needs to widen.
+"""
+
+import uuid
+from pathlib import Path
+from threading import Lock
+
+from settings import get_settings
+
+_INSTANCE_ID_FILENAME = "backend_instance_id"
+
+_cached_id: str | None = None
+_lock = Lock()
+
+
+def _instance_id_path() -> Path:
+    return get_settings().data_dir / _INSTANCE_ID_FILENAME
+
+
+def _read_existing(path: Path) -> str | None:
+    try:
+        content = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    try:
+        return str(uuid.UUID(content))
+    except ValueError:
+        # Corrupt or foreign content: treat as absent rather than adopting it,
+        # so a bad file can never be silently used as an ownership marker.
+        return None
+
+
+def get_backend_instance_id() -> str:
+    """Return this installation's stable backend instance id, creating it once.
+
+    Cached in-process after the first call within a run; re-read from disk on
+    a fresh process so a restart keeps the same id and can reclaim its own
+    still-running containers.
+    """
+    global _cached_id  # noqa: PLW0603 - process-wide identity, intentionally a singleton.
+    if _cached_id is not None:
+        return _cached_id
+
+    with _lock:
+        if _cached_id is not None:
+            return _cached_id
+
+        path = _instance_id_path()
+        existing = _read_existing(path)
+        if existing is not None:
+            _cached_id = existing
+            return _cached_id
+
+        generated = str(uuid.uuid4())
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(generated, encoding="utf-8")
+        _cached_id = generated
+        return _cached_id
+
+
+def reset_backend_instance_id_cache() -> None:
+    """Drop the in-process cache. Test-support only."""
+    global _cached_id  # noqa: PLW0603 - test-support reset of the process-wide singleton.
+    _cached_id = None

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -493,8 +493,11 @@ class TrainerImagePullError(BaseException):
 class TrainerImageVerificationError(BaseException):
     """Raised when the trainer image's signature could not be verified.
 
-    Fails closed: this covers both a failed `cosign verify` and `cosign` being
-    unavailable on the remote host. Studio never launches an unverified image.
+    Fails closed by default: this covers both a failed `cosign verify` and
+    `cosign` being unavailable on the remote host. `cosign` being unavailable
+    can be downgraded to a non-blocking warning via
+    `Settings.ssh_require_cosign_verification`; a failed `cosign verify`
+    always raises.
     """
 
     def __init__(self, image_ref: str, reason: str) -> None:

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -456,3 +456,154 @@ class RemoteServerPreflightError(BaseException):
             error_code="remote_server_preflight_failed",
             http_status=http.HTTPStatus.BAD_REQUEST,
         )
+
+
+class TrainerImageResolutionError(BaseException):
+    """Raised when the device-specific `protocol-<N>` trainer image cannot be resolved.
+
+    There is deliberately no fallback tag: a `latest` fallback here (unlike
+    Tier 1's advisory preflight check) would silently run a job against an
+    image whose protocol compatibility was never established.
+    """
+
+    def __init__(self, image_ref: str, protocol_version: int, detail: str | None = None) -> None:
+        extra = f" ({detail})" if detail else ""
+        super().__init__(
+            message=(
+                f"Could not resolve trainer image '{image_ref}' for protocol version {protocol_version}{extra}. "
+                "A matching `protocol-{n}`-tagged trainer image must be published before this job can run."
+            ),
+            error_code="trainer_image_unresolved",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
+class TrainerImagePullError(BaseException):
+    """Raised when `docker pull` of the resolved digest failed on the remote host."""
+
+    def __init__(self, image_ref: str, detail: str | None = None) -> None:
+        extra = f": {detail}" if detail else ""
+        super().__init__(
+            message=f"Could not pull trainer image '{image_ref}'{extra}.",
+            error_code="trainer_image_pull_failed",
+            http_status=http.HTTPStatus.BAD_GATEWAY,
+        )
+
+
+class TrainerImageVerificationError(BaseException):
+    """Raised when the trainer image's signature could not be verified.
+
+    Fails closed: this covers both a failed `cosign verify` and `cosign` being
+    unavailable on the remote host. Studio never launches an unverified image.
+    """
+
+    def __init__(self, image_ref: str, reason: str) -> None:
+        super().__init__(
+            message=f"Could not verify the signature of trainer image '{image_ref}': {reason}.",
+            error_code="trainer_image_verification_failed",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
+class TrainerLibraryVersionError(BaseException):
+    """Raised when the registry-reported `physicalai-train` version is below policy.
+
+    Read from the registry manifest label before any pull, so a version-policy
+    rejection never costs a multi-gigabyte transfer.
+    """
+
+    def __init__(self, policy_name: str, required_version: str, reported_version: str) -> None:
+        super().__init__(
+            message=(
+                f"Trainer image reports physicalai-train version '{reported_version}', which does not meet "
+                f"the '{policy_name}' policy's minimum of '{required_version}'."
+            ),
+            error_code="trainer_library_version_unmet",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
+class TrainerLibraryVersionMismatchError(BaseException):
+    """Raised when the launched container's `/health` disagrees with the registry label.
+
+    Defense in depth: the registry-manifest label is read before the pull, and
+    this re-confirms it against the running container's own report.
+    """
+
+    def __init__(self, label_version: str, health_version: str) -> None:
+        super().__init__(
+            message=(
+                f"Trainer image's registry label reports physicalai-train version '{label_version}', but the "
+                f"running container's /health reports '{health_version}'."
+            ),
+            error_code="trainer_library_version_mismatch",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
+class GpuBusyTimeoutError(BaseException):
+    """Raised when a remote GPU stayed busy past the configured give-up timeout."""
+
+    def __init__(self, server_name: str, waited_s: float) -> None:
+        super().__init__(
+            message=f"GPU on remote server '{server_name}' stayed busy for {waited_s:.0f}s; giving up.",
+            error_code="gpu_busy_timeout",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
+class RemoteDiskSpaceError(BaseException):
+    """Raised when a remote server lacks room for this job's actual snapshot."""
+
+    def __init__(self, server_name: str, free_bytes: int, required_bytes: int) -> None:
+        super().__init__(
+            message=(
+                f"Remote server '{server_name}' has {free_bytes / (1024**3):.1f} GiB free, "
+                f"but this job needs {required_bytes / (1024**3):.1f} GiB."
+            ),
+            error_code="remote_disk_insufficient",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
+class TrainerContainerLaunchError(BaseException):
+    """Raised when the trainer container could not be started on the remote host."""
+
+    def __init__(self, server_name: str, detail: str | None = None) -> None:
+        extra = f": {detail}" if detail else ""
+        super().__init__(
+            message=f"Could not start the trainer container on remote server '{server_name}'{extra}.",
+            error_code="trainer_container_launch_failed",
+            http_status=http.HTTPStatus.BAD_GATEWAY,
+        )
+
+
+class TrainerReadinessTimeoutError(BaseException):
+    """Raised when the launched trainer never became ready, or reported no protocol version."""
+
+    def __init__(self, server_name: str, detail: str | None = None) -> None:
+        extra = f": {detail}" if detail else ""
+        super().__init__(
+            message=f"Trainer on remote server '{server_name}' did not become ready in time{extra}.",
+            error_code="trainer_readiness_timeout",
+            http_status=http.HTTPStatus.BAD_GATEWAY,
+        )
+
+
+class TrainerProtocolVersionMismatchError(BaseException):
+    """Raised when the launched trainer's reported protocol version does not match.
+
+    Strict for SSH-provisioned trainers: unlike Tier 1's advisory preflight,
+    provisioning a real job never proceeds on a protocol mismatch.
+    """
+
+    def __init__(self, server_name: str, expected: int, reported: int | None) -> None:
+        reported_text = str(reported) if reported is not None else "none"
+        super().__init__(
+            message=(
+                f"Trainer on remote server '{server_name}' reports protocol version {reported_text}, "
+                f"expected {expected}."
+            ),
+            error_code="trainer_protocol_mismatch",
+            http_status=http.HTTPStatus.CONFLICT,
+        )

--- a/application/backend/src/services/ssh/docker_ops.py
+++ b/application/backend/src/services/ssh/docker_ops.py
@@ -204,6 +204,23 @@ async def resolve_protocol_image(
         raise TrainerImageResolutionError(
             tag_ref, protocol_version, detail="the resolved image advertises no trainer protocol version"
         )
+    try:
+        reported_protocol_int = int(str(reported_protocol))
+    except ValueError:
+        raise TrainerImageResolutionError(
+            tag_ref,
+            protocol_version,
+            detail=f"the resolved image advertises an unparseable protocol version: {reported_protocol!r}",
+        ) from None
+    if reported_protocol_int != protocol_version:
+        raise TrainerImageResolutionError(
+            tag_ref,
+            protocol_version,
+            detail=(
+                f"the resolved image advertises protocol {reported_protocol_int}, "
+                f"but '{tag_ref}' was resolved for protocol {protocol_version}"
+            ),
+        )
 
     repository = tag_ref.rsplit(":", 1)[0]
     raw_library_version = labels.get(LIBRARY_VERSION_LABEL)
@@ -300,8 +317,14 @@ def check_library_version(
         reported_parsed = Version(reported)
         minimum_parsed = Version(minimum_version)
     except InvalidVersion:
+        # `reported_version` stays `None`, not the unparseable string:
+        # `SshProvisioningService.provision()` treats any non-`None`
+        # `reported_version` as authoritative against `/health`'s real
+        # version, and would otherwise raise `TrainerLibraryVersionMismatchError`
+        # on every image whose label isn't a valid PEP 440 version (e.g. the
+        # Dockerfile's `PHYSICALAI_TRAIN_VERSION=unknown` default).
         return LibraryVersionCheck(
-            reported_version=reported,
+            reported_version=None,
             minimum_version=minimum_version,
             warning=f"Could not parse trainer library version '{reported}'; proceeding without a version check.",
         )

--- a/application/backend/src/services/ssh/docker_ops.py
+++ b/application/backend/src/services/ssh/docker_ops.py
@@ -72,6 +72,15 @@ _GPU_BUSY_MEMORY_FRACTION: Final = 0.3
 _DF_AVAILABLE_COLUMN: Final = 3
 _DF_MIN_COLUMNS: Final = 5
 
+# Fixed non-root uid/gid the trainer image runs as (Dockerfile.trainer's
+# `TRAINER_UID`/`TRAINER_GID` build args, both default to 10001). Used for both
+# `--user` and the `--tmpfs` mount ownership below: without matching `uid=`/
+# `gid=` mount options, `--read-only` + `--tmpfs` mounts default to root
+# ownership, and the trainer crashes on startup unable to create its own
+# storage subdirectories.
+_TRAINER_UID: Final = 10001
+_TRAINER_GID: Final = 10001
+
 
 @dataclass(frozen=True, slots=True)
 class ResolvedImage:
@@ -209,22 +218,36 @@ async def resolve_protocol_image(
 async def verify_image_signature(transport: SshTransport, image: ResolvedImage, settings: Settings) -> None:
     """Verify the resolved image's signature, pinned to Studio's release identity.
 
-    Fails closed: both a failed `cosign verify` and `cosign` being unavailable
-    on the remote host raise. This is the opposite policy from Tier 1's
-    advisory preflight signature check, which is defense-in-depth on top of the
-    publish-time signature and never blocks a save.
+    Fails closed by default: both a failed `cosign verify` and `cosign` being
+    unavailable on the remote host raise. This is the opposite policy from
+    Tier 1's advisory preflight signature check, which is defense-in-depth on
+    top of the publish-time signature and never blocks a save.
+
+    `cosign` being unavailable can be downgraded to a non-blocking warning by
+    setting `settings.ssh_require_cosign_verification` to `False` (e.g. for a
+    host where installing `cosign` is not viable). A failed `cosign verify`
+    always raises regardless of that setting: it means the image's signature
+    does not match Studio's expected identity, not that a tool is missing.
 
     Args:
         transport: An open transport to the remote server.
         image: The digest-resolved image to verify.
-        settings: Application settings (pinned certificate identity/issuer).
+        settings: Application settings (pinned certificate identity/issuer,
+            and whether `cosign` availability is required).
 
     Raises:
-        TrainerImageVerificationError: `cosign` is unavailable, or verification
-            failed.
+        TrainerImageVerificationError: `cosign` is unavailable and required,
+            or verification failed.
     """
     available = await transport.run_command(["cosign", "version"])
     if not available.ok:
+        if not settings.ssh_require_cosign_verification:
+            logger.warning(
+                "cosign is not available on the remote host; proceeding without signature "
+                "verification for '{}' because SSH_REQUIRE_COSIGN_VERIFICATION is disabled.",
+                image.digest_reference,
+            )
+            return
         raise TrainerImageVerificationError(image.digest_reference, "cosign is not available on the remote host")
 
     verified = await transport.run_command(
@@ -434,10 +457,11 @@ def _device_run_args(device_type: DeviceType, render_gid: str | None = None) -> 
     """Return the `docker run` flags that expose the accelerator.
 
     `render_gid`, when known, is added via `--group-add` so the container's
-    fixed non-root user (`--user 10001:10001`) can actually read/write the
-    render node - `--device /dev/dri` alone passes the node through but its
-    group ownership still gates access, and without this the container's
-    `torch.xpu.is_available()` silently reports zero devices.
+    fixed non-root user (`--user`, set to `_TRAINER_UID:_TRAINER_GID` below)
+    can actually read/write the render node - `--device /dev/dri` alone passes
+    the node through but its group ownership still gates access, and without
+    this the container's `torch.xpu.is_available()` silently reports zero
+    devices.
     """
     if device_type is DeviceType.CUDA:
         return ["--gpus", "all"]
@@ -475,7 +499,13 @@ def build_run_argv(
     XPU container: without it `--device /dev/dri` passes the render node
     through but the fixed non-root user cannot open it, and
     `torch.xpu.is_available()` reports zero devices. Ignored for CUDA.
+
+    Each `--tmpfs` carries explicit `uid=`/`gid=` mount options matching
+    `--user`: an unqualified `--tmpfs` mounts root-owned, and the trainer's
+    fixed non-root user cannot create its own storage subdirectories under it,
+    crashing on startup before it ever binds its port.
     """
+    tmpfs_owner = f"uid={_TRAINER_UID},gid={_TRAINER_GID}"
     return [
         "docker",
         "run",
@@ -488,28 +518,38 @@ def build_run_argv(
         "--publish",
         f"127.0.0.1::{remote_container_port}",
         "--user",
-        "10001:10001",
+        f"{_TRAINER_UID}:{_TRAINER_GID}",
         "--cap-drop",
         "ALL",
         "--security-opt",
         "no-new-privileges",
         "--read-only",
         "--tmpfs",
-        "/tmp:size=2g",  # noqa: S108 - a `docker run` mount spec, not a local temp-file access
+        f"/tmp:size=2g,{tmpfs_owner}",  # noqa: S108  # nosec B108 - a `docker run` mount spec, not a local temp-file access
         "--tmpfs",
-        "/var/lib/physicalai-trainer:size=64g",
+        f"/var/lib/physicalai-trainer:size=64g,{tmpfs_owner}",
         *_device_run_args(device_type, render_gid),
         image_digest_ref,
     ]
 
 
-async def pull_image(transport: SshTransport, image: ResolvedImage) -> None:
+async def pull_image(transport: SshTransport, image: ResolvedImage, settings: Settings) -> None:
     """Pull the resolved image by digest.
 
+    Uses `settings.ssh_image_pull_timeout_s` rather than the default
+    `ssh_command_timeout_s`: that budget is sized for cheap probes
+    (`docker version`, `nvidia-smi`), and is far too short for a multi-gigabyte
+    image transfer. A pull that is still legitimately in progress when the
+    short budget elapses would otherwise surface as a spurious pull failure,
+    with only the partial progress output as its (misleading) detail.
+
     Raises:
-        TrainerImagePullError: The pull failed.
+        TrainerImagePullError: The pull failed, or did not finish within
+            `settings.ssh_image_pull_timeout_s`.
     """
-    result = await transport.run_command(["docker", "pull", image.digest_reference])
+    result = await transport.run_command(
+        ["docker", "pull", image.digest_reference], timeout=settings.ssh_image_pull_timeout_s
+    )
     if not result.ok:
         raise TrainerImagePullError(image.digest_reference, detail=result.stderr or result.stdout or None)
 

--- a/application/backend/src/services/ssh/docker_ops.py
+++ b/application/backend/src/services/ssh/docker_ops.py
@@ -37,7 +37,12 @@ from exceptions import (
     TrainerLibraryVersionError,
 )
 from schemas.hardware import DeviceType
-from services.ssh.preflight import PROTOCOL_LABEL, protocol_tag, trainer_image_ref
+from services.ssh.preflight import (  # noqa: F401 - resolve_render_group_gid re-exported for provisioning.py
+    PROTOCOL_LABEL,
+    protocol_tag,
+    resolve_render_group_gid,
+    trainer_image_ref,
+)
 from services.ssh.transport import SshTransport
 from settings import Settings
 
@@ -425,11 +430,21 @@ async def check_disk_for_job(transport: SshTransport, required_bytes: int, serve
         raise RemoteDiskSpaceError(server_name, free_bytes=free_bytes, required_bytes=required_bytes)
 
 
-def _device_run_args(device_type: DeviceType) -> list[str]:
-    """Return the `docker run` flags that expose the accelerator."""
+def _device_run_args(device_type: DeviceType, render_gid: str | None = None) -> list[str]:
+    """Return the `docker run` flags that expose the accelerator.
+
+    `render_gid`, when known, is added via `--group-add` so the container's
+    fixed non-root user (`--user 10001:10001`) can actually read/write the
+    render node - `--device /dev/dri` alone passes the node through but its
+    group ownership still gates access, and without this the container's
+    `torch.xpu.is_available()` silently reports zero devices.
+    """
     if device_type is DeviceType.CUDA:
         return ["--gpus", "all"]
-    return ["--device", "/dev/dri"]
+    args = ["--device", "/dev/dri"]
+    if render_gid:
+        args.extend(["--group-add", render_gid])
+    return args
 
 
 def build_run_argv(
@@ -440,6 +455,7 @@ def build_run_argv(
     labels: dict[str, str],
     remote_container_port: int,
     stop_timeout_s: int,
+    render_gid: str | None = None,
 ) -> list[str]:
     """Build the least-privilege `docker run` command for one trainer container.
 
@@ -454,6 +470,11 @@ def build_run_argv(
       device nodes the configured accelerator needs are passed through.
     * `--read-only` plus one bounded `--tmpfs` gives the container a writable
       scratch area without unbounded writable storage.
+
+    `render_gid`, from `resolve_render_group_gid`, is required for a working
+    XPU container: without it `--device /dev/dri` passes the render node
+    through but the fixed non-root user cannot open it, and
+    `torch.xpu.is_available()` reports zero devices. Ignored for CUDA.
     """
     return [
         "docker",
@@ -477,7 +498,7 @@ def build_run_argv(
         "/tmp:size=2g",  # noqa: S108 - a `docker run` mount spec, not a local temp-file access
         "--tmpfs",
         "/var/lib/physicalai-trainer:size=64g",
-        *_device_run_args(device_type),
+        *_device_run_args(device_type, render_gid),
         image_digest_ref,
     ]
 

--- a/application/backend/src/services/ssh/docker_ops.py
+++ b/application/backend/src/services/ssh/docker_ops.py
@@ -1,0 +1,575 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Docker image resolution, verification, GPU-busy waiting, and container lifecycle.
+
+Everything in this module runs a command over an already-connected
+:class:`~services.ssh.transport.SshTransport`. No function here opens or closes
+a connection: :mod:`services.ssh.provisioning` owns connection lifetime, so a
+single SSH connection can span image resolution, launch, and later teardown.
+
+Image resolution and verification never pull a layer. ``docker buildx
+imagetools inspect`` reads the registry manifest (and, via ``--format``, the
+image config's labels) over the registry API, the same class of call Tier 1's
+preflight uses for its own registry-reachability probe. The label carrying the
+`physicalai-train` version is read from this same call, before any pull, so a
+version-policy rejection never costs a multi-gigabyte transfer.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+from loguru import logger
+from packaging.version import InvalidVersion, Version
+
+from exceptions import (
+    GpuBusyTimeoutError,
+    RemoteDiskSpaceError,
+    TrainerContainerLaunchError,
+    TrainerImagePullError,
+    TrainerImageResolutionError,
+    TrainerImageVerificationError,
+    TrainerLibraryVersionError,
+)
+from schemas.hardware import DeviceType
+from services.ssh.preflight import PROTOCOL_LABEL, protocol_tag, trainer_image_ref
+from services.ssh.transport import SshTransport
+from settings import Settings
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+# Label carrying the `physicalai-train` version baked into the image, read
+# from the registry manifest before any pull.
+LIBRARY_VERSION_LABEL: Final = "org.open-edge-platform.physicalai.trainer.library-version"
+
+# Management labels. `MANAGED_LABEL` alone never proves ownership: two Studio
+# installations can target the same remote server, so the orphan sweep also
+# requires `INSTANCE_LABEL` to match this installation's own backend_instance_id
+# (see `core.backend_instance`).
+MANAGED_LABEL: Final = "org.open-edge-platform.physicalai.managed"
+JOB_LABEL: Final = "org.open-edge-platform.physicalai.job-id"
+SERVER_LABEL: Final = "org.open-edge-platform.physicalai.server-id"
+INSTANCE_LABEL: Final = "org.open-edge-platform.physicalai.backend-instance-id"
+
+_CONTAINER_NAME_PREFIX: Final = "physicalai-trainer-"
+
+# Fraction of device memory in use above which an accelerator counts as busy.
+# Mirrors the (advisory) preflight heuristic for XPU, which has no
+# per-process attribution comparable to `nvidia-smi --query-compute-apps`.
+_GPU_BUSY_MEMORY_FRACTION: Final = 0.3
+
+_DF_AVAILABLE_COLUMN: Final = 3
+_DF_MIN_COLUMNS: Final = 5
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedImage:
+    """A trainer image resolved to an immutable digest, not yet pulled.
+
+    Attributes:
+        tag_reference: The `protocol-<N>` tag reference that was resolved.
+        digest_reference: `<repository>@<digest>` - the reference every
+            subsequent pull/run/verify call uses. Never the mutable tag.
+        digest: The resolved manifest digest, e.g. `sha256:...`.
+        library_version: The `physicalai-train` version reported by the
+            registry manifest's label, or ``None`` if the image carries none.
+    """
+
+    tag_reference: str
+    digest_reference: str
+    digest: str
+    library_version: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryVersionCheck:
+    """Outcome of comparing a resolved image's library version against policy."""
+
+    reported_version: str | None
+    minimum_version: str
+    warning: str | None = None
+
+
+class ManagedContainer:
+    """One container carrying Studio's management labels, as reported by `docker ps`."""
+
+    __slots__ = ("container_id", "job_id", "labels", "name")
+
+    def __init__(self, container_id: str, name: str, labels: dict[str, str]) -> None:
+        self.container_id = container_id
+        self.name = name
+        self.labels = labels
+        self.job_id = labels.get(JOB_LABEL)
+
+
+def container_name(job_id: str) -> str:
+    """Return the deterministic container name for one job.
+
+    Deterministic so a reattach after a studio restart can find the container
+    by name without having persisted anything beyond the job id itself.
+    """
+    return f"{_CONTAINER_NAME_PREFIX}{job_id}"
+
+
+def management_labels(*, job_id: str, server_id: str, backend_instance_id: str) -> dict[str, str]:
+    """Return the labels every Studio-launched trainer container carries.
+
+    `INSTANCE_LABEL` is the ownership marker the orphan sweep requires in
+    addition to `MANAGED_LABEL`: a remote server can be shared by more than one
+    Studio installation, and sweeping must never touch a container it merely
+    recognizes the shape of.
+    """
+    return {
+        MANAGED_LABEL: "true",
+        JOB_LABEL: job_id,
+        SERVER_LABEL: server_id,
+        INSTANCE_LABEL: backend_instance_id,
+    }
+
+
+def _parse_json(text: str) -> object | None:
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+async def resolve_protocol_image(
+    transport: SshTransport,
+    device_type: DeviceType,
+    protocol_version: int,
+    settings: Settings,
+) -> ResolvedImage:
+    """Resolve the device-specific `protocol-<N>` tag to an immutable digest.
+
+    There is deliberately no fallback tag (unlike Tier 1's advisory preflight
+    check, which may warn and fall back to `latest`): a job that cannot verify
+    the exact protocol it will run against must fail rather than guess.
+
+    Reads the manifest digest and the image config's labels (including
+    `LIBRARY_VERSION_LABEL` and `PROTOCOL_LABEL`) via `docker buildx imagetools
+    inspect --format`, which reads the registry manifest over the registry API
+    and pulls no layer.
+
+    Args:
+        transport: An open transport to the remote server.
+        device_type: The server's configured accelerator.
+        protocol_version: Studio's own compiled-in trainer protocol version.
+        settings: Application settings (registry location).
+
+    Returns:
+        The resolved image, its digest, and its declared library version.
+
+    Raises:
+        TrainerImageResolutionError: The tag does not resolve, or its manifest
+            carries no protocol label.
+    """
+    tag_ref = trainer_image_ref(settings.trainer_image_registry, device_type, protocol_tag(protocol_version))
+
+    digest_result = await transport.run_command(
+        ["docker", "buildx", "imagetools", "inspect", tag_ref, "--format", "{{json .Manifest.Digest}}"]
+    )
+    digest = _parse_json(digest_result.first_line()) if digest_result.ok else None
+    if not digest_result.ok or not isinstance(digest, str) or not digest:
+        raise TrainerImageResolutionError(tag_ref, protocol_version, detail=digest_result.first_line() or None)
+
+    labels_result = await transport.run_command(
+        ["docker", "buildx", "imagetools", "inspect", tag_ref, "--format", "{{json .Image.Config.Labels}}"]
+    )
+    labels = _parse_json(labels_result.stdout) if labels_result.ok else None
+    labels = labels if isinstance(labels, dict) else {}
+
+    reported_protocol = labels.get(PROTOCOL_LABEL)
+    if reported_protocol is None:
+        raise TrainerImageResolutionError(
+            tag_ref, protocol_version, detail="the resolved image advertises no trainer protocol version"
+        )
+
+    repository = tag_ref.rsplit(":", 1)[0]
+    raw_library_version = labels.get(LIBRARY_VERSION_LABEL)
+    return ResolvedImage(
+        tag_reference=tag_ref,
+        digest_reference=f"{repository}@{digest}",
+        digest=digest,
+        library_version=raw_library_version if isinstance(raw_library_version, str) else None,
+    )
+
+
+async def verify_image_signature(transport: SshTransport, image: ResolvedImage, settings: Settings) -> None:
+    """Verify the resolved image's signature, pinned to Studio's release identity.
+
+    Fails closed: both a failed `cosign verify` and `cosign` being unavailable
+    on the remote host raise. This is the opposite policy from Tier 1's
+    advisory preflight signature check, which is defense-in-depth on top of the
+    publish-time signature and never blocks a save.
+
+    Args:
+        transport: An open transport to the remote server.
+        image: The digest-resolved image to verify.
+        settings: Application settings (pinned certificate identity/issuer).
+
+    Raises:
+        TrainerImageVerificationError: `cosign` is unavailable, or verification
+            failed.
+    """
+    available = await transport.run_command(["cosign", "version"])
+    if not available.ok:
+        raise TrainerImageVerificationError(image.digest_reference, "cosign is not available on the remote host")
+
+    verified = await transport.run_command(
+        [
+            "cosign",
+            "verify",
+            image.digest_reference,
+            "--certificate-identity-regexp",
+            settings.cosign_certificate_identity_regexp,
+            "--certificate-oidc-issuer",
+            settings.cosign_oidc_issuer,
+        ]
+    )
+    if not verified.ok:
+        raise TrainerImageVerificationError(image.digest_reference, verified.first_line() or "signature not verified")
+
+
+def check_library_version(
+    image: ResolvedImage,
+    *,
+    minimum_version: str,
+    policy_name: str = "default",
+) -> LibraryVersionCheck:
+    """Range-check a resolved image's library version against a minimum policy.
+
+    Older than the minimum is a non-fatal warning (the job proceeds); equal or
+    newer is silent; a version this policy documents as required but the image
+    does not meet is fatal, raised before any pull.
+
+    Args:
+        image: The digest-resolved image, carrying the registry label.
+        minimum_version: The minimum `physicalai-train` version this policy
+            requires.
+        policy_name: Name surfaced in the failure message (e.g. a model
+            family), for a policy stricter than Studio's own default minimum.
+
+    Returns:
+        The check outcome. `.warning` is set when the image is older than
+        `minimum_version` but the policy is Studio's own non-strict default.
+
+    Raises:
+        TrainerLibraryVersionError: The image's version does not meet
+            `minimum_version` and `policy_name` names a required minimum.
+    """
+    reported = image.library_version
+    if reported is None:
+        return LibraryVersionCheck(reported_version=None, minimum_version=minimum_version)
+
+    try:
+        reported_parsed = Version(reported)
+        minimum_parsed = Version(minimum_version)
+    except InvalidVersion:
+        return LibraryVersionCheck(
+            reported_version=reported,
+            minimum_version=minimum_version,
+            warning=f"Could not parse trainer library version '{reported}'; proceeding without a version check.",
+        )
+
+    if reported_parsed >= minimum_parsed:
+        return LibraryVersionCheck(reported_version=reported, minimum_version=minimum_version)
+
+    if policy_name != "default":
+        raise TrainerLibraryVersionError(policy_name, minimum_version, reported)
+
+    return LibraryVersionCheck(
+        reported_version=reported,
+        minimum_version=minimum_version,
+        warning=f"Trainer image reports physicalai-train version '{reported}', older than '{minimum_version}'.",
+    )
+
+
+def _first_number_pair(stdout: str) -> tuple[float, float] | None:
+    numbers = [float(match) for match in re.findall(r"\d+(?:\.\d+)?", stdout)]
+    if len(numbers) < 2 or numbers[1] <= 0:
+        return None
+    return numbers[0], numbers[1]
+
+
+async def _cuda_gpu_busy(transport: SshTransport) -> bool | None:
+    """Return whether a CUDA GPU is busy, or ``None`` if occupancy is unknown."""
+    result = await transport.run_command(["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"])
+    if not result.ok:
+        return None
+    return bool([line for line in result.stdout.splitlines() if line.strip()])
+
+
+async def _xpu_gpu_busy(transport: SshTransport) -> bool | None:
+    """Return whether an XPU is busy by a memory-utilization heuristic, or ``None``."""
+    result = await transport.run_command(["xpu-smi", "stats", "-d", "0"])
+    if not result.ok:
+        return None
+    pair = _first_number_pair(result.stdout)
+    if pair is None:
+        return None
+    used, total = pair
+    return (used / total) >= _GPU_BUSY_MEMORY_FRACTION
+
+
+async def is_gpu_busy(transport: SshTransport, device_type: DeviceType) -> bool | None:
+    """Return whether the remote accelerator is currently busy.
+
+    Returns ``None`` when occupancy could not be determined - callers should
+    treat that as "not known to be busy" rather than blocking on a monitoring
+    tool that happens to be absent.
+    """
+    if device_type is DeviceType.CUDA:
+        return await _cuda_gpu_busy(transport)
+    return await _xpu_gpu_busy(transport)
+
+
+async def wait_for_gpu_free(
+    open_transport: Callable[[], SshTransport],
+    device_type: DeviceType,
+    settings: Settings,
+    server_name: str,
+    *,
+    on_wait: Callable[[float], Awaitable[None]] | None = None,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+) -> None:
+    """Wait until the remote GPU reports free, with exponential backoff.
+
+    Opens a fresh transport for each probe (rather than holding one connection
+    for the whole wait) so a long wait does not hold a scarce per-server
+    connection slot the whole time; probes still respect the alias's shared
+    connect throttle.
+
+    Args:
+        open_transport: Returns a new, unconnected transport for one probe.
+        device_type: The server's configured accelerator.
+        settings: Application settings (backoff bounds, give-up timeout).
+        server_name: Used only in the raised error message.
+        on_wait: Awaited once per non-final wait, with the elapsed seconds so
+            far - the caller uses this to report a `waiting` phase state.
+        clock: Injected for deterministic tests.
+        sleep: Injected for deterministic tests; defaults to `asyncio.sleep`.
+
+    Raises:
+        GpuBusyTimeoutError: The GPU stayed busy past
+            `settings.ssh_gpu_wait_giveup_s`.
+    """
+    if sleep is None:
+        import asyncio
+
+        sleep = asyncio.sleep
+
+    started = clock()
+    backoff = settings.ssh_gpu_wait_initial_backoff_s
+    while True:
+        transport = open_transport()
+        try:
+            await transport.connect()
+            busy = await is_gpu_busy(transport, device_type)
+        finally:
+            await transport.close()
+
+        if not busy:
+            return
+
+        elapsed = clock() - started
+        if elapsed >= settings.ssh_gpu_wait_giveup_s:
+            raise GpuBusyTimeoutError(server_name, elapsed)
+
+        if on_wait is not None:
+            await on_wait(elapsed)
+
+        await sleep(min(backoff, settings.ssh_gpu_wait_giveup_s - elapsed))
+        backoff = min(backoff * 2, settings.ssh_gpu_wait_max_backoff_s)
+
+
+def _parse_free_bytes(stdout: str) -> int | None:
+    """Parse available bytes out of `df -B1 -P` output."""
+    for line in stdout.splitlines()[1:]:
+        columns = line.split()
+        if len(columns) < _DF_MIN_COLUMNS:
+            continue
+        try:
+            return int(columns[_DF_AVAILABLE_COLUMN])
+        except ValueError:
+            continue
+    return None
+
+
+async def check_disk_for_job(transport: SshTransport, required_bytes: int, server_name: str) -> None:
+    """Re-check free disk against this job's actual snapshot size.
+
+    A server's save-time preflight only checks a nominal minimum; a specific
+    job's dataset can exceed it, so provisioning re-checks against the real
+    size before pulling or launching anything.
+
+    Raises:
+        RemoteDiskSpaceError: Free space is below `required_bytes`.
+    """
+    result = await transport.run_command(["df", "-B1", "-P", "/var/lib/docker"])
+    if not result.ok:
+        result = await transport.run_command(["df", "-B1", "-P", "/"])
+
+    free_bytes = _parse_free_bytes(result.stdout) if result.ok else None
+    if free_bytes is None:
+        # Unable to measure: fail closed rather than silently skipping the check.
+        raise RemoteDiskSpaceError(server_name, free_bytes=0, required_bytes=required_bytes)
+    if free_bytes < required_bytes:
+        raise RemoteDiskSpaceError(server_name, free_bytes=free_bytes, required_bytes=required_bytes)
+
+
+def _device_run_args(device_type: DeviceType) -> list[str]:
+    """Return the `docker run` flags that expose the accelerator."""
+    if device_type is DeviceType.CUDA:
+        return ["--gpus", "all"]
+    return ["--device", "/dev/dri"]
+
+
+def build_run_argv(
+    *,
+    image_digest_ref: str,
+    device_type: DeviceType,
+    name: str,
+    labels: dict[str, str],
+    remote_container_port: int,
+    stop_timeout_s: int,
+) -> list[str]:
+    """Build the least-privilege `docker run` command for one trainer container.
+
+    Security properties, matching the PR's security gate:
+
+    * Launches by digest (`image_digest_ref`), never a mutable tag.
+    * `-p 127.0.0.1::<port>` publishes an OS-assigned ephemeral host port bound
+      only to loopback - never reachable from another host on the network.
+    * `--restart=no` - a crashed container must surface as a failed job, not
+      restart silently out from under a job that already moved on.
+    * Non-root, every Linux capability dropped, no `--privileged`, and only the
+      device nodes the configured accelerator needs are passed through.
+    * `--read-only` plus one bounded `--tmpfs` gives the container a writable
+      scratch area without unbounded writable storage.
+    """
+    return [
+        "docker",
+        "run",
+        "--detach",
+        "--name",
+        name,
+        *(f"--label={key}={value}" for key, value in labels.items()),
+        "--restart=no",
+        f"--stop-timeout={stop_timeout_s}",
+        "--publish",
+        f"127.0.0.1::{remote_container_port}",
+        "--user",
+        "10001:10001",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--read-only",
+        "--tmpfs",
+        "/tmp:size=2g",  # noqa: S108 - a `docker run` mount spec, not a local temp-file access
+        "--tmpfs",
+        "/var/lib/physicalai-trainer:size=64g",
+        *_device_run_args(device_type),
+        image_digest_ref,
+    ]
+
+
+async def pull_image(transport: SshTransport, image: ResolvedImage) -> None:
+    """Pull the resolved image by digest.
+
+    Raises:
+        TrainerImagePullError: The pull failed.
+    """
+    result = await transport.run_command(["docker", "pull", image.digest_reference])
+    if not result.ok:
+        raise TrainerImagePullError(image.digest_reference, detail=result.stderr or result.stdout or None)
+
+
+async def launch_container(transport: SshTransport, argv: list[str], server_name: str) -> str:
+    """Run `docker run --detach ...` and return the started container id.
+
+    Raises:
+        TrainerContainerLaunchError: The container could not be started.
+    """
+    result = await transport.run_command(argv)
+    container_id = result.first_line()
+    if not result.ok or not container_id:
+        raise TrainerContainerLaunchError(server_name, detail=result.stderr or result.stdout or None)
+    return container_id
+
+
+async def resolve_published_port(transport: SshTransport, name: str, remote_container_port: int) -> int | None:
+    """Return the host port Docker assigned for `remote_container_port`, or ``None``."""
+    result = await transport.run_command(["docker", "port", name, str(remote_container_port)])
+    if not result.ok:
+        return None
+    # `docker port` prints e.g. "127.0.0.1:54321".
+    line = result.first_line()
+    _, _, port_text = line.rpartition(":")
+    try:
+        return int(port_text)
+    except ValueError:
+        return None
+
+
+async def stop_and_remove_container(transport: SshTransport, name_or_id: str, stop_timeout_s: int) -> None:
+    """Stop and remove a container by name or id. Best-effort past `docker stop`.
+
+    Tolerates the container already being gone (a previous teardown attempt
+    that partially succeeded is a normal path here, not an error).
+    """
+    await transport.run_command(["docker", "stop", "--time", str(stop_timeout_s), name_or_id])
+    remove = await transport.run_command(["docker", "rm", "--force", name_or_id])
+    if not remove.ok and "No such container" not in (remove.stderr or ""):
+        logger.warning("docker rm reported a failure for container '{}': {}", name_or_id, remove.stderr)
+
+
+def _parse_managed_container_line(line: str) -> ManagedContainer | None:
+    parsed = _parse_json(line)
+    if not isinstance(parsed, dict):
+        return None
+    container_id = parsed.get("ID")
+    name = parsed.get("Names")
+    raw_labels = parsed.get("Labels", "")
+    if not isinstance(container_id, str) or not isinstance(name, str) or not isinstance(raw_labels, str):
+        return None
+    labels: dict[str, str] = {}
+    for entry in raw_labels.split(","):
+        key, sep, value = entry.partition("=")
+        if sep:
+            labels[key] = value
+    return ManagedContainer(container_id=container_id, name=name, labels=labels)
+
+
+async def list_managed_containers(transport: SshTransport, backend_instance_id: str) -> list[ManagedContainer]:
+    """List containers this installation provably owns, running or stopped.
+
+    Filters on both `MANAGED_LABEL` and `INSTANCE_LABEL`: a remote server can be
+    shared by another Studio installation, whose containers must never be
+    listed (and therefore never swept) by this one.
+    """
+    result = await transport.run_command(
+        [
+            "docker",
+            "ps",
+            "--all",
+            "--filter",
+            f"label={MANAGED_LABEL}=true",
+            "--filter",
+            f"label={INSTANCE_LABEL}={backend_instance_id}",
+            "--format",
+            "{{json .}}",
+        ]
+    )
+    if not result.ok:
+        return []
+    containers = (_parse_managed_container_line(line) for line in result.stdout.splitlines() if line.strip())
+    return [container for container in containers if container is not None]

--- a/application/backend/src/services/ssh/provisioning.py
+++ b/application/backend/src/services/ssh/provisioning.py
@@ -1,0 +1,384 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provision, reattach to, and tear down per-job SSH trainer containers.
+
+This is the top-level orchestrator for SSH-provisioned remote training: it
+resolves and verifies the trainer image, waits out a busy GPU, re-checks disk
+against the job's real snapshot size, launches a least-privilege container,
+opens the SSH tunnel to it, verifies readiness, and persists enough state
+(:mod:`schemas.job_provisioning`) that a crashed studio can reattach instead of
+losing track of a still-running container.
+
+Wiring this into job dispatch (``get_training_backend`` / ``TrainingWorker``)
+is a later step; this module is usable standalone against a
+:class:`~repositories.job_provisioning_repo.JobProvisioningRepository` and a
+:class:`~schemas.remote_server.RemoteServer`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from time import monotonic
+from typing import TYPE_CHECKING, Self
+
+import httpx
+from loguru import logger
+
+from core.backend_instance import get_backend_instance_id
+from exceptions import (
+    TrainerLibraryVersionMismatchError,
+    TrainerProtocolVersionMismatchError,
+    TrainerReadinessTimeoutError,
+)
+from schemas.job_provisioning import JobProvisioning, JobProvisioningUpdate
+from services.ssh import docker_ops
+from services.ssh.docker_ops import LibraryVersionCheck, ResolvedImage
+from services.ssh.transport import SshTransport, open_transport
+from services.ssh.tunnel import SshTunnel
+from settings import get_settings
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from types import TracebackType
+    from uuid import UUID
+
+    from repositories.job_provisioning_repo import JobProvisioningRepository
+    from schemas.remote_server import RemoteServer
+    from settings import Settings
+
+# Port the trainer image always listens on inside the container. Fixed by the
+# image build, never user-configurable.
+TRAINER_CONTAINER_PORT = 8080
+
+
+@dataclass
+class ProvisionedTrainer:
+    """A running, tunnel-reachable trainer, and how to tear it down."""
+
+    base_url: str
+    container_name: str
+    image: ResolvedImage
+    library_version_check: LibraryVersionCheck
+    _tunnel: SshTunnel
+    _server_alias: str
+    _stop_timeout_s: int
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.teardown()
+
+    async def teardown(self) -> None:
+        """Tear down the tunnel and stop/remove the container.
+
+        Best-effort: a teardown must never itself raise and mask whatever
+        caused it, so any failure here is logged, not propagated.
+        """
+        await self._tunnel.close()
+        try:
+            async with SshTransport(self._server_alias) as transport:
+                await docker_ops.stop_and_remove_container(transport, self.container_name, self._stop_timeout_s)
+        except Exception as error:
+            logger.warning("Failed to tear down trainer container '{}': {}", self.container_name, error)
+
+
+class SshProvisioningService:
+    """Provisions, reattaches to, and sweeps SSH-provisioned trainer containers."""
+
+    def __init__(
+        self,
+        repository: JobProvisioningRepository,
+        settings: Settings | None = None,
+    ) -> None:
+        self._repository = repository
+        self._settings = settings or get_settings()
+
+    async def provision(
+        self,
+        job_id: UUID,
+        server: RemoteServer,
+        *,
+        protocol_version: int,
+        snapshot_size_bytes: int,
+        min_library_version: str | None = None,
+        library_version_policy_name: str = "default",
+        on_gpu_wait: Callable[[float], Awaitable[None]] | None = None,
+    ) -> ProvisionedTrainer:
+        """Provision a fresh trainer container for one job.
+
+        On any failure, whatever was already started is torn down before the
+        exception propagates - a caller never has to clean up a partially
+        provisioned job itself.
+
+        Args:
+            job_id: The training job this container is provisioned for.
+            server: The SSH-provisioned server to launch on.
+            protocol_version: Studio's own compiled-in trainer protocol version.
+            snapshot_size_bytes: The job's actual dataset snapshot size, for the
+                pre-launch disk re-check.
+            min_library_version: Minimum `physicalai-train` version policy;
+                defaults to `settings.ssh_min_library_version`.
+            library_version_policy_name: Name of the policy, for a stricter,
+                fatal-below-minimum check (e.g. a specific model family).
+            on_gpu_wait: Awaited while waiting out a busy GPU, so a caller can
+                report a `waiting` phase state.
+
+        Returns:
+            A running, tunnel-reachable trainer.
+        """
+        settings = self._settings
+        minimum_version = min_library_version or settings.ssh_min_library_version
+        backend_instance_id = get_backend_instance_id()
+        name = docker_ops.container_name(str(job_id))
+
+        await self._repository.save(
+            JobProvisioning(
+                job_id=job_id,
+                remote_server_id=server.id,
+                ssh_host_alias=server.ssh_host_alias,
+                container_name=name,
+                backend_instance_id=backend_instance_id,
+            )
+        )
+
+        tunnel: SshTunnel | None = None
+        launched = False
+        try:
+            async with SshTransport(server.ssh_host_alias, settings) as transport:
+                image = await docker_ops.resolve_protocol_image(
+                    transport, server.device_type, protocol_version, settings
+                )
+                library_check = docker_ops.check_library_version(
+                    image, minimum_version=minimum_version, policy_name=library_version_policy_name
+                )
+                if library_check.warning:
+                    logger.warning(library_check.warning)
+                await docker_ops.verify_image_signature(transport, image, settings)
+                await docker_ops.check_disk_for_job(transport, snapshot_size_bytes, server.name)
+                await docker_ops.pull_image(transport, image)
+
+                await self._repository.update_by_job_id(
+                    job_id, JobProvisioningUpdate(image_ref=image.tag_reference, image_digest=image.digest)
+                )
+
+            await docker_ops.wait_for_gpu_free(
+                lambda: open_transport(server.ssh_host_alias, settings),
+                server.device_type,
+                settings,
+                server.name,
+                on_wait=on_gpu_wait,
+            )
+
+            async with SshTransport(server.ssh_host_alias, settings) as transport:
+                argv = docker_ops.build_run_argv(
+                    image_digest_ref=image.digest_reference,
+                    device_type=server.device_type,
+                    name=name,
+                    labels=docker_ops.management_labels(
+                        job_id=str(job_id), server_id=str(server.id), backend_instance_id=backend_instance_id
+                    ),
+                    remote_container_port=TRAINER_CONTAINER_PORT,
+                    stop_timeout_s=settings.ssh_container_stop_timeout_s,
+                )
+                container_id = await docker_ops.launch_container(transport, argv, server.name)
+                launched = True
+
+            tunnel = SshTunnel(
+                lambda: open_transport(server.ssh_host_alias, settings),
+                "127.0.0.1",
+                TRAINER_CONTAINER_PORT,
+                settings,
+            )
+            await tunnel.open()
+            base_url = f"http://127.0.0.1:{tunnel.local_port}"
+
+            await self._repository.update_by_job_id(
+                job_id,
+                JobProvisioningUpdate(
+                    container_id=container_id,
+                    container_name=name,
+                    remote_port=TRAINER_CONTAINER_PORT,
+                    local_tunnel_port=tunnel.local_port,
+                    backend_instance_id=backend_instance_id,
+                ),
+            )
+
+            health = await self._await_ready(base_url, server.name)
+            reported_protocol = health.get("protocol_version")
+            if not isinstance(reported_protocol, int) or reported_protocol != protocol_version:
+                raise TrainerProtocolVersionMismatchError(
+                    server.name,
+                    protocol_version,
+                    reported_protocol if isinstance(reported_protocol, int) else None,
+                )
+            health_library_version = health.get("library_version")
+            label_version = library_check.reported_version
+            if (
+                isinstance(label_version, str)
+                and isinstance(health_library_version, str)
+                and health_library_version != label_version
+            ):
+                raise TrainerLibraryVersionMismatchError(str(label_version), str(health_library_version))
+
+            await self._repository.update_by_job_id(
+                job_id,
+                JobProvisioningUpdate(
+                    trainer_build_version=health.get("build_revision")
+                    if isinstance(health.get("build_revision"), str)
+                    else None,
+                    trainer_protocol_version=reported_protocol,
+                ),
+            )
+
+            if tunnel is None:
+                raise RuntimeError("Unreachable: tunnel is always assigned before this point")
+            return ProvisionedTrainer(
+                base_url=base_url,
+                container_name=name,
+                image=image,
+                library_version_check=library_check,
+                _tunnel=tunnel,
+                _server_alias=server.ssh_host_alias,
+                _stop_timeout_s=settings.ssh_container_stop_timeout_s,
+            )
+        except BaseException:
+            if tunnel is not None:
+                await tunnel.close()
+            if launched:
+                try:
+                    async with SshTransport(server.ssh_host_alias, settings) as transport:
+                        await docker_ops.stop_and_remove_container(
+                            transport, name, settings.ssh_container_stop_timeout_s
+                        )
+                except Exception as cleanup_error:
+                    logger.warning(
+                        "Failed to clean up container '{}' after a failed provision: {}", name, cleanup_error
+                    )
+            raise
+
+    async def _await_ready(self, base_url: str, server_name: str) -> dict:
+        """Poll `/health` until it answers or the readiness budget is spent.
+
+        Raises:
+            TrainerReadinessTimeoutError: The trainer never answered, or its
+                `/health` response reported no protocol version.
+        """
+        settings = self._settings
+        started = monotonic()
+        last_error: str | None = None
+        async with httpx.AsyncClient(timeout=5.0, trust_env=False) as client:
+            while monotonic() - started < settings.ssh_readiness_timeout_s:
+                try:
+                    response = await client.get(f"{base_url}/health")
+                    response.raise_for_status()
+                    payload = response.json()
+                except (httpx.HTTPError, ValueError) as error:
+                    last_error = str(error)
+                else:
+                    if isinstance(payload, dict):
+                        if payload.get("protocol_version") is None:
+                            raise TrainerReadinessTimeoutError(
+                                server_name, "the trainer's /health reports no protocol version"
+                            )
+                        return payload
+                    last_error = "malformed /health response"
+                await asyncio.sleep(settings.ssh_readiness_poll_interval_s)
+        raise TrainerReadinessTimeoutError(server_name, last_error)
+
+    async def reattach(self, job_provisioning: JobProvisioning, server: RemoteServer) -> ProvisionedTrainer | None:
+        """Reattach to a still-running container recorded for a job.
+
+        Called on studio startup for jobs left `RUNNING`/`PENDING` by a
+        previous process. Returns ``None`` when the container is no longer
+        running, so the caller can fall back to failing the job instead of
+        reattaching to nothing.
+        """
+        settings = self._settings
+        name = job_provisioning.container_name
+        if name is None:
+            return None
+
+        async with SshTransport(server.ssh_host_alias, settings) as transport:
+            inspect = await transport.run_command(["docker", "inspect", "--format", "{{.State.Running}}", name])
+            if not inspect.ok or inspect.first_line().lower() != "true":
+                return None
+
+        tunnel = SshTunnel(
+            lambda: open_transport(server.ssh_host_alias, settings),
+            "127.0.0.1",
+            job_provisioning.remote_port or TRAINER_CONTAINER_PORT,
+            settings,
+        )
+        await tunnel.open()
+        base_url = f"http://127.0.0.1:{tunnel.local_port}"
+
+        await self._repository.update_by_job_id(
+            job_provisioning.job_id, JobProvisioningUpdate(local_tunnel_port=tunnel.local_port)
+        )
+
+        return ProvisionedTrainer(
+            base_url=base_url,
+            container_name=name,
+            image=ResolvedImage(
+                tag_reference=job_provisioning.image_ref or "",
+                digest_reference="",
+                digest=job_provisioning.image_digest or "",
+                library_version=None,
+            ),
+            library_version_check=LibraryVersionCheck(
+                reported_version=None, minimum_version=settings.ssh_min_library_version
+            ),
+            _tunnel=tunnel,
+            _server_alias=server.ssh_host_alias,
+            _stop_timeout_s=settings.ssh_container_stop_timeout_s,
+        )
+
+    async def teardown(self, job_id: UUID, server: RemoteServer) -> None:
+        """Tear down a job's container by id, without an open tunnel.
+
+        Used for cancellation/cleanup paths that only have the persisted
+        provisioning row, not a live `ProvisionedTrainer`.
+        """
+        job_provisioning = await self._repository.get_by_job_id(job_id)
+        if job_provisioning is None or job_provisioning.container_name is None:
+            return
+        async with SshTransport(server.ssh_host_alias, self._settings) as transport:
+            await docker_ops.stop_and_remove_container(
+                transport, job_provisioning.container_name, self._settings.ssh_container_stop_timeout_s
+            )
+        await self._repository.delete_by_job_id(job_id)
+
+    async def sweep_orphans(self, server: RemoteServer, active_job_ids: set[UUID]) -> list[str]:
+        """Remove containers this installation owns but no job claims anymore.
+
+        Requires every management label to match *and* the container's
+        `backend_instance_id` label to match this installation's own id *and*
+        its job id to be absent from `active_job_ids` - a job that is still
+        `PENDING`/`RUNNING` has an active reattach claim and must never be
+        touched, even if this sweep runs concurrently with its own startup
+        reattach.
+
+        Returns:
+            Names of the containers removed.
+        """
+        backend_instance_id = get_backend_instance_id()
+        removed: list[str] = []
+        async with SshTransport(server.ssh_host_alias, self._settings) as transport:
+            containers = await docker_ops.list_managed_containers(transport, backend_instance_id)
+            active_ids = {str(job_id) for job_id in active_job_ids}
+            for container in containers:
+                if container.job_id is not None and container.job_id in active_ids:
+                    continue
+                await docker_ops.stop_and_remove_container(
+                    transport, container.container_id, self._settings.ssh_container_stop_timeout_s
+                )
+                removed.append(container.name)
+        return removed

--- a/application/backend/src/services/ssh/provisioning.py
+++ b/application/backend/src/services/ssh/provisioning.py
@@ -28,6 +28,7 @@ from loguru import logger
 
 from core.backend_instance import get_backend_instance_id
 from exceptions import (
+    TrainerContainerLaunchError,
     TrainerLibraryVersionMismatchError,
     TrainerProtocolVersionMismatchError,
     TrainerReadinessTimeoutError,
@@ -49,9 +50,10 @@ if TYPE_CHECKING:
     from schemas.remote_server import RemoteServer
     from settings import Settings
 
-# Port the trainer image always listens on inside the container. Fixed by the
-# image build, never user-configurable.
-TRAINER_CONTAINER_PORT = 8080
+# Port the trainer image listens on inside the container. This launch path
+# never sets `TRAINER_PORT`, so this must match `TrainerSettings.port`'s
+# default and the Dockerfile's `EXPOSE`.
+TRAINER_CONTAINER_PORT = 8001
 
 
 @dataclass
@@ -164,7 +166,7 @@ class SshProvisioningService:
                     logger.warning(library_check.warning)
                 await docker_ops.verify_image_signature(transport, image, settings)
                 await docker_ops.check_disk_for_job(transport, snapshot_size_bytes, server.name)
-                await docker_ops.pull_image(transport, image)
+                await docker_ops.pull_image(transport, image, settings)
 
                 await self._repository.update_by_job_id(
                     job_id, JobProvisioningUpdate(image_ref=image.tag_reference, image_digest=image.digest)
@@ -198,10 +200,12 @@ class SshProvisioningService:
                 container_id = await docker_ops.launch_container(transport, argv, server.name)
                 launched = True
 
+                published_port = await self._resolve_published_port(transport, name, server.name)
+
             tunnel = SshTunnel(
                 lambda: open_transport(server.ssh_host_alias, settings),
                 "127.0.0.1",
-                TRAINER_CONTAINER_PORT,
+                published_port,
                 settings,
             )
             await tunnel.open()
@@ -212,7 +216,7 @@ class SshProvisioningService:
                 JobProvisioningUpdate(
                     container_id=container_id,
                     container_name=name,
-                    remote_port=TRAINER_CONTAINER_PORT,
+                    remote_port=published_port,
                     local_tunnel_port=tunnel.local_port,
                     backend_instance_id=backend_instance_id,
                 ),
@@ -270,6 +274,26 @@ class SshProvisioningService:
                         "Failed to clean up container '{}' after a failed provision: {}", name, cleanup_error
                     )
             raise
+
+    async def _resolve_published_port(self, transport: SshTransport, name: str, server_name: str) -> int:
+        """Resolve the real host port docker published for the trainer container.
+
+        `--publish 127.0.0.1::<port>` in `build_run_argv` binds an OS-assigned
+        ephemeral host port, not `TRAINER_CONTAINER_PORT` itself - that number
+        only names the *container's* internal port. The tunnel must forward to
+        the real published port, or it connects to whatever (usually nothing)
+        is listening on the container port number on the host itself.
+
+        Raises:
+            TrainerContainerLaunchError: The published port could not be
+                resolved.
+        """
+        published_port = await docker_ops.resolve_published_port(transport, name, TRAINER_CONTAINER_PORT)
+        if published_port is None:
+            raise TrainerContainerLaunchError(
+                server_name, "container started but its published port could not be resolved"
+            )
+        return published_port
 
     async def _await_ready(self, base_url: str, server_name: str) -> dict:
         """Poll `/health` until it answers or the readiness budget is spent.

--- a/application/backend/src/services/ssh/provisioning.py
+++ b/application/backend/src/services/ssh/provisioning.py
@@ -32,6 +32,7 @@ from exceptions import (
     TrainerProtocolVersionMismatchError,
     TrainerReadinessTimeoutError,
 )
+from schemas.hardware import DeviceType
 from schemas.job_provisioning import JobProvisioning, JobProvisioningUpdate
 from services.ssh import docker_ops
 from services.ssh.docker_ops import LibraryVersionCheck, ResolvedImage
@@ -178,6 +179,11 @@ class SshProvisioningService:
             )
 
             async with SshTransport(server.ssh_host_alias, settings) as transport:
+                render_gid = (
+                    None
+                    if server.device_type is DeviceType.CUDA
+                    else await docker_ops.resolve_render_group_gid(transport)
+                )
                 argv = docker_ops.build_run_argv(
                     image_digest_ref=image.digest_reference,
                     device_type=server.device_type,
@@ -187,6 +193,7 @@ class SshProvisioningService:
                     ),
                     remote_container_port=TRAINER_CONTAINER_PORT,
                     stop_timeout_s=settings.ssh_container_stop_timeout_s,
+                    render_gid=render_gid,
                 )
                 container_id = await docker_ops.launch_container(transport, argv, server.name)
                 launched = True

--- a/application/backend/src/services/ssh/transport.py
+++ b/application/backend/src/services/ssh/transport.py
@@ -628,6 +628,31 @@ class SshTransport:
             if gate is not None:
                 gate.semaphore.release()
 
+    async def forward_local_port(self, remote_host: str, remote_port: int) -> asyncssh.SSHListener:
+        """Open a local-forward tunnel to ``remote_host:remote_port`` over this connection.
+
+        Binds the local end to ``127.0.0.1`` on an OS-assigned ephemeral port,
+        so an SSH-provisioned trainer is reachable only through the tunnel,
+        never from another host on the network.
+
+        Args:
+            remote_host: Host to connect to from the remote end (typically
+                ``127.0.0.1``, since the trainer itself publishes on its
+                container host's loopback interface).
+            remote_port: Port to connect to on ``remote_host``.
+
+        Returns:
+            The listener. ``listener.get_port()`` reports the assigned local
+            port; ``listener.close()`` followed by ``await
+            listener.wait_closed()`` tears the forward down.
+
+        Raises:
+            RuntimeError: The transport is not connected.
+        """
+        if self._connection is None:
+            raise RuntimeError("SshTransport.forward_local_port requires an open connection")
+        return await self._connection.forward_local_port("127.0.0.1", 0, remote_host, remote_port)
+
 
 def open_transport(alias: str, settings: Settings | None = None) -> SshTransport:
     """Return a transport for one alias.

--- a/application/backend/src/services/ssh/tunnel.py
+++ b/application/backend/src/services/ssh/tunnel.py
@@ -1,0 +1,168 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSH local-forward tunnel to an SSH-provisioned trainer container.
+
+The tunnel is the only path a studio process ever reaches a provisioned
+trainer through: the container publishes on its host's loopback interface
+only, and :class:`SshTunnel` forwards a local loopback port to it over the
+same SSH connection class the rest of :mod:`services.ssh` uses. A dropped
+tunnel reconnects and re-forwards against the still-running container within a
+bounded retry budget, so a flaky network path never fails a job that is
+otherwise progressing fine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from time import monotonic
+from typing import TYPE_CHECKING, Self
+
+from loguru import logger
+
+from services.ssh.transport import SshTransport
+from settings import Settings
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import TracebackType
+
+    import asyncssh
+
+
+class TunnelReconnectExhaustedError(RuntimeError):
+    """Raised when a dropped tunnel could not be re-established within its budget."""
+
+
+class SshTunnel:
+    """A local-forward tunnel to one remote `host:port`, with reconnect.
+
+    Use as an async context manager::
+
+        async with SshTunnel(open_transport, "127.0.0.1", 54321, settings) as tunnel:
+            ...  # tunnel.local_port is the loopback port to talk to
+    """
+
+    def __init__(
+        self,
+        open_transport: Callable[[], SshTransport],
+        remote_host: str,
+        remote_port: int,
+        settings: Settings,
+    ) -> None:
+        self._open_transport = open_transport
+        self._remote_host = remote_host
+        self._remote_port = remote_port
+        self._settings = settings
+        self._transport: SshTransport | None = None
+        self._listener: asyncssh.SSHListener | None = None
+        self._local_port: int | None = None
+        self._watchdog_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    @property
+    def local_port(self) -> int:
+        """The loopback port forwarding to the remote trainer."""
+        if self._local_port is None:
+            raise RuntimeError("SshTunnel is not open")
+        return self._local_port
+
+    async def __aenter__(self) -> Self:
+        await self.open()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def open(self) -> None:
+        """Connect and establish the forward. Starts the reconnect watchdog."""
+        await self._connect_and_forward()
+        self._watchdog_task = asyncio.create_task(self._watch())
+
+    async def _connect_and_forward(self) -> None:
+        transport = self._open_transport()
+        await transport.connect()
+        listener = await transport.forward_local_port(self._remote_host, self._remote_port)
+        self._transport = transport
+        self._listener = listener
+        self._local_port = listener.get_port()
+
+    async def _watch(self) -> None:
+        """Reconnect the tunnel if the underlying connection drops.
+
+        Runs for the tunnel's lifetime. A dropped connection is detected by
+        the listener's wait_closed() resolving; this never happens on a
+        deliberate `close()`, since that cancels this task first.
+        """
+        while True:
+            listener = self._listener
+            if listener is None:
+                return
+            try:
+                await listener.wait_closed()
+            except asyncio.CancelledError:
+                return
+            if self._closed:
+                return
+            logger.warning("SSH tunnel to remote trainer dropped; attempting to reconnect")
+            try:
+                await self._reconnect_with_backoff()
+            except TunnelReconnectExhaustedError:
+                logger.error("SSH tunnel reconnect budget exhausted; giving up")
+                return
+
+    async def _reconnect_with_backoff(self) -> None:
+        """Retry `_connect_and_forward` with exponential backoff, within budget.
+
+        On success, the tunnel resumes on the *same* `local_port` value from
+        the caller's point of view is not guaranteed (a fresh ephemeral port is
+        assigned), so callers that need address stability across a reconnect
+        should read `local_port` again after a successful reconnect rather than
+        caching it once.
+        """
+        settings = self._settings
+        started = monotonic()
+        backoff = 1.0
+        last_error: Exception | None = None
+        while monotonic() - started < settings.ssh_tunnel_reconnect_budget_s:
+            try:
+                await self._connect_and_forward()
+                logger.info("SSH tunnel reconnected on local port {}", self._local_port)
+                return
+            except Exception as error:
+                last_error = error
+                await asyncio.sleep(min(backoff, settings.ssh_tunnel_reconnect_backoff_max_s))
+                backoff = min(backoff * 2, settings.ssh_tunnel_reconnect_backoff_max_s)
+        raise TunnelReconnectExhaustedError(
+            f"Could not reconnect the SSH tunnel within {settings.ssh_tunnel_reconnect_budget_s:.0f}s"
+        ) from last_error
+
+    async def close(self) -> None:
+        """Cancel the reconnect watchdog and tear down the tunnel and connection."""
+        self._closed = True
+        watchdog, self._watchdog_task = self._watchdog_task, None
+        if watchdog is not None:
+            watchdog.cancel()
+            try:
+                await watchdog
+            except asyncio.CancelledError:
+                logger.debug("SSH tunnel watchdog task canceled")
+            except Exception as error:
+                logger.debug("SSH tunnel watchdog task ended with {}: {}", type(error).__name__, error)
+
+        listener, self._listener = self._listener, None
+        if listener is not None:
+            listener.close()
+            try:
+                await listener.wait_closed()
+            except Exception as error:
+                logger.debug("SSH tunnel listener close raised {}: {}", type(error).__name__, error)
+
+        transport, self._transport = self._transport, None
+        if transport is not None:
+            await transport.close()

--- a/application/backend/src/services/ssh/tunnel.py
+++ b/application/backend/src/services/ssh/tunnel.py
@@ -15,6 +15,7 @@ otherwise progressing fine.
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from time import monotonic
 from typing import TYPE_CHECKING, Self
 
@@ -85,12 +86,38 @@ class SshTunnel:
         self._watchdog_task = asyncio.create_task(self._watch())
 
     async def _connect_and_forward(self) -> None:
+        """Connect a fresh transport and forward, closing whatever this replaces.
+
+        Tears down any previously-open transport/listener before assigning the
+        new ones (a reconnect must never leak the connection it is replacing),
+        and closes the newly-connected transport itself if `forward_local_port`
+        fails (a half-open connect must never leak either).
+        """
+        await self._close_current_connection()
+
         transport = self._open_transport()
-        await transport.connect()
-        listener = await transport.forward_local_port(self._remote_host, self._remote_port)
+        try:
+            await transport.connect()
+            listener = await transport.forward_local_port(self._remote_host, self._remote_port)
+        except BaseException:
+            await transport.close()
+            raise
+
         self._transport = transport
         self._listener = listener
         self._local_port = listener.get_port()
+
+    async def _close_current_connection(self) -> None:
+        """Close and clear whatever transport/listener are currently held."""
+        listener, self._listener = self._listener, None
+        if listener is not None:
+            listener.close()
+            with suppress(Exception):
+                await listener.wait_closed()
+
+        transport, self._transport = self._transport, None
+        if transport is not None:
+            await transport.close()
 
     async def _watch(self) -> None:
         """Reconnect the tunnel if the underlying connection drops.

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -162,6 +162,45 @@ class Settings(BaseSettings):
         alias="TRAINER_IMAGE_REGISTRY",
     )
 
+    # --- SSH provisioning: GPU-busy wait ------------------------------------
+    # Backoff between GPU-busy re-checks while a job waits `pending`.
+    ssh_gpu_wait_initial_backoff_s: float = Field(default=5.0, alias="SSH_GPU_WAIT_INITIAL_BACKOFF_S")
+    ssh_gpu_wait_max_backoff_s: float = Field(default=60.0, alias="SSH_GPU_WAIT_MAX_BACKOFF_S")
+    # A job waiting this long for a busy GPU fails rather than waiting forever.
+    ssh_gpu_wait_giveup_s: float = Field(default=1800.0, alias="SSH_GPU_WAIT_GIVEUP_S")
+
+    # --- SSH provisioning: container lifecycle ------------------------------
+    # `docker stop`'s grace period before SIGKILL, bounding teardown latency.
+    ssh_container_stop_timeout_s: int = Field(default=30, alias="SSH_CONTAINER_STOP_TIMEOUT_S")
+    # Budget for the container to report healthy after launch, before the job
+    # fails rather than uploading a dataset to a trainer that never came up.
+    ssh_readiness_timeout_s: float = Field(default=120.0, alias="SSH_READINESS_TIMEOUT_S")
+    ssh_readiness_poll_interval_s: float = Field(default=2.0, alias="SSH_READINESS_POLL_INTERVAL_S")
+
+    # --- SSH provisioning: tunnel reconnect ---------------------------------
+    # Total time budget to reconnect a dropped tunnel and resume against the
+    # still-running container before the job fails.
+    ssh_tunnel_reconnect_budget_s: float = Field(default=300.0, alias="SSH_TUNNEL_RECONNECT_BUDGET_S")
+    ssh_tunnel_reconnect_backoff_max_s: float = Field(default=15.0, alias="SSH_TUNNEL_RECONNECT_BACKOFF_MAX_S")
+
+    # --- SSH provisioning: image signature verification ---------------------
+    # Pinned to the Studio release workflow so `cosign verify` cannot be
+    # satisfied by a signature from an unrelated identity/issuer.
+    cosign_certificate_identity_regexp: str = Field(
+        default=r"https://github\.com/open-edge-platform/physical-ai-studio/\.github/workflows/.+",
+        alias="COSIGN_CERTIFICATE_IDENTITY_REGEXP",
+    )
+    cosign_oidc_issuer: str = Field(
+        default="https://token.actions.githubusercontent.com",
+        alias="COSIGN_OIDC_ISSUER",
+    )
+
+    # --- SSH provisioning: library-version policy ---------------------------
+    # Minimum `physicalai-train` version a trainer image must report. A job
+    # policy (e.g. a specific model family) can require newer; see
+    # `services.ssh.docker_ops.check_library_version`.
+    ssh_min_library_version: str = Field(default="0.1.0", alias="SSH_MIN_LIBRARY_VERSION")
+
     @field_validator("ssh_config_path", "ssh_known_hosts_path", mode="before")
     @classmethod
     def expand_ssh_path(cls, value: Path | str) -> Path:

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -135,9 +135,7 @@ class Settings(BaseSettings):
     ssh_connect_timeout_s: float = Field(default=10.0, alias="SSH_CONNECT_TIMEOUT_S")
     # Per-command budget for the cheap Tier 1 probes (docker version, nvidia-smi).
     ssh_command_timeout_s: float = Field(default=15.0, alias="SSH_COMMAND_TIMEOUT_S")
-    # Budget for `docker pull` of the (multi-gigabyte) trainer image. Far larger
-    # than `ssh_command_timeout_s`, which is sized for cheap probes, not a full
-    # image transfer over the network.
+    # Budget for `docker pull` of the (multi-gigabyte) trainer image.
     ssh_image_pull_timeout_s: float = Field(default=1800.0, alias="SSH_IMAGE_PULL_TIMEOUT_S")
     # Overall budget for a full Tier 1 preflight, so a save can never hang.
     ssh_preflight_timeout_s: float = Field(default=30.0, alias="SSH_PREFLIGHT_TIMEOUT_S")

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -135,6 +135,10 @@ class Settings(BaseSettings):
     ssh_connect_timeout_s: float = Field(default=10.0, alias="SSH_CONNECT_TIMEOUT_S")
     # Per-command budget for the cheap Tier 1 probes (docker version, nvidia-smi).
     ssh_command_timeout_s: float = Field(default=15.0, alias="SSH_COMMAND_TIMEOUT_S")
+    # Budget for `docker pull` of the (multi-gigabyte) trainer image. Far larger
+    # than `ssh_command_timeout_s`, which is sized for cheap probes, not a full
+    # image transfer over the network.
+    ssh_image_pull_timeout_s: float = Field(default=1800.0, alias="SSH_IMAGE_PULL_TIMEOUT_S")
     # Overall budget for a full Tier 1 preflight, so a save can never hang.
     ssh_preflight_timeout_s: float = Field(default=30.0, alias="SSH_PREFLIGHT_TIMEOUT_S")
     # Minimum time between preflight/status SSH connections to one server. Shared
@@ -194,6 +198,12 @@ class Settings(BaseSettings):
         default="https://token.actions.githubusercontent.com",
         alias="COSIGN_OIDC_ISSUER",
     )
+    # Fails closed by default: a remote trainer host without `cosign` installed
+    # blocks the job rather than launching an unverified image. Set to `false`
+    # only for hosts where installing `cosign` is not viable; a failed
+    # `cosign verify` (as opposed to `cosign` being absent) still always blocks,
+    # since that indicates a signature mismatch rather than missing tooling.
+    ssh_require_cosign_verification: bool = Field(default=True, alias="SSH_REQUIRE_COSIGN_VERIFICATION")
 
     # --- SSH provisioning: library-version policy ---------------------------
     # Minimum `physicalai-train` version a trainer image must report. A job

--- a/application/backend/src/trainer/schemas.py
+++ b/application/backend/src/trainer/schemas.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 from uuid import UUID  # noqa: TC003
 
@@ -17,6 +18,19 @@ from training import TrainingJobSpec
 
 _SUPPORTED_POLICIES = frozenset({"act", "pi0", "pi05", "smolvla"})
 _DEFAULT_PROTOCOL_VERSION = 1
+
+
+def _installed_library_version() -> str:
+    """Return the installed `physicalai-train` version, or "unknown".
+
+    Read directly from installed package metadata rather than a Docker-build
+    ARG, so the reported version can never drift from what is actually
+    installed in this image.
+    """
+    try:
+        return version("physicalai-train")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 class DatasetTransfer(StrEnum):
@@ -83,6 +97,13 @@ class HealthInfo(BaseSettings):
         default="unknown",
         alias="TRAINER_APPLICATION_VERSION",
         description="Physical AI Studio application version",
+    )
+    library_version: str = Field(
+        default_factory=_installed_library_version,
+        description=(
+            "Installed physicalai-train version. Read from package metadata rather than an "
+            "environment variable, so it always reflects what is actually installed."
+        ),
     )
 
     @field_validator("protocol_version", mode="before")

--- a/application/backend/tests/core/test_backend_instance.py
+++ b/application/backend/tests/core/test_backend_instance.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the stable per-installation backend instance id."""
+
+from __future__ import annotations
+
+from core.backend_instance import get_backend_instance_id, reset_backend_instance_id_cache
+from settings import Settings, get_settings
+
+
+def _use_storage_dir(monkeypatch, tmp_path) -> None:
+    settings = Settings(STORAGE_DIR=str(tmp_path))
+    monkeypatch.setattr("core.backend_instance.get_settings", lambda: settings)
+    get_settings.cache_clear()
+    reset_backend_instance_id_cache()
+
+
+def test_get_backend_instance_id_is_created_once_and_persisted(monkeypatch, tmp_path) -> None:
+    _use_storage_dir(monkeypatch, tmp_path)
+
+    first = get_backend_instance_id()
+    reset_backend_instance_id_cache()
+    second = get_backend_instance_id()
+
+    assert first == second
+    assert (tmp_path / "data" / "backend_instance_id").is_file()
+
+
+def test_get_backend_instance_id_is_cached_without_rereading_disk(monkeypatch, tmp_path) -> None:
+    _use_storage_dir(monkeypatch, tmp_path)
+
+    first = get_backend_instance_id()
+    (tmp_path / "data" / "backend_instance_id").write_text("not-a-uuid", encoding="utf-8")
+    second = get_backend_instance_id()
+
+    assert first == second
+
+
+def test_corrupt_file_is_replaced_rather_than_adopted(monkeypatch, tmp_path) -> None:
+    _use_storage_dir(monkeypatch, tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "backend_instance_id").write_text("not-a-uuid", encoding="utf-8")
+
+    generated = get_backend_instance_id()
+
+    assert generated != "not-a-uuid"

--- a/application/backend/tests/services/ssh/test_docker_ops.py
+++ b/application/backend/tests/services/ssh/test_docker_ops.py
@@ -140,6 +140,23 @@ async def test_verify_image_signature_fails_closed_on_failed_verification(settin
         await docker_ops.verify_image_signature(transport, _image(), settings)
 
 
+async def test_verify_image_signature_allows_missing_cosign_when_not_required(settings) -> None:
+    """`SSH_REQUIRE_COSIGN_VERIFICATION=false` downgrades a missing `cosign` to a warning."""
+    settings = Settings(TRAINER_IMAGE_REGISTRY=_REGISTRY, SSH_REQUIRE_COSIGN_VERIFICATION=False)
+    transport = FakeTransport({"cosign version": _fail()})
+
+    await docker_ops.verify_image_signature(transport, _image(), settings)
+
+
+async def test_verify_image_signature_still_fails_closed_on_bad_signature_when_not_required(settings) -> None:
+    """Opting out of requiring `cosign` never excuses a signature that fails verification."""
+    settings = Settings(TRAINER_IMAGE_REGISTRY=_REGISTRY, SSH_REQUIRE_COSIGN_VERIFICATION=False)
+    transport = FakeTransport({"cosign version": _ok("v2.4.1"), "cosign verify": _fail("no matching signatures")})
+
+    with pytest.raises(TrainerImageVerificationError):
+        await docker_ops.verify_image_signature(transport, _image(), settings)
+
+
 async def test_verify_image_signature_passes_and_pins_identity(settings) -> None:
     transport = FakeTransport({"cosign version": _ok("v2.4.1"), "cosign verify": _ok("Verified OK")})
 
@@ -336,10 +353,10 @@ def test_build_run_argv_xpu_without_render_gid_omits_group_add() -> None:
     assert "--group-add" not in argv
 
 
-async def test_pull_image_raises_on_failure() -> None:
+async def test_pull_image_raises_on_failure(settings) -> None:
     transport = FakeTransport({"docker pull": _fail("no space left on device")})
     with pytest.raises(TrainerImagePullError):
-        await docker_ops.pull_image(transport, _image())
+        await docker_ops.pull_image(transport, _image(), settings)
 
 
 async def test_launch_container_returns_container_id() -> None:

--- a/application/backend/tests/services/ssh/test_docker_ops.py
+++ b/application/backend/tests/services/ssh/test_docker_ops.py
@@ -1,0 +1,350 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Docker image resolution, verification, GPU-busy waiting, and container lifecycle."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from exceptions import (
+    GpuBusyTimeoutError,
+    RemoteDiskSpaceError,
+    TrainerContainerLaunchError,
+    TrainerImagePullError,
+    TrainerImageResolutionError,
+    TrainerImageVerificationError,
+    TrainerLibraryVersionError,
+)
+from schemas.hardware import DeviceType
+from services.ssh import docker_ops
+from services.ssh.docker_ops import LIBRARY_VERSION_LABEL, ResolvedImage
+from services.ssh.preflight import PROTOCOL_LABEL
+from services.ssh.transport import CommandResult
+from settings import Settings
+
+_REGISTRY = "ghcr.io/open-edge-platform"
+_CUDA_TAG_REF = f"{_REGISTRY}/physicalai-trainer-cuda:protocol-1"
+_DIGEST = "sha256:" + "a" * 64
+
+
+def _ok(stdout: str = "") -> CommandResult:
+    return CommandResult(argv=(), command="", exit_status=0, stdout=stdout)
+
+
+def _fail(stderr: str = "command failed") -> CommandResult:
+    return CommandResult(argv=(), command="", exit_status=1, stderr=stderr)
+
+
+class FakeTransport:
+    """Records every command and answers from a prefix-matched script."""
+
+    def __init__(self, script: dict[str, CommandResult] | None = None) -> None:
+        self.script = script or {}
+        self.commands: list[tuple[str, ...]] = []
+
+    async def run_command(self, argv, timeout: float | None = None) -> CommandResult:  # noqa: ASYNC109
+        self.commands.append(tuple(argv))
+        joined = " ".join(argv)
+        for prefix, result in self.script.items():
+            if joined.startswith(prefix):
+                return result
+        return _fail(f"unscripted command: {joined}")
+
+    def ran(self, fragment: str) -> bool:
+        return any(fragment in " ".join(argv) for argv in self.commands)
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(TRAINER_IMAGE_REGISTRY=_REGISTRY)
+
+
+# --------------------------------------------------------------------------- #
+# resolve_protocol_image                                                      #
+# --------------------------------------------------------------------------- #
+
+
+async def test_resolve_protocol_image_returns_digest_and_labels(settings) -> None:
+    labels = {PROTOCOL_LABEL: "1", LIBRARY_VERSION_LABEL: "0.5.0"}
+    transport = FakeTransport(
+        {
+            f"docker buildx imagetools inspect {_CUDA_TAG_REF} --format {{{{json .Manifest.Digest}}}}": _ok(
+                json.dumps(_DIGEST)
+            ),
+            f"docker buildx imagetools inspect {_CUDA_TAG_REF} --format {{{{json .Image.Config.Labels}}}}": _ok(
+                json.dumps(labels)
+            ),
+        }
+    )
+
+    resolved = await docker_ops.resolve_protocol_image(transport, DeviceType.CUDA, 1, settings)
+
+    assert resolved.tag_reference == _CUDA_TAG_REF
+    assert resolved.digest == _DIGEST
+    assert resolved.digest_reference == f"{_REGISTRY}/physicalai-trainer-cuda@{_DIGEST}"
+    assert resolved.library_version == "0.5.0"
+
+
+async def test_resolve_protocol_image_has_no_fallback_tag(settings) -> None:
+    """Unlike Tier 1's advisory preflight, there is no `latest` fallback here."""
+    transport = FakeTransport({})  # every command fails: unscripted
+
+    with pytest.raises(TrainerImageResolutionError):
+        await docker_ops.resolve_protocol_image(transport, DeviceType.CUDA, 1, settings)
+
+    assert not transport.ran("latest")
+
+
+async def test_resolve_protocol_image_rejects_missing_protocol_label(settings) -> None:
+    transport = FakeTransport(
+        {
+            "docker buildx imagetools inspect": _ok(json.dumps(_DIGEST)),
+        }
+    )
+    # Second call (labels) also matches the same broad prefix and returns the digest
+    # payload, which is not a dict, so labels resolve to {} and the protocol label
+    # check below is exercised.
+
+    with pytest.raises(TrainerImageResolutionError):
+        await docker_ops.resolve_protocol_image(transport, DeviceType.CUDA, 1, settings)
+
+
+# --------------------------------------------------------------------------- #
+# verify_image_signature                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _image() -> ResolvedImage:
+    return ResolvedImage(
+        tag_reference=_CUDA_TAG_REF,
+        digest_reference=f"{_REGISTRY}/physicalai-trainer-cuda@{_DIGEST}",
+        digest=_DIGEST,
+        library_version="0.5.0",
+    )
+
+
+async def test_verify_image_signature_fails_closed_when_cosign_unavailable(settings) -> None:
+    transport = FakeTransport({"cosign version": _fail()})
+
+    with pytest.raises(TrainerImageVerificationError):
+        await docker_ops.verify_image_signature(transport, _image(), settings)
+
+
+async def test_verify_image_signature_fails_closed_on_failed_verification(settings) -> None:
+    transport = FakeTransport({"cosign version": _ok("v2.4.1"), "cosign verify": _fail("no matching signatures")})
+
+    with pytest.raises(TrainerImageVerificationError):
+        await docker_ops.verify_image_signature(transport, _image(), settings)
+
+
+async def test_verify_image_signature_passes_and_pins_identity(settings) -> None:
+    transport = FakeTransport({"cosign version": _ok("v2.4.1"), "cosign verify": _ok("Verified OK")})
+
+    await docker_ops.verify_image_signature(transport, _image(), settings)
+
+    assert any(
+        "--certificate-identity-regexp" in " ".join(argv) and settings.cosign_oidc_issuer in " ".join(argv)
+        for argv in transport.commands
+    )
+
+
+# --------------------------------------------------------------------------- #
+# check_library_version                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_check_library_version_no_label_is_silent() -> None:
+    image = ResolvedImage(tag_reference="t", digest_reference="d", digest=_DIGEST, library_version=None)
+    result = docker_ops.check_library_version(image, minimum_version="1.0.0")
+    assert result.warning is None
+    assert result.reported_version is None
+
+
+def test_check_library_version_older_is_a_warning_not_a_failure() -> None:
+    image = ResolvedImage(tag_reference="t", digest_reference="d", digest=_DIGEST, library_version="0.9.0")
+    result = docker_ops.check_library_version(image, minimum_version="1.0.0")
+    assert result.warning is not None
+
+
+def test_check_library_version_equal_or_newer_is_silent() -> None:
+    image = ResolvedImage(tag_reference="t", digest_reference="d", digest=_DIGEST, library_version="1.2.0")
+    result = docker_ops.check_library_version(image, minimum_version="1.0.0")
+    assert result.warning is None
+
+
+def test_check_library_version_below_named_policy_minimum_fails() -> None:
+    image = ResolvedImage(tag_reference="t", digest_reference="d", digest=_DIGEST, library_version="0.9.0")
+    with pytest.raises(TrainerLibraryVersionError):
+        docker_ops.check_library_version(image, minimum_version="1.0.0", policy_name="pi05")
+
+
+# --------------------------------------------------------------------------- #
+# GPU-busy wait                                                               #
+# --------------------------------------------------------------------------- #
+
+
+async def test_wait_for_gpu_free_returns_once_free(settings) -> None:
+    calls = iter([_ok("1234\n"), _ok("\n")])  # busy once, then free
+
+    class _Sequenced(FakeTransport):
+        async def connect(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+        async def run_command(self, argv, timeout: float | None = None) -> CommandResult:  # noqa: ASYNC109
+            return next(calls)
+
+    waits: list[float] = []
+
+    async def on_wait(elapsed: float) -> None:
+        waits.append(elapsed)
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    clock_values = iter([0.0, 0.0, 5.0])
+
+    def fake_clock() -> float:
+        return next(clock_values, 5.0)
+
+    await docker_ops.wait_for_gpu_free(
+        lambda: _Sequenced(),
+        DeviceType.CUDA,
+        settings,
+        "gpu-box",
+        on_wait=on_wait,
+        clock=fake_clock,
+        sleep=fake_sleep,
+    )
+
+    assert waits == [0.0]
+    assert sleeps  # backed off at least once
+
+
+async def test_wait_for_gpu_free_gives_up_after_timeout(settings) -> None:
+    settings = settings.model_copy(update={"ssh_gpu_wait_giveup_s": 1.0, "ssh_gpu_wait_initial_backoff_s": 0.01})
+
+    class _AlwaysBusy(FakeTransport):
+        async def connect(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+        async def run_command(self, argv, timeout: float | None = None) -> CommandResult:  # noqa: ASYNC109
+            return _ok("1234\n")
+
+    async def fake_sleep(seconds: float) -> None:
+        return None
+
+    clock_values = iter([0.0, 0.5, 2.0])
+
+    def fake_clock() -> float:
+        return next(clock_values, 2.0)
+
+    with pytest.raises(GpuBusyTimeoutError):
+        await docker_ops.wait_for_gpu_free(
+            lambda: _AlwaysBusy(),
+            DeviceType.CUDA,
+            settings,
+            "gpu-box",
+            clock=fake_clock,
+            sleep=fake_sleep,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Disk re-check                                                               #
+# --------------------------------------------------------------------------- #
+
+_DF_HEADER = "Filesystem 1B-blocks Used Available Capacity Mounted on\n"
+_PLENTY_OF_DISK = f"{_DF_HEADER}/dev/sda1 900000000000 100000000000 85899345920 12% /var/lib/docker\n"
+_ALMOST_NO_DISK = f"{_DF_HEADER}/dev/sda1 900000000000 890000000000 1073741824 99% /var/lib/docker\n"
+
+
+async def test_check_disk_for_job_passes_with_enough_free_space() -> None:
+    transport = FakeTransport({"df -B1 -P /var/lib/docker": _ok(_PLENTY_OF_DISK)})
+    await docker_ops.check_disk_for_job(transport, required_bytes=10 * 1024**3, server_name="gpu-box")
+
+
+async def test_check_disk_for_job_fails_against_actual_snapshot_size() -> None:
+    transport = FakeTransport({"df -B1 -P /var/lib/docker": _ok(_ALMOST_NO_DISK)})
+    with pytest.raises(RemoteDiskSpaceError):
+        await docker_ops.check_disk_for_job(transport, required_bytes=500 * 1024**3, server_name="gpu-box")
+
+
+# --------------------------------------------------------------------------- #
+# Container launch                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_run_argv_security_properties() -> None:
+    argv = docker_ops.build_run_argv(
+        image_digest_ref=f"{_REGISTRY}/physicalai-trainer-cuda@{_DIGEST}",
+        device_type=DeviceType.CUDA,
+        name="physicalai-trainer-abc",
+        labels={"a": "b"},
+        remote_container_port=8080,
+        stop_timeout_s=30,
+    )
+
+    assert argv[-1] == f"{_REGISTRY}/physicalai-trainer-cuda@{_DIGEST}"
+    assert "--restart=no" in argv
+    assert "127.0.0.1::8080" in argv
+    assert "--privileged" not in argv
+    assert "ALL" in argv and "--cap-drop" in argv
+    assert "--stop-timeout=30" in argv
+    assert not any(":latest" in part or part.endswith(":protocol-1") for part in argv)
+
+
+async def test_pull_image_raises_on_failure() -> None:
+    transport = FakeTransport({"docker pull": _fail("no space left on device")})
+    with pytest.raises(TrainerImagePullError):
+        await docker_ops.pull_image(transport, _image())
+
+
+async def test_launch_container_returns_container_id() -> None:
+    transport = FakeTransport({"docker run": _ok("abc123\n")})
+    container_id = await docker_ops.launch_container(transport, ["docker", "run"], "gpu-box")
+    assert container_id == "abc123"
+
+
+async def test_launch_container_raises_on_failure() -> None:
+    transport = FakeTransport({"docker run": _fail("port already allocated")})
+    with pytest.raises(TrainerContainerLaunchError):
+        await docker_ops.launch_container(transport, ["docker", "run"], "gpu-box")
+
+
+async def test_resolve_published_port_parses_docker_port_output() -> None:
+    transport = FakeTransport({"docker port": _ok("127.0.0.1:54321\n")})
+    port = await docker_ops.resolve_published_port(transport, "physicalai-trainer-abc", 8080)
+    assert port == 54321
+
+
+# --------------------------------------------------------------------------- #
+# Orphan sweep listing                                                        #
+# --------------------------------------------------------------------------- #
+
+
+async def test_list_managed_containers_parses_docker_ps_json_lines() -> None:
+    line = json.dumps(
+        {
+            "ID": "abc123",
+            "Names": "physicalai-trainer-job1",
+            "Labels": f"{docker_ops.MANAGED_LABEL}=true,{docker_ops.JOB_LABEL}=job1",
+        }
+    )
+    transport = FakeTransport({"docker ps": _ok(line + "\n")})
+
+    containers = await docker_ops.list_managed_containers(transport, backend_instance_id="instance-1")
+
+    assert len(containers) == 1
+    assert containers[0].container_id == "abc123"
+    assert containers[0].job_id == "job1"

--- a/application/backend/tests/services/ssh/test_docker_ops.py
+++ b/application/backend/tests/services/ssh/test_docker_ops.py
@@ -112,6 +112,45 @@ async def test_resolve_protocol_image_rejects_missing_protocol_label(settings) -
         await docker_ops.resolve_protocol_image(transport, DeviceType.CUDA, 1, settings)
 
 
+async def test_resolve_protocol_image_rejects_mismatched_protocol_label(settings) -> None:
+    """A `protocol-1` tag whose manifest actually advertises protocol 2 must fail.
+
+    A mis-tagged image, or a tag moved to the wrong manifest, must never
+    proceed to a pull/run just because *some* protocol label is present.
+    """
+    labels = {PROTOCOL_LABEL: "2", LIBRARY_VERSION_LABEL: "0.5.0"}
+    transport = FakeTransport(
+        {
+            f"docker buildx imagetools inspect {_CUDA_TAG_REF} --format {{{{json .Manifest.Digest}}}}": _ok(
+                json.dumps(_DIGEST)
+            ),
+            f"docker buildx imagetools inspect {_CUDA_TAG_REF} --format {{{{json .Image.Config.Labels}}}}": _ok(
+                json.dumps(labels)
+            ),
+        }
+    )
+
+    with pytest.raises(TrainerImageResolutionError):
+        await docker_ops.resolve_protocol_image(transport, DeviceType.CUDA, 1, settings)
+
+
+async def test_resolve_protocol_image_rejects_unparseable_protocol_label(settings) -> None:
+    labels = {PROTOCOL_LABEL: "not-a-number"}
+    transport = FakeTransport(
+        {
+            f"docker buildx imagetools inspect {_CUDA_TAG_REF} --format {{{{json .Manifest.Digest}}}}": _ok(
+                json.dumps(_DIGEST)
+            ),
+            f"docker buildx imagetools inspect {_CUDA_TAG_REF} --format {{{{json .Image.Config.Labels}}}}": _ok(
+                json.dumps(labels)
+            ),
+        }
+    )
+
+    with pytest.raises(TrainerImageResolutionError):
+        await docker_ops.resolve_protocol_image(transport, DeviceType.CUDA, 1, settings)
+
+
 # --------------------------------------------------------------------------- #
 # verify_image_signature                                                      #
 # --------------------------------------------------------------------------- #
@@ -196,6 +235,21 @@ def test_check_library_version_below_named_policy_minimum_fails() -> None:
     image = ResolvedImage(tag_reference="t", digest_reference="d", digest=_DIGEST, library_version="0.9.0")
     with pytest.raises(TrainerLibraryVersionError):
         docker_ops.check_library_version(image, minimum_version="1.0.0", policy_name="pi05")
+
+
+def test_check_library_version_unparseable_label_is_treated_as_unreported() -> None:
+    """An unparseable label (e.g. the Dockerfile's `unknown` default) must warn, not raise.
+
+    `reported_version` must come back `None`, not the raw unparseable string:
+    `SshProvisioningService.provision()` treats any non-`None` `reported_version`
+    as authoritative against `/health`'s real version, and would otherwise raise
+    `TrainerLibraryVersionMismatchError` on every image whose label isn't a
+    valid PEP 440 version string.
+    """
+    image = ResolvedImage(tag_reference="t", digest_reference="d", digest=_DIGEST, library_version="unknown")
+    result = docker_ops.check_library_version(image, minimum_version="1.0.0")
+    assert result.reported_version is None
+    assert result.warning is not None
 
 
 # --------------------------------------------------------------------------- #

--- a/application/backend/tests/services/ssh/test_docker_ops.py
+++ b/application/backend/tests/services/ssh/test_docker_ops.py
@@ -304,6 +304,38 @@ def test_build_run_argv_security_properties() -> None:
     assert not any(":latest" in part or part.endswith(":protocol-1") for part in argv)
 
 
+def test_build_run_argv_xpu_adds_group_add_for_render_gid() -> None:
+    # Without --group-add the container's fixed non-root user cannot open the
+    # render node even though --device /dev/dri passes it through, and
+    # torch.xpu.is_available() silently reports zero devices.
+    argv = docker_ops.build_run_argv(
+        image_digest_ref=f"{_REGISTRY}/physicalai-trainer-xpu@{_DIGEST}",
+        device_type=DeviceType.XPU,
+        name="physicalai-trainer-abc",
+        labels={"a": "b"},
+        remote_container_port=8080,
+        stop_timeout_s=30,
+        render_gid="44",
+    )
+
+    assert "/dev/dri" in argv
+    assert "--group-add" in argv
+    assert "44" in argv
+
+
+def test_build_run_argv_xpu_without_render_gid_omits_group_add() -> None:
+    argv = docker_ops.build_run_argv(
+        image_digest_ref=f"{_REGISTRY}/physicalai-trainer-xpu@{_DIGEST}",
+        device_type=DeviceType.XPU,
+        name="physicalai-trainer-abc",
+        labels={"a": "b"},
+        remote_container_port=8080,
+        stop_timeout_s=30,
+    )
+
+    assert "--group-add" not in argv
+
+
 async def test_pull_image_raises_on_failure() -> None:
     transport = FakeTransport({"docker pull": _fail("no space left on device")})
     with pytest.raises(TrainerImagePullError):

--- a/application/backend/tests/services/ssh/test_provisioning.py
+++ b/application/backend/tests/services/ssh/test_provisioning.py
@@ -1,0 +1,377 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the SSH provisioning orchestrator.
+
+Every remote/docker interaction is faked: `SshTransport` and `SshTunnel` are
+monkeypatched with in-memory doubles, and `docker_ops` calls hit a scripted
+fake transport rather than a real host. This proves the *orchestration* -
+ordering, persistence, and cleanup-on-failure - independent of the individual
+docker_ops/transport unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Self
+from uuid import uuid4
+
+import pytest
+
+from exceptions import (
+    TrainerContainerLaunchError,
+    TrainerImageResolutionError,
+    TrainerImageVerificationError,
+    TrainerProtocolVersionMismatchError,
+    TrainerReadinessTimeoutError,
+)
+from schemas.hardware import DeviceType
+from schemas.job_provisioning import JobProvisioning, JobProvisioningUpdate
+from schemas.remote_server import RemoteServer
+from services.ssh import docker_ops
+from services.ssh import provisioning as provisioning_module
+from services.ssh.docker_ops import JOB_LABEL, LIBRARY_VERSION_LABEL, MANAGED_LABEL
+from services.ssh.preflight import PROTOCOL_LABEL
+from services.ssh.provisioning import SshProvisioningService
+from services.ssh.transport import CommandResult
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+_REGISTRY = "ghcr.io/open-edge-platform"
+_PROTOCOL_VERSION = 1
+_TAG_REF = f"{_REGISTRY}/physicalai-trainer-cuda:protocol-1"
+_DIGEST = "sha256:" + "b" * 64
+
+
+def _ok(stdout: str = "") -> CommandResult:
+    return CommandResult(argv=(), command="", exit_status=0, stdout=stdout)
+
+
+def _fail(stderr: str = "failed") -> CommandResult:
+    return CommandResult(argv=(), command="", exit_status=1, stderr=stderr)
+
+
+def _server() -> RemoteServer:
+    return RemoteServer(id=uuid4(), name="Lab GPU box", ssh_host_alias="gpu-box", device_type=DeviceType.CUDA)
+
+
+def _healthy_script(container_id: str = "abc123", published_port: int = 54321) -> dict[str, CommandResult]:
+    return {
+        f"docker buildx imagetools inspect {_TAG_REF} --format {{{{json .Manifest.Digest}}}}": _ok(json.dumps(_DIGEST)),
+        f"docker buildx imagetools inspect {_TAG_REF} --format {{{{json .Image.Config.Labels}}}}": _ok(
+            json.dumps({PROTOCOL_LABEL: "1", LIBRARY_VERSION_LABEL: "1.0.0"})
+        ),
+        "cosign version": _ok("v2.4.1"),
+        "cosign verify": _ok("Verified OK"),
+        "df -B1 -P /var/lib/docker": _ok(
+            "Filesystem 1B-blocks Used Available Capacity Mounted on\n"
+            "/dev/sda1 900000000000 100000000000 85899345920 12% /var/lib/docker\n"
+        ),
+        "docker pull": _ok("Status: Downloaded"),
+        "nvidia-smi --query-compute-apps": _ok("\n"),  # GPU free
+        "docker run": _ok(f"{container_id}\n"),
+        "docker port": _ok(f"127.0.0.1:{published_port}\n"),
+        "docker stop": _ok(""),
+        "docker rm": _ok(""),
+        "docker inspect": _ok("true\n"),
+    }
+
+
+class FakeSshTransport:
+    """Stand-in for `SshTransport` as an async context manager."""
+
+    def __init__(self, script: dict[str, CommandResult], recorder: list[tuple[str, ...]]) -> None:
+        self.script = script
+        self.recorder = recorder
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
+    ) -> None:
+        return None
+
+    async def connect(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def run_command(self, argv, timeout: float | None = None) -> CommandResult:  # noqa: ASYNC109
+        self.recorder.append(tuple(argv))
+        joined = " ".join(argv)
+        for prefix, result in self.script.items():
+            if joined.startswith(prefix):
+                return result
+        return _fail(f"unscripted command: {joined}")
+
+
+class FakeSshTunnel:
+    """Stand-in for `SshTunnel` that never actually opens a socket."""
+
+    instances: list[FakeSshTunnel] = []
+
+    def __init__(self, open_transport, remote_host: str, remote_port: int, settings) -> None:
+        self._local_port = 40000 + len(FakeSshTunnel.instances)
+        self.closed = False
+        FakeSshTunnel.instances.append(self)
+
+    @property
+    def local_port(self) -> int:
+        return self._local_port
+
+    async def open(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeProvisioningRepository:
+    """In-memory stand-in for `JobProvisioningRepository`."""
+
+    def __init__(self) -> None:
+        self._rows: dict[str, JobProvisioning] = {}
+
+    async def save(self, item: JobProvisioning) -> JobProvisioning:
+        self._rows[str(item.job_id)] = item
+        return item
+
+    async def get_by_job_id(self, job_id) -> JobProvisioning | None:
+        return self._rows.get(str(job_id))
+
+    async def update_by_job_id(self, job_id, update: JobProvisioningUpdate) -> JobProvisioning:
+        current = self._rows[str(job_id)]
+        changes = update.model_dump(exclude_unset=True, exclude_none=True)
+        merged = current.model_copy(update=changes)
+        self._rows[str(job_id)] = merged
+        return merged
+
+    async def delete_by_job_id(self, job_id) -> None:
+        self._rows.pop(str(job_id), None)
+
+
+@pytest.fixture(autouse=True)
+def _patch_transport_and_tunnel(monkeypatch):
+    """Route every SshTransport()/SshTunnel() construction to fakes."""
+    recorder: list[tuple[str, ...]] = []
+    script_holder: dict[str, dict[str, CommandResult]] = {"script": {}}
+
+    def fake_transport_ctor(alias, settings=None):
+        return FakeSshTransport(script_holder["script"], recorder)
+
+    def fake_open_transport(alias, settings=None):
+        return FakeSshTransport(script_holder["script"], recorder)
+
+    monkeypatch.setattr(provisioning_module, "SshTransport", fake_transport_ctor)
+    monkeypatch.setattr(provisioning_module, "open_transport", fake_open_transport)
+    monkeypatch.setattr(provisioning_module, "SshTunnel", FakeSshTunnel)
+    FakeSshTunnel.instances.clear()
+
+    yield recorder, script_holder
+
+
+def _set_script(fixture, script: dict[str, CommandResult]) -> None:
+    _, holder = fixture
+    holder["script"] = script
+
+
+def _commands(fixture) -> list[tuple[str, ...]]:
+    recorder, _ = fixture
+    return recorder
+
+
+@pytest.fixture
+def repository() -> FakeProvisioningRepository:
+    return FakeProvisioningRepository()
+
+
+async def test_provision_happy_path(_patch_transport_and_tunnel, repository) -> None:
+    _set_script(_patch_transport_and_tunnel, _healthy_script())
+    service = SshProvisioningService(repository)
+    server = _server()
+    job_id = uuid4()
+
+    async def fake_ready(base_url, server_name):
+        return {"protocol_version": _PROTOCOL_VERSION, "library_version": "1.0.0", "build_revision": "abc"}
+
+    service._await_ready = fake_ready  # type: ignore[method-assign]
+
+    trainer = await service.provision(job_id, server, protocol_version=_PROTOCOL_VERSION, snapshot_size_bytes=1024)
+
+    assert trainer.base_url.startswith("http://127.0.0.1:")
+    assert trainer.container_name == docker_ops.container_name(str(job_id))
+
+    persisted = await repository.get_by_job_id(job_id)
+    assert persisted.container_id == "abc123"
+    assert persisted.image_digest == _DIGEST
+    assert persisted.trainer_protocol_version == _PROTOCOL_VERSION
+
+    await trainer.teardown()
+    assert any(cmd[:2] == ("docker", "stop") for cmd in _commands(_patch_transport_and_tunnel))
+
+
+async def test_provision_fails_with_no_fallback_tag(_patch_transport_and_tunnel, repository) -> None:
+    _set_script(_patch_transport_and_tunnel, {})  # every docker call fails
+    service = SshProvisioningService(repository)
+
+    with pytest.raises(TrainerImageResolutionError):
+        await service.provision(uuid4(), _server(), protocol_version=_PROTOCOL_VERSION, snapshot_size_bytes=1)
+
+    assert not any(cmd[:2] == ("docker", "run") for cmd in _commands(_patch_transport_and_tunnel))
+
+
+async def test_provision_fails_closed_on_signature_verification(_patch_transport_and_tunnel, repository) -> None:
+    script = _healthy_script()
+    script["cosign verify"] = _fail("no matching signatures")
+    _set_script(_patch_transport_and_tunnel, script)
+    service = SshProvisioningService(repository)
+
+    with pytest.raises(TrainerImageVerificationError):
+        await service.provision(uuid4(), _server(), protocol_version=_PROTOCOL_VERSION, snapshot_size_bytes=1)
+
+    # Signature verification fails before any pull.
+    assert not any(cmd[:2] == ("docker", "pull") for cmd in _commands(_patch_transport_and_tunnel))
+
+
+async def test_provision_waits_out_a_busy_gpu(_patch_transport_and_tunnel, repository, monkeypatch) -> None:
+    _set_script(_patch_transport_and_tunnel, _healthy_script())
+    service = SshProvisioningService(repository)
+    waited: list[float] = []
+
+    async def fake_ready(base_url, server_name):
+        return {"protocol_version": _PROTOCOL_VERSION, "library_version": "1.0.0"}
+
+    service._await_ready = fake_ready  # type: ignore[method-assign]
+
+    async def patched_wait(open_transport, device_type, settings, server_name, *, on_wait=None, **kwargs):
+        if on_wait is not None:
+            await on_wait(1.0)
+
+    monkeypatch.setattr(docker_ops, "wait_for_gpu_free", patched_wait)
+
+    async def on_gpu_wait(elapsed: float) -> None:
+        waited.append(elapsed)
+
+    await service.provision(
+        uuid4(),
+        _server(),
+        protocol_version=_PROTOCOL_VERSION,
+        snapshot_size_bytes=1,
+        on_gpu_wait=on_gpu_wait,
+    )
+
+    assert waited == [1.0]
+
+
+async def test_provision_cleans_up_container_on_protocol_mismatch(_patch_transport_and_tunnel, repository) -> None:
+    _set_script(_patch_transport_and_tunnel, _healthy_script())
+    service = SshProvisioningService(repository)
+
+    async def mismatched_ready(base_url, server_name):
+        return {"protocol_version": 99, "library_version": "1.0.0"}
+
+    service._await_ready = mismatched_ready  # type: ignore[method-assign]
+
+    with pytest.raises(TrainerProtocolVersionMismatchError):
+        await service.provision(uuid4(), _server(), protocol_version=_PROTOCOL_VERSION, snapshot_size_bytes=1)
+
+    assert any(cmd[:2] == ("docker", "stop") for cmd in _commands(_patch_transport_and_tunnel))
+    assert FakeSshTunnel.instances[-1].closed
+
+
+async def test_provision_cleans_up_on_readiness_timeout(_patch_transport_and_tunnel, repository) -> None:
+    _set_script(_patch_transport_and_tunnel, _healthy_script())
+    service = SshProvisioningService(repository)
+
+    async def never_ready(base_url, server_name):
+        raise TrainerReadinessTimeoutError(server_name, "no response")
+
+    service._await_ready = never_ready  # type: ignore[method-assign]
+
+    with pytest.raises(TrainerReadinessTimeoutError):
+        await service.provision(uuid4(), _server(), protocol_version=_PROTOCOL_VERSION, snapshot_size_bytes=1)
+
+    assert any(cmd[:2] == ("docker", "stop") for cmd in _commands(_patch_transport_and_tunnel))
+
+
+async def test_provision_launch_failure_needs_no_cleanup(_patch_transport_and_tunnel, repository) -> None:
+    script = _healthy_script()
+    script["docker run"] = _fail("port already allocated")
+    _set_script(_patch_transport_and_tunnel, script)
+    service = SshProvisioningService(repository)
+
+    with pytest.raises(TrainerContainerLaunchError):
+        await service.provision(uuid4(), _server(), protocol_version=_PROTOCOL_VERSION, snapshot_size_bytes=1)
+
+    # docker run never produced a container id, so there is nothing to stop.
+    assert not any(cmd[:2] == ("docker", "stop") for cmd in _commands(_patch_transport_and_tunnel))
+
+
+async def test_reattach_returns_none_when_container_not_running(_patch_transport_and_tunnel, repository) -> None:
+    script = _healthy_script()
+    script["docker inspect"] = _ok("false\n")
+    _set_script(_patch_transport_and_tunnel, script)
+    service = SshProvisioningService(repository)
+    server = _server()
+    job_id = uuid4()
+    provisioning_row = JobProvisioning(
+        job_id=job_id,
+        remote_server_id=server.id,
+        ssh_host_alias=server.ssh_host_alias,
+        container_name=docker_ops.container_name(str(job_id)),
+        remote_port=8080,
+    )
+    await repository.save(provisioning_row)
+
+    result = await service.reattach(provisioning_row, server)
+
+    assert result is None
+
+
+async def test_reattach_reopens_tunnel_when_container_running(_patch_transport_and_tunnel, repository) -> None:
+    _set_script(_patch_transport_and_tunnel, _healthy_script())
+    service = SshProvisioningService(repository)
+    server = _server()
+    job_id = uuid4()
+    provisioning_row = JobProvisioning(
+        job_id=job_id,
+        remote_server_id=server.id,
+        ssh_host_alias=server.ssh_host_alias,
+        container_name=docker_ops.container_name(str(job_id)),
+        remote_port=8080,
+    )
+    await repository.save(provisioning_row)
+
+    result = await service.reattach(provisioning_row, server)
+
+    assert result is not None
+    assert result.base_url.startswith("http://127.0.0.1:")
+
+
+async def test_sweep_orphans_never_touches_active_or_foreign_containers(
+    _patch_transport_and_tunnel, repository
+) -> None:
+    server = _server()
+    active_job_id = uuid4()
+    orphan_job_id = uuid4()
+    ps_lines = "\n".join(
+        json.dumps(
+            {
+                "ID": f"container-{job_id}",
+                "Names": docker_ops.container_name(str(job_id)),
+                "Labels": f"{MANAGED_LABEL}=true,{JOB_LABEL}={job_id}",
+            }
+        )
+        for job_id in (active_job_id, orphan_job_id)
+    )
+    script = _healthy_script()
+    script["docker ps"] = _ok(ps_lines + "\n")
+    _set_script(_patch_transport_and_tunnel, script)
+    service = SshProvisioningService(repository)
+
+    removed = await service.sweep_orphans(server, active_job_ids={active_job_id})
+
+    assert removed == [docker_ops.container_name(str(orphan_job_id))]

--- a/application/backend/tests/services/ssh/test_tunnel.py
+++ b/application/backend/tests/services/ssh/test_tunnel.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the SSH local-forward tunnel and its reconnect behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from services.ssh.tunnel import SshTunnel
+from settings import Settings
+
+
+class FakeListener:
+    """A minimal stand-in for `asyncssh.SSHListener`."""
+
+    def __init__(self, port: int) -> None:
+        self._port = port
+        self._closed_event = asyncio.Event()
+        self.closed = False
+
+    def get_port(self) -> int:
+        return self._port
+
+    def close(self) -> None:
+        self.closed = True
+        self._closed_event.set()
+
+    async def wait_closed(self) -> None:
+        await self._closed_event.wait()
+
+    def drop(self) -> None:
+        """Simulate the remote side dropping the connection (not a deliberate close)."""
+        self._closed_event.set()
+
+
+class FakeTransport:
+    """A minimal stand-in for `SshTransport`, tracking connect/close and one listener."""
+
+    def __init__(self, listener: FakeListener, *, fail_connect: bool = False) -> None:
+        self.listener = listener
+        self.fail_connect = fail_connect
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        if self.fail_connect:
+            raise ConnectionError("simulated connect failure")
+        self.connected = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def forward_local_port(self, remote_host: str, remote_port: int):
+        return self.listener
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        SSH_TUNNEL_RECONNECT_BUDGET_S=5,
+        SSH_TUNNEL_RECONNECT_BACKOFF_MAX_S=0.01,
+    )
+
+
+async def test_open_forwards_to_an_ephemeral_local_port(settings) -> None:
+    listener = FakeListener(port=54321)
+    transport = FakeTransport(listener)
+
+    tunnel = SshTunnel(lambda: transport, "127.0.0.1", 8080, settings)
+    await tunnel.open()
+
+    assert tunnel.local_port == 54321
+    assert transport.connected
+
+    await tunnel.close()
+    assert transport.closed
+    assert listener.closed
+
+
+async def test_local_port_raises_before_open(settings) -> None:
+    tunnel = SshTunnel(lambda: FakeTransport(FakeListener(1)), "127.0.0.1", 8080, settings)
+    with pytest.raises(RuntimeError):
+        _ = tunnel.local_port
+
+
+async def test_dropped_tunnel_reconnects_without_failing(settings) -> None:
+    """A dropped tunnel reconnects and resumes, rather than raising to the caller."""
+    first_listener = FakeListener(port=1111)
+    second_listener = FakeListener(port=2222)
+    transports = [FakeTransport(first_listener), FakeTransport(second_listener)]
+    calls = iter(transports)
+
+    tunnel = SshTunnel(lambda: next(calls), "127.0.0.1", 8080, settings)
+    await tunnel.open()
+    assert tunnel.local_port == 1111
+
+    # Simulate the network drop; the watchdog should reconnect on a new transport.
+    first_listener.drop()
+    for _ in range(50):
+        if tunnel.local_port == 2222:
+            break
+        await asyncio.sleep(0.01)
+
+    assert tunnel.local_port == 2222
+    await tunnel.close()
+
+
+async def test_reconnect_gives_up_after_budget_exhausted() -> None:
+    settings = Settings(SSH_TUNNEL_RECONNECT_BUDGET_S=0.05, SSH_TUNNEL_RECONNECT_BACKOFF_MAX_S=0.01)
+    listener = FakeListener(port=1111)
+    transport = FakeTransport(listener)
+
+    def open_transport():
+        return transport if not transport.connected else FakeTransport(listener, fail_connect=True)
+
+    tunnel = SshTunnel(open_transport, "127.0.0.1", 8080, settings)
+    await tunnel.open()
+
+    listener.drop()
+    await asyncio.sleep(0.2)  # let the watchdog exhaust its reconnect budget
+
+    # The tunnel gave up quietly (logged, not raised) - closing it must still be safe.
+    await tunnel.close()

--- a/application/backend/tests/services/ssh/test_tunnel.py
+++ b/application/backend/tests/services/ssh/test_tunnel.py
@@ -124,3 +124,45 @@ async def test_reconnect_gives_up_after_budget_exhausted() -> None:
 
     # The tunnel gave up quietly (logged, not raised) - closing it must still be safe.
     await tunnel.close()
+
+
+async def test_reconnect_closes_the_previous_transport_it_replaces(settings) -> None:
+    """A reconnect must never leak the connection it is replacing."""
+    first_listener = FakeListener(port=1111)
+    second_listener = FakeListener(port=2222)
+    first_transport = FakeTransport(first_listener)
+    second_transport = FakeTransport(second_listener)
+    transports = iter([first_transport, second_transport])
+
+    tunnel = SshTunnel(lambda: next(transports), "127.0.0.1", 8080, settings)
+    await tunnel.open()
+    assert tunnel.local_port == 1111
+
+    first_listener.drop()
+    for _ in range(50):
+        if tunnel.local_port == 2222:
+            break
+        await asyncio.sleep(0.01)
+
+    assert tunnel.local_port == 2222
+    # The dropped connection's transport must have been closed, not left open.
+    assert first_transport.closed
+
+    await tunnel.close()
+
+
+async def test_forward_failure_closes_the_newly_connected_transport(settings) -> None:
+    """A transport that connects but fails to forward must not be leaked."""
+
+    class _FailingForwardTransport(FakeTransport):
+        async def forward_local_port(self, remote_host: str, remote_port: int):
+            raise RuntimeError("simulated forward failure")
+
+    transport = _FailingForwardTransport(FakeListener(port=1111))
+
+    tunnel = SshTunnel(lambda: transport, "127.0.0.1", 8080, settings)
+    with pytest.raises(RuntimeError):
+        await tunnel.open()
+
+    assert transport.connected
+    assert transport.closed

--- a/application/backend/tests/trainer/test_health.py
+++ b/application/backend/tests/trainer/test_health.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 
 from trainer.main import health
-from trainer.schemas import _DEFAULT_PROTOCOL_VERSION
+from trainer.schemas import _DEFAULT_PROTOCOL_VERSION, _installed_library_version
 
 
 def test_health_reports_image_compatibility_metadata(monkeypatch) -> None:
@@ -28,6 +28,7 @@ def test_health_reports_image_compatibility_metadata(monkeypatch) -> None:
         "build_revision": "a" * 40,
         "build_date": "2026-07-14T08:00:00Z",
         "application_version": "0.1.0",
+        "library_version": _installed_library_version(),
     }
 
 
@@ -71,4 +72,5 @@ def test_health_endpoint_serializes_by_field_name_not_env_alias(monkeypatch) -> 
         "build_revision": "a" * 40,
         "build_date": "2026-07-14T08:00:00Z",
         "application_version": "0.1.0",
+        "library_version": _installed_library_version(),
     }

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -54,7 +54,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-08-10T09:40:54.561052Z"
+exclude-newer = "2026-08-10T12:09:19.303364Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -2572,6 +2572,7 @@ dependencies = [
     { name = "numpy" },
     { name = "omegaconf" },
     { name = "opencv-python" },
+    { name = "packaging" },
     { name = "physicalai", extra = ["capture", "robots", "transport"] },
     { name = "physicalai-studio-plugin" },
     { name = "physicalai-train", extra = ["pi0", "smolvla"] },
@@ -2650,6 +2651,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "opencv-python" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "physicalai", extras = ["robots", "capture", "transport"], git = "https://github.com/openvinotoolkit/physicalai.git?rev=2528309e55ab6a5f7f71c6dc23b8baae21f80108" },
     { name = "physicalai-studio-plugin", editable = "../plugin" },
     { name = "physicalai-train", extras = ["executorch"], marker = "extra == 'cpu'", editable = "../../library" },

--- a/application/docker/Dockerfile.trainer
+++ b/application/docker/Dockerfile.trainer
@@ -182,6 +182,11 @@ ARG GIT_SHA=unknown
 ARG BUILD_DATE=unknown
 ARG APPLICATION_VERSION=unknown
 ARG TRAINER_API_PROTOCOL_VERSION=1
+# Version of the installed `physicalai-train` package. Populated by CI from the
+# same wheel `uv sync` resolved into this image, so it can never drift from
+# what actually runs; read pre-pull by `services.ssh.docker_ops` via the
+# registry manifest, and re-confirmed at runtime by `/health`.
+ARG PHYSICALAI_TRAIN_VERSION=unknown
 LABEL org.opencontainers.image.source="https://github.com/open-edge-platform/physical-ai-studio" \
       org.opencontainers.image.description="Physical AI Studio remote CUDA training service" \
       org.opencontainers.image.revision="${GIT_SHA}" \
@@ -190,6 +195,7 @@ LABEL org.opencontainers.image.source="https://github.com/open-edge-platform/phy
       org.opencontainers.image.title="physicalai-trainer-cuda" \
       org.opencontainers.image.vendor="Open Edge Platform" \
       org.open-edge-platform.physicalai.trainer.api-protocol="${TRAINER_API_PROTOCOL_VERSION}" \
+      org.open-edge-platform.physicalai.trainer.library-version="${PHYSICALAI_TRAIN_VERSION}" \
       org.open-edge-platform.physicalai.trainer.device="cuda"
 ENV TRAINER_BUILD_REVISION="${GIT_SHA}" \
     TRAINER_BUILD_DATE="${BUILD_DATE}" \
@@ -203,6 +209,7 @@ ARG GIT_SHA=unknown
 ARG BUILD_DATE=unknown
 ARG APPLICATION_VERSION=unknown
 ARG TRAINER_API_PROTOCOL_VERSION=1
+ARG PHYSICALAI_TRAIN_VERSION=unknown
 LABEL org.opencontainers.image.source="https://github.com/open-edge-platform/physical-ai-studio" \
       org.opencontainers.image.description="Physical AI Studio remote Intel XPU training service" \
       org.opencontainers.image.revision="${GIT_SHA}" \
@@ -211,6 +218,7 @@ LABEL org.opencontainers.image.source="https://github.com/open-edge-platform/phy
       org.opencontainers.image.title="physicalai-trainer-xpu" \
       org.opencontainers.image.vendor="Open Edge Platform" \
       org.open-edge-platform.physicalai.trainer.api-protocol="${TRAINER_API_PROTOCOL_VERSION}" \
+      org.open-edge-platform.physicalai.trainer.library-version="${PHYSICALAI_TRAIN_VERSION}" \
       org.open-edge-platform.physicalai.trainer.device="xpu"
 ENV TRAINER_BUILD_REVISION="${GIT_SHA}" \
     TRAINER_BUILD_DATE="${BUILD_DATE}" \


### PR DESCRIPTION
## Description

Implements PR7 of the remote-ssh-trainer plan: secure lifecycle
management for a per-job trainer container over SSH.

- services/ssh/docker_ops.py: resolve the device-specific protocol-<N>
  trainer image to an immutable digest with no fallback tag, verify its
  cosign signature (fail closed), range-check the pre-pull
  library-version label against policy, wait out a busy GPU with
  exponential backoff and a give-up timeout, re-check free disk against
  the job's real snapshot size, build a least-privilege docker run
  invocation (loopback-only port, non-root, dropped capabilities, no
  --privileged, read-only root fs), and list/stop/remove
  management-labeled containers for the orphan sweep.
- services/ssh/tunnel.py: SSH local-forward tunnel with a reconnect
  watchdog and bounded retry budget, so a dropped tunnel resumes against
  the still-running container instead of failing the job.
- services/ssh/provisioning.py: SshProvisioningService orchestrates
  provision/reattach/teardown/sweep_orphans, persisting state via
  JobProvisioningRepository at each step and tearing down whatever was
  already started on any failure.
- core/backend_instance.py: a stable per-installation id persisted to
  disk, used as an ownership label so the orphan sweep never touches a
  container owned by a different Studio installation sharing the same
  remote server.
- trainer/schemas.py, Dockerfile.trainer: HealthInfo now reports
  library_version (read from installed package metadata); both trainer
  targets carry the org.open-edge-platform.physicalai.trainer.library-version
  OCI label.
- exceptions.py, settings.py: new actionable error types and SSH
  provisioning settings (GPU-wait backoff, container stop timeout,
  readiness/tunnel-reconnect budgets, cosign identity/issuer, minimum
  library version).

Wiring into TrainingWorker/get_training_backend is PR8; this module is
usable standalone against a JobProvisioningRepository and RemoteServer.
