### PR TITLE
feat(ssh-trainer): startup reattach recovery and orphan sweep wiring

### DIFF
--- a/application/backend/src/repositories/job_provisioning_repo.py
+++ b/application/backend/src/repositories/job_provisioning_repo.py
@@ -91,3 +91,19 @@ class JobProvisioningRepository(BaseRepository[JobProvisioning, JobProvisioningD
         )
         results = await self.db.execute(query)
         return [self.from_schema(model) for model in results.scalars().all()]
+
+    async def list_stale(self) -> list[JobProvisioning]:
+        """Return provisioning rows whose job has already reached a terminal state.
+
+        Recovers a row a crashed teardown left behind: `_teardown` deletes the
+        row only after stopping the container, so a crash between the two
+        leaves a row describing a job that will never run again.
+        """
+        query = (
+            select(JobProvisioningDB)
+            .join(JobDB, JobDB.id == JobProvisioningDB.job_id)
+            .where(JobDB.status.notin_(_NON_TERMINAL_JOB_STATUSES))
+            .order_by(JobProvisioningDB.created_at.asc())
+        )
+        results = await self.db.execute(query)
+        return [self.from_schema(model) for model in results.scalars().all()]

--- a/application/backend/src/repositories/job_provisioning_repo.py
+++ b/application/backend/src/repositories/job_provisioning_repo.py
@@ -92,6 +92,28 @@ class JobProvisioningRepository(BaseRepository[JobProvisioning, JobProvisioningD
         results = await self.db.execute(query)
         return [self.from_schema(model) for model in results.scalars().all()]
 
+    async def get_active_for_server(self, remote_server_id: str | UUID) -> JobProvisioning | None:
+        """Return the one provisioning row on this server whose job can still own a container.
+
+        Drives the remote-server status endpoint's ``in_use_by_job_id``: the
+        target-per-job serialization (`TrainingWorker._target_key`) guarantees at
+        most one job is ever actively provisioning/training on a given server at
+        a time, so at most one row is expected here even though the query does
+        not itself enforce that invariant.
+        """
+        query = (
+            select(JobProvisioningDB)
+            .join(JobDB, JobDB.id == JobProvisioningDB.job_id)
+            .where(
+                JobProvisioningDB.remote_server_id == self._id_to_str(remote_server_id),
+                JobDB.status.in_(_NON_TERMINAL_JOB_STATUSES),
+            )
+            .order_by(JobProvisioningDB.created_at.asc())
+        )
+        results = await self.db.execute(query)
+        model = results.scalars().first()
+        return self.from_schema(model) if model is not None else None
+
     async def list_stale(self) -> list[JobProvisioning]:
         """Return provisioning rows whose job has already reached a terminal state.
 

--- a/application/backend/src/services/ssh/docker_ops.py
+++ b/application/backend/src/services/ssh/docker_ops.py
@@ -61,6 +61,9 @@ MANAGED_LABEL: Final = "org.open-edge-platform.physicalai.managed"
 JOB_LABEL: Final = "org.open-edge-platform.physicalai.job-id"
 SERVER_LABEL: Final = "org.open-edge-platform.physicalai.server-id"
 INSTANCE_LABEL: Final = "org.open-edge-platform.physicalai.backend-instance-id"
+# Recorded so a reattach can detect drift between the persisted `JobProvisioningDB`
+# row and the container actually running, without a second registry round trip.
+IMAGE_DIGEST_LABEL: Final = "org.open-edge-platform.physicalai.image-digest"
 
 _CONTAINER_NAME_PREFIX: Final = "physicalai-trainer-"
 
@@ -131,20 +134,50 @@ def container_name(job_id: str) -> str:
     return f"{_CONTAINER_NAME_PREFIX}{job_id}"
 
 
-def management_labels(*, job_id: str, server_id: str, backend_instance_id: str) -> dict[str, str]:
+def management_labels(*, job_id: str, server_id: str, backend_instance_id: str, image_digest: str) -> dict[str, str]:
     """Return the labels every Studio-launched trainer container carries.
 
     `INSTANCE_LABEL` is the ownership marker the orphan sweep requires in
     addition to `MANAGED_LABEL`: a remote server can be shared by more than one
     Studio installation, and sweeping must never touch a container it merely
-    recognizes the shape of.
+    recognizes the shape of. `IMAGE_DIGEST_LABEL` lets a reattach detect that a
+    running container disagrees with the digest persisted for its job, without
+    a second registry call.
     """
     return {
         MANAGED_LABEL: "true",
         JOB_LABEL: job_id,
         SERVER_LABEL: server_id,
         INSTANCE_LABEL: backend_instance_id,
+        IMAGE_DIGEST_LABEL: image_digest,
     }
+
+
+@dataclass(frozen=True, slots=True)
+class ContainerInspection:
+    """A container's running state and labels, as reported by `docker inspect`."""
+
+    running: bool
+    labels: dict[str, str]
+
+
+async def inspect_container(transport: SshTransport, name_or_id: str) -> ContainerInspection | None:
+    """Inspect a container's running state and labels.
+
+    Returns:
+        ``None`` when the container does not exist at all. A container that
+        exists but is stopped is still returned, with ``running=False``.
+    """
+    running_result = await transport.run_command(["docker", "inspect", "--format", "{{.State.Running}}", name_or_id])
+    if not running_result.ok:
+        return None
+
+    labels_result = await transport.run_command(
+        ["docker", "inspect", "--format", "{{json .Config.Labels}}", name_or_id]
+    )
+    labels = _parse_json(labels_result.stdout) if labels_result.ok else None
+    labels = labels if isinstance(labels, dict) else {}
+    return ContainerInspection(running=running_result.first_line().lower() == "true", labels=labels)
 
 
 def _parse_json(text: str) -> object | None:

--- a/application/backend/src/services/ssh/provisioning.py
+++ b/application/backend/src/services/ssh/provisioning.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from enum import StrEnum
 from time import monotonic
 from typing import TYPE_CHECKING, Self
 
@@ -28,6 +29,10 @@ from loguru import logger
 
 from core.backend_instance import get_backend_instance_id
 from exceptions import (
+    SshConnectionError,
+    SshHostAliasNotFoundError,
+    SshHostKeyMismatchError,
+    SshHostKeyUnknownError,
     TrainerContainerLaunchError,
     TrainerLibraryVersionMismatchError,
     TrainerProtocolVersionMismatchError,
@@ -55,6 +60,54 @@ if TYPE_CHECKING:
 # never sets `TRAINER_PORT`, so this must match `TrainerSettings.port`'s
 # default and the Dockerfile's `EXPOSE`.
 TRAINER_CONTAINER_PORT = 8001
+
+
+class ReattachFailureReason(StrEnum):
+    """Why `verify_reattach` could not confirm a persisted job's container.
+
+    Each member drives a distinct recovery outcome (see
+    `services.ssh.recovery`): some are safe to tear down because ownership was
+    already established, some must never be touched because it wasn't, and some
+    are transient and should simply be retried on the next normal pickup.
+    """
+
+    # The container is gone entirely. Nothing to tear down.
+    CONTAINER_GONE = "container_gone"
+    # Ownership (backend_instance_id + job id labels) never matched. This may be
+    # another Studio installation's container - never touch it.
+    OWNERSHIP_MISMATCH = "ownership_mismatch"
+    # Ownership matched, but the running image disagrees with the persisted
+    # digest. Ownership is established, so this one is safe to tear down.
+    DIGEST_MISMATCH = "digest_mismatch"
+    # Ownership and digest matched, but `/health` never answered in time. May
+    # simply be slow to start; leave it for the next attempt.
+    HEALTH_NEVER_READY = "health_never_ready"
+    # The SSH host key could not be verified. Fails closed: never tear down a
+    # container it was not possible to authenticate the host for.
+    HOST_KEY_FAILURE = "host_key_failure"
+    # The alias is no longer in the user's SSH config. Cannot connect at all.
+    ALIAS_MISSING = "alias_missing"
+    # Connected before, but the host or the tunnel could not be reached this
+    # time. Transient; leave it for the next attempt.
+    PORT_UNREACHABLE = "port_unreachable"
+
+
+@dataclass(frozen=True, slots=True)
+class ReattachVerification:
+    """Outcome of confirming a persisted job's container is still trustworthy.
+
+    `verify_reattach` only classifies; it never tears a container down itself,
+    so a caller that conflates "could not verify" with "verified and is wrong"
+    can never destroy a container it simply failed to reach.
+    """
+
+    ok: bool
+    reason: ReattachFailureReason | None = None
+    detail: str | None = None
+    # True once ownership (backend_instance_id + job id labels) was positively
+    # confirmed, so a caller knows a subsequent teardown is provably this
+    # installation's own container and not a guess.
+    safe_to_teardown: bool = False
 
 
 @dataclass
@@ -209,7 +262,10 @@ class SshProvisioningService:
                     device_type=server.device_type,
                     name=name,
                     labels=docker_ops.management_labels(
-                        job_id=str(job_id), server_id=str(server.id), backend_instance_id=backend_instance_id
+                        job_id=str(job_id),
+                        server_id=str(server.id),
+                        backend_instance_id=backend_instance_id,
+                        image_digest=image.digest,
                     ),
                     remote_container_port=TRAINER_CONTAINER_PORT,
                     stop_timeout_s=settings.ssh_container_stop_timeout_s,
@@ -389,6 +445,90 @@ class SshProvisioningService:
             _server_alias=server.ssh_host_alias,
             _stop_timeout_s=settings.ssh_container_stop_timeout_s,
         )
+
+    # PLR0911: one return per classified outcome (see `ReattachFailureReason`) -
+    # a lookup table would obscure which branch establishes ownership and which
+    # never connects at all, and that distinction is what a caller relies on to
+    # decide what is safe to clean up.
+    async def verify_reattach(  # noqa: PLR0911
+        self, job_provisioning: JobProvisioning, server: RemoteServer
+    ) -> ReattachVerification:
+        """Confirm a persisted job's container is still trustworthy, without keeping a tunnel open.
+
+        Called once at studio startup, before `reattach` opens the tunnel the
+        training backend actually trains through - this only classifies
+        whether that later reattach should be trusted to proceed. A throwaway
+        tunnel is opened just long enough to confirm `/health` answers, then
+        closed immediately: leaving a tunnel open here would idle it for
+        however long the job takes to be picked back up.
+
+        Never tears a container down itself: every failure branch below is a
+        pure classification, so the caller decides what is safe to clean up.
+        """
+        name = job_provisioning.container_name
+        if name is None:
+            return ReattachVerification(
+                ok=False, reason=ReattachFailureReason.CONTAINER_GONE, detail="no container was ever launched"
+            )
+
+        settings = self._settings
+        try:
+            async with SshTransport(server.ssh_host_alias, settings) as transport:
+                inspection = await docker_ops.inspect_container(transport, name)
+                if inspection is None or not inspection.running:
+                    return ReattachVerification(ok=False, reason=ReattachFailureReason.CONTAINER_GONE)
+
+                backend_instance_id = get_backend_instance_id()
+                owner = inspection.labels.get(docker_ops.INSTANCE_LABEL)
+                job_label = inspection.labels.get(docker_ops.JOB_LABEL)
+                if owner != backend_instance_id or job_label != str(job_provisioning.job_id):
+                    return ReattachVerification(
+                        ok=False,
+                        reason=ReattachFailureReason.OWNERSHIP_MISMATCH,
+                        detail="the running container's ownership labels do not match this installation and job",
+                    )
+
+                digest_label = inspection.labels.get(docker_ops.IMAGE_DIGEST_LABEL)
+                if job_provisioning.image_digest and digest_label and digest_label != job_provisioning.image_digest:
+                    return ReattachVerification(
+                        ok=False,
+                        reason=ReattachFailureReason.DIGEST_MISMATCH,
+                        detail=(
+                            f"running image digest '{digest_label}' does not match "
+                            f"persisted '{job_provisioning.image_digest}'"
+                        ),
+                        safe_to_teardown=True,
+                    )
+        except SshHostAliasNotFoundError as error:
+            return ReattachVerification(ok=False, reason=ReattachFailureReason.ALIAS_MISSING, detail=str(error))
+        except (SshHostKeyUnknownError, SshHostKeyMismatchError) as error:
+            return ReattachVerification(ok=False, reason=ReattachFailureReason.HOST_KEY_FAILURE, detail=str(error))
+        except SshConnectionError as error:
+            return ReattachVerification(ok=False, reason=ReattachFailureReason.PORT_UNREACHABLE, detail=str(error))
+
+        # Ownership and digest are confirmed; open a throwaway tunnel just long
+        # enough to confirm `/health` answers, then close it. The real reattach
+        # (opened by `SshTrainingBackend` when the job is next picked up) gets
+        # its own, longer-lived tunnel.
+        tunnel = SshTunnel(
+            lambda: open_transport(server.ssh_host_alias, settings),
+            "127.0.0.1",
+            job_provisioning.remote_port or TRAINER_CONTAINER_PORT,
+            settings,
+        )
+        try:
+            await tunnel.open()
+            await self._await_ready(f"http://127.0.0.1:{tunnel.local_port}", server.name)
+        except TrainerReadinessTimeoutError as error:
+            return ReattachVerification(
+                ok=False, reason=ReattachFailureReason.HEALTH_NEVER_READY, detail=str(error), safe_to_teardown=True
+            )
+        except SshConnectionError as error:
+            return ReattachVerification(ok=False, reason=ReattachFailureReason.PORT_UNREACHABLE, detail=str(error))
+        finally:
+            await tunnel.close()
+
+        return ReattachVerification(ok=True, safe_to_teardown=True)
 
     async def teardown(self, job_id: UUID, server: RemoteServer) -> None:
         """Tear down a job's container by id, without an open tunnel.

--- a/application/backend/src/services/ssh/recovery.py
+++ b/application/backend/src/services/ssh/recovery.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Startup recovery for SSH-provisioned training jobs.
+
+Runs once at studio startup, before the generic orphan-job abort in
+`services.training_service.TrainingService.abort_orphan_jobs`. For every
+non-terminal job with a persisted `JobProvisioningDB` row, `recover_ssh_jobs`:
+
+1. Reconciles stale rows - a row whose job already reached a terminal state,
+   left behind by a crash between stopping a container and deleting its row.
+2. Verifies every remaining row's container with
+   `SshProvisioningService.verify_reattach`, and requeues (`PENDING`) or fails
+   the job depending on the outcome (see `ReattachFailureReason`).
+3. Sweeps orphan containers per configured server, excluding every job this
+   pass just confirmed or left pending - so a container reattach is about to
+   claim is never swept out from under it.
+
+Step order matters: sweeping runs last, and only after every non-terminal
+job's container has had a chance to be recognized as still claimed.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from core.logging.utils import job_logging_ctx
+from exceptions import ResourceNotFoundError
+from schemas.base_job import JobStatus
+from services.ssh.provisioning import ReattachFailureReason, SshProvisioningService
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from repositories.job_provisioning_repo import JobProvisioningRepository
+    from services.job_service import JobService
+    from services.remote_server_service import RemoteServerService
+    from settings import Settings
+
+# Reasons whose container is provably this installation's own and safe to
+# reclaim once the job is failed - the report never counts a foreign or
+# unreachable container as "cleaned up".
+_ACTIONABLE_MESSAGES: dict[ReattachFailureReason, str] = {
+    ReattachFailureReason.CONTAINER_GONE: "its trainer container is no longer running on the remote server",
+    ReattachFailureReason.OWNERSHIP_MISMATCH: (
+        "a container with its name exists but is not owned by this installation"
+    ),
+    ReattachFailureReason.DIGEST_MISMATCH: "its trainer container is running an unexpected image",
+    ReattachFailureReason.HOST_KEY_FAILURE: (
+        "the remote server's SSH host key could not be verified; accept its current fingerprint, then resubmit the job"
+    ),
+    ReattachFailureReason.ALIAS_MISSING: ("its remote server's SSH host alias is no longer present in the SSH config"),
+}
+
+# Outcomes left for the normal per-job reattach path to retry, rather than
+# failed outright: each is either transient (a slow-starting trainer, a flaky
+# network path) or an outcome this pass could not evaluate at all.
+_TRANSIENT_REASONS = frozenset({ReattachFailureReason.HEALTH_NEVER_READY, ReattachFailureReason.PORT_UNREACHABLE})
+
+
+@dataclass(frozen=True, slots=True)
+class SshRecoveryReport:
+    """Summary of one startup recovery pass, for a single structured log line."""
+
+    confirmed: int = 0
+    transient: int = 0
+    failed: int = 0
+    stale_rows_cleaned: int = 0
+    orphans_removed: int = 0
+    failures_by_reason: dict[str, int] = field(default_factory=dict)
+
+
+async def _reconcile_stale_rows(
+    provisioning_service: SshProvisioningService,
+    provisioning_repo: JobProvisioningRepository,
+    remote_server_service: RemoteServerService,
+) -> int:
+    """Tear down and drop provisioning rows whose job already finished."""
+    stale_rows = await provisioning_repo.list_stale()
+    cleaned = 0
+    for row in stale_rows:
+        with job_logging_ctx(job_id=str(row.job_id)):
+            try:
+                server = await remote_server_service.get_remote_server(row.remote_server_id)
+            except ResourceNotFoundError:
+                # The server itself is gone; there is nothing left to dial.
+                logger.warning(
+                    "Dropping stale provisioning row for job {}: remote server {} no longer registered",
+                    row.job_id,
+                    row.remote_server_id,
+                )
+                await provisioning_repo.delete_by_job_id(row.job_id)
+                cleaned += 1
+                continue
+            try:
+                await provisioning_service.teardown(row.job_id, server)
+            except Exception as error:  # one server's failure must not abort the pass
+                logger.warning(
+                    "Could not reconcile stale provisioning row for job {} on server '{}': {}",
+                    row.job_id,
+                    server.name,
+                    error,
+                )
+                continue
+            logger.info("Reconciled stale provisioning row for finished job {}", row.job_id)
+            cleaned += 1
+    return cleaned
+
+
+async def recover_ssh_jobs(
+    job_service: JobService,
+    provisioning_repo: JobProvisioningRepository,
+    remote_server_service: RemoteServerService,
+    settings: Settings | None = None,
+) -> SshRecoveryReport:
+    """Reattach or fail every SSH-provisioned job left non-terminal by a restart.
+
+    Safe to call with no SSH servers registered and no provisioning rows at
+    all: every step degrades to a no-op.
+    """
+    provisioning_service = SshProvisioningService(provisioning_repo, settings)
+    active_rows = await provisioning_repo.list_active()
+
+    stale_cleaned = await _reconcile_stale_rows(provisioning_service, provisioning_repo, remote_server_service)
+
+    confirmed = 0
+    transient = 0
+    failed = 0
+    failures_by_reason: dict[str, int] = defaultdict(int)
+    active_job_ids_by_server: dict[UUID, set[UUID]] = defaultdict(set)
+
+    for row in active_rows:
+        with job_logging_ctx(job_id=str(row.job_id)):
+            if row.container_name is None:
+                # Never got far enough to launch a container - nothing here for
+                # this pass to verify; leave it to the normal pickup path.
+                active_job_ids_by_server[row.remote_server_id].add(row.job_id)
+                transient += 1
+                continue
+
+            try:
+                server = await remote_server_service.get_remote_server(row.remote_server_id)
+            except ResourceNotFoundError:
+                logger.error("Failing job {}: remote server {} no longer registered", row.job_id, row.remote_server_id)
+                await job_service.update_job_status(
+                    job_id=row.job_id,
+                    status=JobStatus.FAILED,
+                    message="Training job failed: its remote server is no longer registered",
+                )
+                failed += 1
+                failures_by_reason["server_not_registered"] += 1
+                continue
+
+            outcome = await provisioning_service.verify_reattach(row, server)
+
+            if outcome.ok:
+                logger.info("Confirmed reattach for job {} on server '{}'", row.job_id, server.name)
+                active_job_ids_by_server[server.id].add(row.job_id)
+                confirmed += 1
+                continue
+
+            if outcome.reason in _TRANSIENT_REASONS:
+                logger.warning(
+                    "Reattach check for job {} on server '{}' was inconclusive ({}); leaving pending for retry: {}",
+                    row.job_id,
+                    server.name,
+                    outcome.reason,
+                    outcome.detail,
+                )
+                active_job_ids_by_server[server.id].add(row.job_id)
+                transient += 1
+                continue
+
+            message = (
+                _ACTIONABLE_MESSAGES.get(outcome.reason, "its trainer container could not be verified")
+                if outcome.reason is not None
+                else "its trainer container could not be verified"
+            )
+            logger.error("Failing job {} on server '{}': {} ({})", row.job_id, server.name, message, outcome.detail)
+            await job_service.update_job_status(
+                job_id=row.job_id,
+                status=JobStatus.FAILED,
+                message=f"Training job failed: {message}",
+            )
+            # A failed job is never added back to active_job_ids_by_server, so
+            # the sweep below reclaims its container - but only when ownership
+            # was actually established; a foreign container is never listed by
+            # the sweep in the first place (it filters on this installation's
+            # own backend_instance_id label).
+            failed += 1
+            if outcome.reason is not None:
+                failures_by_reason[outcome.reason.value] += 1
+
+    orphans_removed = 0
+    for server in await remote_server_service.list_remote_servers():
+        try:
+            removed = await provisioning_service.sweep_orphans(server, active_job_ids_by_server.get(server.id, set()))
+        except Exception as error:  # one server's failure must not abort the sweep of others
+            logger.warning("Could not sweep orphan containers on server '{}': {}", server.name, error)
+            continue
+        if removed:
+            logger.info("Swept {} orphan container(s) on server '{}'", len(removed), server.name)
+        orphans_removed += len(removed)
+
+    return SshRecoveryReport(
+        confirmed=confirmed,
+        transient=transient,
+        failed=failed,
+        stale_rows_cleaned=stale_cleaned,
+        orphans_removed=orphans_removed,
+        failures_by_reason=dict(failures_by_reason),
+    )
+
+
+__all__ = ["SshRecoveryReport", "recover_ssh_jobs"]

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -14,14 +14,17 @@ from loguru import logger
 
 from core.logging.utils import job_logging_ctx
 from db import get_async_db_session_ctx
+from repositories.job_provisioning_repo import JobProvisioningRepository
 from schemas import Job, Model, Snapshot
 from schemas.base_job import JobStatus
 from schemas.job import TrainingTarget, TrainJobPayload
 from services import DatasetService, ModelService
 from services.event_processor import EventType
 from services.job_service import JobService
+from services.remote_server_service import RemoteServerService
 from services.remote_trainer_service import RemoteTrainerService
 from services.snapshot_service import SnapshotService
+from services.ssh.recovery import recover_ssh_jobs
 from services.training_backends import (
     TrainingCanceledError,
     TrainingContext,
@@ -151,6 +154,10 @@ class TrainingWorker(BaseProcessWorker):
     async def setup(self) -> None:
         await super().setup()
         with logger.contextualize(worker=self.__class__.__name__):
+            # SSH recovery must run before the generic orphan abort: it confirms
+            # or fails each SSH job's container explicitly, so the generic pass
+            # only ever needs to catch a job this one somehow failed to reach.
+            await self._recover_ssh_jobs()
             await self._abort_orphan_jobs()
 
     async def teardown(self) -> None:
@@ -162,6 +169,24 @@ class TrainingWorker(BaseProcessWorker):
     async def _abort_orphan_jobs() -> None:
         async with get_async_db_session_ctx() as session:
             await TrainingService.abort_orphan_jobs(JobService(session, RemoteTrainerService(session)))
+
+    @staticmethod
+    async def _recover_ssh_jobs() -> None:
+        """Reattach or fail every SSH-provisioned job left non-terminal by a restart."""
+        async with get_async_db_session_ctx() as session:
+            provisioning_repo = JobProvisioningRepository(session)
+            remote_server_service = RemoteServerService(session)
+            job_service = JobService(session, RemoteTrainerService(session), remote_server_service)
+            report = await recover_ssh_jobs(job_service, provisioning_repo, remote_server_service)
+        logger.info(
+            "SSH job recovery: {} confirmed, {} pending retry, {} failed, {} stale row(s) cleaned, "
+            "{} orphan container(s) removed",
+            report.confirmed,
+            report.transient,
+            report.failed,
+            report.stale_rows_cleaned,
+            report.orphans_removed,
+        )
 
     @staticmethod
     async def _update_training_progress(

--- a/application/backend/tests/repositories/test_job_provisioning_repo.py
+++ b/application/backend/tests/repositories/test_job_provisioning_repo.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `JobProvisioningRepository.list_active` / `list_stale` against a real DB.
+
+Both drive startup recovery: `list_active` finds jobs whose container might
+still be reclaimable, `list_stale` finds provisioning rows a crashed teardown
+left behind for a job that already finished.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from db.schema import Base, JobProvisioningDB, ProjectDB, RemoteServerDB
+from repositories.job_provisioning_repo import JobProvisioningRepository
+from repositories.mappers.job_mapper import JobMapper
+from schemas.base_job import JobStatus
+from schemas.job import TrainingTarget, TrainJob, TrainJobPayload
+
+
+def _make_job(project_id, remote_server_id, status: JobStatus) -> TrainJob:
+    payload = TrainJobPayload(
+        project_id=project_id,
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="test-model",
+        training_target=TrainingTarget.SSH,
+        remote_server_id=remote_server_id,
+    )
+    return TrainJob(project_id=project_id, payload=payload, status=status, created_at=datetime.now(tz=UTC))
+
+
+def test_list_active_and_list_stale_partition_by_job_status() -> None:
+    """A PENDING/RUNNING job's row is active; a terminal job's row is stale."""
+
+    async def run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite://")
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        project_id = uuid4()
+        server_id = uuid4()
+
+        async with engine.begin() as connection:
+            await connection.run_sync(lambda sync_connection: Base.metadata.create_all(sync_connection))
+
+        async with session_factory() as session:
+            session.add(ProjectDB(id=str(project_id), name="Test project"))
+            session.add(
+                RemoteServerDB(id=str(server_id), name="Lab GPU box", ssh_host_alias="gpu-box", device_type="cuda")
+            )
+            await session.commit()
+
+            pending_job = JobMapper.to_schema(_make_job(project_id, server_id, JobStatus.PENDING))
+            running_job = JobMapper.to_schema(_make_job(project_id, server_id, JobStatus.RUNNING))
+            failed_job = JobMapper.to_schema(_make_job(project_id, server_id, JobStatus.FAILED))
+            session.add_all([pending_job, running_job, failed_job])
+            await session.commit()
+
+            session.add_all(
+                [
+                    JobProvisioningDB(
+                        job_id=pending_job.id,
+                        remote_server_id=str(server_id),
+                        ssh_host_alias="gpu-box",
+                        container_name="physicalai-trainer-pending",
+                    ),
+                    JobProvisioningDB(
+                        job_id=running_job.id,
+                        remote_server_id=str(server_id),
+                        ssh_host_alias="gpu-box",
+                        container_name="physicalai-trainer-running",
+                    ),
+                    JobProvisioningDB(
+                        job_id=failed_job.id,
+                        remote_server_id=str(server_id),
+                        ssh_host_alias="gpu-box",
+                        container_name="physicalai-trainer-failed",
+                    ),
+                ]
+            )
+            await session.commit()
+
+            repository = JobProvisioningRepository(session)
+            active = await repository.list_active()
+            stale = await repository.list_stale()
+
+            assert {str(row.job_id) for row in active} == {pending_job.id, running_job.id}
+            assert {str(row.job_id) for row in stale} == {failed_job.id}
+
+        await engine.dispose()
+
+    asyncio.run(run())

--- a/application/backend/tests/repositories/test_job_provisioning_repo.py
+++ b/application/backend/tests/repositories/test_job_provisioning_repo.py
@@ -1,11 +1,12 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for `JobProvisioningRepository.list_active` / `list_stale` against a real DB.
+"""Tests for `JobProvisioningRepository`'s active/stale queries against a real DB.
 
-Both drive startup recovery: `list_active` finds jobs whose container might
-still be reclaimable, `list_stale` finds provisioning rows a crashed teardown
-left behind for a job that already finished.
+`list_active` finds jobs whose container might still be reclaimable, `list_stale`
+finds provisioning rows a crashed teardown left behind for a job that already
+finished, and `get_active_for_server` narrows `list_active` to a single server
+(backing the remote-server status endpoint's `in_use_by_job_id`).
 """
 
 import asyncio
@@ -88,6 +89,74 @@ def test_list_active_and_list_stale_partition_by_job_status() -> None:
 
             assert {str(row.job_id) for row in active} == {pending_job.id, running_job.id}
             assert {str(row.job_id) for row in stale} == {failed_job.id}
+
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_get_active_for_server_returns_the_non_terminal_job_only() -> None:
+    """`get_active_for_server` backs the status endpoint's `in_use_by_job_id`.
+
+    A server with one terminal and one non-terminal provisioning row should
+    report only the non-terminal one; a server with no rows at all reports
+    `None`.
+    """
+
+    async def run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite://")
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        project_id = uuid4()
+        busy_server_id = uuid4()
+        idle_server_id = uuid4()
+
+        async with engine.begin() as connection:
+            await connection.run_sync(lambda sync_connection: Base.metadata.create_all(sync_connection))
+
+        async with session_factory() as session:
+            session.add(ProjectDB(id=str(project_id), name="Test project"))
+            session.add_all(
+                [
+                    RemoteServerDB(
+                        id=str(busy_server_id), name="Busy GPU box", ssh_host_alias="busy-box", device_type="cuda"
+                    ),
+                    RemoteServerDB(
+                        id=str(idle_server_id), name="Idle GPU box", ssh_host_alias="idle-box", device_type="cuda"
+                    ),
+                ]
+            )
+            await session.commit()
+
+            running_job = JobMapper.to_schema(_make_job(project_id, busy_server_id, JobStatus.RUNNING))
+            failed_job = JobMapper.to_schema(_make_job(project_id, busy_server_id, JobStatus.FAILED))
+            session.add_all([running_job, failed_job])
+            await session.commit()
+
+            session.add_all(
+                [
+                    JobProvisioningDB(
+                        job_id=failed_job.id,
+                        remote_server_id=str(busy_server_id),
+                        ssh_host_alias="busy-box",
+                        container_name="physicalai-trainer-failed",
+                    ),
+                    JobProvisioningDB(
+                        job_id=running_job.id,
+                        remote_server_id=str(busy_server_id),
+                        ssh_host_alias="busy-box",
+                        container_name="physicalai-trainer-running",
+                    ),
+                ]
+            )
+            await session.commit()
+
+            repository = JobProvisioningRepository(session)
+            active = await repository.get_active_for_server(busy_server_id)
+            idle = await repository.get_active_for_server(idle_server_id)
+
+            assert active is not None
+            assert str(active.job_id) == running_job.id
+            assert idle is None
 
         await engine.dispose()
 

--- a/application/backend/tests/services/ssh/test_docker_ops.py
+++ b/application/backend/tests/services/ssh/test_docker_ops.py
@@ -451,3 +451,56 @@ async def test_list_managed_containers_parses_docker_ps_json_lines() -> None:
     assert len(containers) == 1
     assert containers[0].container_id == "abc123"
     assert containers[0].job_id == "job1"
+
+
+# --------------------------------------------------------------------------- #
+# management_labels / inspect_container (reattach support)                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_management_labels_records_the_launched_image_digest() -> None:
+    labels = docker_ops.management_labels(
+        job_id="job1", server_id="server1", backend_instance_id="instance-1", image_digest=_DIGEST
+    )
+
+    assert labels[docker_ops.IMAGE_DIGEST_LABEL] == _DIGEST
+    assert labels[docker_ops.JOB_LABEL] == "job1"
+    assert labels[docker_ops.INSTANCE_LABEL] == "instance-1"
+
+
+async def test_inspect_container_returns_none_when_container_is_gone() -> None:
+    transport = FakeTransport({"docker inspect --format {{.State.Running}}": _fail("No such container")})
+
+    result = await docker_ops.inspect_container(transport, "physicalai-trainer-job1")
+
+    assert result is None
+
+
+async def test_inspect_container_reports_running_state_and_labels() -> None:
+    labels = {docker_ops.INSTANCE_LABEL: "instance-1", docker_ops.JOB_LABEL: "job1"}
+    transport = FakeTransport(
+        {
+            "docker inspect --format {{.State.Running}}": _ok("true\n"),
+            "docker inspect --format {{json .Config.Labels}}": _ok(json.dumps(labels)),
+        }
+    )
+
+    result = await docker_ops.inspect_container(transport, "physicalai-trainer-job1")
+
+    assert result is not None
+    assert result.running is True
+    assert result.labels == labels
+
+
+async def test_inspect_container_reports_stopped_state() -> None:
+    transport = FakeTransport(
+        {
+            "docker inspect --format {{.State.Running}}": _ok("false\n"),
+            "docker inspect --format {{json .Config.Labels}}": _ok("{}"),
+        }
+    )
+
+    result = await docker_ops.inspect_container(transport, "physicalai-trainer-job1")
+
+    assert result is not None
+    assert result.running is False

--- a/application/backend/tests/services/ssh/test_provisioning.py
+++ b/application/backend/tests/services/ssh/test_provisioning.py
@@ -19,6 +19,9 @@ from uuid import uuid4
 import pytest
 
 from exceptions import (
+    SshConnectionError,
+    SshHostAliasNotFoundError,
+    SshHostKeyMismatchError,
     TrainerContainerLaunchError,
     TrainerImageResolutionError,
     TrainerImageVerificationError,
@@ -32,7 +35,7 @@ from services.ssh import docker_ops
 from services.ssh import provisioning as provisioning_module
 from services.ssh.docker_ops import JOB_LABEL, LIBRARY_VERSION_LABEL, MANAGED_LABEL
 from services.ssh.preflight import PROTOCOL_LABEL
-from services.ssh.provisioning import SshProvisioningService
+from services.ssh.provisioning import ReattachFailureReason, SshProvisioningService
 from services.ssh.transport import CommandResult
 from services.training_backends.phase import PhaseKey
 
@@ -55,6 +58,19 @@ def _fail(stderr: str = "failed") -> CommandResult:
 
 def _server() -> RemoteServer:
     return RemoteServer(id=uuid4(), name="Lab GPU box", ssh_host_alias="gpu-box", device_type=DeviceType.CUDA)
+
+
+def _inspection_script(*, running: bool, labels: dict[str, str]) -> dict[str, CommandResult]:
+    """Script `docker inspect --format ...` for the two distinct calls `inspect_container` makes.
+
+    `_healthy_script()`'s single catch-all `"docker inspect"` key would match
+    both calls with the same reply, so these tests build the two format-scoped
+    keys directly instead.
+    """
+    return {
+        "docker inspect --format {{.State.Running}}": _ok(f"{str(running).lower()}\n"),
+        "docker inspect --format {{json .Config.Labels}}": _ok(json.dumps(labels)),
+    }
 
 
 def _healthy_script(container_id: str = "abc123", published_port: int = 54321) -> dict[str, CommandResult]:
@@ -400,3 +416,276 @@ async def test_sweep_orphans_never_touches_active_or_foreign_containers(
     removed = await service.sweep_orphans(server, active_job_ids={active_job_id})
 
     assert removed == [docker_ops.container_name(str(orphan_job_id))]
+
+
+# --------------------------------------------------------------------------- #
+# verify_reattach                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def _provisioning_row(server: RemoteServer, job_id, *, image_digest: str | None = _DIGEST) -> JobProvisioning:
+    return JobProvisioning(
+        job_id=job_id,
+        remote_server_id=server.id,
+        ssh_host_alias=server.ssh_host_alias,
+        container_name=docker_ops.container_name(str(job_id)),
+        remote_port=8080,
+        image_digest=image_digest,
+    )
+
+
+async def test_verify_reattach_confirms_a_healthy_owned_container(
+    _patch_transport_and_tunnel, repository, monkeypatch
+) -> None:
+    monkeypatch.setattr(provisioning_module, "get_backend_instance_id", lambda: "this-instance")
+    server = _server()
+    job_id = uuid4()
+    row = _provisioning_row(server, job_id)
+    await repository.save(row)
+    script = _healthy_script()
+    del script["docker inspect"]
+    script.update(
+        _inspection_script(
+            running=True,
+            labels={
+                docker_ops.INSTANCE_LABEL: "this-instance",
+                docker_ops.JOB_LABEL: str(job_id),
+                docker_ops.IMAGE_DIGEST_LABEL: _DIGEST,
+            },
+        )
+    )
+    _set_script(_patch_transport_and_tunnel, script)
+    service = SshProvisioningService(repository)
+
+    async def fake_ready(base_url, server_name):
+        return {"protocol_version": _PROTOCOL_VERSION}
+
+    service._await_ready = fake_ready  # type: ignore[method-assign]
+
+    result = await service.verify_reattach(row, server)
+
+    assert result.ok
+    assert result.reason is None
+    assert result.safe_to_teardown
+
+
+async def test_verify_reattach_reports_container_gone_when_no_container_was_ever_launched(
+    _patch_transport_and_tunnel, repository
+) -> None:
+    server = _server()
+    job_id = uuid4()
+    row = JobProvisioning(
+        job_id=job_id, remote_server_id=server.id, ssh_host_alias=server.ssh_host_alias, container_name=None
+    )
+    await repository.save(row)
+    service = SshProvisioningService(repository)
+
+    result = await service.verify_reattach(row, server)
+
+    assert not result.ok
+    assert result.reason is provisioning_module.ReattachFailureReason.CONTAINER_GONE
+    assert not result.safe_to_teardown
+
+
+async def test_verify_reattach_reports_container_gone_when_not_running(_patch_transport_and_tunnel, repository) -> None:
+    server = _server()
+    job_id = uuid4()
+    row = _provisioning_row(server, job_id)
+    await repository.save(row)
+    script = _healthy_script()
+    del script["docker inspect"]
+    script.update(_inspection_script(running=False, labels={}))
+    _set_script(_patch_transport_and_tunnel, script)
+    service = SshProvisioningService(repository)
+
+    result = await service.verify_reattach(row, server)
+
+    assert not result.ok
+    assert result.reason is ReattachFailureReason.CONTAINER_GONE
+    assert not result.safe_to_teardown
+
+
+async def test_verify_reattach_reports_ownership_mismatch_without_teardown(
+    _patch_transport_and_tunnel, repository, monkeypatch
+) -> None:
+    monkeypatch.setattr(provisioning_module, "get_backend_instance_id", lambda: "this-instance")
+    server = _server()
+    job_id = uuid4()
+    row = _provisioning_row(server, job_id)
+    await repository.save(row)
+    script = _healthy_script()
+    del script["docker inspect"]
+    script.update(
+        _inspection_script(
+            running=True,
+            labels={docker_ops.INSTANCE_LABEL: "some-other-instance", docker_ops.JOB_LABEL: str(job_id)},
+        )
+    )
+    _set_script(_patch_transport_and_tunnel, script)
+    service = SshProvisioningService(repository)
+
+    result = await service.verify_reattach(row, server)
+
+    assert not result.ok
+    assert result.reason is ReattachFailureReason.OWNERSHIP_MISMATCH
+    # Ownership was never established, so a caller must never tear this down -
+    # it may belong to another Studio installation.
+    assert not result.safe_to_teardown
+
+
+async def test_verify_reattach_reports_digest_mismatch_and_allows_teardown(
+    _patch_transport_and_tunnel, repository, monkeypatch
+) -> None:
+    monkeypatch.setattr(provisioning_module, "get_backend_instance_id", lambda: "this-instance")
+    server = _server()
+    job_id = uuid4()
+    row = _provisioning_row(server, job_id, image_digest=_DIGEST)
+    await repository.save(row)
+    script = _healthy_script()
+    del script["docker inspect"]
+    script.update(
+        _inspection_script(
+            running=True,
+            labels={
+                docker_ops.INSTANCE_LABEL: "this-instance",
+                docker_ops.JOB_LABEL: str(job_id),
+                docker_ops.IMAGE_DIGEST_LABEL: "sha256:" + "f" * 64,
+            },
+        )
+    )
+    _set_script(_patch_transport_and_tunnel, script)
+    service = SshProvisioningService(repository)
+
+    result = await service.verify_reattach(row, server)
+
+    assert not result.ok
+    assert result.reason is ReattachFailureReason.DIGEST_MISMATCH
+    # Ownership was confirmed, so this one is provably ours to reclaim.
+    assert result.safe_to_teardown
+
+
+async def test_verify_reattach_reports_health_never_ready_as_transient(
+    _patch_transport_and_tunnel, repository, monkeypatch
+) -> None:
+    monkeypatch.setattr(provisioning_module, "get_backend_instance_id", lambda: "this-instance")
+    server = _server()
+    job_id = uuid4()
+    row = _provisioning_row(server, job_id)
+    await repository.save(row)
+    script = _healthy_script()
+    del script["docker inspect"]
+    script.update(
+        _inspection_script(
+            running=True,
+            labels={
+                docker_ops.INSTANCE_LABEL: "this-instance",
+                docker_ops.JOB_LABEL: str(job_id),
+                docker_ops.IMAGE_DIGEST_LABEL: _DIGEST,
+            },
+        )
+    )
+    _set_script(_patch_transport_and_tunnel, script)
+    service = SshProvisioningService(repository)
+
+    async def never_ready(base_url, server_name):
+        raise TrainerReadinessTimeoutError(server_name, "no response")
+
+    service._await_ready = never_ready  # type: ignore[method-assign]
+
+    result = await service.verify_reattach(row, server)
+
+    assert not result.ok
+    assert result.reason is ReattachFailureReason.HEALTH_NEVER_READY
+    assert result.safe_to_teardown
+
+
+async def test_verify_reattach_reports_host_key_failure_without_teardown(
+    _patch_transport_and_tunnel, repository, monkeypatch
+) -> None:
+    server = _server()
+    job_id = uuid4()
+    row = _provisioning_row(server, job_id)
+    await repository.save(row)
+
+    class _RaisingTransport:
+        def __init__(self, alias, settings=None) -> None:
+            self._alias = alias
+
+        async def __aenter__(self):
+            raise SshHostKeyMismatchError(self._alias)
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    monkeypatch.setattr(provisioning_module, "SshTransport", _RaisingTransport)
+    service = SshProvisioningService(repository)
+
+    result = await service.verify_reattach(row, server)
+
+    assert not result.ok
+    assert result.reason is ReattachFailureReason.HOST_KEY_FAILURE
+    assert not result.safe_to_teardown
+
+
+async def test_verify_reattach_reports_alias_missing_without_teardown(
+    _patch_transport_and_tunnel, repository, monkeypatch
+) -> None:
+    server = _server()
+    job_id = uuid4()
+    row = _provisioning_row(server, job_id)
+    await repository.save(row)
+
+    class _RaisingTransport:
+        def __init__(self, alias, settings=None) -> None:
+            self._alias = alias
+
+        async def __aenter__(self):
+            raise SshHostAliasNotFoundError(self._alias)
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    monkeypatch.setattr(provisioning_module, "SshTransport", _RaisingTransport)
+    service = SshProvisioningService(repository)
+
+    result = await service.verify_reattach(row, server)
+
+    assert not result.ok
+    assert result.reason is ReattachFailureReason.ALIAS_MISSING
+    assert not result.safe_to_teardown
+
+
+async def test_verify_reattach_reports_port_unreachable_when_tunnel_fails(
+    _patch_transport_and_tunnel, repository, monkeypatch
+) -> None:
+    monkeypatch.setattr(provisioning_module, "get_backend_instance_id", lambda: "this-instance")
+    server = _server()
+    job_id = uuid4()
+    row = _provisioning_row(server, job_id)
+    await repository.save(row)
+    script = _healthy_script()
+    del script["docker inspect"]
+    script.update(
+        _inspection_script(
+            running=True,
+            labels={
+                docker_ops.INSTANCE_LABEL: "this-instance",
+                docker_ops.JOB_LABEL: str(job_id),
+                docker_ops.IMAGE_DIGEST_LABEL: _DIGEST,
+            },
+        )
+    )
+    _set_script(_patch_transport_and_tunnel, script)
+
+    class _FailingTunnel(FakeSshTunnel):
+        async def open(self) -> None:
+            raise SshConnectionError(server.ssh_host_alias, reason="unreachable")
+
+    monkeypatch.setattr(provisioning_module, "SshTunnel", _FailingTunnel)
+    service = SshProvisioningService(repository)
+
+    result = await service.verify_reattach(row, server)
+
+    assert not result.ok
+    assert result.reason is ReattachFailureReason.PORT_UNREACHABLE
+    assert not result.safe_to_teardown

--- a/application/backend/tests/services/ssh/test_recovery.py
+++ b/application/backend/tests/services/ssh/test_recovery.py
@@ -1,0 +1,247 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for SSH startup recovery orchestration.
+
+`SshProvisioningService` itself is faked out entirely: these tests prove the
+*orchestration* - reconciling stale rows, classifying each active row's
+`verify_reattach` outcome, and excluding the right job ids from the per-server
+sweep - independent of the real docker/SSH calls `verify_reattach` makes
+(covered in `test_provisioning.py`).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from exceptions import ResourceNotFoundError, ResourceType
+from schemas.hardware import DeviceType
+from schemas.job_provisioning import JobProvisioning
+from schemas.remote_server import RemoteServer
+from services.ssh import recovery as recovery_module
+from services.ssh.provisioning import ReattachFailureReason, ReattachVerification
+from services.ssh.recovery import recover_ssh_jobs
+
+
+def _server(name: str = "Lab GPU box") -> RemoteServer:
+    return RemoteServer(id=uuid4(), name=name, ssh_host_alias="gpu-box", device_type=DeviceType.CUDA)
+
+
+def _row(server: RemoteServer, *, container_name: str | None = "physicalai-trainer-job") -> JobProvisioning:
+    return JobProvisioning(
+        job_id=uuid4(), remote_server_id=server.id, ssh_host_alias=server.ssh_host_alias, container_name=container_name
+    )
+
+
+class FakeProvisioningRepository:
+    """Stands in for `JobProvisioningRepository`: only the methods recovery calls."""
+
+    def __init__(self, active: list[JobProvisioning], stale: list[JobProvisioning] | None = None) -> None:
+        self._active = list(active)
+        self._stale = list(stale or [])
+        self.deleted: list = []
+
+    async def list_active(self) -> list[JobProvisioning]:
+        return list(self._active)
+
+    async def list_stale(self) -> list[JobProvisioning]:
+        return list(self._stale)
+
+    async def delete_by_job_id(self, job_id) -> None:
+        self.deleted.append(job_id)
+
+
+class FakeRemoteServerService:
+    """Stands in for `RemoteServerService`."""
+
+    def __init__(self, servers: list[RemoteServer]) -> None:
+        self._servers = {server.id: server for server in servers}
+
+    async def get_remote_server(self, remote_server_id) -> RemoteServer:
+        server = self._servers.get(remote_server_id)
+        if server is None:
+            raise ResourceNotFoundError(ResourceType.REMOTE_SERVER, str(remote_server_id))
+        return server
+
+    async def list_remote_servers(self) -> list[RemoteServer]:
+        return list(self._servers.values())
+
+
+class FakeJobService:
+    """Stands in for `JobService`: records every terminal-status write."""
+
+    def __init__(self) -> None:
+        self.status_updates: list[tuple] = []
+
+    async def update_job_status(self, *, job_id, status, message=None, **kwargs) -> None:
+        self.status_updates.append((job_id, status, message))
+
+
+class FakeProvisioningService:
+    """Stands in for `SshProvisioningService`, scripted per test.
+
+    Recovery constructs this itself (`SshProvisioningService(provisioning_repo,
+    settings)`), so the class - not an instance - is monkeypatched in; the
+    scripted outcomes and call log live on class-level state reset per test via
+    the `_fake_provisioning_service` fixture.
+    """
+
+    verify_outcomes: dict = {}
+    sweep_results: dict = {}
+    teardown_calls: list = []
+    verify_calls: list = []
+    sweep_calls: list = []
+
+    def __init__(self, repository, settings=None) -> None:
+        self._repository = repository
+
+    async def teardown(self, job_id, server) -> None:
+        FakeProvisioningService.teardown_calls.append(job_id)
+        await self._repository.delete_by_job_id(job_id)
+
+    async def verify_reattach(self, row: JobProvisioning, server: RemoteServer) -> ReattachVerification:
+        FakeProvisioningService.verify_calls.append(row.job_id)
+        return FakeProvisioningService.verify_outcomes[row.job_id]
+
+    async def sweep_orphans(self, server: RemoteServer, active_job_ids: set) -> list[str]:
+        FakeProvisioningService.sweep_calls.append((server.id, frozenset(active_job_ids)))
+        return FakeProvisioningService.sweep_results.get(server.id, [])
+
+
+@pytest.fixture(autouse=True)
+def _fake_provisioning_service(monkeypatch):
+    FakeProvisioningService.verify_outcomes = {}
+    FakeProvisioningService.sweep_results = {}
+    FakeProvisioningService.teardown_calls = []
+    FakeProvisioningService.verify_calls = []
+    FakeProvisioningService.sweep_calls = []
+    monkeypatch.setattr(recovery_module, "SshProvisioningService", FakeProvisioningService)
+    yield
+
+
+async def test_confirmed_job_is_excluded_from_orphan_sweep() -> None:
+    server = _server()
+    row = _row(server)
+    FakeProvisioningService.verify_outcomes[row.job_id] = ReattachVerification(ok=True)
+
+    job_service = FakeJobService()
+    report = await recover_ssh_jobs(job_service, FakeProvisioningRepository([row]), FakeRemoteServerService([server]))
+
+    assert report.confirmed == 1
+    assert report.failed == 0
+    assert job_service.status_updates == []
+    assert FakeProvisioningService.sweep_calls == [(server.id, frozenset({row.job_id}))]
+
+
+async def test_unrecoverable_outcome_fails_the_job_and_is_excluded_from_active_set() -> None:
+    server = _server()
+    row = _row(server)
+    FakeProvisioningService.verify_outcomes[row.job_id] = ReattachVerification(
+        ok=False, reason=ReattachFailureReason.CONTAINER_GONE
+    )
+
+    job_service = FakeJobService()
+    report = await recover_ssh_jobs(job_service, FakeProvisioningRepository([row]), FakeRemoteServerService([server]))
+
+    assert report.failed == 1
+    assert report.confirmed == 0
+    assert len(job_service.status_updates) == 1
+    failed_job_id, status, message = job_service.status_updates[0]
+    assert failed_job_id == row.job_id
+    assert status.value == "failed"
+    assert "no longer running" in message
+    # Excluded from the active set the sweep is told about, so its container
+    # (if this installation still owns one) is reclaimed by the sweep.
+    assert FakeProvisioningService.sweep_calls == [(server.id, frozenset())]
+
+
+async def test_transient_outcome_leaves_job_pending_but_still_excludes_it_from_sweep() -> None:
+    """Transient outcomes are neither failed nor torn down; they stay claimed by this job."""
+    server = _server()
+    row = _row(server)
+    FakeProvisioningService.verify_outcomes[row.job_id] = ReattachVerification(
+        ok=False, reason=ReattachFailureReason.HEALTH_NEVER_READY
+    )
+
+    job_service = FakeJobService()
+    report = await recover_ssh_jobs(job_service, FakeProvisioningRepository([row]), FakeRemoteServerService([server]))
+
+    assert report.transient == 1
+    assert report.failed == 0
+    assert job_service.status_updates == []
+    # Still claimed - a transient outcome does not lose its exclusion from the sweep.
+    assert FakeProvisioningService.sweep_calls == [(server.id, frozenset({row.job_id}))]
+
+
+async def test_row_with_no_container_yet_is_transient_and_never_calls_verify_reattach() -> None:
+    server = _server()
+    row = _row(server, container_name=None)
+
+    job_service = FakeJobService()
+    report = await recover_ssh_jobs(job_service, FakeProvisioningRepository([row]), FakeRemoteServerService([server]))
+
+    assert report.transient == 1
+    assert FakeProvisioningService.verify_calls == []
+    assert FakeProvisioningService.sweep_calls == [(server.id, frozenset({row.job_id}))]
+
+
+async def test_reattach_verification_runs_before_the_orphan_sweep() -> None:
+    server = _server()
+    row = _row(server)
+    FakeProvisioningService.verify_outcomes[row.job_id] = ReattachVerification(ok=True)
+
+    await recover_ssh_jobs(FakeJobService(), FakeProvisioningRepository([row]), FakeRemoteServerService([server]))
+
+    assert FakeProvisioningService.verify_calls == [row.job_id]
+    assert len(FakeProvisioningService.sweep_calls) == 1
+
+
+async def test_stale_rows_are_torn_down_and_deleted_before_active_rows_are_processed() -> None:
+    server = _server()
+    stale_row = _row(server)
+    active_row = _row(server)
+    FakeProvisioningService.verify_outcomes[active_row.job_id] = ReattachVerification(ok=True)
+
+    repo = FakeProvisioningRepository([active_row], stale=[stale_row])
+    report = await recover_ssh_jobs(FakeJobService(), repo, FakeRemoteServerService([server]))
+
+    assert report.stale_rows_cleaned == 1
+    assert FakeProvisioningService.teardown_calls == [stale_row.job_id]
+    assert repo.deleted == [stale_row.job_id]
+    # The stale row was never handed to verify_reattach.
+    assert FakeProvisioningService.verify_calls == [active_row.job_id]
+
+
+async def test_stale_row_for_a_deregistered_server_is_dropped_without_a_teardown_attempt() -> None:
+    server = _server()
+    stale_row = _row(server)
+    repo = FakeProvisioningRepository([], stale=[stale_row])
+    # No server registered at all: `get_remote_server` always raises.
+    report = await recover_ssh_jobs(FakeJobService(), repo, FakeRemoteServerService([]))
+
+    assert report.stale_rows_cleaned == 1
+    assert FakeProvisioningService.teardown_calls == []
+    assert repo.deleted == [stale_row.job_id]
+
+
+async def test_missing_server_fails_the_active_job_without_touching_other_servers() -> None:
+    known_server = _server("Known box")
+    row_for_missing_server = JobProvisioning(
+        job_id=uuid4(), remote_server_id=uuid4(), ssh_host_alias="ghost", container_name="physicalai-trainer-ghost"
+    )
+    row_for_known_server = _row(known_server)
+    FakeProvisioningService.verify_outcomes[row_for_known_server.job_id] = ReattachVerification(ok=True)
+
+    job_service = FakeJobService()
+    repo = FakeProvisioningRepository([row_for_missing_server, row_for_known_server])
+    report = await recover_ssh_jobs(job_service, repo, FakeRemoteServerService([known_server]))
+
+    assert report.failed == 1
+    assert report.confirmed == 1
+    assert job_service.status_updates[0][0] == row_for_missing_server.job_id
+    assert job_service.status_updates[0][1].value == "failed"
+    # Only the known server was ever swept - there is no transport to dial for
+    # a server that no longer exists.
+    assert [server_id for server_id, _ in FakeProvisioningService.sweep_calls] == [known_server.id]

--- a/application/backend/tests/workers/test_training_worker.py
+++ b/application/backend/tests/workers/test_training_worker.py
@@ -488,6 +488,52 @@ class TestTargetKey:
         assert "None" not in second_key
 
 
+class TestSetupRecovery:
+    """`setup()` must recover SSH jobs before the generic orphan abort runs."""
+
+    @pytest.mark.anyio
+    async def test_setup_runs_ssh_recovery_before_generic_orphan_abort(self, worker) -> None:
+        from workers.training_worker import TrainingWorker
+
+        calls: list[str] = []
+
+        async def fake_recover_ssh_jobs() -> None:
+            calls.append("recover_ssh_jobs")
+
+        async def fake_abort_orphan_jobs() -> None:
+            calls.append("abort_orphan_jobs")
+
+        with (
+            patch.object(TrainingWorker, "_recover_ssh_jobs", staticmethod(fake_recover_ssh_jobs)),
+            patch.object(TrainingWorker, "_abort_orphan_jobs", staticmethod(fake_abort_orphan_jobs)),
+            patch(f"{MODULE}.BaseProcessWorker.setup", new=AsyncMock()),
+        ):
+            await worker.setup()
+
+        assert calls == ["recover_ssh_jobs", "abort_orphan_jobs"]
+
+    @pytest.mark.anyio
+    async def test_recover_ssh_jobs_wires_recovery_dependencies(self, worker) -> None:
+        """`_recover_ssh_jobs` builds the repo/service trio and logs the report."""
+        from services.ssh.recovery import SshRecoveryReport
+
+        report = SshRecoveryReport(confirmed=1, transient=2, failed=3, stale_rows_cleaned=4, orphans_removed=5)
+
+        with (
+            patch(f"{MODULE}.JobProvisioningRepository") as MockProvisioningRepo,
+            patch(f"{MODULE}.RemoteServerService") as MockRemoteServerService,
+            patch(f"{MODULE}.JobService") as MockJobService,
+            patch(f"{MODULE}.recover_ssh_jobs", AsyncMock(return_value=report)) as mock_recover,
+        ):
+            await worker._recover_ssh_jobs()
+
+            mock_recover.assert_awaited_once_with(
+                MockJobService.return_value,
+                MockProvisioningRepo.return_value,
+                MockRemoteServerService.return_value,
+            )
+
+
 class TestTrainingScheduling:
     @pytest.mark.anyio
     async def test_jobs_on_distinct_targets_start_without_waiting(self, worker) -> None:


### PR DESCRIPTION
## Description
Adds startup recovery for SSH-provisioned training jobs, run from
TrainingWorker.setup() before the generic orphan-job abort:

- services.ssh.provisioning.SshProvisioningService.verify_reattach
  classifies a persisted job's container without keeping a tunnel open:
  confirms it is running, owned by this backend_instance_id, and running
  the persisted image digest, then re-verifies /health through a
  throwaway tunnel. Each failure (container gone, ownership mismatch,
  digest mismatch, health never ready, host-key failure, alias missing,
  port unreachable) is a distinct ReattachFailureReason, so a caller
  never conflates "could not verify" with "verified and is wrong".
- docker_ops gains inspect_container (running state + labels) and an
  IMAGE_DIGEST_LABEL recorded on launch, so a reattach can detect drift
  without a second registry call.
- services.ssh.recovery.recover_ssh_jobs orchestrates one startup pass:
  reconciles JobProvisioningDB rows left behind by a crashed teardown for
  an already-terminal job, verifies every non-terminal job's container
  and fails or leaves it pending for the normal per-job reattach
  depending on the outcome, then sweeps orphan containers per server
  excluding every job this pass just confirmed or left pending - so a
  container about to be reattached to is never swept out from under it.
- JobProvisioningRepository gains list_stale() for the first step above.
- TrainingWorker.setup() now calls the new recovery pass before the
  existing generic abort_orphan_jobs, so SSH jobs get their
  container-aware recovery first and the generic pass only ever needs to
  catch what this one somehow missed.

Tests cover every ReattachFailureReason branch, the recovery
orchestration (reattach-before-sweep, exclusion, stale-row
reconciliation, per-server failure isolation), a real-DB test for
list_active/list_stale, and the worker wiring.