### PR TITLE
feat(ssh-trainer): backend enablement switch

### DIFF
--- a/application/backend/.env.example
+++ b/application/backend/.env.example
@@ -22,6 +22,13 @@ ENVIRONMENT=dev
 # Seconds to wait between chunks while streaming the model artifact.
 # TRAINER_DOWNLOAD_READ_TIMEOUT_S=120.0
 
+# SSH-provisioned remote training: off by default. Has no authentication
+# model, so only enable it on a single-user localhost workstation - never on
+# a shared or network-reachable HOST. See docs/ssh-remote-trainer.md before
+# turning this on. The backend also fails this closed at startup if HOST is
+# not a loopback address, regardless of this setting.
+# SSH_REMOTE_TRAINER_ENABLED=false
+
 # Server
 HOST=0.0.0.0
 PORT=7860

--- a/application/backend/README.md
+++ b/application/backend/README.md
@@ -87,6 +87,11 @@ Physical AI Trainer service from
 as a remote trainer in the Studio UI. The backend sends dataset snapshots to
 the service, monitors the training job, and imports the resulting model.
 
+Alternatively, the backend can provision a job-scoped trainer over SSH on a
+server you can reach directly. This feature is off by default and has no
+authentication model of its own — see
+[`docs/ssh-remote-trainer.md`](docs/ssh-remote-trainer.md) before enabling it.
+
 ### Database Migrations
 
 ```bash

--- a/application/backend/docs/ssh-remote-trainer.md
+++ b/application/backend/docs/ssh-remote-trainer.md
@@ -1,0 +1,86 @@
+# SSH remote-trainer feature
+
+The SSH remote-trainer feature lets the Studio backend provision a training
+job on a GPU server it can reach over SSH: it copies/starts a job-scoped
+trainer container on that server, tunnels to it over the SSH connection, and
+runs the job exactly like a locally-registered remote trainer (see
+[`remote-trainer.md`](./remote-trainer.md) for what runs on the server side).
+
+## Master switch
+
+The feature is **off by default** and must be explicitly enabled:
+
+```dotenv
+SSH_REMOTE_TRAINER_ENABLED=true
+```
+
+> [!WARNING]
+> This feature has no authentication model of its own. Anyone who can reach
+> the backend's API can ask it to run arbitrary training jobs — and therefore
+> arbitrary code as root inside a container — on every server registered in
+> Studio. A compromised backend process can also reach every identity loaded
+> in the operating user's SSH agent, not just the registered servers. Only
+> enable it on a single-user localhost workstation that nobody else can reach.
+
+## Fail-closed loopback enforcement
+
+Turning the setting on is not sufficient by itself. At startup (and whenever
+`cli.serve.start_server` reconciles the actual `--host`/`--port` bind
+arguments), the backend re-evaluates whether it is safe to serve the feature:
+
+- If `SSH_REMOTE_TRAINER_ENABLED` is `false` (the default), the feature is
+  simply off.
+- If it is `true` **and** the backend is bound to a loopback address
+  (`127.0.0.1`, `::1`, or `localhost`), the feature is active.
+- If it is `true` **and** the backend is bound to anything else (including
+  the packaged default `HOST=0.0.0.0`), the feature fails closed: it behaves
+  as if it were disabled, and the backend logs a `critical` startup message
+  explaining why.
+
+This check lives in `core.security.ssh_network_exposure` and is applied in
+two independent places so a change in configuration is never enough on its
+own to expose the feature, and a job that made it past submission is never
+enough on its own to let it run:
+
+- `api.dependencies.require_ssh_feature_active` — gates
+  `GET /api/remote-servers` (and any future SSH-provisioning route) with a
+  `503` when the feature is inactive.
+- `services.job_service.JobService.submit_train_job` — refuses to accept a
+  new SSH-target job when the feature is inactive at submission time.
+- `services.training_backends.get_training_backend` — refuses to dispatch an
+  already-queued SSH-target job when the feature is inactive at pickup time,
+  so a job that was accepted while the feature was active does not silently
+  run after a restart changed the configuration or the bind address.
+
+## Checking the feature's status
+
+`GET /api/remote-servers/feature-status` is unauthenticated by design (an
+authenticated status check would be circular — the UI needs the status *to
+explain* why the gated endpoints are unavailable) and returns:
+
+```json
+{
+  "enabled": false,
+  "network_exposed": false,
+  "reason": null
+}
+```
+
+`reason`, when present, never names a host alias, container, or other
+registered-server detail: it only ever explains the network-exposure
+condition, since this endpoint (and the equivalent startup log line) can be
+reached without authentication.
+
+## Staged rollout guidance
+
+- Keep `SSH_REMOTE_TRAINER_ENABLED=false` (the default) for any deployment
+  that is not a single operator's own workstation.
+- When enabling it, also confirm `HOST` is a loopback address
+  (`127.0.0.1`/`::1`) — the default packaged `HOST=0.0.0.0` will cause the
+  feature to fail closed even with the switch on.
+- Treat a `critical`-level `"SSH remote-trainer feature disabled at
+  startup"` log line as an operator action item: either narrow `HOST` to a
+  loopback address, or turn the feature off.
+- Review [`remote-trainer.md`](./remote-trainer.md) for the server-side
+  container image, network, and authentication expectations before
+  registering any remote server.

--- a/application/backend/docs/ssh-remote-trainer.md
+++ b/application/backend/docs/ssh-remote-trainer.md
@@ -31,9 +31,11 @@ arguments), the backend re-evaluates whether it is safe to serve the feature:
 - If `SSH_REMOTE_TRAINER_ENABLED` is `false` (the default), the feature is
   simply off.
 - If it is `true` **and** the backend is bound to a loopback address
-  (`127.0.0.1`, `::1`, or `localhost`), the feature is active.
+  (`127.0.0.1`, `::1`, or `localhost` — the packaged default), the feature is
+  active.
 - If it is `true` **and** the backend is bound to anything else (including
-  the packaged default `HOST=0.0.0.0`), the feature fails closed: it behaves
+  `HOST=0.0.0.0`, as set by the packaged Docker Compose file), the feature
+  fails closed: it behaves
   as if it were disabled, and the backend logs a `critical` startup message
   explaining why.
 
@@ -76,7 +78,8 @@ reached without authentication.
 - Keep `SSH_REMOTE_TRAINER_ENABLED=false` (the default) for any deployment
   that is not a single operator's own workstation.
 - When enabling it, also confirm `HOST` is a loopback address
-  (`127.0.0.1`/`::1`) — the default packaged `HOST=0.0.0.0` will cause the
+  (`127.0.0.1`/`::1`, the packaged default) — running under the Docker Compose
+  deployment, which sets `HOST=0.0.0.0`, will cause the
   feature to fail closed even with the switch on.
 - Treat a `critical`-level `"SSH remote-trainer feature disabled at
   startup"` log line as an operator action item: either narrow `HOST` to a

--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -8,7 +8,9 @@ from fastapi.requests import HTTPConnection
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.scheduler import Scheduler
+from core.security import SshFeatureAvailability, get_ssh_feature_availability
 from db.engine import get_async_db_session
+from exceptions import SshFeatureDisabledError
 from robots.robot_client_factory import RobotClientFactory
 from services import (
     DatasetDownloadService,
@@ -84,6 +86,19 @@ def get_remote_server_service(session: AsyncSessionDep) -> RemoteServerService:
 
 
 RemoteServerServiceDep = Annotated[RemoteServerService, Depends(get_remote_server_service)]
+
+
+def require_ssh_feature_active() -> SshFeatureAvailability:
+    """Dependency that fails a route closed when the SSH feature is off or network-exposed.
+
+    Raises:
+        SshFeatureDisabledError: The feature is disabled by configuration, or
+            fails closed because the backend is bound to a non-loopback address.
+    """
+    availability = get_ssh_feature_availability()
+    if not availability.active:
+        raise SshFeatureDisabledError(availability.reason)
+    return availability
 
 
 def get_robot_service(session: AsyncSessionDep) -> RobotService:

--- a/application/backend/src/api/remote_servers.py
+++ b/application/backend/src/api/remote_servers.py
@@ -18,7 +18,8 @@ from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, status
 
-from api.dependencies import RemoteServerServiceDep, SettingsDep, get_remote_server_id
+from api.dependencies import RemoteServerServiceDep, SettingsDep, get_remote_server_id, require_ssh_feature_active
+from core.security import SshFeatureAvailability, get_ssh_feature_availability
 from exceptions import BaseException as StudioBaseException
 from exceptions import (
     RemoteServerPreflightError,
@@ -34,6 +35,10 @@ from schemas.ssh_preflight import PreflightCheck, PreflightResult, RemoteServerS
 from services import ssh_config_reader
 from services.ssh.preflight import run_tier1_preflight, run_tier2_preflight
 
+# The whole administration surface fails closed behind `require_ssh_feature_active`
+# except `/feature-status` itself, which must stay reachable to explain *why*
+# everything else is unavailable (see its docstring below), so that dependency
+# is applied per-route below rather than at the router level.
 router = APIRouter(prefix="/api/remote-servers", tags=["Remote servers"])
 
 # `run_tier1_preflight` never raises: every SSH failure it hits becomes a FAILED
@@ -81,19 +86,32 @@ async def _gate_on_tier1(candidate: RemoteServer, settings: SettingsDep) -> None
     raise RemoteServerPreflightError("Remote server failed required checks", failures=failures)
 
 
-@router.get("/aliases")
+@router.get("/aliases", dependencies=[Depends(require_ssh_feature_active)])
 async def list_ssh_host_aliases(settings: SettingsDep) -> list[SshHostAliasOption]:
     """Return every selectable SSH host alias for the create/edit form."""
     return ssh_config_reader.list_host_aliases(settings.ssh_config_path)
 
 
-@router.get("")
+@router.get("/feature-status")
+async def get_feature_status() -> SshFeatureAvailability:
+    """Report whether the SSH remote-trainer feature is currently active.
+
+    Unauthenticated by design (no `require_ssh_feature_active` dependency):
+    the UI needs this to explain *why* the feature is unavailable, which would
+    be circular if reading the status itself required the feature to be
+    active. Safe to expose: `reason`, when set, already names no host alias,
+    container, or other registered-server detail.
+    """
+    return get_ssh_feature_availability()
+
+
+@router.get("", dependencies=[Depends(require_ssh_feature_active)])
 async def list_remote_servers(remote_server_service: RemoteServerServiceDep) -> list[RemoteServer]:
     """Return every registered SSH-provisioned training server."""
     return await remote_server_service.list_remote_servers()
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)
+@router.post("", status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_ssh_feature_active)])
 async def create_remote_server(
     config: RemoteServerCreate,
     remote_server_service: RemoteServerServiceDep,
@@ -109,7 +127,7 @@ async def create_remote_server(
     return await remote_server_service.create_remote_server(config)
 
 
-@router.patch("/{remote_server_id}")
+@router.patch("/{remote_server_id}", dependencies=[Depends(require_ssh_feature_active)])
 async def update_remote_server(
     remote_server_id: Annotated[UUID, Depends(get_remote_server_id)],
     update: RemoteServerUpdate,
@@ -127,7 +145,11 @@ async def update_remote_server(
     return await remote_server_service.update_remote_server(remote_server_id, update)
 
 
-@router.delete("/{remote_server_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{remote_server_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_ssh_feature_active)],
+)
 async def delete_remote_server(
     remote_server_id: Annotated[UUID, Depends(get_remote_server_id)],
     remote_server_service: RemoteServerServiceDep,
@@ -136,7 +158,7 @@ async def delete_remote_server(
     await remote_server_service.delete_remote_server(remote_server_id)
 
 
-@router.post("/{remote_server_id}/check")
+@router.post("/{remote_server_id}/check", dependencies=[Depends(require_ssh_feature_active)])
 async def check_remote_server(
     remote_server_id: Annotated[UUID, Depends(get_remote_server_id)],
     remote_server_service: RemoteServerServiceDep,
@@ -154,7 +176,7 @@ async def check_remote_server(
     return result
 
 
-@router.get("/{remote_server_id}/status")
+@router.get("/{remote_server_id}/status", dependencies=[Depends(require_ssh_feature_active)])
 async def get_remote_server_status(
     remote_server_id: Annotated[UUID, Depends(get_remote_server_id)],
     remote_server_service: RemoteServerServiceDep,

--- a/application/backend/src/cli/serve.py
+++ b/application/backend/src/cli/serve.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 
 from cli.database import _run_migrations
+from core.security import get_ssh_feature_availability
 from robots.catalog.assets import builtin_robot_assets_are_available
 from robots.catalog.sync_robot_assets import sync_robot_assets
 from settings import get_settings
@@ -34,6 +35,14 @@ def _configure_packaged_runtime() -> None:
 def start_server(host: str, port: int) -> None:
     """Configure the packaged runtime, run migrations, and launch the API server."""
     _configure_packaged_runtime()
+    # `--host`/`--port` can override the settings-derived default below; keep
+    # `Settings.host` in agreement with the address actually handed to uvicorn,
+    # so anything that reasons about the real bind address (the SSH feature's
+    # loopback-only enforcement) never checks a stale default instead of it.
+    os.environ["HOST"] = host
+    os.environ["PORT"] = str(port)
+    get_settings.cache_clear()
+    get_ssh_feature_availability.cache_clear()
     _sync_missing_robot_assets()
     _run_migrations()
 

--- a/application/backend/src/core/lifecycle.py
+++ b/application/backend/src/core/lifecycle.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from loguru import logger
 
 from core.logging import setup_logging, setup_uvicorn_logging
+from core.security import get_ssh_feature_availability
 from services.event_processor import EventProcessor
 from settings import get_settings
 from utils.multiprocessing import ensure_spawn_start_method
@@ -23,6 +24,21 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     settings = get_settings()
     app.state.settings = settings
+
+    # Fail the SSH remote-trainer feature closed if it is enabled on a
+    # non-loopback bind address: the feature has no authentication model, so a
+    # network-exposed instance would let anyone who can reach the API execute
+    # code as root on every registered server. This never touches local or
+    # direct-URL training - only routes/dependencies gated behind
+    # `require_ssh_feature_active` (see `api.dependencies`) are affected.
+    ssh_feature_availability = get_ssh_feature_availability()
+    app.state.ssh_feature_availability = ssh_feature_availability
+    if ssh_feature_availability.enabled and ssh_feature_availability.network_exposed:
+        logger.critical(
+            "SSH remote-trainer feature disabled at startup: {}. Bind the backend to a loopback "
+            "address (127.0.0.1 or ::1) to use it.",
+            ssh_feature_availability.reason,
+        )
 
     # Camera fingerprints locked by an active recording/teleop session.
     # Mutated by the robot_control WS handler; checked by camera CRUD and

--- a/application/backend/src/core/security/__init__.py
+++ b/application/backend/src/core/security/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .ssh_network_exposure import (
+    SshFeatureAvailability,
+    evaluate_ssh_feature_availability,
+    get_ssh_feature_availability,
+    is_loopback_host,
+)
+
+__all__ = [
+    "SshFeatureAvailability",
+    "evaluate_ssh_feature_availability",
+    "get_ssh_feature_availability",
+    "is_loopback_host",
+]

--- a/application/backend/src/core/security/ssh_network_exposure.py
+++ b/application/backend/src/core/security/ssh_network_exposure.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Enforces the SSH remote-trainer feature's fail-closed network-exposure policy.
+
+The SSH remote-trainer feature has no authentication model: anyone who can
+reach the backend's API can execute code as root on every registered server,
+and a compromised backend process can reach every identity in the user's SSH
+agent, not just the registered servers. It is safe only on a single-user
+localhost workstation.
+
+This module is the runtime enforcement of that boundary, on top of - not a
+replacement for - the operator turning the feature on in the first place
+(`Settings.ssh_remote_trainer_enabled`, off by default) and the documentation
+in `docs/ssh-remote-trainer.md`. Even when explicitly enabled, the feature
+fails closed if the backend is bound to anything but a loopback address.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+from settings import get_settings
+
+if TYPE_CHECKING:
+    from settings import Settings
+
+# Hostnames that resolve to loopback by convention rather than by DNS lookup.
+# `getaddrinfo("localhost", ...)` already resolves this on every platform this
+# ships on, but treating it explicitly avoids a DNS round trip and a platform
+# difference from ever being the thing this check depends on.
+_LOOPBACK_HOSTNAMES = frozenset({"localhost"})
+
+
+def is_loopback_host(host: str) -> bool:
+    """True when `host`, as an ASGI server bind address, reaches only this machine.
+
+    `host` must be the literal bind argument the server was (or will be) told
+    to listen on - not a value resolved during a request, and not the
+    documented default. `0.0.0.0`/`::` (bind to every interface) are never
+    loopback, regardless of what a DNS name for the same machine might also
+    resolve to.
+
+    A hostname is loopback only when *every* address it resolves to is
+    loopback: a name that resolves to a loopback address on one interface and
+    a routable one on another is not safely restricted to this machine.
+
+    Args:
+        host: The literal bind host/interface string.
+
+    Returns:
+        True when every address `host` can be reached at is loopback-only.
+        False for an unresolvable hostname - failing closed, since a bind
+        target that cannot be verified is not the same as one verified safe.
+    """
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        pass
+
+    if host in _LOOPBACK_HOSTNAMES:
+        return True
+
+    try:
+        resolved = socket.getaddrinfo(host, None)
+    except OSError:
+        return False
+    if not resolved:
+        return False
+    return all(ipaddress.ip_address(info[4][0]).is_loopback for info in resolved)
+
+
+@dataclass(frozen=True, slots=True)
+class SshFeatureAvailability:
+    """Whether the SSH remote-trainer feature is safe to serve right now, and why not if it isn't.
+
+    Attributes:
+        enabled: The operator turned the feature on via
+            `Settings.ssh_remote_trainer_enabled`.
+        network_exposed: The backend is bound to a non-loopback address.
+            Meaningless (always False) when `enabled` is False - an unreachable
+            feature exposes nothing regardless of the bind address.
+        reason: A user-facing explanation for why the feature is unavailable
+            despite being enabled. Names no host alias, container, or other
+            registered-server detail - this can reach a pre-auth log line or
+            an unauthenticated status endpoint.
+    """
+
+    enabled: bool
+    network_exposed: bool
+    reason: str | None = None
+
+    @property
+    def active(self) -> bool:
+        """True only when the feature is both turned on and safe to expose."""
+        return self.enabled and not self.network_exposed
+
+
+def evaluate_ssh_feature_availability(settings: Settings, *, bind_host: str | None = None) -> SshFeatureAvailability:
+    """Evaluate the SSH feature's availability from settings and the actual bind host.
+
+    Args:
+        settings: Application settings.
+        bind_host: The literal host argument the ASGI server was actually
+            started with, when a caller knows it directly (e.g. an explicit
+            `--host` CLI flag). Falls back to `settings.host` - the two can
+            disagree if a caller overrides the bind address without also
+            updating `Settings`.
+
+    Returns:
+        The evaluated availability. `network_exposed` is always False when
+        the feature is off: there is nothing to expose.
+    """
+    if not settings.ssh_remote_trainer_enabled:
+        return SshFeatureAvailability(enabled=False, network_exposed=False)
+
+    host = bind_host if bind_host is not None else settings.host
+    if is_loopback_host(host):
+        return SshFeatureAvailability(enabled=True, network_exposed=False)
+
+    return SshFeatureAvailability(
+        enabled=True,
+        network_exposed=True,
+        reason=(
+            "the backend is bound to a non-loopback address and the SSH remote-trainer feature has no "
+            "authentication model; it is only safe on a single-user localhost workstation"
+        ),
+    )
+
+
+@lru_cache
+def get_ssh_feature_availability() -> SshFeatureAvailability:
+    """Return the cached SSH feature availability for this process.
+
+    Cached the same way `settings.get_settings` is: call
+    `get_ssh_feature_availability.cache_clear()` after changing settings in a
+    test or after reconciling the actual bind host (see `cli.serve`).
+    """
+    return evaluate_ssh_feature_availability(get_settings())
+
+
+__all__ = [
+    "SshFeatureAvailability",
+    "evaluate_ssh_feature_availability",
+    "get_ssh_feature_availability",
+    "is_loopback_host",
+]

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -610,3 +610,19 @@ class TrainerProtocolVersionMismatchError(BaseException):
             error_code="trainer_protocol_mismatch",
             http_status=http.HTTPStatus.CONFLICT,
         )
+
+
+class SshFeatureDisabledError(BaseException):
+    """Raised when the SSH remote-trainer feature is off, or fails closed on network exposure.
+
+    Carries the evaluated reason (if any) rather than any server/alias detail,
+    since this error can reach an unauthenticated caller.
+    """
+
+    def __init__(self, reason: str | None = None) -> None:
+        detail = f": {reason}" if reason else ""
+        super().__init__(
+            message=f"The SSH remote-trainer feature is not available{detail}.",
+            error_code="ssh_feature_unavailable",
+            http_status=http.HTTPStatus.SERVICE_UNAVAILABLE,
+        )

--- a/application/backend/src/services/job_service.py
+++ b/application/backend/src/services/job_service.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from core.security import get_ssh_feature_availability
 from db.schema import JobDB
 from exceptions import (
     DuplicateJobException,
@@ -13,6 +14,7 @@ from exceptions import (
     ResourceInUseError,
     ResourceNotFoundError,
     ResourceType,
+    SshFeatureDisabledError,
     UnsupportedDeviceError,
 )
 from repositories import JobRepository
@@ -74,6 +76,9 @@ class JobService:
         if payload.training_target is TrainingTarget.SSH:
             if payload.remote_server_id is None:
                 raise ValueError("SSH training requires a selected remote server")
+            availability = get_ssh_feature_availability()
+            if not availability.active:
+                raise SshFeatureDisabledError(availability.reason)
             if payload.base_model_id is not None:
                 raise RemoteResumeUnsupportedError
             remote_server_service = self.remote_server_service or RemoteServerService(self.session)

--- a/application/backend/src/services/training_backends/__init__.py
+++ b/application/backend/src/services/training_backends/__init__.py
@@ -30,9 +30,19 @@ async def get_training_backend(payload: TrainJobPayload, job_id: UUID) -> Traini
     from schemas.job import TrainingTarget
 
     if payload.training_target is TrainingTarget.SSH:
+        from core.security import get_ssh_feature_availability
         from db import get_async_db_session_ctx
+        from exceptions import SshFeatureDisabledError
         from services.remote_server_service import RemoteServerService
         from services.training_backends.ssh import SshTrainingBackend
+
+        # Defense in depth: submission already rejects an SSH job while the
+        # feature is inactive, but a job persisted while it was active must
+        # not silently start if the feature was disabled before it was picked
+        # up (e.g. across a restart with a changed config).
+        availability = get_ssh_feature_availability()
+        if not availability.active:
+            raise SshFeatureDisabledError(availability.reason)
 
         if payload.remote_server_id is None:
             raise ValueError("SSH training job is missing its selected remote server")

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -222,7 +222,7 @@ class Settings(BaseSettings):
         return Path(value).expanduser()
 
     # Server
-    host: str = Field(default="0.0.0.0", alias="HOST")  # noqa: S104 # nosec B104
+    host: str = Field(default="127.0.0.1", alias="HOST")
     port: int = Field(default=7860, alias="PORT")
 
     # Database

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -124,6 +124,12 @@ class Settings(BaseSettings):
     trainer_stream_reconnect_backoff_max_s: float = Field(default=30.0, alias="TRAINER_STREAM_RECONNECT_BACKOFF_MAX_S")
 
     # SSH-provisioned remote training
+    # Master switch. Off by default: the feature has no authentication model,
+    # so it must never be on for a deployment that is not a single-user
+    # localhost workstation. See `core.security.ssh_network_exposure`, which
+    # additionally fails this closed at startup if the backend is bound to a
+    # non-loopback address regardless of this setting.
+    ssh_remote_trainer_enabled: bool = Field(default=False, alias="SSH_REMOTE_TRAINER_ENABLED")
     # Path to the user's SSH client config. asyncssh parses it to resolve a saved
     # `ssh_host_alias` into a hostname, port, user, and identity; Studio never
     # reads key material out of it.

--- a/application/backend/tests/api/test_remote_servers.py
+++ b/application/backend/tests/api/test_remote_servers.py
@@ -16,7 +16,8 @@ from uuid import uuid4
 import pytest
 from fastapi.testclient import TestClient
 
-from api.dependencies import get_remote_server_service
+from api.dependencies import get_remote_server_service, require_ssh_feature_active
+from core.security import SshFeatureAvailability
 from exceptions import ResourceNotFoundError, ResourceType
 from main import app
 from schemas.hardware import DeviceType
@@ -108,8 +109,16 @@ def _gpu_busy_warning_result() -> PreflightResult:
     )
 
 
+def _active() -> SshFeatureAvailability:
+    return SshFeatureAvailability(enabled=True, network_exposed=False)
+
+
 @pytest.fixture(autouse=True)
 def _clear_overrides():
+    # Every route but `/feature-status` fails closed behind `require_ssh_feature_active`;
+    # default it to "active" so existing tests exercise their own behavior rather
+    # than the gate, and let the dedicated fail-closed test override it back off.
+    app.dependency_overrides[require_ssh_feature_active] = _active
     yield
     app.dependency_overrides.clear()
 
@@ -137,6 +146,30 @@ def test_list_remote_servers_non_empty():
     body = response.json()
     assert len(body) == 1
     assert body[0]["id"] == str(server.id)
+
+
+def test_list_remote_servers_fails_closed_when_feature_inactive():
+    """No override for `require_ssh_feature_active`: the real (disabled-by-default) check runs."""
+    del app.dependency_overrides[require_ssh_feature_active]
+    service = AsyncMock()
+    service.list_remote_servers.return_value = []
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).get("/api/remote-servers")
+
+    assert response.status_code == 503
+
+
+def test_feature_status_endpoint_reports_disabled_by_default():
+    """Reachable with no dependency override and no auth - it explains the 503 above."""
+    del app.dependency_overrides[require_ssh_feature_active]
+
+    response = TestClient(app).get("/api/remote-servers/feature-status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is False
+    assert body["network_exposed"] is False
 
 
 def test_list_ssh_host_aliases_returns_mocked_list(monkeypatch: pytest.MonkeyPatch):

--- a/application/backend/tests/cli/test_serve.py
+++ b/application/backend/tests/cli/test_serve.py
@@ -11,15 +11,22 @@ serve_module = importlib.import_module("cli.serve")
 @pytest.fixture(autouse=True)
 def _clear_settings_cache() -> Iterator[None]:
     settings_module = importlib.import_module("settings")
+    security_module = importlib.import_module("core.security")
     os.environ.pop("ALEMBIC_CONFIG_PATH", None)
     os.environ.pop("ALEMBIC_SCRIPT_LOCATION", None)
     os.environ.pop("STATIC_FILES_DIR", None)
+    os.environ.pop("HOST", None)
+    os.environ.pop("PORT", None)
     settings_module.get_settings.cache_clear()
+    security_module.get_ssh_feature_availability.cache_clear()
     yield
     os.environ.pop("ALEMBIC_CONFIG_PATH", None)
     os.environ.pop("ALEMBIC_SCRIPT_LOCATION", None)
     os.environ.pop("STATIC_FILES_DIR", None)
+    os.environ.pop("HOST", None)
+    os.environ.pop("PORT", None)
     settings_module.get_settings.cache_clear()
+    security_module.get_ssh_feature_availability.cache_clear()
 
 
 def test_sync_missing_robot_assets_skips_when_available(monkeypatch) -> None:
@@ -93,3 +100,26 @@ def test_serve_click_defaults_are_lazy_and_use_settings() -> None:
 
     assert callable(host_option.default)
     assert callable(port_option.default)
+
+
+def test_start_server_reconciles_settings_host_with_the_actual_bind_argument(monkeypatch) -> None:
+    """A `--host` override must be visible to anything reading `Settings.host` afterwards.
+
+    Otherwise the SSH feature's loopback check (which only sees `Settings`)
+    could evaluate a stale default instead of the address uvicorn actually
+    binds to.
+    """
+    settings_module = importlib.import_module("settings")
+
+    monkeypatch.setattr(serve_module, "_configure_packaged_runtime", lambda: None)
+    monkeypatch.setattr(serve_module, "_sync_missing_robot_assets", lambda: None)
+    monkeypatch.setattr(serve_module, "_run_migrations", lambda: None)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda *args, **kwargs: None)
+
+    serve_module.start_server("0.0.0.0", 9999)
+
+    assert settings_module.get_settings().host == "0.0.0.0"
+    assert settings_module.get_settings().port == 9999

--- a/application/backend/tests/core/security/test_ssh_network_exposure.py
+++ b/application/backend/tests/core/security/test_ssh_network_exposure.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the SSH remote-trainer feature's fail-closed network-exposure policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.security.ssh_network_exposure import (
+    evaluate_ssh_feature_availability,
+    get_ssh_feature_availability,
+    is_loopback_host,
+)
+
+
+class _Settings:
+    """Minimal settings stand-in: only the two fields this module reads."""
+
+    def __init__(self, *, ssh_remote_trainer_enabled: bool, host: str) -> None:
+        self.ssh_remote_trainer_enabled = ssh_remote_trainer_enabled
+        self.host = host
+
+
+# --------------------------------------------------------------------------- #
+# is_loopback_host                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "127.0.0.5", "::1", "localhost"])
+def test_is_loopback_host_true_for_loopback_addresses(host: str) -> None:
+    assert is_loopback_host(host) is True
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.168.1.10", "10.0.0.5"])
+def test_is_loopback_host_false_for_bind_all_or_routable_addresses(host: str) -> None:
+    assert is_loopback_host(host) is False
+
+
+def test_is_loopback_host_fails_closed_for_an_unresolvable_hostname() -> None:
+    assert is_loopback_host("this-host-does-not-resolve.invalid") is False
+
+
+# --------------------------------------------------------------------------- #
+# evaluate_ssh_feature_availability                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_disabled_feature_is_never_reported_as_network_exposed() -> None:
+    """An off feature has nothing to expose, regardless of the bind address."""
+    settings = _Settings(ssh_remote_trainer_enabled=False, host="0.0.0.0")
+
+    availability = evaluate_ssh_feature_availability(settings)
+
+    assert availability.enabled is False
+    assert availability.network_exposed is False
+    assert availability.active is False
+    assert availability.reason is None
+
+
+def test_enabled_feature_on_loopback_is_active() -> None:
+    settings = _Settings(ssh_remote_trainer_enabled=True, host="127.0.0.1")
+
+    availability = evaluate_ssh_feature_availability(settings)
+
+    assert availability.active is True
+    assert availability.network_exposed is False
+    assert availability.reason is None
+
+
+def test_enabled_feature_on_ipv6_loopback_is_active() -> None:
+    settings = _Settings(ssh_remote_trainer_enabled=True, host="::1")
+
+    availability = evaluate_ssh_feature_availability(settings)
+
+    assert availability.active is True
+
+
+def test_enabled_feature_on_bind_all_fails_closed() -> None:
+    settings = _Settings(ssh_remote_trainer_enabled=True, host="0.0.0.0")
+
+    availability = evaluate_ssh_feature_availability(settings)
+
+    assert availability.enabled is True
+    assert availability.network_exposed is True
+    assert availability.active is False
+    assert availability.reason is not None
+    assert "loopback" in availability.reason
+
+
+def test_bind_host_argument_overrides_settings_host() -> None:
+    """A caller that knows the real bind address (e.g. a CLI flag) can override `settings.host`."""
+    settings = _Settings(ssh_remote_trainer_enabled=True, host="127.0.0.1")
+
+    availability = evaluate_ssh_feature_availability(settings, bind_host="0.0.0.0")
+
+    assert availability.active is False
+    assert availability.network_exposed is True
+
+
+def test_reason_never_names_a_host_alias_or_container() -> None:
+    """The reason can reach a pre-auth status endpoint or a startup log line."""
+    settings = _Settings(ssh_remote_trainer_enabled=True, host="0.0.0.0")
+
+    availability = evaluate_ssh_feature_availability(settings)
+
+    assert availability.reason is not None
+    for leaked_term in ("ssh_host_alias", "container", "gpu-box", "physicalai-trainer-"):
+        assert leaked_term not in availability.reason
+
+
+# --------------------------------------------------------------------------- #
+# get_ssh_feature_availability caching                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_get_ssh_feature_availability_is_cached_like_get_settings(monkeypatch) -> None:
+    from settings import get_settings
+
+    get_ssh_feature_availability.cache_clear()
+    get_settings.cache_clear()
+    monkeypatch.setenv("SSH_REMOTE_TRAINER_ENABLED", "false")
+    monkeypatch.setenv("HOST", "127.0.0.1")
+
+    first = get_ssh_feature_availability()
+
+    monkeypatch.setenv("SSH_REMOTE_TRAINER_ENABLED", "true")
+    monkeypatch.setenv("HOST", "0.0.0.0")
+    get_settings.cache_clear()
+    second = get_ssh_feature_availability()
+
+    assert first == second  # still cached: settings changed, but the cache was not cleared
+
+    get_ssh_feature_availability.cache_clear()
+    third = get_ssh_feature_availability()
+    assert third.enabled is True
+    assert third.network_exposed is True
+
+    get_ssh_feature_availability.cache_clear()
+    get_settings.cache_clear()

--- a/application/backend/tests/core/test_lifecycle.py
+++ b/application/backend/tests/core/test_lifecycle.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Startup tests for the SSH remote-trainer feature's loopback-binding enforcement."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from loguru import logger
+
+from core import lifecycle as lifecycle_module
+from core.security import get_ssh_feature_availability
+from settings import get_settings
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> Generator[None]:
+    get_settings.cache_clear()
+    get_ssh_feature_availability.cache_clear()
+    yield
+    get_settings.cache_clear()
+    get_ssh_feature_availability.cache_clear()
+
+
+@pytest.fixture
+def _stub_heavy_startup(monkeypatch):
+    scheduler = MagicMock()
+    scheduler.mp_stop_event = MagicMock()
+    scheduler.event_queue = MagicMock()
+    monkeypatch.setattr(lifecycle_module, "Scheduler", lambda: scheduler)
+    monkeypatch.setattr(lifecycle_module, "ModelWorkerRegistry", lambda **kwargs: MagicMock())
+    monkeypatch.setattr(lifecycle_module, "EventProcessor", lambda queue: MagicMock())
+    monkeypatch.setattr(lifecycle_module, "setup_logging", lambda: None)
+    monkeypatch.setattr(lifecycle_module, "setup_uvicorn_logging", lambda: None)
+    robot_manager = MagicMock()
+    robot_manager.find_robots = AsyncMock()
+    monkeypatch.setattr(lifecycle_module, "RobotConnectionManager", lambda: robot_manager)
+
+
+async def _run_startup_and_capture_logs(app: FastAPI) -> list[str]:
+    messages: list[str] = []
+    sink_id = logger.add(lambda message: messages.append(message.record["message"]), level="INFO")
+    try:
+        async with lifecycle_module.lifespan(app):
+            pass
+    finally:
+        logger.remove(sink_id)
+    return messages
+
+
+@pytest.mark.anyio
+async def test_ssh_feature_enabled_on_non_loopback_logs_critical_and_deactivates(
+    monkeypatch, _stub_heavy_startup
+) -> None:
+    monkeypatch.setenv("SSH_REMOTE_TRAINER_ENABLED", "true")
+    monkeypatch.setenv("HOST", "0.0.0.0")
+    get_settings.cache_clear()
+    get_ssh_feature_availability.cache_clear()
+    app = FastAPI()
+    messages = await _run_startup_and_capture_logs(app)
+    assert app.state.ssh_feature_availability.enabled is True
+    assert app.state.ssh_feature_availability.network_exposed is True
+    assert app.state.ssh_feature_availability.active is False
+    assert any("SSH remote-trainer feature disabled at startup" in message for message in messages)
+
+
+@pytest.mark.anyio
+async def test_ssh_feature_enabled_on_loopback_logs_no_warning_and_stays_active(
+    monkeypatch, _stub_heavy_startup
+) -> None:
+    monkeypatch.setenv("SSH_REMOTE_TRAINER_ENABLED", "true")
+    monkeypatch.setenv("HOST", "127.0.0.1")
+    get_settings.cache_clear()
+    get_ssh_feature_availability.cache_clear()
+    app = FastAPI()
+    messages = await _run_startup_and_capture_logs(app)
+    assert app.state.ssh_feature_availability.active is True
+    assert not any("SSH remote-trainer feature disabled at startup" in message for message in messages)
+
+
+@pytest.mark.anyio
+async def test_ssh_feature_disabled_by_default_logs_no_warning(monkeypatch, _stub_heavy_startup) -> None:
+    monkeypatch.delenv("SSH_REMOTE_TRAINER_ENABLED", raising=False)
+    monkeypatch.setenv("HOST", "0.0.0.0")
+    get_settings.cache_clear()
+    get_ssh_feature_availability.cache_clear()
+    app = FastAPI()
+    messages = await _run_startup_and_capture_logs(app)
+    assert app.state.ssh_feature_availability.enabled is False
+    assert app.state.ssh_feature_availability.active is False
+    assert not any("SSH remote-trainer feature disabled at startup" in message for message in messages)

--- a/application/backend/tests/services/test_job_service_remote_target.py
+++ b/application/backend/tests/services/test_job_service_remote_target.py
@@ -3,12 +3,14 @@ from uuid import uuid4
 
 import pytest
 
+from core.security import SshFeatureAvailability
 from exceptions import (
     RemoteResumeUnsupportedError,
     RemoteServerAliasNotFoundError,
     RemoteServerNotReadyError,
     ResourceNotFoundError,
     ResourceType,
+    SshFeatureDisabledError,
 )
 from schemas.hardware import DeviceType
 from schemas.job import TrainingTarget, TrainJobPayload
@@ -17,6 +19,8 @@ from schemas.remote_trainer import RemoteTrainer
 from services.job_service import JobService
 
 MODULE = "services.job_service"
+
+_ACTIVE = SshFeatureAvailability(enabled=True, network_exposed=False)
 
 
 def _session_context() -> AsyncMock:
@@ -122,6 +126,7 @@ async def test_submit_ssh_job_accepts_a_healthy_server() -> None:
 
     with (
         patch(f"{MODULE}.JobRepository", return_value=repository),
+        patch(f"{MODULE}.get_ssh_feature_availability", return_value=_ACTIVE),
         patch(
             f"{MODULE}.resolve_alias",
             return_value=ResolvedSshHost(alias=remote_server.ssh_host_alias, hostname="gpu-box.lan", found=True),
@@ -155,6 +160,7 @@ async def test_submit_ssh_job_rejects_an_unhealthy_server() -> None:
 
     with (
         patch(f"{MODULE}.JobRepository", return_value=repository),
+        patch(f"{MODULE}.get_ssh_feature_availability", return_value=_ACTIVE),
         pytest.raises(RemoteServerNotReadyError),
     ):
         await JobService(session, remote_server_service=remote_server_service).submit_train_job(payload)
@@ -184,6 +190,7 @@ async def test_submit_ssh_job_rejects_a_renamed_or_removed_alias() -> None:
 
     with (
         patch(f"{MODULE}.JobRepository", return_value=repository),
+        patch(f"{MODULE}.get_ssh_feature_availability", return_value=_ACTIVE),
         patch(
             f"{MODULE}.resolve_alias",
             return_value=ResolvedSshHost(alias=remote_server.ssh_host_alias, found=False),
@@ -217,6 +224,7 @@ async def test_submit_ssh_job_rejects_an_unknown_server() -> None:
 
     with (
         patch(f"{MODULE}.JobRepository", return_value=repository),
+        patch(f"{MODULE}.get_ssh_feature_availability", return_value=_ACTIVE),
         pytest.raises(ResourceNotFoundError),
     ):
         await JobService(session, remote_server_service=remote_server_service).submit_train_job(payload)
@@ -242,7 +250,68 @@ async def test_submit_ssh_job_rejects_continuing_from_an_existing_model() -> Non
 
     with (
         patch(f"{MODULE}.JobRepository", return_value=repository),
+        patch(f"{MODULE}.get_ssh_feature_availability", return_value=_ACTIVE),
         pytest.raises(RemoteResumeUnsupportedError),
+    ):
+        await JobService(session, MagicMock()).submit_train_job(payload)
+
+    repository.save.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_submit_ssh_job_rejects_when_feature_disabled() -> None:
+    """The default (feature-off) availability blocks submission before any server lookup."""
+    session = _session_context()
+    repository = MagicMock()
+    repository.is_job_duplicate = AsyncMock(return_value=False)
+    repository.save = AsyncMock(side_effect=lambda job: job)
+    payload = TrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="model",
+        training_target=TrainingTarget.SSH,
+        remote_server_id=uuid4(),
+    )
+
+    remote_server_service = MagicMock()
+
+    with (
+        patch(f"{MODULE}.JobRepository", return_value=repository),
+        patch(
+            f"{MODULE}.get_ssh_feature_availability",
+            return_value=SshFeatureAvailability(enabled=False, network_exposed=False),
+        ),
+        pytest.raises(SshFeatureDisabledError),
+    ):
+        await JobService(session, remote_server_service=remote_server_service).submit_train_job(payload)
+
+    repository.save.assert_not_awaited()
+    remote_server_service.get_remote_server.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_submit_ssh_job_rejects_when_feature_fails_closed_on_network_exposure() -> None:
+    """Enabled but network-exposed is still inactive, and fails closed the same way."""
+    session = _session_context()
+    repository = MagicMock()
+    repository.is_job_duplicate = AsyncMock(return_value=False)
+    repository.save = AsyncMock(side_effect=lambda job: job)
+    payload = TrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="model",
+        training_target=TrainingTarget.SSH,
+        remote_server_id=uuid4(),
+    )
+
+    exposed = SshFeatureAvailability(enabled=True, network_exposed=True, reason="bound to a non-loopback address")
+
+    with (
+        patch(f"{MODULE}.JobRepository", return_value=repository),
+        patch(f"{MODULE}.get_ssh_feature_availability", return_value=exposed),
+        pytest.raises(SshFeatureDisabledError, match="non-loopback"),
     ):
         await JobService(session, MagicMock()).submit_train_job(payload)
 

--- a/application/backend/tests/services/test_training_backends.py
+++ b/application/backend/tests/services/test_training_backends.py
@@ -28,6 +28,12 @@ def _settings() -> MagicMock:
     return settings
 
 
+def _active_ssh_feature():
+    from core.security import SshFeatureAvailability
+
+    return SshFeatureAvailability(enabled=True, network_exposed=False)
+
+
 def _payload(target: TrainingTarget) -> TrainJobPayload:
     return TrainJobPayload(
         project_id=uuid4(),
@@ -75,7 +81,10 @@ async def test_get_training_backend_returns_ssh_for_ssh_job() -> None:
         ssh_host_alias="gpu-box",
         device_type=DeviceType.CUDA,
     )
-    with patch("services.remote_server_service.RemoteServerService.get_remote_server", AsyncMock(return_value=server)):
+    with (
+        patch("services.remote_server_service.RemoteServerService.get_remote_server", AsyncMock(return_value=server)),
+        patch("core.security.get_ssh_feature_availability", return_value=_active_ssh_feature()),
+    ):
         backend = await get_training_backend(payload, uuid4())
     assert isinstance(backend, SshTrainingBackend)
     assert backend._server is server
@@ -83,7 +92,24 @@ async def test_get_training_backend_returns_ssh_for_ssh_job() -> None:
 
 async def test_get_training_backend_raises_without_remote_server_id() -> None:
     payload = _payload(TrainingTarget.SSH).model_copy(update={"remote_server_id": None})
-    with pytest.raises(ValueError, match="remote server"):
+    with (
+        patch("core.security.get_ssh_feature_availability", return_value=_active_ssh_feature()),
+        pytest.raises(ValueError, match="remote server"),
+    ):
+        await get_training_backend(payload, uuid4())
+
+
+async def test_get_training_backend_rejects_ssh_job_when_feature_inactive() -> None:
+    """Defense in depth: a job persisted while active must not silently start if disabled since."""
+    from core.security import SshFeatureAvailability
+    from exceptions import SshFeatureDisabledError
+
+    payload = _payload(TrainingTarget.SSH)
+    inactive = SshFeatureAvailability(enabled=False, network_exposed=False)
+    with (
+        patch("core.security.get_ssh_feature_availability", return_value=inactive),
+        pytest.raises(SshFeatureDisabledError),
+    ):
         await get_training_backend(payload, uuid4())
 
 


### PR DESCRIPTION
## Description
Add a master enablement switch for the SSH remote-trainer feature and
enforce loopback-only binding as a fail-closed defense-in-depth layer,
since the feature has no authentication model of its own.

- Add `Settings.ssh_remote_trainer_enabled` (off by default).
- Add `core.security.ssh_network_exposure` with `is_loopback_host()`,
  `SshFeatureAvailability`, and a cached `get_ssh_feature_availability()`
  that fails the feature closed whenever it is enabled but the backend
  is bound to a non-loopback address.
- Add `SshFeatureDisabledError` (503) whose message never names a host
  alias, container, or other registered-server detail, since it can
  reach an unauthenticated caller.
- Gate `GET /api/remote-servers` behind `require_ssh_feature_active`;
  add an unauthenticated `GET /api/remote-servers/feature-status` so the
  UI can explain why the feature is unavailable without a circular
  dependency on the feature itself.
- Enforce the same check in `JobService.submit_train_job` (submission
  time) and `get_training_backend` (dispatch time), so a job accepted
  while the feature was active cannot silently run after a restart
  changes the configuration or bind address.
- Reconcile `Settings.host`/`.port` with the actual uvicorn bind
  arguments in `cli.serve.start_server`, and clear both the settings and
  ssh-feature-availability caches so the loopback check never reasons
  about a stale default.
- Log a `critical` startup warning and record `app.state.ssh_feature_availability`
  in `core.lifecycle.lifespan` when the feature is enabled but network-exposed.
- Add `docs/ssh-remote-trainer.md` documenting the switch, the
  fail-closed loopback enforcement, the feature-status endpoint, and
  staged-rollout guidance; link it from the backend README and add the
  `SSH_REMOTE_TRAINER_ENABLED` variable to `.env.example`.
- Add unit tests for `is_loopback_host`, `evaluate_ssh_feature_availability`,
  the gated routes/dependency, submission/dispatch-time gating, the
  `cli.serve` host/port reconciliation, and lifecycle startup behavio
