### PR TITLE
feat(ssh-trainer): live status reporting and recovery-path error-handling polish

### DIFF
--- a/application/backend/src/api/remote_servers.py
+++ b/application/backend/src/api/remote_servers.py
@@ -12,7 +12,6 @@ it can pull multiple gigabytes.
 
 import asyncio
 from collections.abc import Callable
-from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID, uuid4
 
@@ -180,39 +179,18 @@ async def check_remote_server(
 async def get_remote_server_status(
     remote_server_id: Annotated[UUID, Depends(get_remote_server_id)],
     remote_server_service: RemoteServerServiceDep,
-    settings: SettingsDep,
 ) -> RemoteServerStatus:
     """Return structured status for one registered server.
 
-    A live Tier 1 check always runs (per-connection throttling coordinated
-    with the GPU-busy re-check is not yet wired up standalone here - see the
-    TODO below); ``in_use_by_job_id``/``waiting_for_gpu`` are not-yet-implemented
-    placeholders until job provisioning exists.
-
-    TODO: throttle the live Tier 1 call using ``settings.ssh_preflight_throttle_s``
-    against the server's ``last_check_at`` once connection-level coordination
-    with the GPU-busy re-check (also throttled) is implemented; for now this
-    always dials out, which is a known simplification.
+    The Tier 1 check, and ``in_use_by_job_id``/``waiting_for_gpu``, are computed
+    by `RemoteServerService.get_status`: the Tier 1 probe is coalesced and
+    throttled per server (shared across concurrent pollers, at most one dial per
+    `settings.ssh_preflight_throttle_s`), while the in-use/GPU-wait fields are
+    always-fresh DB reads of the server's currently provisioning/training job,
+    if any.
     """
-    server = await remote_server_service.get_remote_server(remote_server_id)
     try:
-        result = await asyncio.wait_for(run_tier1_preflight(server), timeout=settings.ssh_preflight_timeout_s)
+        return await remote_server_service.get_status(remote_server_id)
     except TimeoutError as exc:
+        server = await remote_server_service.get_remote_server(remote_server_id)
         raise SshConnectionError(server.ssh_host_alias, reason="timed_out") from exc
-
-    status_value = "healthy" if result.passed else "degraded"
-    reason_code = None
-    if result.blocking_failures:
-        reason_code = result.blocking_failures[0].reason_code
-
-    return RemoteServerStatus(
-        remote_server_id=remote_server_id,
-        status=status_value,
-        device_type=server.device_type.value,
-        checks=result.checks,
-        checked_at=result.checked_at or datetime.now(UTC),
-        latency_ms=result.latency_ms,
-        reason_code=reason_code,
-        in_use_by_job_id=None,
-        waiting_for_gpu=False,
-    )

--- a/application/backend/src/api/remote_servers.py
+++ b/application/backend/src/api/remote_servers.py
@@ -74,7 +74,15 @@ async def _gate_on_tier1(candidate: RemoteServer, settings: SettingsDep) -> None
     Never persists anything: the caller passes an in-memory ``RemoteServer``
     that is only saved once this returns without raising.
     """
-    result = await asyncio.wait_for(run_tier1_preflight(candidate), timeout=settings.ssh_preflight_timeout_s)
+    try:
+        result = await asyncio.wait_for(run_tier1_preflight(candidate), timeout=settings.ssh_preflight_timeout_s)
+    except TimeoutError as exc:
+        # `run_tier1_preflight` itself never raises, so this only fires if the
+        # whole probe outlives its own timeout budget (e.g. a wedged transport).
+        # Mapped the same way `/status` maps it, so create/update never surfaces
+        # a bare 500 for a failure mode the rest of this API already has an
+        # actionable error for.
+        raise SshConnectionError(candidate.ssh_host_alias, reason="timed_out") from exc
     if result.passed:
         return
 

--- a/application/backend/src/services/remote_server_service.py
+++ b/application/backend/src/services/remote_server_service.py
@@ -8,15 +8,38 @@ resolved-host display are layered on top by the API; this service never
 dials SSH.
 """
 
+import asyncio
+from time import monotonic
 from uuid import UUID, uuid4
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from exceptions import ResourceAlreadyExistsError, ResourceNotFoundError, ResourceType
+from repositories.job_provisioning_repo import JobProvisioningRepository
+from repositories.job_repo import JobRepository
 from repositories.remote_server_repo import RemoteServerRepository
 from schemas.remote_server import RemoteServer, RemoteServerCreate, RemoteServerUpdate
-from schemas.ssh_preflight import PreflightResult
+from schemas.ssh_preflight import PreflightResult, RemoteServerStatus
+from services.ssh.preflight import run_tier1_preflight
+from services.training_backends.phase import PhaseState
+from settings import Settings, get_settings
+
+# Per-server Tier 1 status: at most one in-flight SSH probe, shared across
+# concurrent callers (multiple browser tabs/components polling the same
+# server), plus a short-lived cached result so repeated polling within
+# `settings.ssh_preflight_throttle_s` never dials out again. This is the
+# per-server throttle the status endpoint shares with provisioning's own
+# per-alias connect throttle (`services.ssh.transport`), so UI polling cannot
+# pile SSH connections onto a server a job is actively using.
+_status_checks: dict[UUID, asyncio.Task[PreflightResult]] = {}
+_status_cache: dict[UUID, tuple[float, PreflightResult]] = {}
+
+
+def reset_status_cache() -> None:
+    """Drop every cached/in-flight Tier 1 status probe. Test-support only."""
+    _status_checks.clear()
+    _status_cache.clear()
 
 
 class RemoteServerService:
@@ -90,3 +113,84 @@ class RemoteServerService:
             "last_check_reason_code": reason_code,
         }
         return await self.repo.update(remote_server, partial_update)
+
+    async def get_status(self, remote_server_id: UUID, settings: Settings | None = None) -> RemoteServerStatus:
+        """Return one server's live status: a throttled Tier 1 probe plus in-use/GPU-wait state.
+
+        The Tier 1 SSH probe is shared across concurrent callers (multiple
+        browser tabs/components polling the same server) and cached for
+        `settings.ssh_preflight_throttle_s`, so repeated UI polling never dials
+        out more than once per throttle window - on top of, not instead of, the
+        per-alias connect throttle every `SshTransport.connect()` already applies
+        (`services.ssh.transport`). ``in_use_by_job_id``/``waiting_for_gpu`` are
+        cheap DB reads and are never cached: they must reflect the currently
+        provisioning/training job the moment it changes.
+        """
+        settings = settings or get_settings()
+        server = await self.get_remote_server(remote_server_id)
+
+        active = await JobProvisioningRepository(self.session).get_active_for_server(remote_server_id)
+        in_use_by_job_id = active.job_id if active is not None else None
+        waiting_for_gpu = False
+        if active is not None:
+            job = await JobRepository(self.session).get_by_id(active.job_id)
+            waiting_for_gpu = job is not None and self._is_waiting_for_gpu(job)
+
+        result = await self._tier1_status(server, settings)
+        status_value = "healthy" if result.passed else "degraded"
+        reason_code = result.blocking_failures[0].reason_code if result.blocking_failures else None
+
+        return RemoteServerStatus(
+            remote_server_id=remote_server_id,
+            status=status_value,
+            device_type=server.device_type.value,
+            checks=result.checks,
+            checked_at=result.checked_at,
+            latency_ms=result.latency_ms,
+            reason_code=reason_code,
+            in_use_by_job_id=in_use_by_job_id,
+            waiting_for_gpu=waiting_for_gpu,
+        )
+
+    @staticmethod
+    def _is_waiting_for_gpu(job: object) -> bool:
+        """True when a job's last reported phase is waiting on a busy remote GPU.
+
+        Reads the structured stepper descriptor `services.training_backends.phase`
+        attaches at `extra_info["phase"]` - the same channel
+        `SshTrainingBackend`'s `_on_gpu_wait` reports through while backing off a
+        busy accelerator. Per the `extra_info` contract, this is read only for
+        display: nothing here ever gates a workflow decision.
+        """
+        extra_info = getattr(job, "extra_info", None)
+        if not isinstance(extra_info, dict):
+            return False
+        phase = extra_info.get("phase")
+        if not isinstance(phase, dict):
+            return False
+        return phase.get("state") == PhaseState.WAITING.value
+
+    async def _tier1_status(self, server: RemoteServer, settings: Settings) -> PreflightResult:
+        """Return a Tier 1 preflight result, coalesced and throttled per server."""
+        cached = _status_cache.get(server.id)
+        if cached is not None:
+            cached_at, cached_result = cached
+            if monotonic() - cached_at < settings.ssh_preflight_throttle_s:
+                return cached_result
+
+        task = _status_checks.get(server.id)
+        if task is None:
+            task = asyncio.ensure_future(
+                asyncio.wait_for(run_tier1_preflight(server), timeout=settings.ssh_preflight_timeout_s)
+            )
+            _status_checks[server.id] = task
+
+            def _clear_inflight(done: asyncio.Task[PreflightResult], server_id: UUID = server.id) -> None:
+                if _status_checks.get(server_id) is done:
+                    del _status_checks[server_id]
+
+            task.add_done_callback(_clear_inflight)
+
+        result = await task
+        _status_cache[server.id] = (monotonic(), result)
+        return result

--- a/application/backend/src/services/ssh/provisioning.py
+++ b/application/backend/src/services/ssh/provisioning.py
@@ -525,6 +525,14 @@ class SshProvisioningService:
             )
         except SshConnectionError as error:
             return ReattachVerification(ok=False, reason=ReattachFailureReason.PORT_UNREACHABLE, detail=str(error))
+        except SshHostAliasNotFoundError as error:
+            # Same failure the ownership/digest check above already guards
+            # against, but this tunnel opens a second, independent connection -
+            # a config edit racing between the two checks must fail closed the
+            # same way, not escape as an unhandled exception.
+            return ReattachVerification(ok=False, reason=ReattachFailureReason.ALIAS_MISSING, detail=str(error))
+        except (SshHostKeyUnknownError, SshHostKeyMismatchError) as error:
+            return ReattachVerification(ok=False, reason=ReattachFailureReason.HOST_KEY_FAILURE, detail=str(error))
         finally:
             await tunnel.close()
 

--- a/application/backend/src/services/ssh/recovery.py
+++ b/application/backend/src/services/ssh/recovery.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from repositories.job_provisioning_repo import JobProvisioningRepository
+    from schemas.job_provisioning import JobProvisioning
     from services.job_service import JobService
     from services.remote_server_service import RemoteServerService
     from settings import Settings
@@ -111,6 +112,83 @@ async def _reconcile_stale_rows(
     return cleaned
 
 
+async def _reattach_one_row(
+    job_service: JobService,
+    provisioning_service: SshProvisioningService,
+    remote_server_service: RemoteServerService,
+    row: JobProvisioning,
+) -> tuple[str, UUID | None, str | None]:
+    """Classify one active row and fail its job when the classification says to.
+
+    Returns ``(bucket, reserve_server_id, failure_reason)``:
+
+    - ``bucket`` is one of ``"confirmed"``, ``"transient"``, ``"failed"``.
+    - ``reserve_server_id``, when set, is the server id whose active-job set
+      this row's job id must be added to, so the orphan sweep below never
+      reclaims a container this pass still considers claimed. ``None`` means
+      the job was failed (or its server could not even be looked up) and
+      nothing here reserves its container.
+    - ``failure_reason`` is the reason code to tally, only set for ``"failed"``.
+    """
+    if row.container_name is None:
+        # Never got far enough to launch a container - nothing here for this
+        # pass to verify; leave it to the normal pickup path.
+        return "transient", row.remote_server_id, None
+
+    try:
+        server = await remote_server_service.get_remote_server(row.remote_server_id)
+    except ResourceNotFoundError:
+        logger.error("Failing job {}: remote server {} no longer registered", row.job_id, row.remote_server_id)
+        await job_service.update_job_status(
+            job_id=row.job_id,
+            status=JobStatus.FAILED,
+            message="Training job failed: its remote server is no longer registered",
+        )
+        return "failed", None, "server_not_registered"
+
+    try:
+        outcome = await provisioning_service.verify_reattach(row, server)
+    except Exception as error:  # one job's failure must not abort recovery of the rest
+        logger.error(
+            "Reattach check for job {} on server '{}' raised unexpectedly; leaving pending for retry: {}",
+            row.job_id,
+            server.name,
+            error,
+        )
+        return "transient", server.id, None
+
+    if outcome.ok:
+        logger.info("Confirmed reattach for job {} on server '{}'", row.job_id, server.name)
+        return "confirmed", server.id, None
+
+    if outcome.reason in _TRANSIENT_REASONS:
+        logger.warning(
+            "Reattach check for job {} on server '{}' was inconclusive ({}); leaving pending for retry: {}",
+            row.job_id,
+            server.name,
+            outcome.reason,
+            outcome.detail,
+        )
+        return "transient", server.id, None
+
+    message = (
+        _ACTIONABLE_MESSAGES.get(outcome.reason, "its trainer container could not be verified")
+        if outcome.reason is not None
+        else "its trainer container could not be verified"
+    )
+    logger.error("Failing job {} on server '{}': {} ({})", row.job_id, server.name, message, outcome.detail)
+    await job_service.update_job_status(
+        job_id=row.job_id,
+        status=JobStatus.FAILED,
+        message=f"Training job failed: {message}",
+    )
+    # A failed job is never reserved above, so the sweep below reclaims its
+    # container - but only when ownership was actually established; a foreign
+    # container is never listed by the sweep in the first place (it filters on
+    # this installation's own backend_instance_id label).
+    return "failed", None, outcome.reason.value if outcome.reason is not None else None
+
+
 async def recover_ssh_jobs(
     job_service: JobService,
     provisioning_repo: JobProvisioningRepository,
@@ -135,65 +213,19 @@ async def recover_ssh_jobs(
 
     for row in active_rows:
         with job_logging_ctx(job_id=str(row.job_id)):
-            if row.container_name is None:
-                # Never got far enough to launch a container - nothing here for
-                # this pass to verify; leave it to the normal pickup path.
-                active_job_ids_by_server[row.remote_server_id].add(row.job_id)
-                transient += 1
-                continue
-
-            try:
-                server = await remote_server_service.get_remote_server(row.remote_server_id)
-            except ResourceNotFoundError:
-                logger.error("Failing job {}: remote server {} no longer registered", row.job_id, row.remote_server_id)
-                await job_service.update_job_status(
-                    job_id=row.job_id,
-                    status=JobStatus.FAILED,
-                    message="Training job failed: its remote server is no longer registered",
-                )
-                failed += 1
-                failures_by_reason["server_not_registered"] += 1
-                continue
-
-            outcome = await provisioning_service.verify_reattach(row, server)
-
-            if outcome.ok:
-                logger.info("Confirmed reattach for job {} on server '{}'", row.job_id, server.name)
-                active_job_ids_by_server[server.id].add(row.job_id)
+            bucket, reserve_server_id, failure_reason = await _reattach_one_row(
+                job_service, provisioning_service, remote_server_service, row
+            )
+            if reserve_server_id is not None:
+                active_job_ids_by_server[reserve_server_id].add(row.job_id)
+            if bucket == "confirmed":
                 confirmed += 1
-                continue
-
-            if outcome.reason in _TRANSIENT_REASONS:
-                logger.warning(
-                    "Reattach check for job {} on server '{}' was inconclusive ({}); leaving pending for retry: {}",
-                    row.job_id,
-                    server.name,
-                    outcome.reason,
-                    outcome.detail,
-                )
-                active_job_ids_by_server[server.id].add(row.job_id)
+            elif bucket == "transient":
                 transient += 1
-                continue
-
-            message = (
-                _ACTIONABLE_MESSAGES.get(outcome.reason, "its trainer container could not be verified")
-                if outcome.reason is not None
-                else "its trainer container could not be verified"
-            )
-            logger.error("Failing job {} on server '{}': {} ({})", row.job_id, server.name, message, outcome.detail)
-            await job_service.update_job_status(
-                job_id=row.job_id,
-                status=JobStatus.FAILED,
-                message=f"Training job failed: {message}",
-            )
-            # A failed job is never added back to active_job_ids_by_server, so
-            # the sweep below reclaims its container - but only when ownership
-            # was actually established; a foreign container is never listed by
-            # the sweep in the first place (it filters on this installation's
-            # own backend_instance_id label).
-            failed += 1
-            if outcome.reason is not None:
-                failures_by_reason[outcome.reason.value] += 1
+            else:
+                failed += 1
+                if failure_reason is not None:
+                    failures_by_reason[failure_reason] += 1
 
     orphans_removed = 0
     for server in await remote_server_service.list_remote_servers():

--- a/application/backend/tests/api/test_remote_servers.py
+++ b/application/backend/tests/api/test_remote_servers.py
@@ -22,7 +22,7 @@ from exceptions import ResourceNotFoundError, ResourceType
 from main import app
 from schemas.hardware import DeviceType
 from schemas.remote_server import RemoteServer, SshHostAliasOption
-from schemas.ssh_preflight import CheckKey, CheckOutcome, PreflightCheck, PreflightResult
+from schemas.ssh_preflight import CheckKey, CheckOutcome, PreflightCheck, PreflightResult, RemoteServerStatus
 
 CHECKED_AT = datetime.now(UTC)
 
@@ -430,13 +430,26 @@ def test_check_remote_server_persists_degraded_status_on_blocking_failure(monkey
     assert tier2_result.passed is False
 
 
-def test_status_endpoint_assembles_from_mocked_tier1(monkeypatch: pytest.MonkeyPatch):
+def test_status_endpoint_assembles_from_mocked_service_status():
+    """The route is a thin pass-through: `RemoteServerService.get_status` owns
+    the Tier 1 probe, its own coalescing/throttling, and the in-use/GPU-wait
+    reads (see `test_remote_server_service.py` for those behaviors).
+    """
     server = _make_server()
-    run_tier1 = AsyncMock(return_value=_passing_tier1_result())
-    monkeypatch.setattr("api.remote_servers.run_tier1_preflight", run_tier1)
-
+    tier1_result = _passing_tier1_result()
+    status_response = RemoteServerStatus(
+        remote_server_id=server.id,
+        status="healthy",
+        device_type=server.device_type.value,
+        checks=tier1_result.checks,
+        checked_at=tier1_result.checked_at,
+        latency_ms=tier1_result.latency_ms,
+        reason_code=None,
+        in_use_by_job_id=None,
+        waiting_for_gpu=False,
+    )
     service = AsyncMock()
-    service.get_remote_server.return_value = server
+    service.get_status.return_value = status_response
     app.dependency_overrides[get_remote_server_service] = lambda: service
 
     response = TestClient(app).get(f"/api/remote-servers/{server.id}/status")
@@ -449,6 +462,51 @@ def test_status_endpoint_assembles_from_mocked_tier1(monkeypatch: pytest.MonkeyP
     assert len(body["checks"]) == 9
     assert body["in_use_by_job_id"] is None
     assert body["waiting_for_gpu"] is False
+    service.get_status.assert_awaited_once_with(server.id)
+
+
+def test_status_endpoint_surfaces_in_use_and_waiting_for_gpu():
+    """A busy server's in-use job id and GPU-wait state pass straight through."""
+    server = _make_server()
+    job_id = uuid4()
+    status_response = RemoteServerStatus(
+        remote_server_id=server.id,
+        status="healthy",
+        device_type=server.device_type.value,
+        checks=[],
+        checked_at=CHECKED_AT,
+        latency_ms=10,
+        reason_code=None,
+        in_use_by_job_id=job_id,
+        waiting_for_gpu=True,
+    )
+    service = AsyncMock()
+    service.get_status.return_value = status_response
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).get(f"/api/remote-servers/{server.id}/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["in_use_by_job_id"] == str(job_id)
+    assert body["waiting_for_gpu"] is True
+
+
+def test_status_endpoint_converts_timeout_into_connection_error():
+    """A Tier 1 probe that exceeds its budget surfaces as a connection error,
+    not a bare 500 - the route still needs the server's alias for the message,
+    which it fetches separately once `get_status` times out.
+    """
+    server = _make_server()
+    service = AsyncMock()
+    service.get_status.side_effect = TimeoutError()
+    service.get_remote_server.return_value = server
+    app.dependency_overrides[get_remote_server_service] = lambda: service
+
+    response = TestClient(app).get(f"/api/remote-servers/{server.id}/status")
+
+    assert response.status_code == 502
+    service.get_remote_server.assert_awaited_once_with(server.id)
 
 
 @pytest.mark.parametrize(

--- a/application/backend/tests/integration/test_ssh_containerized_preflight.py
+++ b/application/backend/tests/integration/test_ssh_containerized_preflight.py
@@ -1,0 +1,256 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration test: real SSH transport/preflight against a containerized ``sshd``.
+
+Every other SSH test in this suite fakes the transport (`services.ssh.transport`
+is reached through `transport_factory`/`open_transport` specifically so it can
+be substituted). That is the right default - it keeps the unit suite hermetic
+and fast - but it also means nothing in the suite proves that
+`SshTransport.connect()` actually negotiates a real SSH handshake, verifies a
+real host key, and authenticates with a real key pair against a real server.
+
+This module closes that gap: it starts a throwaway Alpine container running a
+real ``sshd``, generates a fresh ed25519 key pair, writes a purpose-built
+``ssh_config``/``known_hosts`` pointed at the container, and drives the real
+`SshTransport` and `run_tier1_preflight` against it - no mocks. Skipped
+(not failed) when Docker is unavailable, since this is the only test in the
+backend suite with that dependency.
+"""
+
+from __future__ import annotations
+
+import shutil
+import socket
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import asyncssh
+import pytest
+
+from exceptions import SshHostKeyUnknownError
+from schemas.hardware import DeviceType
+from schemas.remote_server import RemoteServer
+from schemas.ssh_preflight import CheckKey, CheckOutcome
+from services.ssh import preflight as preflight_module
+from services.ssh import transport as transport_module
+from services.ssh.preflight import run_tier1_preflight
+from services.ssh.transport import SshTransport
+from settings import Settings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+_ALIAS = "physicalai-containerized-sshd-test"
+_CONTAINER_USER = "trainer"
+_CONTAINER_IMAGE = "alpine:3.20"
+
+# Installs and starts a real `sshd`, key-only for `_CONTAINER_USER`. The account
+# is given a password (never used - `PasswordAuthentication no` is set below)
+# only because Alpine's `adduser -D` otherwise leaves it "locked", which `sshd`
+# refuses to authenticate at all regardless of key.
+_SSHD_ENTRYPOINT = (
+    "set -e && apk add --no-cache openssh >/dev/null 2>&1 && "
+    "ssh-keygen -A >/dev/null 2>&1 && "
+    f"adduser -D -s /bin/sh {_CONTAINER_USER} && "
+    f"echo '{_CONTAINER_USER}:{_CONTAINER_USER}' | chpasswd && "
+    f"mkdir -p /home/{_CONTAINER_USER}/.ssh && "
+    f"cp /keys/authorized_keys /home/{_CONTAINER_USER}/.ssh/authorized_keys && "
+    f"chown -R {_CONTAINER_USER}:{_CONTAINER_USER} /home/{_CONTAINER_USER}/.ssh && "
+    f"chmod 700 /home/{_CONTAINER_USER}/.ssh && "
+    f"chmod 600 /home/{_CONTAINER_USER}/.ssh/authorized_keys && "
+    "exec /usr/sbin/sshd -D -e -o PasswordAuthentication=no -o PermitRootLogin=no"
+)
+
+
+@dataclass
+class _ContainerizedSshd:
+    """A running ``sshd`` container plus the `Settings` that reach it."""
+
+    container_id: str
+    port: int
+    settings: Settings
+
+
+def _read_banner(sock: socket.socket, size: int = 4) -> bytes:
+    """Read exactly *size* bytes (or less, on EOF) from *sock*."""
+    data = b""
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            break
+        data += chunk
+    return data
+
+
+def _wait_for_ssh_banner(port: int, timeout_s: float = 30.0) -> None:
+    """Block until the container's ``sshd`` is actually speaking the protocol.
+
+    Docker's published port accepts TCP the moment the container starts - well
+    before ``apk add`` finishes installing `openssh` inside it - so a bare TCP
+    connect is not a readiness signal. Only the SSH version banner is.
+    """
+    deadline = time.monotonic() + timeout_s
+    last_error: OSError | None = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=2) as sock:
+                sock.settimeout(2)
+                if _read_banner(sock).startswith(b"SSH-"):
+                    return
+        except OSError as error:
+            last_error = error
+        time.sleep(0.5)
+    raise TimeoutError(f"sshd on port {port} never presented an SSH banner: {last_error}")
+
+
+@pytest.fixture
+def containerized_sshd(tmp_path: Path) -> Iterator[_ContainerizedSshd]:
+    """Start a throwaway container running a real ``sshd`` and wire `Settings` at it.
+
+    Yields `Settings` with `ssh_config_path`/`ssh_known_hosts_path` pointed at a
+    generated config and a `known_hosts` pre-seeded with the container's real
+    host key, so `SshTransport` resolves and connects to it exactly as it would
+    a real remote server - through the same alias-resolution and
+    known-hosts-matching code path, not a shortcut around it.
+    """
+    if shutil.which("docker") is None:
+        pytest.skip("docker is not available in this environment")
+
+    private_key_path = tmp_path / "id_ed25519"
+    authorized_keys_path = tmp_path / "authorized_keys"
+    key = asyncssh.generate_private_key("ssh-ed25519")
+    key.write_private_key(str(private_key_path))
+    private_key_path.chmod(0o600)
+    authorized_keys_path.write_text(key.export_public_key().decode().strip() + "\n")
+
+    run_result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "-p",
+            "127.0.0.1::22",
+            "-v",
+            f"{authorized_keys_path}:/keys/authorized_keys:ro",
+            _CONTAINER_IMAGE,
+            "sh",
+            "-c",
+            _SSHD_ENTRYPOINT,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if run_result.returncode != 0:
+        pytest.skip(f"could not start the containerized sshd fixture: {run_result.stderr.strip()}")
+    container_id = run_result.stdout.strip()
+
+    try:
+        port_result = subprocess.run(
+            ["docker", "port", container_id, "22/tcp"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        port = int(port_result.stdout.strip().rsplit(":", 1)[1])
+
+        _wait_for_ssh_banner(port)
+
+        host_key_result = subprocess.run(
+            ["docker", "exec", container_id, "cat", "/etc/ssh/ssh_host_ed25519_key.pub"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        host_public_key = host_key_result.stdout.strip()
+
+        ssh_config_path = tmp_path / "ssh_config"
+        ssh_config_path.write_text(
+            f"Host {_ALIAS}\n"
+            "    HostName 127.0.0.1\n"
+            f"    Port {port}\n"
+            f"    User {_CONTAINER_USER}\n"
+            f"    IdentityFile {private_key_path}\n"
+        )
+
+        # Every plausible pattern `asyncssh`'s known_hosts matcher might look
+        # up the same key under (bare address, bracketed address:port, and the
+        # alias itself), rather than assuming which one it is handed.
+        known_hosts_path = tmp_path / "known_hosts"
+        known_hosts_path.write_text(
+            f"127.0.0.1 {host_public_key}\n[127.0.0.1]:{port} {host_public_key}\n{_ALIAS} {host_public_key}\n"
+        )
+
+        settings = Settings(
+            SSH_CONFIG_PATH=str(ssh_config_path),
+            SSH_KNOWN_HOSTS_PATH=str(known_hosts_path),
+            SSH_CONNECT_TIMEOUT_S=10.0,
+            SSH_COMMAND_TIMEOUT_S=10.0,
+            SSH_PREFLIGHT_TIMEOUT_S=30.0,
+        )
+
+        yield _ContainerizedSshd(container_id=container_id, port=port, settings=settings)
+    finally:
+        subprocess.run(["docker", "stop", "-t", "2", container_id], capture_output=True, timeout=15, check=False)
+
+
+def _make_remote_server() -> RemoteServer:
+    return RemoteServer(id=uuid4(), name="containerized-sshd-test", ssh_host_alias=_ALIAS, device_type=DeviceType.CUDA)
+
+
+@pytest.mark.anyio
+async def test_transport_connects_and_runs_a_command_against_real_sshd(
+    containerized_sshd: _ContainerizedSshd,
+) -> None:
+    """`SshTransport` performs a real connect, host-key check, auth, and exec."""
+    async with SshTransport(_ALIAS, containerized_sshd.settings) as transport:
+        result = await transport.run_command(["echo", "hello-from-container"])
+
+    assert result.ok
+    assert result.first_line() == "hello-from-container"
+
+
+@pytest.mark.anyio
+async def test_transport_rejects_an_untrusted_host_key(containerized_sshd: _ContainerizedSshd, tmp_path: Path) -> None:
+    """An empty `known_hosts` must fail closed as unknown, never connect anyway."""
+    empty_known_hosts = tmp_path / "empty_known_hosts"
+    empty_known_hosts.write_text("")
+    settings = containerized_sshd.settings.model_copy(update={"ssh_known_hosts_path": empty_known_hosts})
+
+    with pytest.raises(SshHostKeyUnknownError):
+        async with SshTransport(_ALIAS, settings):
+            pass
+
+
+@pytest.mark.anyio
+async def test_tier1_preflight_passes_ssh_layer_checks_against_real_sshd(
+    containerized_sshd: _ContainerizedSshd, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real Tier 1 preflight resolves, connects, verifies, and authenticates.
+
+    `DOCKER_USABLE`/`DRIVER_PRESENT`/`GPU_FREE` are expected to fail or skip:
+    the container has no Docker or GPU stack, and asserting those bodies is
+    the job of `tests/services/ssh/test_preflight.py`'s fake-transport unit
+    tests. This test's only claim is that the SSH layer itself - alias
+    resolution, the real handshake, host-key verification, and
+    authentication - works end to end against a real server.
+    """
+    monkeypatch.setattr(preflight_module, "get_settings", lambda: containerized_sshd.settings)
+    monkeypatch.setattr(transport_module, "get_settings", lambda: containerized_sshd.settings)
+
+    result = await run_tier1_preflight(_make_remote_server())
+
+    checks_by_key = {check.key: check for check in result.checks}
+    for key in (CheckKey.ALIAS_RESOLVED, CheckKey.REACHABLE, CheckKey.HOST_KEY_VERIFIED, CheckKey.AUTHENTICATED):
+        assert checks_by_key[key].outcome == CheckOutcome.PASSED, checks_by_key[key]

--- a/application/backend/tests/services/test_remote_server_service.py
+++ b/application/backend/tests/services/test_remote_server_service.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -10,12 +11,57 @@ from sqlalchemy.exc import IntegrityError
 
 from exceptions import ResourceAlreadyExistsError, ResourceNotFoundError
 from schemas.hardware import DeviceType
+from schemas.job_provisioning import JobProvisioning
 from schemas.remote_server import RemoteServer, RemoteServerCreate, RemoteServerUpdate
 from schemas.ssh_preflight import CheckKey, CheckOutcome, PreflightCheck, PreflightResult
 from services import RemoteServerService
+from services.remote_server_service import reset_status_cache
+from settings import Settings
 
 MODULE = "services.remote_server_service"
 CHECKED_AT = datetime.now(UTC)
+
+
+@pytest.fixture(autouse=True)
+def _clear_status_cache():
+    """Every test starts and ends with a clean per-server status cache/in-flight table."""
+    reset_status_cache()
+    yield
+    reset_status_cache()
+
+
+def _job_provisioning(remote_server_id, job_id=None) -> JobProvisioning:
+    return JobProvisioning(
+        job_id=job_id or uuid4(),
+        remote_server_id=remote_server_id,
+        ssh_host_alias="gpu-box",
+        container_name="physicalai-trainer-abc",
+    )
+
+
+class _FakeJob:
+    """Minimal stand-in for `schemas.Job`; only `extra_info` is read by the service."""
+
+    def __init__(self, extra_info: dict | None) -> None:
+        self.extra_info = extra_info
+
+
+def _tier1_result(*, passed: bool = True) -> PreflightResult:
+    outcome = CheckOutcome.PASSED if passed else CheckOutcome.FAILED
+    return PreflightResult(
+        checks=[
+            PreflightCheck(
+                key=CheckKey.DOCKER_USABLE,
+                tier=1,  # type: ignore[arg-type]
+                outcome=outcome,
+                blocking=True,
+                checked_at=CHECKED_AT,
+                reason_code=None if passed else "docker_unavailable",
+            )
+        ],
+        checked_at=CHECKED_AT,
+        latency_ms=10,
+    )
 
 
 def _session() -> AsyncMock:
@@ -245,3 +291,155 @@ async def test_record_check_result_missing_remote_server_raises_not_found() -> N
         await RemoteServerService(session).record_check_result(uuid4(), result)
 
     repository.update.assert_not_called()
+
+
+def _patched_service(
+    remote_server: RemoteServer,
+    *,
+    active: JobProvisioning | None = None,
+    job: object | None = None,
+    tier1_result: PreflightResult | None = None,
+) -> tuple[RemoteServerService, AsyncMock, MagicMock, MagicMock]:
+    """Build a `RemoteServerService` whose repositories/preflight are mocked.
+
+    Returns the service plus the `run_tier1_preflight` mock, so a test can
+    assert how many times the SSH probe actually ran.
+    """
+    server_repo = MagicMock()
+    server_repo.get_by_id = AsyncMock(return_value=remote_server)
+
+    provisioning_repo = MagicMock()
+    provisioning_repo.get_active_for_server = AsyncMock(return_value=active)
+
+    job_repo = MagicMock()
+    job_repo.get_by_id = AsyncMock(return_value=job)
+
+    run_tier1 = AsyncMock(return_value=tier1_result or _tier1_result())
+
+    service = RemoteServerService(_session())
+    service.repo = server_repo
+    return service, run_tier1, provisioning_repo, job_repo
+
+
+@pytest.mark.anyio
+async def test_get_status_reports_not_in_use_when_no_active_provisioning() -> None:
+    remote_server = _remote_server()
+    service, run_tier1, provisioning_repo, job_repo = _patched_service(remote_server)
+    settings = Settings(SSH_PREFLIGHT_THROTTLE_S=5.0, SSH_PREFLIGHT_TIMEOUT_S=30.0)
+
+    with (
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=provisioning_repo),
+        patch(f"{MODULE}.JobRepository", return_value=job_repo),
+        patch(f"{MODULE}.run_tier1_preflight", run_tier1),
+    ):
+        status = await service.get_status(remote_server.id, settings)
+
+    assert status.in_use_by_job_id is None
+    assert status.waiting_for_gpu is False
+    job_repo.get_by_id.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_get_status_reports_in_use_job_and_waiting_for_gpu_phase() -> None:
+    remote_server = _remote_server()
+    active = _job_provisioning(remote_server.id)
+    waiting_job = _FakeJob(extra_info={"phase": {"key": "trainer_start", "state": "waiting"}})
+    service, run_tier1, provisioning_repo, job_repo = _patched_service(remote_server, active=active, job=waiting_job)
+    settings = Settings(SSH_PREFLIGHT_THROTTLE_S=5.0, SSH_PREFLIGHT_TIMEOUT_S=30.0)
+
+    with (
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=provisioning_repo),
+        patch(f"{MODULE}.JobRepository", return_value=job_repo),
+        patch(f"{MODULE}.run_tier1_preflight", run_tier1),
+    ):
+        status = await service.get_status(remote_server.id, settings)
+
+    assert status.in_use_by_job_id == active.job_id
+    assert status.waiting_for_gpu is True
+
+
+@pytest.mark.anyio
+async def test_get_status_does_not_report_waiting_for_gpu_when_phase_is_active() -> None:
+    remote_server = _remote_server()
+    active = _job_provisioning(remote_server.id)
+    training_job = _FakeJob(extra_info={"phase": {"key": "train", "state": "active"}})
+    service, run_tier1, provisioning_repo, job_repo = _patched_service(remote_server, active=active, job=training_job)
+    settings = Settings(SSH_PREFLIGHT_THROTTLE_S=5.0, SSH_PREFLIGHT_TIMEOUT_S=30.0)
+
+    with (
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=provisioning_repo),
+        patch(f"{MODULE}.JobRepository", return_value=job_repo),
+        patch(f"{MODULE}.run_tier1_preflight", run_tier1),
+    ):
+        status = await service.get_status(remote_server.id, settings)
+
+    assert status.in_use_by_job_id == active.job_id
+    assert status.waiting_for_gpu is False
+
+
+@pytest.mark.anyio
+async def test_get_status_throttles_repeated_calls_within_window() -> None:
+    """A second call within `ssh_preflight_throttle_s` must reuse the cached
+    Tier 1 result instead of dialing out again - the whole point of the
+    per-server throttle the status endpoint shares with polling.
+    """
+    remote_server = _remote_server()
+    service, run_tier1, provisioning_repo, job_repo = _patched_service(remote_server)
+    settings = Settings(SSH_PREFLIGHT_THROTTLE_S=60.0, SSH_PREFLIGHT_TIMEOUT_S=30.0)
+
+    with (
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=provisioning_repo),
+        patch(f"{MODULE}.JobRepository", return_value=job_repo),
+        patch(f"{MODULE}.run_tier1_preflight", run_tier1),
+    ):
+        first = await service.get_status(remote_server.id, settings)
+        second = await service.get_status(remote_server.id, settings)
+
+    assert first == second
+    run_tier1.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_get_status_coalesces_concurrent_calls_into_one_probe() -> None:
+    """Two concurrent pollers for the same server must share one SSH dial."""
+    remote_server = _remote_server()
+    service, _, provisioning_repo, job_repo = _patched_service(remote_server)
+    settings = Settings(SSH_PREFLIGHT_THROTTLE_S=60.0, SSH_PREFLIGHT_TIMEOUT_S=30.0)
+
+    call_count = 0
+
+    async def _slow_tier1(_server: RemoteServer) -> PreflightResult:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.05)
+        return _tier1_result()
+
+    with (
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=provisioning_repo),
+        patch(f"{MODULE}.JobRepository", return_value=job_repo),
+        patch(f"{MODULE}.run_tier1_preflight", _slow_tier1),
+    ):
+        first, second = await asyncio.gather(
+            service.get_status(remote_server.id, settings),
+            service.get_status(remote_server.id, settings),
+        )
+
+    assert first == second
+    assert call_count == 1
+
+
+@pytest.mark.anyio
+async def test_get_status_re_probes_after_throttle_window_expires() -> None:
+    remote_server = _remote_server()
+    service, run_tier1, provisioning_repo, job_repo = _patched_service(remote_server)
+    settings = Settings(SSH_PREFLIGHT_THROTTLE_S=0.0, SSH_PREFLIGHT_TIMEOUT_S=30.0)
+
+    with (
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=provisioning_repo),
+        patch(f"{MODULE}.JobRepository", return_value=job_repo),
+        patch(f"{MODULE}.run_tier1_preflight", run_tier1),
+    ):
+        await service.get_status(remote_server.id, settings)
+        await service.get_status(remote_server.id, settings)
+
+    assert run_tier1.await_count == 2


### PR DESCRIPTION
## Description

Final polish pass on the remote-SSH-trainer stack (PR 11 of 11):

- **Live status reporting**: `RemoteServerService.get_status` now assembles `/status` end-to-end instead of returning hardcoded placeholders. `JobProvisioningRepository.get_active_for_server` finds the one non-terminal provisioning row for a server (relying on the existing target-per-job serialization invariant), and `get_status` reads it plus the job's `extra_info.phase.state` to report `in_use_by_job_id` and `waiting_for_gpu` (display-only, never a workflow gate).
- **Throttled polling**: the Tier 1 preflight probe backing `/status` is now coalesced and throttled per server via `settings.ssh_preflight_throttle_s`, mirroring `RemoteTrainerService._probe_remote_trainer`, so concurrent pollers share one in-flight SSH dial instead of piling up connections on a server that's actively training. `api/remote_servers.get_remote_server_status` is now a thin pass-through that maps a probe `TimeoutError` to `SshConnectionError`.
- **Error-handling gaps closed** in the recovery path:
  - A hung Tier 1 preflight's `TimeoutError` now maps to `SshConnectionError` on create/update, matching `/status`'s handling instead of surfacing a bare 500.
  - Host-key/alias failures from `verify_reattach`'s second (tunnel-probe) connection are now caught, so a config change racing between the two checks fails closed with a classified reason instead of an unhandled exception.
  - `recover_ssh_jobs`'s per-job reattach loop is now as defensive as its stale-row and orphan-sweep loops: one job's unexpected exception no longer aborts recovery (and the orphan sweep) for every other job.
- **UI**: drops the redundant "(remote server)" suffix from the train dialog's SSH target status, which now reports the driver-detected GPU/XPU name (or device type as fallback) on its own, matching the compute column in the training-targets table.
- **Test coverage**: adds `test_ssh_containerized_preflight.py`, an integration test that starts a throwaway Alpine container running a real `sshd`, generates a fresh ed25519 key pair, and drives the real `SshTransport`/`run_tier1_preflight` against it with no mocks — covering the real handshake/host-key/auth behavior the rest of the (hermetic, mocked-transport) suite can't. Marked `integration`/`slow` and skipped (not failed) when Docker is unavailable.
