### PR TITLE
feat(backend): thread remote_server_id through training jobs

### DIFF
--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -30,7 +30,6 @@ from services.environment_service import EnvironmentService
 from services.event_processor import EventProcessor
 from services.job_service import JobService
 from services.log_service import LogService
-from services.remote_server_service import RemoteServerService
 from services.robot_catalog_service import RobotCatalogService
 from services.snapshot_service import SnapshotService
 from services.system_service import SystemService

--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -20,6 +20,7 @@ from services import (
     ProjectCameraService,
     ProjectService,
     ProjectThumbnailService,
+    RemoteServerService,
     RemoteTrainerService,
     RobotService,
 )
@@ -214,7 +215,7 @@ ModelDownloadServiceDep = Annotated[ModelDownloadService, Depends(get_model_down
 
 def get_job_service(session: AsyncSessionDep) -> JobService:
     """Provides a JobService instance for managing jobs."""
-    return JobService(session, RemoteTrainerService(session))
+    return JobService(session, RemoteTrainerService(session), RemoteServerService(session))
 
 
 JobServiceDep = Annotated[JobService, Depends(get_job_service)]

--- a/application/backend/src/api/job.py
+++ b/application/backend/src/api/job.py
@@ -17,7 +17,7 @@ from core.scheduler import Scheduler
 from exceptions import ResourceNotFoundError, ResourceType
 from schemas import Job
 from schemas.base_job import JobStatus
-from schemas.job import TrainingTarget, TrainJob, TrainJobPayload
+from schemas.job import RemoteTrainJobPayload, TrainJob, TrainJobPayload
 from services import JobService, ModelMetricsService
 from services.event_processor import EventProcessor, EventType
 
@@ -90,7 +90,7 @@ async def get_model_job_metrics(
         return EventSourceResponse(model_metrics_service.tail_csv_file(metrics_path))
     if (
         isinstance(job, TrainJob)
-        and job.payload.training_target is TrainingTarget.REMOTE
+        and isinstance(job.payload, RemoteTrainJobPayload)
         and job.payload.remote_trainer_url is not None
         and job.payload.remote_job_id is not None
     ):

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -137,6 +137,43 @@ class RemoteResumeUnsupportedError(BaseException):
         )
 
 
+class RemoteServerNotReadyError(BaseException):
+    """Raised when an SSH job targets a server that has not passed preflight.
+
+    Studio never dials SSH from job submission (only the explicit save/check
+    actions do); this only consults the server's persisted last-check summary.
+    """
+
+    def __init__(self, server_name: str, last_check_status: str) -> None:
+        super().__init__(
+            message=(
+                f"Remote server '{server_name}' is not ready for training "
+                f"(last check status: {last_check_status}). Verify the server before submitting a job."
+            ),
+            error_code="remote_server_not_ready",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
+class RemoteServerAliasNotFoundError(BaseException):
+    """Raised when an SSH job's server names an SSH alias no longer in the config.
+
+    Unlike `RemoteServerNotReadyError`, this is checked by parsing the SSH
+    config file directly (no SSH dial), so it also catches a `Host` entry that
+    was renamed or removed since the server was last verified.
+    """
+
+    def __init__(self, server_name: str, ssh_host_alias: str) -> None:
+        super().__init__(
+            message=(
+                f"Remote server '{server_name}' points at SSH host alias '{ssh_host_alias}', "
+                "which is no longer in your SSH config. Restore the Host entry, or edit the server."
+            ),
+            error_code="remote_server_alias_not_found",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
 class InvalidJobStateError(BaseException):
     """Raised when a job action is not valid in the current state."""
 

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from loguru import logger
-from pydantic import BaseModel, Field, field_serializer, model_validator
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_serializer, model_validator
 
 from schemas.base_job import BaseJob, JobType
 from schemas.dataset_import_job import DatasetImportJobPayload
@@ -71,7 +71,20 @@ class TrainingDevice(BaseModel):
 _DEFAULT_MAX_EPOCHS = 5
 
 
-class TrainJobPayload(BaseModel):
+class TrainJobPayloadBase(BaseModel):
+    """Fields shared by every training execution target.
+
+    Concrete payloads are `LocalTrainJobPayload`, `RemoteTrainJobPayload`, and
+    `SshTrainJobPayload` below: each adds only the fields meaningful for its
+    target and forbids the rest (`extra="forbid"`), so a payload can never
+    express two targets at once and target-specific fields don't need a
+    manual mutual-exclusion validator. Adding a target (e.g. a future
+    AWS-provisioned trainer) means adding one subclass here and one entry in
+    the `TrainJobPayload` union, not another branch in a validator.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
     project_id: UUID
     dataset_id: UUID
     policy: str
@@ -91,7 +104,7 @@ class TrainJobPayload(BaseModel):
     batch_size: int = Field(default=8, ge=1, le=256, description="Training batch size")
 
     @model_validator(mode="after")
-    def resolve_training_limit(self) -> "TrainJobPayload":
+    def resolve_training_limit(self) -> "TrainJobPayloadBase":
         """Resolve training-limit fields, applying precedence and defaults.
 
         Rules (in order of priority):
@@ -127,62 +140,16 @@ class TrainJobPayload(BaseModel):
         description="Training precision ('32-true', 'bf16-mixed')",
     )
     compile_model: bool = Field(default=False, description="Enable torch.compile for supported policies")
-    training_target: TrainingTarget = Field(
-        default=TrainingTarget.LOCAL,
-        description="Whether training runs in the Studio process or on a configured remote trainer",
-    )
-    remote_trainer_id: UUID | None = Field(
-        default=None,
-        description="Configured remote trainer selected for a remote run",
-    )
-    remote_trainer_url: str | None = Field(
-        default=None,
-        description="Resolved remote trainer URL pinned when the job is submitted for restart recovery",
-    )
-    remote_trainer_name: str | None = Field(
-        default=None,
-        description="Resolved remote trainer name pinned when the job is submitted, for display in job logs",
-    )
-    remote_server_id: UUID | None = Field(
-        default=None,
-        description="Configured SSH-provisioned remote server selected for an SSH run",
-    )
 
+    # Set by the worker for every target (not just remote ones): a snapshot is
+    # taken up front so a job's model has stable provenance, and a remote/SSH
+    # run additionally needs its remote job id to reattach after a restart.
     remote_job_id: UUID | None = Field(
         default=None, description="Remote trainer job id, set when a remote run is in flight (for restart reattach)"
     )
     snapshot_id: UUID | None = Field(
         default=None, description="Dataset snapshot id retained while a remote run is in flight (for model provenance)"
     )
-
-    @model_validator(mode="after")
-    def validate_training_target(self) -> "TrainJobPayload":
-        """Keep local, direct-URL remote, and SSH jobs from expressing more than one target."""
-        if self.training_target is TrainingTarget.LOCAL:
-            if (
-                self.remote_trainer_id is not None
-                or self.remote_trainer_url is not None
-                or self.remote_trainer_name is not None
-                or self.remote_server_id is not None
-            ):
-                raise ValueError("Local training cannot specify a remote trainer or remote server")
-            return self
-        if self.training_target is TrainingTarget.SSH:
-            if self.remote_server_id is None:
-                raise ValueError("SSH training requires remote_server_id")
-            if (
-                self.remote_trainer_id is not None
-                or self.remote_trainer_url is not None
-                or self.remote_trainer_name is not None
-            ):
-                raise ValueError("SSH training cannot specify a direct-URL remote trainer")
-            return self
-        # TrainingTarget.REMOTE: the existing direct-URL registry.
-        if self.remote_trainer_id is None:
-            raise ValueError("Remote training requires remote_trainer_id")
-        if self.remote_server_id is not None:
-            raise ValueError("Remote training cannot specify a remote server")
-        return self
 
     @field_serializer("project_id")
     def serialize_project_id(self, project_id: UUID, _info: Any) -> str:
@@ -205,6 +172,57 @@ class TrainJobPayload(BaseModel):
         return str(remote_job_id) if remote_job_id else None
 
 
+class LocalTrainJobPayload(TrainJobPayloadBase):
+    """Trains in the Studio process on a local device."""
+
+    training_target: Literal[TrainingTarget.LOCAL] = TrainingTarget.LOCAL
+
+
+class RemoteTrainJobPayload(TrainJobPayloadBase):
+    """Offloads to a directly-configured remote trainer.
+
+    `base_model_id` resume is rejected by `RemoteTrainingTargetHandler.prepare`
+    (not here): the trainer protocol has no way to upload a base checkpoint,
+    and that check raises a domain-specific `RemoteResumeUnsupportedError`
+    rather than a generic schema validation error.
+    """
+
+    training_target: Literal[TrainingTarget.REMOTE] = TrainingTarget.REMOTE
+    remote_trainer_id: UUID = Field(..., description="Configured remote trainer selected for a remote run")
+    remote_trainer_url: str | None = Field(
+        default=None,
+        description="Resolved remote trainer URL pinned when the job is submitted for restart recovery",
+    )
+    remote_trainer_name: str | None = Field(
+        default=None,
+        description="Resolved remote trainer name pinned when the job is submitted, for display in job logs",
+    )
+
+
+class SshTrainJobPayload(TrainJobPayloadBase):
+    """Trains on an SSH-provisioned remote server.
+
+    `base_model_id` resume is rejected by `SshTrainingTargetHandler.prepare`
+    for the same reason as `RemoteTrainJobPayload`.
+    """
+
+    training_target: Literal[TrainingTarget.SSH] = TrainingTarget.SSH
+    remote_server_id: UUID = Field(..., description="Configured SSH-provisioned remote server selected for an SSH run")
+
+
+TrainJobPayload = Annotated[
+    LocalTrainJobPayload | RemoteTrainJobPayload | SshTrainJobPayload,
+    Field(discriminator="training_target"),
+]
+
+# Used to (de)serialize a persisted/request payload dict into the right
+# variant, since `TrainJobPayload` is a type alias (not a class) and has no
+# `model_validate`/`model_dump` of its own.
+TrainJobPayloadAdapter: TypeAdapter[LocalTrainJobPayload | RemoteTrainJobPayload | SshTrainJobPayload] = TypeAdapter(
+    TrainJobPayload
+)
+
+
 class TrainJob(BaseJob):
     type: Literal[JobType.TRAINING] = JobType.TRAINING  # type: ignore[valid-type]
     payload: TrainJobPayload
@@ -215,7 +233,7 @@ class DatasetImportJob(BaseJob):
     payload: DatasetImportJobPayload
 
 
-JobPayload = TrainJobPayload | DatasetImportJobPayload
+JobPayload = LocalTrainJobPayload | RemoteTrainJobPayload | SshTrainJobPayload | DatasetImportJobPayload
 
 Job = Annotated[
     TrainJob | DatasetImportJob,

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -23,10 +23,19 @@ class TrainingPrecision(StrEnum):
 
 
 class TrainingTarget(StrEnum):
-    """Where a training job executes."""
+    """Where a training job executes.
+
+    ``SSH`` is a distinct target from ``REMOTE`` rather than an overload of it:
+    an SSH job is discriminated by ``remote_server_id`` (an SSH-provisioned
+    server), while ``REMOTE`` keeps its existing ``remote_trainer_id`` /
+    pinned ``remote_trainer_url`` (a direct-URL registry entry). Keeping them
+    as separate enum members is what lets the payload validator reject a job
+    that tries to express both at once.
+    """
 
     LOCAL = "local"
     REMOTE = "remote"
+    SSH = "ssh"
 
 
 class JobList(BaseModel):
@@ -142,6 +151,10 @@ class TrainJobPayload(BaseModel):
         default=None,
         description="Resolved remote trainer name pinned when the job is submitted, for display in job logs",
     )
+    remote_server_id: UUID | None = Field(
+        default=None,
+        description="Configured SSH-provisioned remote server selected for an SSH run",
+    )
 
     remote_job_id: UUID | None = Field(
         default=None, description="Remote trainer job id, set when a remote run is in flight (for restart reattach)"
@@ -152,17 +165,31 @@ class TrainJobPayload(BaseModel):
 
     @model_validator(mode="after")
     def validate_training_target(self) -> "TrainJobPayload":
-        """Keep local jobs and pinned remote endpoints mutually consistent."""
+        """Keep local, direct-URL remote, and SSH jobs from expressing more than one target."""
         if self.training_target is TrainingTarget.LOCAL:
             if (
                 self.remote_trainer_id is not None
                 or self.remote_trainer_url is not None
                 or self.remote_trainer_name is not None
+                or self.remote_server_id is not None
             ):
-                raise ValueError("Local training cannot specify a remote trainer")
+                raise ValueError("Local training cannot specify a remote trainer or remote server")
             return self
+        if self.training_target is TrainingTarget.SSH:
+            if self.remote_server_id is None:
+                raise ValueError("SSH training requires remote_server_id")
+            if (
+                self.remote_trainer_id is not None
+                or self.remote_trainer_url is not None
+                or self.remote_trainer_name is not None
+            ):
+                raise ValueError("SSH training cannot specify a direct-URL remote trainer")
+            return self
+        # TrainingTarget.REMOTE: the existing direct-URL registry.
         if self.remote_trainer_id is None:
             raise ValueError("Remote training requires remote_trainer_id")
+        if self.remote_server_id is not None:
+            raise ValueError("Remote training cannot specify a remote server")
         return self
 
     @field_serializer("project_id")

--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -23,15 +23,7 @@ class TrainingPrecision(StrEnum):
 
 
 class TrainingTarget(StrEnum):
-    """Where a training job executes.
-
-    ``SSH`` is a distinct target from ``REMOTE`` rather than an overload of it:
-    an SSH job is discriminated by ``remote_server_id`` (an SSH-provisioned
-    server), while ``REMOTE`` keeps its existing ``remote_trainer_id`` /
-    pinned ``remote_trainer_url`` (a direct-URL registry entry). Keeping them
-    as separate enum members is what lets the payload validator reject a job
-    that tries to express both at once.
-    """
+    """Where a training job executes."""
 
     LOCAL = "local"
     REMOTE = "remote"

--- a/application/backend/src/services/job_service.py
+++ b/application/backend/src/services/job_service.py
@@ -5,25 +5,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.schema import JobDB
-from exceptions import (
-    DuplicateJobException,
-    RemoteResumeUnsupportedError,
-    RemoteServerAliasNotFoundError,
-    RemoteServerNotReadyError,
-    ResourceInUseError,
-    ResourceNotFoundError,
-    ResourceType,
-    UnsupportedDeviceError,
-)
+from exceptions import DuplicateJobException, ResourceInUseError, ResourceNotFoundError, ResourceType
 from repositories import JobRepository
 from schemas import Job
 from schemas.base_job import JobStatus, JobType
-from schemas.job import JobPayload, TrainingTarget, TrainJob, TrainJobPayload
+from schemas.job import JobPayload, TrainJob, TrainJobPayload
 from services.remote_server_service import RemoteServerService
 from services.remote_trainer_service import RemoteTrainerService
-from services.ssh_config_reader import resolve_alias
-from services.system_service import SystemService
-from settings import get_settings
+from services.training_targets import get_training_target_handler
 
 
 class JobService:
@@ -59,49 +48,10 @@ class JobService:
 
     async def submit_train_job(self, payload: TrainJobPayload) -> Job:
         """Validate and persist a training job with its execution target pinned."""
-        if payload.training_target is TrainingTarget.REMOTE:
-            if payload.remote_trainer_id is None:
-                raise ValueError("Remote training requires a selected remote trainer")
-            if payload.base_model_id is not None:
-                raise RemoteResumeUnsupportedError
-            remote_trainer_service = self.remote_trainer_service or RemoteTrainerService(self.session)
-            remote_trainer = await remote_trainer_service.get_remote_trainer(payload.remote_trainer_id)
-            payload = TrainJobPayload.model_validate(
-                payload.model_dump()
-                | {"remote_trainer_url": str(remote_trainer.url), "remote_trainer_name": remote_trainer.name}
-            )
-
-        if payload.training_target is TrainingTarget.SSH:
-            if payload.remote_server_id is None:
-                raise ValueError("SSH training requires a selected remote server")
-            if payload.base_model_id is not None:
-                raise RemoteResumeUnsupportedError
-            remote_server_service = self.remote_server_service or RemoteServerService(self.session)
-            # Raises ResourceNotFoundError for an unknown server. Studio never
-            # dials SSH from job submission, so this only consults the
-            # persisted last-check summary from the explicit save/verify
-            # actions (last_check_status != "healthy" also catches a server
-            # that has never been checked at all).
-            remote_server = await remote_server_service.get_remote_server(payload.remote_server_id)
-            if remote_server.last_check_status != "healthy":
-                raise RemoteServerNotReadyError(remote_server.name, remote_server.last_check_status)
-            # A renamed/removed Host entry is caught by re-parsing the config
-            # file directly (no SSH dial), so it fails closed even if the
-            # server's last preflight happened before the alias disappeared.
-            resolved = resolve_alias(get_settings().ssh_config_path, remote_server.ssh_host_alias)
-            if not resolved.found:
-                raise RemoteServerAliasNotFoundError(remote_server.name, remote_server.ssh_host_alias)
-
-        # A remote trainer validates its own devices. Validate only local device choices here.
-        if (
-            payload.training_target is TrainingTarget.LOCAL
-            and payload.device is not None
-            and not SystemService.is_device_supported_for_training(payload.device.type)
-        ):
-            raise UnsupportedDeviceError(
-                device_type=payload.device.type,
-                supported=SystemService.supported_training_device_types(),
-            )
+        handler = get_training_target_handler(
+            payload, self.session, self.remote_trainer_service, self.remote_server_service
+        )
+        payload = await handler.prepare(payload)
 
         if await self.repo.is_job_duplicate(project_id=payload.project_id, payload=payload):
             raise DuplicateJobException

--- a/application/backend/src/services/job_service.py
+++ b/application/backend/src/services/job_service.py
@@ -8,6 +8,8 @@ from db.schema import JobDB
 from exceptions import (
     DuplicateJobException,
     RemoteResumeUnsupportedError,
+    RemoteServerAliasNotFoundError,
+    RemoteServerNotReadyError,
     ResourceInUseError,
     ResourceNotFoundError,
     ResourceType,
@@ -17,15 +19,24 @@ from repositories import JobRepository
 from schemas import Job
 from schemas.base_job import JobStatus, JobType
 from schemas.job import JobPayload, TrainingTarget, TrainJob, TrainJobPayload
+from services.remote_server_service import RemoteServerService
 from services.remote_trainer_service import RemoteTrainerService
+from services.ssh_config_reader import resolve_alias
 from services.system_service import SystemService
+from settings import get_settings
 
 
 class JobService:
-    def __init__(self, session: AsyncSession, remote_trainer_service: RemoteTrainerService | None = None) -> None:
+    def __init__(
+        self,
+        session: AsyncSession,
+        remote_trainer_service: RemoteTrainerService | None = None,
+        remote_server_service: RemoteServerService | None = None,
+    ) -> None:
         self.session = session
         self.repo = JobRepository(session)
         self.remote_trainer_service = remote_trainer_service
+        self.remote_server_service = remote_server_service
 
     async def create_job(self, job: Job) -> Job:
         return await self.repo.save(job)
@@ -59,6 +70,27 @@ class JobService:
                 payload.model_dump()
                 | {"remote_trainer_url": str(remote_trainer.url), "remote_trainer_name": remote_trainer.name}
             )
+
+        if payload.training_target is TrainingTarget.SSH:
+            if payload.remote_server_id is None:
+                raise ValueError("SSH training requires a selected remote server")
+            if payload.base_model_id is not None:
+                raise RemoteResumeUnsupportedError
+            remote_server_service = self.remote_server_service or RemoteServerService(self.session)
+            # Raises ResourceNotFoundError for an unknown server. Studio never
+            # dials SSH from job submission, so this only consults the
+            # persisted last-check summary from the explicit save/verify
+            # actions (last_check_status != "healthy" also catches a server
+            # that has never been checked at all).
+            remote_server = await remote_server_service.get_remote_server(payload.remote_server_id)
+            if remote_server.last_check_status != "healthy":
+                raise RemoteServerNotReadyError(remote_server.name, remote_server.last_check_status)
+            # A renamed/removed Host entry is caught by re-parsing the config
+            # file directly (no SSH dial), so it fails closed even if the
+            # server's last preflight happened before the alias disappeared.
+            resolved = resolve_alias(get_settings().ssh_config_path, remote_server.ssh_host_alias)
+            if not resolved.found:
+                raise RemoteServerAliasNotFoundError(remote_server.name, remote_server.ssh_host_alias)
 
         # A remote trainer validates its own devices. Validate only local device choices here.
         if (

--- a/application/backend/src/services/log_service.py
+++ b/application/backend/src/services/log_service.py
@@ -16,7 +16,7 @@ from sse_starlette import ServerSentEvent
 from core.logging.utils import get_job_logs_path
 from schemas.base_job import JobType
 from schemas.dataset_import_job import DatasetImportJobPayload
-from schemas.job import TrainJobPayload
+from schemas.job import TrainJobPayloadAdapter
 from schemas.logs import LogSource
 from services.job_service import JobService
 from settings import Settings
@@ -92,7 +92,7 @@ class LogService:
 
         for job in jobs:
             if job.type == JobType.TRAINING:
-                payload = TrainJobPayload.model_validate(job.payload)
+                payload = TrainJobPayloadAdapter.validate_python(job.payload)
                 names[str(job.id)] = f"{payload.model_name} ({payload.policy})"
             elif job.type == JobType.DATASET_IMPORT:
                 payload = DatasetImportJobPayload.model_validate(job.payload)

--- a/application/backend/src/services/model_import_service.py
+++ b/application/backend/src/services/model_import_service.py
@@ -10,7 +10,7 @@ from exceptions import InvalidArchiveError
 from schemas import Model, TrainJob
 from schemas.base_job import JobStatus
 from schemas.dataset import Dataset
-from schemas.job import TrainJobPayload
+from schemas.job import LocalTrainJobPayload
 from settings import get_settings
 
 # We assume the directory/zip is taken directly from Physical AI Studio, either
@@ -127,7 +127,7 @@ class ModelImportService:
 
         job = TrainJob(
             project_id=project_id,
-            payload=TrainJobPayload(
+            payload=LocalTrainJobPayload(
                 project_id=project_id,
                 dataset_id=dataset_id,
                 policy=policy,

--- a/application/backend/src/services/training_backends/__init__.py
+++ b/application/backend/src/services/training_backends/__init__.py
@@ -23,6 +23,13 @@ def get_training_backend(payload: TrainJobPayload) -> TrainingBackend:
     """Return the backend selected by a job's persisted execution target."""
     from schemas.job import TrainingTarget
 
+    if payload.training_target is TrainingTarget.SSH:
+        # SSH provisioning (PR7/PR8) is not wired in yet. JobService rejects SSH
+        # submissions before a job reaches this factory (see submit_train_job),
+        # so this should be unreachable; fail loudly rather than silently
+        # falling through to local training if it ever is reached.
+        raise NotImplementedError("SSH-provisioned training backend is not yet implemented")
+
     if payload.training_target is TrainingTarget.REMOTE:
         from services.training_backends.remote import RemoteTrainingBackend
 

--- a/application/backend/src/services/training_backends/__init__.py
+++ b/application/backend/src/services/training_backends/__init__.py
@@ -9,7 +9,7 @@ service. The active backend is selected per job from its persisted execution
 target.
 """
 
-from schemas.job import TrainJobPayload
+from schemas.job import RemoteTrainJobPayload, SshTrainJobPayload, TrainJobPayload
 from services.training_backends.base import (
     ProgressReporter,
     TrainingBackend,
@@ -21,16 +21,14 @@ from services.training_backends.base import (
 
 def get_training_backend(payload: TrainJobPayload) -> TrainingBackend:
     """Return the backend selected by a job's persisted execution target."""
-    from schemas.job import TrainingTarget
-
-    if payload.training_target is TrainingTarget.SSH:
+    if isinstance(payload, SshTrainJobPayload):
         # SSH provisioning (PR7/PR8) is not wired in yet. JobService rejects SSH
         # submissions before a job reaches this factory (see submit_train_job),
         # so this should be unreachable; fail loudly rather than silently
         # falling through to local training if it ever is reached.
         raise NotImplementedError("SSH-provisioned training backend is not yet implemented")
 
-    if payload.training_target is TrainingTarget.REMOTE:
+    if isinstance(payload, RemoteTrainJobPayload):
         from services.training_backends.remote import RemoteTrainingBackend
 
         if payload.remote_trainer_url is None:

--- a/application/backend/src/services/training_backends/phase.py
+++ b/application/backend/src/services/training_backends/phase.py
@@ -1,0 +1,146 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Phase-windowed progress reporting shared by remote training backends.
+
+A remote SSH job has more phases than a local or direct-URL run (connect,
+image pull, image verification, trainer start) layered on top of the existing
+upload -> train -> download. This module extends the existing progress model
+(``ProgressReporter(progress, message, extra_info)``) rather than changing its
+contract: each phase owns a slice of the 0-100 bar, and a structured
+descriptor rides inside the existing ``extra_info["phase"]`` dict so the UI
+can render a stepper while the plain bar still drives unaware consumers.
+
+Local and direct-URL backends are untouched by this module: they keep their
+own ``SNAPSHOT_UPLOAD_PROGRESS`` / ``TRAINING_PROGRESS_END`` windows in
+``services.training_backends.remote`` and never attach a ``phase`` descriptor.
+This table is selected only by the (not-yet-implemented) SSH backend.
+
+``PHASE_TABLE_VERSION`` and ``PhaseKey`` must stay in lockstep with whatever
+the UI consumes, so both sides drift together rather than silently apart.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from services.training_backends.base import ProgressReporter
+
+# Bump whenever the set or order of PhaseKey members changes in a way that
+# would break a UI consumer keyed off `extra_info["phase"]["version"]`.
+PHASE_TABLE_VERSION = 1
+
+
+class PhaseKey(StrEnum):
+    """Ordered stages of an SSH-provisioned training job."""
+
+    CONNECT = "connect"
+    IMAGE_PULL = "image_pull"
+    IMAGE_VERIFY = "image_verify"
+    TRAINER_START = "trainer_start"
+    UPLOAD = "upload"
+    TRAIN = "train"
+    DOWNLOAD = "download"
+
+
+class PhaseState(StrEnum):
+    """Rendering state of one phase in the stepper."""
+
+    ACTIVE = "active"
+    DONE = "done"
+    SKIPPED = "skipped"
+    WAITING = "waiting"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class PhaseWindow:
+    """One phase's slice of the overall 0-100 progress bar."""
+
+    key: PhaseKey
+    label: str
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.start <= self.end <= 100:
+            raise ValueError(f"Invalid phase window for {self.key}: [{self.start}, {self.end}]")
+
+
+# The SSH phase table (see docs/feature_plans/remote-ssh-trainer-plan.md,
+# "Progress Reporting for SSH Train Jobs"). Local and direct-URL backends keep
+# their own SNAPSHOT_UPLOAD_PROGRESS/TRAINING_PROGRESS_END windows unchanged;
+# retuning those shared constants to fit this table would shift their curves
+# and force rewriting their existing progress assertions for no gain.
+SSH_PHASE_WINDOWS: tuple[PhaseWindow, ...] = (
+    PhaseWindow(PhaseKey.CONNECT, "Connect & preflight", 0, 2),
+    PhaseWindow(PhaseKey.IMAGE_PULL, "Image pull", 2, 5),
+    PhaseWindow(PhaseKey.IMAGE_VERIFY, "Image verification", 5, 7),
+    PhaseWindow(PhaseKey.TRAINER_START, "Trainer start", 7, 9),
+    PhaseWindow(PhaseKey.UPLOAD, "Dataset upload", 9, 17),
+    PhaseWindow(PhaseKey.TRAIN, "Training", 17, 96),
+    PhaseWindow(PhaseKey.DOWNLOAD, "Model download", 96, 100),
+)
+
+
+def _map_into_window(sub_progress: float, window: PhaseWindow) -> int:
+    """Map a phase-local 0-100 percentage into its reserved window."""
+    clamped = max(0.0, min(100.0, sub_progress))
+    span = window.end - window.start
+    return window.start + round(clamped / 100 * span)
+
+
+def report_phase(
+    progress: ProgressReporter,
+    windows: Sequence[PhaseWindow],
+    key: PhaseKey,
+    *,
+    state: PhaseState = PhaseState.ACTIVE,
+    sub_progress: float | None = 0.0,
+    message: str | None = None,
+    extra_info: dict | None = None,
+) -> None:
+    """Report progress for one phase, attaching a structured stepper descriptor.
+
+    Maps ``sub_progress`` (0-100, the phase's own completion) into the phase's
+    reserved slice of the overall bar and calls ``progress`` with a
+    ``phase`` descriptor in ``extra_info`` alongside any caller-supplied keys.
+    ``sub_progress=None`` marks the phase indeterminate (e.g. a Docker pull
+    with no stable percentage): the bar pins to the window start so a spinner
+    can be shown instead of a misleading exact percent.
+
+    Args:
+        progress: The backend's `ProgressReporter` callback.
+        windows: The ordered phase table this job uses.
+        key: Which phase is being reported.
+        state: The phase's rendering state for the stepper.
+        sub_progress: The phase's own 0-100 completion, or None if indeterminate.
+        message: Optional human-readable status line.
+        extra_info: Additional telemetry to merge alongside the phase descriptor.
+
+    Raises:
+        ValueError: If `key` is not present in `windows`.
+    """
+    index = next((i for i, window in enumerate(windows) if window.key == key), None)
+    if index is None:
+        raise ValueError(f"Phase {key} is not part of the given phase table")
+    window = windows[index]
+    indeterminate = sub_progress is None
+    overall_progress = window.start if sub_progress is None else _map_into_window(sub_progress, window)
+
+    descriptor: dict = dict(extra_info or {})
+    descriptor["phase"] = {
+        "version": PHASE_TABLE_VERSION,
+        "key": window.key.value,
+        "label": window.label,
+        "index": index,
+        "total": len(windows),
+        "state": state.value,
+        "indeterminate": indeterminate,
+    }
+    progress(overall_progress, message=message, extra_info=descriptor)

--- a/application/backend/src/services/training_backends/phase.py
+++ b/application/backend/src/services/training_backends/phase.py
@@ -72,8 +72,7 @@ class PhaseWindow:
             raise ValueError(f"Invalid phase window for {self.key}: [{self.start}, {self.end}]")
 
 
-# The SSH phase table (see docs/feature_plans/remote-ssh-trainer-plan.md,
-# "Progress Reporting for SSH Train Jobs"). Local and direct-URL backends keep
+# The SSH phase table for an SSH-provisioned training job. Local and direct-URL backends keep
 # their own SNAPSHOT_UPLOAD_PROGRESS/TRAINING_PROGRESS_END windows unchanged;
 # retuning those shared constants to fit this table would shift their curves
 # and force rewriting their existing progress assertions for no gain.

--- a/application/backend/src/services/training_backends/remote.py
+++ b/application/backend/src/services/training_backends/remote.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
     from loguru import Logger, Record
 
+    from schemas.job import TrainingDevice
     from services.training_backends._training_methods import TrainingMethod
     from services.training_backends.base import TrainingContext
 
@@ -77,7 +78,13 @@ class RemoteTrainingBackend:
 
     _last_progress_log: str | None = None
 
-    def __init__(self, base_url: str, *, trainer_name: str | None = None) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        trainer_name: str | None = None,
+        device: TrainingDevice | None = None,
+    ) -> None:
         settings = get_settings()
         self._base_url = base_url.rstrip("/")
         self._timeout = settings.trainer.request_timeout_s
@@ -88,6 +95,11 @@ class RemoteTrainingBackend:
         # Suppress duplicate consecutive progress lines (e.g. the trainer
         # re-emitting the final training state while it optimizes/exports).
         self._last_progress_log: str | None = None
+        # An injected device (e.g. an SSH-provisioned server's configured
+        # accelerator) is sent to the trainer instead of stripping the spec's
+        # device to None. The direct-URL registry path never sets this, so its
+        # behavior is unchanged: the trainer keeps selecting its own device.
+        self._device = device
         # Prefix every log line from this backend with its trainer, so a job's
         # log (and the shared "training" worker log) identify which remote
         # server produced each line when several trainers run concurrently.
@@ -320,7 +332,17 @@ class RemoteTrainingBackend:
         """
         from services.training_backends.local import build_spec
 
-        spec = build_spec(context).model_copy(update={"device_type": None, "device_index": None})
+        # An injected device (SSH-provisioned server) is sent as-is: that trainer
+        # image runs on one known accelerator, so there is nothing to probe. The
+        # direct-URL registry path leaves ``self._device`` unset and keeps the
+        # existing behavior of stripping the device so the trainer selects its
+        # own hardware.
+        device_update = (
+            {"device_type": str(self._device.type), "device_index": self._device.index}
+            if self._device is not None
+            else {"device_type": None, "device_index": None}
+        )
+        spec = build_spec(context).model_copy(update=device_update)
         body: dict[str, Any] = {
             "spec": spec.model_dump(mode="json", exclude={"run_options"}),
             "dataset_transfer": "http",

--- a/application/backend/src/services/training_service.py
+++ b/application/backend/src/services/training_service.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from schemas import Job
 from schemas.base_job import JobStatus, JobType
-from schemas.job import TrainingTarget, TrainJobPayload
+from schemas.job import RemoteTrainJobPayload, SshTrainJobPayload, TrainingTarget
 from services.event_processor import EventType
 from services.job_service import JobService
 from workers.base import BaseThreadWorker
@@ -112,10 +112,15 @@ class TrainingService:
 
     @staticmethod
     def _reattachable_remote_job_id(job: object) -> UUID | None:
-        """Return the persisted remote job id for a training job, if any."""
+        """Return the persisted remote job id for a training job, if any.
+
+        Only `RemoteTrainJobPayload` and `SshTrainJobPayload` carry a
+        reattachable `remote_job_id`; class identity already encodes the
+        target, so no separate read of `training_target` is needed here.
+        """
         payload = getattr(job, "payload", None)
-        if isinstance(payload, TrainJobPayload):
-            return payload.remote_job_id if payload.training_target in TrainingService._REATTACHABLE_TARGETS else None
+        if isinstance(payload, RemoteTrainJobPayload | SshTrainJobPayload):
+            return payload.remote_job_id
         if isinstance(payload, dict):
             remote_job_id = payload.get("remote_job_id")
             if payload.get("training_target") not in {target.value for target in TrainingService._REATTACHABLE_TARGETS}:

--- a/application/backend/src/services/training_service.py
+++ b/application/backend/src/services/training_service.py
@@ -76,12 +76,12 @@ class TrainingService:
         """
         Reconcile RUNNING training jobs left behind by a previous process.
 
-        Called on training-worker setup and teardown. A remote job keeps running
-        on the trainer independently of the studio, so a RUNNING job that already
-        recorded its ``remote_job_id`` is requeued (back to PENDING) to reattach
-        and mirror progress on the next pickup -- this is what lets a run survive
-        the studio restarting (e.g. the laptop was closed overnight). Any other
-        orphaned RUNNING training job cannot resume and is marked FAILED.
+        Called on training-worker setup and teardown. A remote or SSH-provisioned
+        trainer keeps running independently of the studio, so a RUNNING job that
+        already recorded its ``remote_job_id`` is requeued (back to PENDING) to
+        reattach and mirror progress on the next pickup -- this is what lets a run
+        survive the studio restarting (e.g. the laptop was closed overnight). Any
+        other orphaned RUNNING training job cannot resume and is marked FAILED.
         """
         query = {"status": JobStatus.RUNNING, "type": JobType.TRAINING}
         running_jobs = await job_service.get_job_list(extra_filters=query)
@@ -106,15 +106,19 @@ class TrainingService:
                 message="Job aborted due to application shutdown",
             )
 
+    # Targets whose trainer keeps running independently of the studio process,
+    # and so can be reattached to after a restart via their remote_job_id.
+    _REATTACHABLE_TARGETS = (TrainingTarget.REMOTE, TrainingTarget.SSH)
+
     @staticmethod
     def _reattachable_remote_job_id(job: object) -> UUID | None:
         """Return the persisted remote job id for a training job, if any."""
         payload = getattr(job, "payload", None)
         if isinstance(payload, TrainJobPayload):
-            return payload.remote_job_id if payload.training_target is TrainingTarget.REMOTE else None
+            return payload.remote_job_id if payload.training_target in TrainingService._REATTACHABLE_TARGETS else None
         if isinstance(payload, dict):
             remote_job_id = payload.get("remote_job_id")
-            if payload.get("training_target") != TrainingTarget.REMOTE:
+            if payload.get("training_target") not in {target.value for target in TrainingService._REATTACHABLE_TARGETS}:
                 return None
             try:
                 return UUID(str(remote_job_id))

--- a/application/backend/src/services/training_targets/__init__.py
+++ b/application/backend/src/services/training_targets/__init__.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Training targets selected by each submitted training job.
+
+`TrainingTargetHandler` validates a job payload for one execution target
+(local, direct-URL remote, or SSH-provisioned) and computes the worker key
+that keeps two jobs on the same target from running concurrently.
+`JobService.submit_train_job` uses `get_training_target_handler(...).prepare`
+at submission time; `TrainingWorker` uses `target_key` to serialize
+scheduling. Adding a target (e.g. a future AWS-provisioned trainer) means
+adding one handler class here, not another branch in each caller.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from schemas.job import TrainingTarget, TrainJobPayload
+from services.training_targets.base import TrainingTargetHandler
+from services.training_targets.local import LocalTrainingTargetHandler
+from services.training_targets.remote import RemoteTrainingTargetHandler
+from services.training_targets.ssh import SshTrainingTargetHandler
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from services.remote_server_service import RemoteServerService
+    from services.remote_trainer_service import RemoteTrainerService
+
+_KEY_HANDLERS: dict[TrainingTarget, type[TrainingTargetHandler]] = {
+    TrainingTarget.LOCAL: LocalTrainingTargetHandler,
+    TrainingTarget.REMOTE: RemoteTrainingTargetHandler,
+    TrainingTarget.SSH: SshTrainingTargetHandler,
+}
+
+
+def get_training_target_handler(
+    payload: TrainJobPayload,
+    session: AsyncSession,
+    remote_trainer_service: RemoteTrainerService | None = None,
+    remote_server_service: RemoteServerService | None = None,
+) -> TrainingTargetHandler:
+    """Return the handler selected by a payload's execution target.
+
+    Falls back to constructing a request-scoped service from `session` when
+    the caller (typically `JobService`) was not given one.
+    """
+    if payload.training_target is TrainingTarget.LOCAL:
+        return LocalTrainingTargetHandler()
+    if payload.training_target is TrainingTarget.SSH:
+        from services.remote_server_service import RemoteServerService as _RemoteServerService
+
+        return SshTrainingTargetHandler(remote_server_service or _RemoteServerService(session))
+    from services.remote_trainer_service import RemoteTrainerService as _RemoteTrainerService
+
+    return RemoteTrainingTargetHandler(remote_trainer_service or _RemoteTrainerService(session))
+
+
+def target_key(payload: TrainJobPayload) -> str:
+    """Return the exclusive worker-scheduling key for a payload.
+
+    Pure lookup on `payload`: no service instance or DB session is needed,
+    so a worker can compute this for every pending job without touching the
+    database.
+    """
+    return _KEY_HANDLERS[payload.training_target].target_key(payload)
+
+
+__all__ = [
+    "LocalTrainingTargetHandler",
+    "RemoteTrainingTargetHandler",
+    "SshTrainingTargetHandler",
+    "TrainingTargetHandler",
+    "get_training_target_handler",
+    "target_key",
+]

--- a/application/backend/src/services/training_targets/base.py
+++ b/application/backend/src/services/training_targets/base.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Training target contract shared by local, remote, and SSH implementations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from schemas.job import TrainJobPayload
+
+
+@runtime_checkable
+class TrainingTargetHandler(Protocol):
+    """Validates and keys a job payload for one training execution target.
+
+    `JobService.submit_train_job` calls `prepare` once, at submission time, to
+    reject an invalid target selection and pin any target-specific fields
+    (e.g. a resolved remote trainer URL) onto the payload. `TrainingWorker`
+    calls `target_key` for every pending job to derive the key that keeps two
+    jobs on the same target (the same remote trainer, the same SSH server)
+    from running concurrently. Adding a target (e.g. a future
+    AWS-provisioned trainer) means adding one handler class, not another
+    branch in each caller.
+    """
+
+    async def prepare(self, payload: TrainJobPayload) -> TrainJobPayload:
+        """Validate `payload` for this target and return it, pinning target-specific fields."""
+        ...
+
+    @staticmethod
+    def target_key(payload: TrainJobPayload) -> str:
+        """Return the exclusive worker-scheduling key for a payload of this target."""
+        ...

--- a/application/backend/src/services/training_targets/base.py
+++ b/application/backend/src/services/training_targets/base.py
@@ -23,6 +23,13 @@ class TrainingTargetHandler(Protocol):
     from running concurrently. Adding a target (e.g. a future
     AWS-provisioned trainer) means adding one handler class, not another
     branch in each caller.
+
+    Each concrete handler is only ever invoked with the payload variant
+    matching its target (`get_training_target_handler` routes on
+    `payload.training_target`), so it narrows via `isinstance` internally
+    before touching a target-specific field. The signature stays the full
+    `TrainJobPayload` union so every handler is substitutable for this
+    Protocol regardless of which variant it actually handles.
     """
 
     async def prepare(self, payload: TrainJobPayload) -> TrainJobPayload:

--- a/application/backend/src/services/training_targets/local.py
+++ b/application/backend/src/services/training_targets/local.py
@@ -17,7 +17,9 @@ class LocalTrainingTargetHandler:
         """Reject a local device SystemService reports as unsupported for training.
 
         A remote or SSH-provisioned trainer validates its own devices, so only
-        local device choices are checked here.
+        local device choices are checked here. `device` is a shared field
+        (declared on `TrainJobPayloadBase`), so no narrowing to
+        `LocalTrainJobPayload` is needed to read it.
         """
         if payload.device is not None and not SystemService.is_device_supported_for_training(payload.device.type):
             raise UnsupportedDeviceError(

--- a/application/backend/src/services/training_targets/local.py
+++ b/application/backend/src/services/training_targets/local.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local training target: runs in the Studio process on a local device."""
+
+from __future__ import annotations
+
+from exceptions import UnsupportedDeviceError
+from schemas.job import TrainingTarget, TrainJobPayload
+from services.system_service import SystemService
+
+
+class LocalTrainingTargetHandler:
+    """Validates and keys jobs that train in the Studio process."""
+
+    async def prepare(self, payload: TrainJobPayload) -> TrainJobPayload:
+        """Reject a local device SystemService reports as unsupported for training.
+
+        A remote or SSH-provisioned trainer validates its own devices, so only
+        local device choices are checked here.
+        """
+        if payload.device is not None and not SystemService.is_device_supported_for_training(payload.device.type):
+            raise UnsupportedDeviceError(
+                device_type=payload.device.type,
+                supported=SystemService.supported_training_device_types(),
+            )
+        return payload
+
+    @staticmethod
+    def target_key(payload: TrainJobPayload) -> str:  # noqa: ARG004 - shared key, no per-job fields
+        return TrainingTarget.LOCAL.value

--- a/application/backend/src/services/training_targets/remote.py
+++ b/application/backend/src/services/training_targets/remote.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Remote (direct-URL) training target: offloads to a configured remote trainer."""
+
+from __future__ import annotations
+
+from exceptions import RemoteResumeUnsupportedError
+from schemas.job import TrainingTarget, TrainJobPayload
+from services.remote_trainer_service import RemoteTrainerService
+
+
+class RemoteTrainingTargetHandler:
+    """Validates and keys jobs that offload to a directly-configured remote trainer."""
+
+    def __init__(self, remote_trainer_service: RemoteTrainerService) -> None:
+        self.remote_trainer_service = remote_trainer_service
+
+    async def prepare(self, payload: TrainJobPayload) -> TrainJobPayload:
+        """Resolve the configured trainer and pin its url/name onto the payload.
+
+        Rejects resuming from a base model: the trainer protocol can receive a
+        dataset but has no way to upload a base checkpoint.
+        """
+        if payload.remote_trainer_id is None:
+            raise ValueError("Remote training requires a selected remote trainer")
+        if payload.base_model_id is not None:
+            raise RemoteResumeUnsupportedError
+        remote_trainer = await self.remote_trainer_service.get_remote_trainer(payload.remote_trainer_id)
+        return TrainJobPayload.model_validate(
+            payload.model_dump()
+            | {"remote_trainer_url": str(remote_trainer.url), "remote_trainer_name": remote_trainer.name}
+        )
+
+    @staticmethod
+    def target_key(payload: TrainJobPayload) -> str:
+        return f"{TrainingTarget.REMOTE.value}:{payload.remote_trainer_id}"

--- a/application/backend/src/services/training_targets/remote.py
+++ b/application/backend/src/services/training_targets/remote.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from exceptions import RemoteResumeUnsupportedError
-from schemas.job import TrainingTarget, TrainJobPayload
+from schemas.job import RemoteTrainJobPayload, TrainingTarget, TrainJobPayload
 from services.remote_trainer_service import RemoteTrainerService
 
 
@@ -21,17 +21,22 @@ class RemoteTrainingTargetHandler:
 
         Rejects resuming from a base model: the trainer protocol can receive a
         dataset but has no way to upload a base checkpoint.
+
+        `get_training_target_handler` only ever routes a `RemoteTrainJobPayload`
+        here (selected by `payload.training_target`), so this narrows via
+        `isinstance` before touching `remote_trainer_id`.
         """
-        if payload.remote_trainer_id is None:
-            raise ValueError("Remote training requires a selected remote trainer")
+        if not isinstance(payload, RemoteTrainJobPayload):
+            raise TypeError("RemoteTrainingTargetHandler.prepare requires a RemoteTrainJobPayload")
         if payload.base_model_id is not None:
             raise RemoteResumeUnsupportedError
         remote_trainer = await self.remote_trainer_service.get_remote_trainer(payload.remote_trainer_id)
-        return TrainJobPayload.model_validate(
-            payload.model_dump()
-            | {"remote_trainer_url": str(remote_trainer.url), "remote_trainer_name": remote_trainer.name}
+        return payload.model_copy(
+            update={"remote_trainer_url": str(remote_trainer.url), "remote_trainer_name": remote_trainer.name}
         )
 
     @staticmethod
     def target_key(payload: TrainJobPayload) -> str:
+        if not isinstance(payload, RemoteTrainJobPayload):
+            raise TypeError("RemoteTrainingTargetHandler.target_key requires a RemoteTrainJobPayload")
         return f"{TrainingTarget.REMOTE.value}:{payload.remote_trainer_id}"

--- a/application/backend/src/services/training_targets/ssh.py
+++ b/application/backend/src/services/training_targets/ssh.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSH-provisioned training target: dials a remote server registered by SSH host alias."""
+
+from __future__ import annotations
+
+from exceptions import RemoteResumeUnsupportedError, RemoteServerAliasNotFoundError, RemoteServerNotReadyError
+from schemas.job import TrainingTarget, TrainJobPayload
+from services.remote_server_service import RemoteServerService
+from services.ssh_config_reader import resolve_alias
+from settings import get_settings
+
+
+class SshTrainingTargetHandler:
+    """Validates and keys jobs that train on an SSH-provisioned remote server."""
+
+    def __init__(self, remote_server_service: RemoteServerService) -> None:
+        self.remote_server_service = remote_server_service
+
+    async def prepare(self, payload: TrainJobPayload) -> TrainJobPayload:
+        """Verify the selected server's last preflight result and current SSH-config alias.
+
+        Studio never dials SSH from job submission, so this only consults the
+        persisted last-check summary from the explicit save/verify actions
+        (`last_check_status != "healthy"` also catches a server that has never
+        been checked at all). A renamed/removed Host entry is caught by
+        re-parsing the config file directly (no SSH dial), so it fails closed
+        even if the server's last preflight happened before the alias
+        disappeared.
+        """
+        if payload.remote_server_id is None:
+            raise ValueError("SSH training requires a selected remote server")
+        if payload.base_model_id is not None:
+            raise RemoteResumeUnsupportedError
+        remote_server = await self.remote_server_service.get_remote_server(payload.remote_server_id)
+        if remote_server.last_check_status != "healthy":
+            raise RemoteServerNotReadyError(remote_server.name, remote_server.last_check_status)
+        resolved = resolve_alias(get_settings().ssh_config_path, remote_server.ssh_host_alias)
+        if not resolved.found:
+            raise RemoteServerAliasNotFoundError(remote_server.name, remote_server.ssh_host_alias)
+        return payload
+
+    @staticmethod
+    def target_key(payload: TrainJobPayload) -> str:
+        return f"{TrainingTarget.SSH.value}:{payload.remote_server_id}"

--- a/application/backend/src/services/training_targets/ssh.py
+++ b/application/backend/src/services/training_targets/ssh.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from exceptions import RemoteResumeUnsupportedError, RemoteServerAliasNotFoundError, RemoteServerNotReadyError
-from schemas.job import TrainingTarget, TrainJobPayload
+from schemas.job import SshTrainJobPayload, TrainingTarget, TrainJobPayload
 from services.remote_server_service import RemoteServerService
 from services.ssh_config_reader import resolve_alias
 from settings import get_settings
@@ -28,9 +28,13 @@ class SshTrainingTargetHandler:
         re-parsing the config file directly (no SSH dial), so it fails closed
         even if the server's last preflight happened before the alias
         disappeared.
+
+        `get_training_target_handler` only ever routes an `SshTrainJobPayload`
+        here (selected by `payload.training_target`), so this narrows via
+        `isinstance` before touching `remote_server_id`.
         """
-        if payload.remote_server_id is None:
-            raise ValueError("SSH training requires a selected remote server")
+        if not isinstance(payload, SshTrainJobPayload):
+            raise TypeError("SshTrainingTargetHandler.prepare requires an SshTrainJobPayload")
         if payload.base_model_id is not None:
             raise RemoteResumeUnsupportedError
         remote_server = await self.remote_server_service.get_remote_server(payload.remote_server_id)
@@ -43,4 +47,6 @@ class SshTrainingTargetHandler:
 
     @staticmethod
     def target_key(payload: TrainJobPayload) -> str:
+        if not isinstance(payload, SshTrainJobPayload):
+            raise TypeError("SshTrainingTargetHandler.target_key requires an SshTrainJobPayload")
         return f"{TrainingTarget.SSH.value}:{payload.remote_server_id}"

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -229,6 +229,19 @@ class Settings(BaseSettings):
     # Proxy settings
     no_proxy: str = Field(default="localhost,127.0.0.1,::1", alias="no_proxy")
 
+    # SSH-provisioned remote training
+    # Path to the user's SSH client config. The read-only config reader parses
+    # it to resolve a saved `ssh_host_alias` into its effective hostname/port/
+    # user for display and submission-time validation; Studio never reads key
+    # material from it.
+    ssh_config_path: Path = Field(default=Path("~/.ssh/config"), alias="SSH_CONFIG_PATH")
+
+    @field_validator("ssh_config_path", mode="before")
+    @classmethod
+    def expand_ssh_config_path(cls, value: Path | str) -> Path:
+        """Expand `~` so the default resolves to the running user's SSH config."""
+        return Path(value).expanduser()
+
     @property
     def database_url(self) -> str:
         """Get database URL"""

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -229,19 +229,6 @@ class Settings(BaseSettings):
     # Proxy settings
     no_proxy: str = Field(default="localhost,127.0.0.1,::1", alias="no_proxy")
 
-    # SSH-provisioned remote training
-    # Path to the user's SSH client config. The read-only config reader parses
-    # it to resolve a saved `ssh_host_alias` into its effective hostname/port/
-    # user for display and submission-time validation; Studio never reads key
-    # material from it.
-    ssh_config_path: Path = Field(default=Path("~/.ssh/config"), alias="SSH_CONFIG_PATH")
-
-    @field_validator("ssh_config_path", mode="before")
-    @classmethod
-    def expand_ssh_config_path(cls, value: Path | str) -> Path:
-        """Expand `~` so the default resolves to the running user's SSH config."""
-        return Path(value).expanduser()
-
     @property
     def database_url(self) -> str:
         """Get database URL"""

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -29,6 +29,7 @@ from services.training_backends import (
     get_training_backend,
 )
 from services.training_service import TrainingService, TrainingTrackingDispatcher
+from services.training_targets import target_key as training_target_key
 from settings import get_settings
 from workers.base import BaseProcessWorker
 
@@ -89,17 +90,12 @@ class TrainingWorker(BaseProcessWorker):
     def _target_key(payload: TrainJobPayload) -> str:
         """Return the exclusive execution target for a training job.
 
-        Each remote kind gets its own key namespace so an SSH job never
-        collapses onto the direct-URL registry's ``remote:<id>`` key (or vice
-        versa): the two id fields are unrelated, and their validator keeps
-        exactly one of them set per job, so neither branch can ever embed
-        ``None`` for a well-formed payload.
+        Delegates to `services.training_targets.target_key` so submission
+        validation (`JobService`) and worker scheduling derive this key from
+        the same per-target handler registry, instead of each keeping its own
+        copy of the target-to-key mapping.
         """
-        if payload.training_target is TrainingTarget.LOCAL:
-            return TrainingTarget.LOCAL.value
-        if payload.training_target is TrainingTarget.SSH:
-            return f"{TrainingTarget.SSH.value}:{payload.remote_server_id}"
-        return f"{TrainingTarget.REMOTE.value}:{payload.remote_trainer_id}"
+        return training_target_key(payload)
 
     async def _run_training_job(self, job: Job, payload: TrainJobPayload) -> None:
         """Prepare and execute one job after its execution target has been reserved."""

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -16,7 +16,7 @@ from core.logging.utils import job_logging_ctx
 from db import get_async_db_session_ctx
 from schemas import Job, Model, Snapshot
 from schemas.base_job import JobStatus
-from schemas.job import TrainingTarget, TrainJobPayload
+from schemas.job import TrainingTarget, TrainJobPayload, TrainJobPayloadAdapter
 from services import DatasetService, ModelService
 from services.event_processor import EventType
 from services.job_service import JobService
@@ -60,7 +60,7 @@ class TrainingWorker(BaseProcessWorker):
                 async with get_async_db_session_ctx() as session:
                     pending_jobs = await JobService(session, RemoteTrainerService(session)).get_pending_train_jobs()
                 for job in pending_jobs:
-                    payload = TrainJobPayload.model_validate(job.payload)
+                    payload = TrainJobPayloadAdapter.validate_python(job.payload)
                     target = self._target_key(payload)
                     if target in self._active_training_tasks:
                         continue

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -87,9 +87,18 @@ class TrainingWorker(BaseProcessWorker):
 
     @staticmethod
     def _target_key(payload: TrainJobPayload) -> str:
-        """Return the exclusive execution target for a training job."""
+        """Return the exclusive execution target for a training job.
+
+        Each remote kind gets its own key namespace so an SSH job never
+        collapses onto the direct-URL registry's ``remote:<id>`` key (or vice
+        versa): the two id fields are unrelated, and their validator keeps
+        exactly one of them set per job, so neither branch can ever embed
+        ``None`` for a well-formed payload.
+        """
         if payload.training_target is TrainingTarget.LOCAL:
             return TrainingTarget.LOCAL.value
+        if payload.training_target is TrainingTarget.SSH:
+            return f"{TrainingTarget.SSH.value}:{payload.remote_server_id}"
         return f"{TrainingTarget.REMOTE.value}:{payload.remote_trainer_id}"
 
     async def _run_training_job(self, job: Job, payload: TrainJobPayload) -> None:
@@ -97,7 +106,10 @@ class TrainingWorker(BaseProcessWorker):
         with job_logging_ctx(job_id=str(job.id)):
             settings = get_settings()
             model_id = uuid4()
-            reattaching = payload.training_target is TrainingTarget.REMOTE and bool(payload.remote_job_id)
+            # Both remote kinds keep their trainer running independently of the
+            # studio process, so either can carry a persisted remote_job_id to
+            # reattach to across a restart; only local training never does.
+            reattaching = payload.training_target is not TrainingTarget.LOCAL and bool(payload.remote_job_id)
 
             base_model = None
             if payload.base_model_id is not None:

--- a/application/backend/tests/integration/test_e2e_dataset_to_export.py
+++ b/application/backend/tests/integration/test_e2e_dataset_to_export.py
@@ -29,7 +29,7 @@ from fastapi.testclient import TestClient
 from api.dependencies import get_scheduler
 from main import app
 from schemas.base_job import JobStatus
-from schemas.job import TrainJobPayload
+from schemas.job import LocalTrainJobPayload, TrainJobPayloadAdapter
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -75,7 +75,7 @@ def _run_training_job_step() -> None:
         async with get_async_db_session_ctx() as session:
             job = await JobService(session).get_pending_train_job()
         assert job is not None, "Expected a pending training job"
-        payload = TrainJobPayload.model_validate(job.payload)
+        payload = TrainJobPayloadAdapter.validate_python(job.payload)
 
         settings = get_settings()
         model_id = uuid4()
@@ -303,7 +303,7 @@ def test_interrupt_job_marks_job_canceled(migrated_db: None) -> None:
         async with get_async_db_session_ctx() as session:
             job_service = JobService(session)
             job = await job_service.submit_train_job(
-                TrainJobPayload(
+                LocalTrainJobPayload(
                     project_id=project_id,
                     dataset_id=uuid4(),
                     policy="act",

--- a/application/backend/tests/repositories/test_job_repository.py
+++ b/application/backend/tests/repositories/test_job_repository.py
@@ -8,7 +8,7 @@ from db.schema import Base, ProjectDB
 from repositories.job_repo import JobRepository
 from repositories.mappers.job_mapper import JobMapper
 from schemas.base_job import JobStatus, JobType
-from schemas.job import TrainingTarget, TrainJob, TrainJobPayload
+from schemas.job import LocalTrainJobPayload, RemoteTrainJobPayload, TrainJob
 
 
 def test_duplicate_remote_job_payload_with_uuids_is_json_serializable() -> None:
@@ -18,14 +18,13 @@ def test_duplicate_remote_job_payload_with_uuids_is_json_serializable() -> None:
         engine = create_async_engine("sqlite+aiosqlite://")
         session_factory = async_sessionmaker(engine, expire_on_commit=False)
         project_id = uuid4()
-        payload = TrainJobPayload(
+        payload = RemoteTrainJobPayload(
             project_id=project_id,
             dataset_id=uuid4(),
             policy="act",
             model_name="test-model",
             base_model_id=uuid4(),
             snapshot_id=uuid4(),
-            training_target=TrainingTarget.REMOTE,
             remote_trainer_id=uuid4(),
             remote_trainer_url="https://trainer.example.test",
         )
@@ -60,7 +59,7 @@ def test_pending_jobs_are_filtered_and_returned_in_submission_order() -> None:
         engine = create_async_engine("sqlite+aiosqlite://")
         session_factory = async_sessionmaker(engine, expire_on_commit=False)
         project_id = uuid4()
-        payload = TrainJobPayload(
+        payload = LocalTrainJobPayload(
             project_id=project_id,
             dataset_id=uuid4(),
             policy="act",

--- a/application/backend/tests/schemas/test_base_job.py
+++ b/application/backend/tests/schemas/test_base_job.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""JobStatus is generated into the UI's openapi-spec.d.ts and consumed widely.
+
+Adding a member is a breaking change for every generated consumer, so this
+pins the exact member set explicitly rather than relying on an implicit
+"it still imports" check -- a future change (e.g. a GPU-busy "waiting" status)
+must fail this test and be a deliberate decision, not an incidental one.
+"""
+
+from schemas.base_job import JobStatus
+
+
+def test_job_status_has_exactly_the_expected_members() -> None:
+    assert {status.value for status in JobStatus} == {
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "canceled",
+    }

--- a/application/backend/tests/schemas/test_job.py
+++ b/application/backend/tests/schemas/test_job.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TrainJobPayload's execution-target validator.
+
+Local training, the direct-URL remote trainer registry, and SSH-provisioned
+servers are mutually exclusive targets. Each must reject fields that belong to
+a different target so a payload can never express two targets at once.
+"""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.job import TrainingTarget, TrainJobPayload
+
+
+def _base_kwargs() -> dict:
+    return {
+        "project_id": uuid4(),
+        "dataset_id": uuid4(),
+        "policy": "act",
+        "model_name": "model",
+    }
+
+
+class TestLocalTarget:
+    def test_local_job_accepts_no_remote_fields(self) -> None:
+        payload = TrainJobPayload(**_base_kwargs(), training_target=TrainingTarget.LOCAL)
+        assert payload.training_target is TrainingTarget.LOCAL
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {"remote_trainer_id": uuid4()},
+            {"remote_trainer_url": "https://trainer.test"},
+            {"remote_trainer_name": "trainer"},
+            {"remote_server_id": uuid4()},
+        ],
+    )
+    def test_local_job_rejects_any_remote_field(self, extra: dict) -> None:
+        with pytest.raises(ValidationError):
+            TrainJobPayload(**_base_kwargs(), training_target=TrainingTarget.LOCAL, **extra)
+
+
+class TestRemoteTarget:
+    def test_remote_job_requires_remote_trainer_id(self) -> None:
+        with pytest.raises(ValidationError):
+            TrainJobPayload(**_base_kwargs(), training_target=TrainingTarget.REMOTE)
+
+    def test_remote_job_accepts_direct_url_fields(self) -> None:
+        payload = TrainJobPayload(
+            **_base_kwargs(),
+            training_target=TrainingTarget.REMOTE,
+            remote_trainer_id=uuid4(),
+            remote_trainer_url="https://trainer.test",
+        )
+        assert payload.training_target is TrainingTarget.REMOTE
+
+    def test_remote_job_rejects_remote_server_id(self) -> None:
+        with pytest.raises(ValidationError):
+            TrainJobPayload(
+                **_base_kwargs(),
+                training_target=TrainingTarget.REMOTE,
+                remote_trainer_id=uuid4(),
+                remote_server_id=uuid4(),
+            )
+
+
+class TestSshTarget:
+    def test_ssh_job_requires_remote_server_id(self) -> None:
+        with pytest.raises(ValidationError):
+            TrainJobPayload(**_base_kwargs(), training_target=TrainingTarget.SSH)
+
+    def test_ssh_job_accepts_remote_server_id(self) -> None:
+        payload = TrainJobPayload(
+            **_base_kwargs(),
+            training_target=TrainingTarget.SSH,
+            remote_server_id=uuid4(),
+        )
+        assert payload.training_target is TrainingTarget.SSH
+        assert payload.remote_server_id is not None
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {"remote_trainer_id": uuid4()},
+            {"remote_trainer_url": "https://trainer.test"},
+            {"remote_trainer_name": "trainer"},
+        ],
+    )
+    def test_ssh_job_rejects_direct_url_fields(self, extra: dict) -> None:
+        with pytest.raises(ValidationError):
+            TrainJobPayload(
+                **_base_kwargs(),
+                training_target=TrainingTarget.SSH,
+                remote_server_id=uuid4(),
+                **extra,
+            )

--- a/application/backend/tests/schemas/test_job.py
+++ b/application/backend/tests/schemas/test_job.py
@@ -1,11 +1,14 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for TrainJobPayload's execution-target validator.
+"""Tests for the `TrainJobPayload` discriminated union.
 
 Local training, the direct-URL remote trainer registry, and SSH-provisioned
-servers are mutually exclusive targets. Each must reject fields that belong to
-a different target so a payload can never express two targets at once.
+servers are mutually exclusive targets, each modeled as its own payload class
+(`LocalTrainJobPayload`, `RemoteTrainJobPayload`, `SshTrainJobPayload`). A
+payload can never express two targets at once: a target's fields simply don't
+exist on another target's class, and `extra="forbid"` rejects any attempt to
+pass them in anyway.
 """
 
 from uuid import uuid4
@@ -13,7 +16,7 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
-from schemas.job import TrainingTarget, TrainJobPayload
+from schemas.job import LocalTrainJobPayload, RemoteTrainJobPayload, SshTrainJobPayload, TrainingTarget
 
 
 def _base_kwargs() -> dict:
@@ -27,7 +30,7 @@ def _base_kwargs() -> dict:
 
 class TestLocalTarget:
     def test_local_job_accepts_no_remote_fields(self) -> None:
-        payload = TrainJobPayload(**_base_kwargs(), training_target=TrainingTarget.LOCAL)
+        payload = LocalTrainJobPayload(**_base_kwargs())
         assert payload.training_target is TrainingTarget.LOCAL
 
     @pytest.mark.parametrize(
@@ -41,18 +44,17 @@ class TestLocalTarget:
     )
     def test_local_job_rejects_any_remote_field(self, extra: dict) -> None:
         with pytest.raises(ValidationError):
-            TrainJobPayload(**_base_kwargs(), training_target=TrainingTarget.LOCAL, **extra)
+            LocalTrainJobPayload(**_base_kwargs(), **extra)
 
 
 class TestRemoteTarget:
     def test_remote_job_requires_remote_trainer_id(self) -> None:
         with pytest.raises(ValidationError):
-            TrainJobPayload(**_base_kwargs(), training_target=TrainingTarget.REMOTE)
+            RemoteTrainJobPayload(**_base_kwargs())
 
     def test_remote_job_accepts_direct_url_fields(self) -> None:
-        payload = TrainJobPayload(
+        payload = RemoteTrainJobPayload(
             **_base_kwargs(),
-            training_target=TrainingTarget.REMOTE,
             remote_trainer_id=uuid4(),
             remote_trainer_url="https://trainer.test",
         )
@@ -60,23 +62,19 @@ class TestRemoteTarget:
 
     def test_remote_job_rejects_remote_server_id(self) -> None:
         with pytest.raises(ValidationError):
-            TrainJobPayload(
-                **_base_kwargs(),
-                training_target=TrainingTarget.REMOTE,
-                remote_trainer_id=uuid4(),
-                remote_server_id=uuid4(),
+            RemoteTrainJobPayload.model_validate(
+                {**_base_kwargs(), "remote_trainer_id": uuid4(), "remote_server_id": uuid4()}
             )
 
 
 class TestSshTarget:
     def test_ssh_job_requires_remote_server_id(self) -> None:
         with pytest.raises(ValidationError):
-            TrainJobPayload(**_base_kwargs(), training_target=TrainingTarget.SSH)
+            SshTrainJobPayload(**_base_kwargs())
 
     def test_ssh_job_accepts_remote_server_id(self) -> None:
-        payload = TrainJobPayload(
+        payload = SshTrainJobPayload(
             **_base_kwargs(),
-            training_target=TrainingTarget.SSH,
             remote_server_id=uuid4(),
         )
         assert payload.training_target is TrainingTarget.SSH
@@ -92,9 +90,8 @@ class TestSshTarget:
     )
     def test_ssh_job_rejects_direct_url_fields(self, extra: dict) -> None:
         with pytest.raises(ValidationError):
-            TrainJobPayload(
+            SshTrainJobPayload(
                 **_base_kwargs(),
-                training_target=TrainingTarget.SSH,
                 remote_server_id=uuid4(),
                 **extra,
             )

--- a/application/backend/tests/services/test_job_service.py
+++ b/application/backend/tests/services/test_job_service.py
@@ -17,7 +17,7 @@ def _job(*, status: JobStatus = JobStatus.PENDING) -> TrainJob:
         project_id=project_id,
         status=status,
         payload={
-            "type": "training",
+            "training_target": "local",
             "project_id": str(project_id),
             "dataset_id": str(uuid4()),
             "policy": "act",

--- a/application/backend/tests/services/test_job_service_remote_target.py
+++ b/application/backend/tests/services/test_job_service_remote_target.py
@@ -3,8 +3,16 @@ from uuid import uuid4
 
 import pytest
 
-from exceptions import RemoteResumeUnsupportedError
+from exceptions import (
+    RemoteResumeUnsupportedError,
+    RemoteServerAliasNotFoundError,
+    RemoteServerNotReadyError,
+    ResourceNotFoundError,
+    ResourceType,
+)
+from schemas.hardware import DeviceType
 from schemas.job import TrainingTarget, TrainJobPayload
+from schemas.remote_server import RemoteServer, RemoteServerCheckStatus, ResolvedSshHost
 from schemas.remote_trainer import RemoteTrainer
 from services.job_service import JobService
 
@@ -71,6 +79,164 @@ async def test_submit_remote_job_rejects_continuing_from_an_existing_model() -> 
         model_name="model",
         training_target=TrainingTarget.REMOTE,
         remote_trainer_id=uuid4(),
+        base_model_id=uuid4(),
+    )
+
+    with (
+        patch(f"{MODULE}.JobRepository", return_value=repository),
+        pytest.raises(RemoteResumeUnsupportedError),
+    ):
+        await JobService(session, MagicMock()).submit_train_job(payload)
+
+    repository.save.assert_not_awaited()
+
+
+def _remote_server(*, last_check_status: RemoteServerCheckStatus = "healthy") -> RemoteServer:
+    return RemoteServer(
+        id=uuid4(),
+        name="gpu-box",
+        ssh_host_alias="gpu-box",
+        device_type=DeviceType.CUDA,
+        last_check_status=last_check_status,
+    )
+
+
+@pytest.mark.anyio
+async def test_submit_ssh_job_accepts_a_healthy_server() -> None:
+    session = _session_context()
+    repository = MagicMock()
+    repository.is_job_duplicate = AsyncMock(return_value=False)
+    repository.save = AsyncMock(side_effect=lambda job: job)
+    remote_server = _remote_server()
+    payload = TrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="model",
+        training_target=TrainingTarget.SSH,
+        remote_server_id=remote_server.id,
+    )
+
+    remote_server_service = MagicMock()
+    remote_server_service.get_remote_server = AsyncMock(return_value=remote_server)
+
+    with (
+        patch(f"{MODULE}.JobRepository", return_value=repository),
+        patch(
+            f"{MODULE}.resolve_alias",
+            return_value=ResolvedSshHost(alias=remote_server.ssh_host_alias, hostname="gpu-box.lan", found=True),
+        ),
+    ):
+        job = await JobService(session, remote_server_service=remote_server_service).submit_train_job(payload)
+
+    assert job.payload.remote_server_id == remote_server.id
+    repository.save.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_submit_ssh_job_rejects_an_unhealthy_server() -> None:
+    """A server that has not passed its last preflight cannot be selected for a job."""
+    session = _session_context()
+    repository = MagicMock()
+    repository.is_job_duplicate = AsyncMock(return_value=False)
+    repository.save = AsyncMock(side_effect=lambda job: job)
+    remote_server = _remote_server(last_check_status="unreachable")
+    payload = TrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="model",
+        training_target=TrainingTarget.SSH,
+        remote_server_id=remote_server.id,
+    )
+
+    remote_server_service = MagicMock()
+    remote_server_service.get_remote_server = AsyncMock(return_value=remote_server)
+
+    with (
+        patch(f"{MODULE}.JobRepository", return_value=repository),
+        pytest.raises(RemoteServerNotReadyError),
+    ):
+        await JobService(session, remote_server_service=remote_server_service).submit_train_job(payload)
+
+    repository.save.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_submit_ssh_job_rejects_a_renamed_or_removed_alias() -> None:
+    """A healthy server whose Host entry has since disappeared still fails closed."""
+    session = _session_context()
+    repository = MagicMock()
+    repository.is_job_duplicate = AsyncMock(return_value=False)
+    repository.save = AsyncMock(side_effect=lambda job: job)
+    remote_server = _remote_server()
+    payload = TrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="model",
+        training_target=TrainingTarget.SSH,
+        remote_server_id=remote_server.id,
+    )
+
+    remote_server_service = MagicMock()
+    remote_server_service.get_remote_server = AsyncMock(return_value=remote_server)
+
+    with (
+        patch(f"{MODULE}.JobRepository", return_value=repository),
+        patch(
+            f"{MODULE}.resolve_alias",
+            return_value=ResolvedSshHost(alias=remote_server.ssh_host_alias, found=False),
+        ),
+        pytest.raises(RemoteServerAliasNotFoundError),
+    ):
+        await JobService(session, remote_server_service=remote_server_service).submit_train_job(payload)
+
+    repository.save.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_submit_ssh_job_rejects_an_unknown_server() -> None:
+    session = _session_context()
+    repository = MagicMock()
+    repository.is_job_duplicate = AsyncMock(return_value=False)
+    repository.save = AsyncMock(side_effect=lambda job: job)
+    payload = TrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="model",
+        training_target=TrainingTarget.SSH,
+        remote_server_id=uuid4(),
+    )
+
+    remote_server_service = MagicMock()
+    remote_server_service.get_remote_server = AsyncMock(
+        side_effect=ResourceNotFoundError(ResourceType.REMOTE_SERVER, str(payload.remote_server_id))
+    )
+
+    with (
+        patch(f"{MODULE}.JobRepository", return_value=repository),
+        pytest.raises(ResourceNotFoundError),
+    ):
+        await JobService(session, remote_server_service=remote_server_service).submit_train_job(payload)
+
+    repository.save.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_submit_ssh_job_rejects_continuing_from_an_existing_model() -> None:
+    session = _session_context()
+    repository = MagicMock()
+    repository.is_job_duplicate = AsyncMock(return_value=False)
+    repository.save = AsyncMock(side_effect=lambda job: job)
+    payload = TrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="model",
+        training_target=TrainingTarget.SSH,
+        remote_server_id=uuid4(),
         base_model_id=uuid4(),
     )
 

--- a/application/backend/tests/services/test_job_service_remote_target.py
+++ b/application/backend/tests/services/test_job_service_remote_target.py
@@ -11,7 +11,7 @@ from exceptions import (
     ResourceType,
 )
 from schemas.hardware import DeviceType
-from schemas.job import TrainingTarget, TrainJobPayload
+from schemas.job import RemoteTrainJobPayload, SshTrainJobPayload
 from schemas.remote_server import RemoteServer, RemoteServerCheckStatus, ResolvedSshHost
 from schemas.remote_trainer import RemoteTrainer
 from services.job_service import JobService
@@ -39,12 +39,11 @@ async def test_submit_remote_job_pins_configured_url_and_ignores_client_url() ->
         name="trainer",
         url="https://configured-trainer.test",
     )
-    payload = TrainJobPayload(
+    payload = RemoteTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="model",
-        training_target=TrainingTarget.REMOTE,
         remote_trainer_id=remote_trainer_id,
         remote_trainer_url="https://client-supplied.test",
     )
@@ -73,12 +72,11 @@ async def test_submit_remote_job_rejects_continuing_from_an_existing_model() -> 
     repository = MagicMock()
     repository.is_job_duplicate = AsyncMock(return_value=False)
     repository.save = AsyncMock(side_effect=lambda job: job)
-    payload = TrainJobPayload(
+    payload = RemoteTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="model",
-        training_target=TrainingTarget.REMOTE,
         remote_trainer_id=uuid4(),
         base_model_id=uuid4(),
     )
@@ -109,12 +107,11 @@ async def test_submit_ssh_job_accepts_a_healthy_server() -> None:
     repository.is_job_duplicate = AsyncMock(return_value=False)
     repository.save = AsyncMock(side_effect=lambda job: job)
     remote_server = _remote_server()
-    payload = TrainJobPayload(
+    payload = SshTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="model",
-        training_target=TrainingTarget.SSH,
         remote_server_id=remote_server.id,
     )
 
@@ -142,12 +139,11 @@ async def test_submit_ssh_job_rejects_an_unhealthy_server() -> None:
     repository.is_job_duplicate = AsyncMock(return_value=False)
     repository.save = AsyncMock(side_effect=lambda job: job)
     remote_server = _remote_server(last_check_status="unreachable")
-    payload = TrainJobPayload(
+    payload = SshTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="model",
-        training_target=TrainingTarget.SSH,
         remote_server_id=remote_server.id,
     )
 
@@ -171,12 +167,11 @@ async def test_submit_ssh_job_rejects_a_renamed_or_removed_alias() -> None:
     repository.is_job_duplicate = AsyncMock(return_value=False)
     repository.save = AsyncMock(side_effect=lambda job: job)
     remote_server = _remote_server()
-    payload = TrainJobPayload(
+    payload = SshTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="model",
-        training_target=TrainingTarget.SSH,
         remote_server_id=remote_server.id,
     )
 
@@ -202,12 +197,11 @@ async def test_submit_ssh_job_rejects_an_unknown_server() -> None:
     repository = MagicMock()
     repository.is_job_duplicate = AsyncMock(return_value=False)
     repository.save = AsyncMock(side_effect=lambda job: job)
-    payload = TrainJobPayload(
+    payload = SshTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="model",
-        training_target=TrainingTarget.SSH,
         remote_server_id=uuid4(),
     )
 
@@ -231,12 +225,11 @@ async def test_submit_ssh_job_rejects_continuing_from_an_existing_model() -> Non
     repository = MagicMock()
     repository.is_job_duplicate = AsyncMock(return_value=False)
     repository.save = AsyncMock(side_effect=lambda job: job)
-    payload = TrainJobPayload(
+    payload = SshTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="model",
-        training_target=TrainingTarget.SSH,
         remote_server_id=uuid4(),
         base_model_id=uuid4(),
     )

--- a/application/backend/tests/services/test_job_service_remote_target.py
+++ b/application/backend/tests/services/test_job_service_remote_target.py
@@ -17,6 +17,7 @@ from schemas.remote_trainer import RemoteTrainer
 from services.job_service import JobService
 
 MODULE = "services.job_service"
+SSH_MODULE = "services.training_targets.ssh"
 
 
 def _session_context() -> AsyncMock:
@@ -123,7 +124,7 @@ async def test_submit_ssh_job_accepts_a_healthy_server() -> None:
     with (
         patch(f"{MODULE}.JobRepository", return_value=repository),
         patch(
-            f"{MODULE}.resolve_alias",
+            f"{SSH_MODULE}.resolve_alias",
             return_value=ResolvedSshHost(alias=remote_server.ssh_host_alias, hostname="gpu-box.lan", found=True),
         ),
     ):
@@ -185,7 +186,7 @@ async def test_submit_ssh_job_rejects_a_renamed_or_removed_alias() -> None:
     with (
         patch(f"{MODULE}.JobRepository", return_value=repository),
         patch(
-            f"{MODULE}.resolve_alias",
+            f"{SSH_MODULE}.resolve_alias",
             return_value=ResolvedSshHost(alias=remote_server.ssh_host_alias, found=False),
         ),
         pytest.raises(RemoteServerAliasNotFoundError),

--- a/application/backend/tests/services/test_local_training_backend.py
+++ b/application/backend/tests/services/test_local_training_backend.py
@@ -19,7 +19,7 @@ import pytest
 from pydantic import SecretStr
 
 from schemas.dataset import Snapshot
-from schemas.job import _DEFAULT_MAX_EPOCHS, TrainingDevice, TrainingPrecision, TrainJobPayload
+from schemas.job import _DEFAULT_MAX_EPOCHS, LocalTrainJobPayload, TrainingDevice, TrainingPrecision, TrainJobPayload
 from schemas.model import Model
 from services.training_backends.base import TrainingContext
 from services.training_backends.local import LocalTrainingBackend, build_spec
@@ -33,7 +33,7 @@ LOCAL = "services.training_backends.local"
 
 
 def _payload(**overrides) -> TrainJobPayload:
-    return TrainJobPayload.model_validate(
+    return LocalTrainJobPayload.model_validate(
         {
             "project_id": uuid4(),
             "dataset_id": uuid4(),

--- a/application/backend/tests/services/test_log_service.py
+++ b/application/backend/tests/services/test_log_service.py
@@ -63,7 +63,7 @@ async def test_discover_job_sources_includes_training_name_and_created_at(tmp_pa
         id=job_id,
         project_id=uuid4(),
         payload={
-            "type": "training",
+            "training_target": "local",
             "project_id": str(uuid4()),
             "dataset_id": str(uuid4()),
             "policy": "pi0",
@@ -100,7 +100,7 @@ async def test_discover_job_sources_ignores_rotated_job_logs(tmp_path) -> None:
         id=job_id,
         project_id=uuid4(),
         payload={
-            "type": "training",
+            "training_target": "local",
             "project_id": str(uuid4()),
             "dataset_id": str(uuid4()),
             "policy": "pi0",

--- a/application/backend/tests/services/test_model_import_service.py
+++ b/application/backend/tests/services/test_model_import_service.py
@@ -61,6 +61,7 @@ def job(project_id, dataset_id):
             "type": "training",
             "status": "completed",
             "payload": {
+                "training_target": "local",
                 "project_id": str(project_id),
                 "dataset_id": str(dataset_id),
                 "policy": "act",

--- a/application/backend/tests/services/test_remote_training_backend.py
+++ b/application/backend/tests/services/test_remote_training_backend.py
@@ -20,7 +20,7 @@ import pytest
 from loguru import logger
 
 from schemas.dataset import Snapshot
-from schemas.job import TrainingDevice, TrainJobPayload
+from schemas.job import RemoteTrainJobPayload, TrainingDevice
 from schemas.model import Model
 from services.training_backends._transfer_progress import TransferProgressLogger, format_bytes, format_throughput
 from services.training_backends.base import TrainingContext
@@ -235,7 +235,9 @@ def _context(
         version=1,
         created_at=None,
     )
-    payload = TrainJobPayload(project_id=uuid4(), dataset_id=uuid4(), policy="act", model_name="m")
+    payload = RemoteTrainJobPayload(
+        project_id=uuid4(), dataset_id=uuid4(), policy="act", model_name="m", remote_trainer_id=uuid4()
+    )
     return TrainingContext(
         job=MagicMock(),
         model=model,

--- a/application/backend/tests/services/test_training_backends.py
+++ b/application/backend/tests/services/test_training_backends.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 from loguru import logger
 
-from schemas.job import TrainingTarget, TrainJobPayload
+from schemas.job import LocalTrainJobPayload, RemoteTrainJobPayload, TrainJobPayload
 from services.training_backends import get_training_backend
 from services.training_backends.local import LocalTrainingBackend
 from services.training_backends.remote import SNAPSHOT_UPLOAD_PROGRESS, TRAINING_PROGRESS_END, RemoteTrainingBackend
@@ -24,21 +24,29 @@ def _settings() -> MagicMock:
     return settings
 
 
-def _payload(target: TrainingTarget) -> TrainJobPayload:
-    return TrainJobPayload(
+def _local_payload() -> TrainJobPayload:
+    return LocalTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="model",
-        training_target=target,
-        remote_trainer_id=uuid4() if target is TrainingTarget.REMOTE else None,
-        remote_trainer_url="https://trainer.test" if target is TrainingTarget.REMOTE else None,
-        remote_trainer_name="gpu-box-1" if target is TrainingTarget.REMOTE else None,
+    )
+
+
+def _remote_payload() -> TrainJobPayload:
+    return RemoteTrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="model",
+        remote_trainer_id=uuid4(),
+        remote_trainer_url="https://trainer.test",
+        remote_trainer_name="gpu-box-1",
     )
 
 
 def test_get_training_backend_returns_local_for_local_job() -> None:
-    backend = get_training_backend(_payload(TrainingTarget.LOCAL))
+    backend = get_training_backend(_local_payload())
     assert isinstance(backend, LocalTrainingBackend)
 
 
@@ -48,7 +56,7 @@ def test_get_training_backend_returns_remote_for_remote_job() -> None:
         patch("settings.get_settings", return_value=settings),
         patch("services.training_backends.remote.get_settings", return_value=settings),
     ):
-        backend = get_training_backend(_payload(TrainingTarget.REMOTE))
+        backend = get_training_backend(_remote_payload())
     assert isinstance(backend, RemoteTrainingBackend)
 
     # The pinned trainer name reaches the backend, so its job logs are attributable.

--- a/application/backend/tests/services/test_training_service_reattach.py
+++ b/application/backend/tests/services/test_training_service_reattach.py
@@ -78,6 +78,54 @@ class TestReattachOrphans:
 
         assert service.update_job_status.call_args.kwargs["status"] == JobStatus.FAILED
 
+    @pytest.mark.anyio
+    async def test_ssh_running_job_with_remote_id_is_requeued(self):
+        """An SSH-provisioned job that recorded its remote id is requeued, not failed.
+
+        Its trainer container keeps running independently of the studio process,
+        the same way a direct-URL remote trainer does.
+        """
+        payload = TrainJobPayload(
+            project_id=uuid4(),
+            dataset_id=uuid4(),
+            policy="act",
+            model_name="m",
+            training_target=TrainingTarget.SSH,
+            remote_server_id=uuid4(),
+            remote_job_id=uuid4(),
+        )
+        job = _job(payload)
+
+        service = MagicMock()
+        service.get_job_list = AsyncMock(return_value=[job])
+        service.update_job_status = AsyncMock(return_value=MagicMock())
+
+        await TrainingService.abort_orphan_jobs(service)
+
+        service.update_job_status.assert_awaited_once()
+        assert service.update_job_status.call_args.kwargs["status"] == JobStatus.PENDING
+
+    @pytest.mark.anyio
+    async def test_ssh_running_job_without_remote_id_is_failed(self):
+        """An SSH job that never got a remote id cannot resume and is failed."""
+        payload = TrainJobPayload(
+            project_id=uuid4(),
+            dataset_id=uuid4(),
+            policy="act",
+            model_name="m",
+            training_target=TrainingTarget.SSH,
+            remote_server_id=uuid4(),
+        )
+        job = _job(payload)
+
+        service = MagicMock()
+        service.get_job_list = AsyncMock(return_value=[job])
+        service.update_job_status = AsyncMock(return_value=MagicMock())
+
+        await TrainingService.abort_orphan_jobs(service)
+
+        assert service.update_job_status.call_args.kwargs["status"] == JobStatus.FAILED
+
     def test_reattachable_remote_job_id_reads_dict_payload(self):
         """Payloads persisted as plain dicts are also understood."""
         job = MagicMock()
@@ -88,4 +136,14 @@ class TestReattachOrphans:
         job.payload = {"training_target": "remote", "remote_job_id": "not-a-uuid"}
         assert TrainingService._reattachable_remote_job_id(job) is None
         job.payload = {"training_target": "remote", "remote_job_id": None}
+        assert TrainingService._reattachable_remote_job_id(job) is None
+
+    def test_reattachable_remote_job_id_reads_ssh_dict_payload(self):
+        """An SSH job's dict payload is reattachable the same way a remote one is."""
+        job = MagicMock()
+        remote_job_id = uuid4()
+        job.payload = {"training_target": "ssh", "remote_job_id": str(remote_job_id)}
+        assert TrainingService._reattachable_remote_job_id(job) == remote_job_id
+
+        job.payload = {"training_target": "local", "remote_job_id": str(remote_job_id)}
         assert TrainingService._reattachable_remote_job_id(job) is None

--- a/application/backend/tests/services/test_training_service_reattach.py
+++ b/application/backend/tests/services/test_training_service_reattach.py
@@ -11,21 +11,20 @@ from uuid import UUID, uuid4
 import pytest
 
 from schemas.base_job import JobStatus
-from schemas.job import TrainingTarget, TrainJobPayload
+from schemas.job import LocalTrainJobPayload, RemoteTrainJobPayload, SshTrainJobPayload, TrainJobPayload
 from services.training_service import TrainingService
 
 MODULE = "services.training_service"
 
 
-def _payload(*, remote_job_id: UUID | None = None, target: TrainingTarget = TrainingTarget.REMOTE) -> TrainJobPayload:
-    return TrainJobPayload(
+def _payload(*, remote_job_id: UUID | None = None) -> TrainJobPayload:
+    return RemoteTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="m",
-        training_target=target,
-        remote_trainer_id=uuid4() if target is TrainingTarget.REMOTE else None,
-        remote_trainer_url="https://trainer.test" if target is TrainingTarget.REMOTE else None,
+        remote_trainer_id=uuid4(),
+        remote_trainer_url="https://trainer.test",
         remote_job_id=remote_job_id,
     )
 
@@ -68,7 +67,14 @@ class TestReattachOrphans:
     @pytest.mark.anyio
     async def test_local_job_always_fails_orphans(self):
         """A local job cannot reattach, even if a stale remote id is present."""
-        job = _job(_payload(remote_job_id=uuid4(), target=TrainingTarget.LOCAL))
+        payload = LocalTrainJobPayload(
+            project_id=uuid4(),
+            dataset_id=uuid4(),
+            policy="act",
+            model_name="m",
+            remote_job_id=uuid4(),
+        )
+        job = _job(payload)
 
         service = MagicMock()
         service.get_job_list = AsyncMock(return_value=[job])
@@ -85,12 +91,11 @@ class TestReattachOrphans:
         Its trainer container keeps running independently of the studio process,
         the same way a direct-URL remote trainer does.
         """
-        payload = TrainJobPayload(
+        payload = SshTrainJobPayload(
             project_id=uuid4(),
             dataset_id=uuid4(),
             policy="act",
             model_name="m",
-            training_target=TrainingTarget.SSH,
             remote_server_id=uuid4(),
             remote_job_id=uuid4(),
         )
@@ -108,12 +113,11 @@ class TestReattachOrphans:
     @pytest.mark.anyio
     async def test_ssh_running_job_without_remote_id_is_failed(self):
         """An SSH job that never got a remote id cannot resume and is failed."""
-        payload = TrainJobPayload(
+        payload = SshTrainJobPayload(
             project_id=uuid4(),
             dataset_id=uuid4(),
             policy="act",
             model_name="m",
-            training_target=TrainingTarget.SSH,
             remote_server_id=uuid4(),
         )
         job = _job(payload)

--- a/application/backend/tests/services/training_backends/test_phase.py
+++ b/application/backend/tests/services/training_backends/test_phase.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the phase-windowed progress helper shared by remote backends."""
+
+from itertools import pairwise
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.training_backends.phase import (
+    PHASE_TABLE_VERSION,
+    SSH_PHASE_WINDOWS,
+    PhaseKey,
+    PhaseState,
+    PhaseWindow,
+    report_phase,
+)
+
+
+def test_ssh_phase_windows_are_contiguous_and_span_0_to_100() -> None:
+    """Each phase must own a slice of the bar with no gaps or overlaps."""
+    assert SSH_PHASE_WINDOWS[0].start == 0
+    assert SSH_PHASE_WINDOWS[-1].end == 100
+    for previous, current in pairwise(SSH_PHASE_WINDOWS):
+        assert previous.end == current.start
+
+
+def test_phase_window_rejects_an_inverted_range() -> None:
+    with pytest.raises(ValueError, match="Invalid phase window"):
+        PhaseWindow(PhaseKey.CONNECT, "Connect", start=10, end=5)
+
+
+def test_report_phase_maps_sub_progress_into_the_window() -> None:
+    reporter = MagicMock()
+    windows = (PhaseWindow(PhaseKey.UPLOAD, "Dataset upload", 9, 17),)
+
+    report_phase(reporter, windows, PhaseKey.UPLOAD, sub_progress=50.0, message="halfway")
+
+    reporter.assert_called_once()
+    args, kwargs = reporter.call_args
+    assert args[0] == 13  # 9 + round(50/100 * 8)
+    assert kwargs["message"] == "halfway"
+    phase = kwargs["extra_info"]["phase"]
+    assert phase == {
+        "version": PHASE_TABLE_VERSION,
+        "key": "upload",
+        "label": "Dataset upload",
+        "index": 0,
+        "total": 1,
+        "state": PhaseState.ACTIVE.value,
+        "indeterminate": False,
+    }
+
+
+def test_report_phase_indeterminate_pins_to_window_start() -> None:
+    reporter = MagicMock()
+    windows = (PhaseWindow(PhaseKey.IMAGE_PULL, "Image pull", 2, 5),)
+
+    report_phase(reporter, windows, PhaseKey.IMAGE_PULL, sub_progress=None, message="Pulling image")
+
+    args, kwargs = reporter.call_args
+    assert args[0] == 2
+    assert kwargs["extra_info"]["phase"]["indeterminate"] is True
+
+
+def test_report_phase_merges_caller_extra_info() -> None:
+    reporter = MagicMock()
+    windows = (PhaseWindow(PhaseKey.TRAIN, "Training", 17, 96),)
+
+    report_phase(reporter, windows, PhaseKey.TRAIN, sub_progress=0.0, extra_info={"loss": 0.5})
+
+    _, kwargs = reporter.call_args
+    assert kwargs["extra_info"]["loss"] == 0.5
+    assert "phase" in kwargs["extra_info"]
+
+
+def test_report_phase_rejects_a_key_not_in_the_table() -> None:
+    reporter = MagicMock()
+    windows = (PhaseWindow(PhaseKey.CONNECT, "Connect", 0, 2),)
+
+    with pytest.raises(ValueError, match="not part of"):
+        report_phase(reporter, windows, PhaseKey.TRAIN)
+
+
+def test_local_and_direct_url_phase_windows_are_untouched() -> None:
+    """This module must not retune the shared local/direct-URL progress constants."""
+    from services.training_backends.remote import SNAPSHOT_UPLOAD_PROGRESS, TRAINING_PROGRESS_END
+
+    assert SNAPSHOT_UPLOAD_PROGRESS == 10
+    assert TRAINING_PROGRESS_END == 95

--- a/application/backend/tests/workers/test_training_worker.py
+++ b/application/backend/tests/workers/test_training_worker.py
@@ -444,6 +444,50 @@ class TestTraining:
             assert args[1].snapshot_id == snapshot_id
 
 
+class TestTargetKey:
+    """`_target_key` must give every remote kind its own key namespace."""
+
+    def test_local_target_key(self) -> None:
+        from workers.training_worker import TrainingWorker
+
+        payload = _make_payload()
+        assert TrainingWorker._target_key(payload) == "local"
+
+    def test_remote_target_key_uses_remote_trainer_id(self) -> None:
+        from workers.training_worker import TrainingWorker
+
+        payload = _make_payload()
+        payload.training_target = TrainingTarget.REMOTE
+        payload.remote_trainer_id = uuid4()
+        assert TrainingWorker._target_key(payload) == f"remote:{payload.remote_trainer_id}"
+
+    def test_ssh_target_key_uses_remote_server_id(self) -> None:
+        from workers.training_worker import TrainingWorker
+
+        payload = _make_payload()
+        payload.training_target = TrainingTarget.SSH
+        payload.remote_server_id = uuid4()
+        assert TrainingWorker._target_key(payload) == f"ssh:{payload.remote_server_id}"
+
+    def test_ssh_and_remote_targets_never_collide_on_none(self) -> None:
+        """Two well-formed jobs on different servers never collapse onto one key."""
+        from workers.training_worker import TrainingWorker
+
+        first = _make_payload()
+        first.training_target = TrainingTarget.SSH
+        first.remote_server_id = uuid4()
+        second = _make_payload()
+        second.training_target = TrainingTarget.SSH
+        second.remote_server_id = uuid4()
+
+        first_key = TrainingWorker._target_key(first)
+        second_key = TrainingWorker._target_key(second)
+
+        assert first_key != second_key
+        assert "None" not in first_key
+        assert "None" not in second_key
+
+
 class TestTrainingScheduling:
     @pytest.mark.anyio
     async def test_jobs_on_distinct_targets_start_without_waiting(self, worker) -> None:

--- a/application/backend/tests/workers/test_training_worker.py
+++ b/application/backend/tests/workers/test_training_worker.py
@@ -9,7 +9,7 @@ import queue
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -17,7 +17,13 @@ import pytest
 import core.scheduler  # noqa: F401
 from schemas.base_job import JobStatus, JobType
 from schemas.dataset import Snapshot
-from schemas.job import TrainingPrecision, TrainingTarget, TrainJobPayload
+from schemas.job import (
+    LocalTrainJobPayload,
+    RemoteTrainJobPayload,
+    SshTrainJobPayload,
+    TrainingPrecision,
+    TrainJobPayload,
+)
 from schemas.model import Model
 
 if TYPE_CHECKING:
@@ -35,7 +41,7 @@ MODULE = "workers.training_worker"
 def _make_payload(
     *, compile_model: bool = True, precision: TrainingPrecision = TrainingPrecision.BF16_MIXED
 ) -> TrainJobPayload:
-    return TrainJobPayload(
+    return LocalTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
@@ -46,6 +52,26 @@ def _make_payload(
         auto_scale_batch_size=False,
         compile_model=compile_model,
         precision=precision,
+    )
+
+
+def _make_remote_payload(*, remote_trainer_id: UUID | None = None) -> RemoteTrainJobPayload:
+    return RemoteTrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="test-model",
+        remote_trainer_id=remote_trainer_id or uuid4(),
+    )
+
+
+def _make_ssh_payload(*, remote_server_id: UUID | None = None) -> SshTrainJobPayload:
+    return SshTrainJobPayload(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        policy="act",
+        model_name="test-model",
+        remote_server_id=remote_server_id or uuid4(),
     )
 
 
@@ -456,29 +482,21 @@ class TestTargetKey:
     def test_remote_target_key_uses_remote_trainer_id(self) -> None:
         from workers.training_worker import TrainingWorker
 
-        payload = _make_payload()
-        payload.training_target = TrainingTarget.REMOTE
-        payload.remote_trainer_id = uuid4()
+        payload = _make_remote_payload()
         assert TrainingWorker._target_key(payload) == f"remote:{payload.remote_trainer_id}"
 
     def test_ssh_target_key_uses_remote_server_id(self) -> None:
         from workers.training_worker import TrainingWorker
 
-        payload = _make_payload()
-        payload.training_target = TrainingTarget.SSH
-        payload.remote_server_id = uuid4()
+        payload = _make_ssh_payload()
         assert TrainingWorker._target_key(payload) == f"ssh:{payload.remote_server_id}"
 
     def test_ssh_and_remote_targets_never_collide_on_none(self) -> None:
         """Two well-formed jobs on different servers never collapse onto one key."""
         from workers.training_worker import TrainingWorker
 
-        first = _make_payload()
-        first.training_target = TrainingTarget.SSH
-        first.remote_server_id = uuid4()
-        second = _make_payload()
-        second.training_target = TrainingTarget.SSH
-        second.remote_server_id = uuid4()
+        first = _make_ssh_payload()
+        second = _make_ssh_payload()
 
         first_key = TrainingWorker._target_key(first)
         second_key = TrainingWorker._target_key(second)
@@ -492,9 +510,7 @@ class TestTrainingScheduling:
     @pytest.mark.anyio
     async def test_jobs_on_distinct_targets_start_without_waiting(self, worker) -> None:
         """A local job and jobs on separate remote trainers run concurrently."""
-        remote_payload = _make_payload()
-        remote_payload.training_target = TrainingTarget.REMOTE
-        remote_payload.remote_trainer_id = uuid4()
+        remote_payload = _make_remote_payload()
         other_remote_payload = remote_payload.model_copy(update={"remote_trainer_id": uuid4()})
         jobs = [_make_job(_make_payload()), _make_job(remote_payload), _make_job(other_remote_payload)]
         worker._active_training_tasks = {}
@@ -513,9 +529,7 @@ class TestTrainingScheduling:
     @pytest.mark.anyio
     async def test_second_job_on_same_target_remains_pending(self, worker) -> None:
         """Only the oldest job for an occupied local or remote target starts."""
-        remote_payload = _make_payload()
-        remote_payload.training_target = TrainingTarget.REMOTE
-        remote_payload.remote_trainer_id = uuid4()
+        remote_payload = _make_remote_payload()
         jobs = [
             _make_job(_make_payload()),
             _make_job(_make_payload()),

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.tsx
@@ -139,7 +139,7 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
 
         const name = baseModel?.name ?? MODELS.find((policy) => policy.id === selectedPolicy)?.name ?? '';
 
-        const payload: SchemaJob['payload'] = {
+        const commonPayload = {
             dataset_id,
             project_id: projectId,
             model_name: name,
@@ -151,10 +151,19 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
             precision: (precision?.toString() ?? 'bf16-mixed') as SchemaJob['payload']['precision'],
             compile_model: compileModel,
             val_split: 0.1,
-            training_target: isRemoteTarget ? 'remote' : 'local',
-            ...(isRemoteTarget ? { remote_trainer_id: remoteTrainerId?.toString() } : {}),
             ...extraPayload,
-        };
+        } as const;
+
+        const payload: SchemaJob['payload'] = isRemoteTarget
+            ? {
+                  ...commonPayload,
+                  training_target: 'remote',
+                  remote_trainer_id: remoteTrainerId?.toString() ?? '',
+              }
+            : {
+                  ...commonPayload,
+                  training_target: 'local',
+              };
         trainMutation.mutateAsync({ body: payload }).then((response) => {
             close(response as SchemaTrainJob | undefined);
         });


### PR DESCRIPTION
The job model only understood "local" or "remote URL". SSH training needs a target of its own so a job can name a server, and that has to land without disturbing the two existing paths.

## What changed

- `TrainingTarget.SSH` and `TrainJobPayload.remote_server_id`, with the validator keeping local, direct-URL, and SSH mutually exclusive.
- `TrainingWorker._target_key` returns `ssh:<remote_server_id>`; it previously collapsed every SSH job on every server onto the single key `remote:None`.
- Reattach: an SSH job with a persisted `remote_job_id` requeues to `PENDING` on restart, like a direct-URL job.
- Submission validation in `JobService.submit_train_job`: server exists, last preflight healthy, alias still resolves.
- Versioned per-target phase table (`training_backends/phase.py`) plus a `report_phase` helper.
- `RemoteTrainingBackend` accepts an injected device; `get_training_backend` guards SSH payloads so they fail loudly instead of silently training locally.

## Design notes

- **Overloading `REMOTE` was rejected**: `get_training_backend` raises when `remote_trainer_url is None`, and the worker's `reattaching` check would misfire.
- **No new `JobStatus` member** — a GPU-busy wait is a `waiting` phase state in `extra_info["phase"]` and the job stays `pending`. A new member would break every generated UI consumer.
- Local and direct-URL keep `SNAPSHOT_UPLOAD_PROGRESS = 10` / `TRAINING_PROGRESS_END = 95` and their existing assertions.

## Out of scope

No SSH transport, tunnels, or Docker operations. `get_training_backend` still doesn't select an SSH backend — that's #1014.

---

**Plan:** [PR 6 — Training job contract and progress framework](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md#pr-6--training-job-contract-and-progress-framework) · [backend plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-plan.md) · [full PR plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md)
