### PR TITLE
feat(ssh-trainer): wire SSH-provisioned execution into training dispatch

### DIFF
--- a/application/backend/src/services/ssh/provisioning.py
+++ b/application/backend/src/services/ssh/provisioning.py
@@ -39,6 +39,7 @@ from services.ssh import docker_ops
 from services.ssh.docker_ops import LibraryVersionCheck, ResolvedImage
 from services.ssh.transport import SshTransport, open_transport
 from services.ssh.tunnel import SshTunnel
+from services.training_backends.phase import PhaseKey
 from settings import get_settings
 
 if TYPE_CHECKING:
@@ -107,7 +108,11 @@ class SshProvisioningService:
         self._repository = repository
         self._settings = settings or get_settings()
 
-    async def provision(  # noqa: PLR0915 - top-level orchestrator; its teardown path must stay inlined
+    # PLR0913/PLR0915: one keyword-only parameter per tunable/callback and one
+    # statement per orchestration step; splitting either up would obscure the
+    # single, carefully-ordered happy path this method exists to document (see
+    # the module and class docstrings).
+    async def provision(  # noqa: PLR0913, PLR0915
         self,
         job_id: UUID,
         server: RemoteServer,
@@ -117,6 +122,7 @@ class SshProvisioningService:
         min_library_version: str | None = None,
         library_version_policy_name: str = "default",
         on_gpu_wait: Callable[[float], Awaitable[None]] | None = None,
+        on_phase: Callable[[PhaseKey], None] | None = None,
     ) -> ProvisionedTrainer:
         """Provision a fresh trainer container for one job.
 
@@ -136,6 +142,11 @@ class SshProvisioningService:
                 fatal-below-minimum check (e.g. a specific model family).
             on_gpu_wait: Awaited while waiting out a busy GPU, so a caller can
                 report a `waiting` phase state.
+            on_phase: Called synchronously as provisioning enters each new
+                stage (image verification, image pull, trainer start), so a
+                caller can drive the SSH phase stepper. `connect` is reported
+                by the caller before this method is invoked at all, since the
+                job provisioning row is already persisted by then.
 
         Returns:
             A running, tunnel-reachable trainer.
@@ -148,6 +159,10 @@ class SshProvisioningService:
         labels = docker_ops.management_labels(
             job_id=str(job_id), server_id=str(server.id), backend_instance_id=backend_instance_id
         )
+
+        def _phase(key: PhaseKey) -> None:
+            if on_phase is not None:
+                on_phase(key)
 
         await self._repository.save(
             JobProvisioning(
@@ -172,8 +187,10 @@ class SshProvisioningService:
                 )
                 if library_check.warning:
                     logger.warning(library_check.warning)
+                _phase(PhaseKey.IMAGE_VERIFY)
                 await docker_ops.verify_image_signature(transport, image, settings)
                 await docker_ops.check_disk_for_job(transport, snapshot_size_bytes, server.name)
+                _phase(PhaseKey.IMAGE_PULL)
                 await docker_ops.pull_image(transport, image, settings)
 
                 await self._repository.update_by_job_id(
@@ -188,6 +205,7 @@ class SshProvisioningService:
                 on_wait=on_gpu_wait,
             )
 
+            _phase(PhaseKey.TRAINER_START)
             async with SshTransport(server.ssh_host_alias, settings) as transport:
                 render_gid = (
                     None

--- a/application/backend/src/services/training_backends/__init__.py
+++ b/application/backend/src/services/training_backends/__init__.py
@@ -9,7 +9,9 @@ service. The active backend is selected per job from its persisted execution
 target.
 """
 
-from schemas.job import RemoteTrainJobPayload, SshTrainJobPayload, TrainJobPayload
+from uuid import UUID
+
+from schemas.job import RemoteTrainJobPayload, TrainJobPayload
 from services.training_backends.base import (
     ProgressReporter,
     TrainingBackend,
@@ -19,14 +21,24 @@ from services.training_backends.base import (
 )
 
 
-def get_training_backend(payload: TrainJobPayload) -> TrainingBackend:
-    """Return the backend selected by a job's persisted execution target."""
-    if isinstance(payload, SshTrainJobPayload):
-        # SSH provisioning (PR7/PR8) is not wired in yet. JobService rejects SSH
-        # submissions before a job reaches this factory (see submit_train_job),
-        # so this should be unreachable; fail loudly rather than silently
-        # falling through to local training if it ever is reached.
-        raise NotImplementedError("SSH-provisioned training backend is not yet implemented")
+async def get_training_backend(payload: TrainJobPayload, job_id: UUID) -> TrainingBackend:
+    """Return the backend selected by a job's persisted execution target.
+
+    ``job_id`` is only used by the SSH target, to key its provisioning record;
+    the local and direct-URL remote targets ignore it.
+    """
+    from schemas.job import TrainingTarget
+
+    if payload.training_target is TrainingTarget.SSH:
+        from db import get_async_db_session_ctx
+        from services.remote_server_service import RemoteServerService
+        from services.training_backends.ssh import SshTrainingBackend
+
+        if payload.remote_server_id is None:
+            raise ValueError("SSH training job is missing its selected remote server")
+        async with get_async_db_session_ctx() as session:
+            server = await RemoteServerService(session).get_remote_server(payload.remote_server_id)
+        return SshTrainingBackend(job_id, server)
 
     if isinstance(payload, RemoteTrainJobPayload):
         from services.training_backends.remote import RemoteTrainingBackend

--- a/application/backend/src/services/training_backends/phase.py
+++ b/application/backend/src/services/training_backends/phase.py
@@ -14,10 +14,17 @@ can render a stepper while the plain bar still drives unaware consumers.
 Local and direct-URL backends are untouched by this module: they keep their
 own ``SNAPSHOT_UPLOAD_PROGRESS`` / ``TRAINING_PROGRESS_END`` windows in
 ``services.training_backends.remote`` and never attach a ``phase`` descriptor.
-This table is selected only by the (not-yet-implemented) SSH backend.
+This table is selected only by ``services.training_backends.ssh.SshTrainingBackend``.
 
 ``PHASE_TABLE_VERSION`` and ``PhaseKey`` must stay in lockstep with whatever
 the UI consumes, so both sides drift together rather than silently apart.
+
+Window order deliberately follows `SshProvisioningService.provision`'s real
+execution order (verify the image's signature *before* ever pulling it, so an
+unsigned/tampered image is never fetched at all) rather than the earlier,
+purely descriptive "image pull, then verification" ordering: image
+verification runs, then the (indeterminate) pull, then the trainer container
+is launched.
 """
 
 from __future__ import annotations
@@ -40,8 +47,8 @@ class PhaseKey(StrEnum):
     """Ordered stages of an SSH-provisioned training job."""
 
     CONNECT = "connect"
-    IMAGE_PULL = "image_pull"
     IMAGE_VERIFY = "image_verify"
+    IMAGE_PULL = "image_pull"
     TRAINER_START = "trainer_start"
     UPLOAD = "upload"
     TRAIN = "train"
@@ -78,8 +85,8 @@ class PhaseWindow:
 # and force rewriting their existing progress assertions for no gain.
 SSH_PHASE_WINDOWS: tuple[PhaseWindow, ...] = (
     PhaseWindow(PhaseKey.CONNECT, "Connect & preflight", 0, 2),
-    PhaseWindow(PhaseKey.IMAGE_PULL, "Image pull", 2, 5),
-    PhaseWindow(PhaseKey.IMAGE_VERIFY, "Image verification", 5, 7),
+    PhaseWindow(PhaseKey.IMAGE_VERIFY, "Image verification", 2, 4),
+    PhaseWindow(PhaseKey.IMAGE_PULL, "Image pull", 4, 7),
     PhaseWindow(PhaseKey.TRAINER_START, "Trainer start", 7, 9),
     PhaseWindow(PhaseKey.UPLOAD, "Dataset upload", 9, 17),
     PhaseWindow(PhaseKey.TRAIN, "Training", 17, 96),

--- a/application/backend/src/services/training_backends/ssh.py
+++ b/application/backend/src/services/training_backends/ssh.py
@@ -123,10 +123,11 @@ class SshTrainingBackend:
         await self._provision_and_train(context)
 
     async def _provision_and_train(self, context: TrainingContext) -> None:
-        snapshot_size_bytes = 0
-        if context.snapshot is not None:
-            snapshot_size_bytes = await asyncio.to_thread(_directory_size_bytes, Path(context.snapshot.path))
+        if context.snapshot is None:
+            raise ValueError("SSH training requires a dataset snapshot")
 
+        snapshot_path = Path(context.snapshot.path)
+        snapshot_size_bytes = await asyncio.to_thread(_directory_size_bytes, snapshot_path)
         current_phase = PhaseKey.CONNECT
 
         def _report(

--- a/application/backend/src/services/training_backends/ssh.py
+++ b/application/backend/src/services/training_backends/ssh.py
@@ -26,14 +26,20 @@ from schemas.job import TrainingDevice
 from services.ssh.preflight import DEFAULT_PROTOCOL_VERSION
 from services.ssh.provisioning import ProvisionedTrainer, SshProvisioningService
 from services.training_backends.base import TrainingCanceledError, TrainingSuspendedError
-from services.training_backends.remote import RemoteTrainingBackend, RemoteTrainingError
+from services.training_backends.phase import SSH_PHASE_WINDOWS, PhaseKey, PhaseState, report_phase
+from services.training_backends.remote import (
+    SNAPSHOT_UPLOAD_PROGRESS,
+    TRAINING_PROGRESS_END,
+    RemoteTrainingBackend,
+    RemoteTrainingError,
+)
 from settings import get_settings
 
 if TYPE_CHECKING:
     from uuid import UUID
 
     from schemas.remote_server import RemoteServer
-    from services.training_backends.base import TrainingContext
+    from services.training_backends.base import ProgressReporter, TrainingContext
 
 # Trainer containers only ever run on cuda/xpu servers (see
 # `schemas.remote_server.SSH_SERVER_DEVICE_TYPES`), so the accelerator always
@@ -46,6 +52,47 @@ def _directory_size_bytes(path: Path) -> int:
     if not path.exists():
         return 0
     return sum(entry.stat().st_size for entry in path.rglob("*") if entry.is_file())
+
+
+def _map_remote_progress_to_phase(raw_progress: int) -> tuple[PhaseKey, float]:
+    """Map `RemoteTrainingBackend`'s own 0-100 progress into an SSH phase key + local completion.
+
+    `RemoteTrainingBackend` partitions 0-100 into upload/train/download using
+    its own constants, unaware that an SSH-provisioned job reserves a smaller
+    slice of the overall bar for those same three steps. This translates one
+    partition into the other.
+    """
+    if raw_progress < SNAPSHOT_UPLOAD_PROGRESS:
+        return PhaseKey.UPLOAD, raw_progress / SNAPSHOT_UPLOAD_PROGRESS * 100
+    if raw_progress < TRAINING_PROGRESS_END:
+        span = TRAINING_PROGRESS_END - SNAPSHOT_UPLOAD_PROGRESS
+        return PhaseKey.TRAIN, (raw_progress - SNAPSHOT_UPLOAD_PROGRESS) / span * 100
+    span = 100 - TRAINING_PROGRESS_END
+    if span <= 0:
+        return PhaseKey.DOWNLOAD, 100.0
+    return PhaseKey.DOWNLOAD, (raw_progress - TRAINING_PROGRESS_END) / span * 100
+
+
+class _PhaseTaggingProgress:
+    """Wrap a job's real `ProgressReporter` so `RemoteTrainingBackend`'s plain
+    upload/train/download progress is remapped into the SSH phase table
+    before it reaches the job store, without `RemoteTrainingBackend` itself
+    knowing an SSH phase table exists.
+    """
+
+    def __init__(self, progress: ProgressReporter) -> None:
+        self._progress = progress
+
+    def __call__(self, progress: int, *, message: str | None = None, extra_info: dict | None = None) -> None:
+        key, sub_progress = _map_remote_progress_to_phase(progress)
+        report_phase(
+            self._progress,
+            SSH_PHASE_WINDOWS,
+            key,
+            sub_progress=sub_progress,
+            message=message,
+            extra_info=extra_info,
+        )
 
 
 class SshTrainingBackend:
@@ -80,25 +127,59 @@ class SshTrainingBackend:
         if context.snapshot is not None:
             snapshot_size_bytes = await asyncio.to_thread(_directory_size_bytes, Path(context.snapshot.path))
 
+        current_phase = PhaseKey.CONNECT
+
+        def _report(
+            key: PhaseKey,
+            *,
+            state: PhaseState = PhaseState.ACTIVE,
+            sub_progress: float | None = 0.0,
+            message: str | None = None,
+            extra_info: dict | None = None,
+        ) -> None:
+            nonlocal current_phase
+            current_phase = key
+            report_phase(
+                context.progress,
+                SSH_PHASE_WINDOWS,
+                key,
+                state=state,
+                sub_progress=sub_progress,
+                message=message,
+                extra_info=extra_info,
+            )
+
         async def _on_gpu_wait(elapsed_s: float) -> None:
             if context.should_stop():
                 raise TrainingCanceledError("Training canceled while waiting for a busy remote GPU")
-            context.progress(
-                0,
+            _report(
+                PhaseKey.TRAINER_START,
+                state=PhaseState.WAITING,
+                sub_progress=None,
                 message=f"Waiting for GPU to free up on remote server '{self._server.name}'",
-                extra_info={"phase": {"key": "waiting", "elapsed_s": round(elapsed_s)}},
+                extra_info={"elapsed_s": round(elapsed_s)},
             )
 
-        context.progress(0, message=f"Provisioning trainer on remote server '{self._server.name}'")
-        async with get_async_db_session_ctx() as session:
-            provisioning_service = SshProvisioningService(JobProvisioningRepository(session), self._settings)
-            trainer = await provisioning_service.provision(
-                self._job_id,
-                self._server,
-                protocol_version=self._protocol_version,
-                snapshot_size_bytes=snapshot_size_bytes,
-                on_gpu_wait=_on_gpu_wait,
-            )
+        def _on_phase(key: PhaseKey) -> None:
+            # Docker pull output has no stable percentage; pin it to the
+            # window start and let the UI show a spinner instead.
+            _report(key, sub_progress=None if key is PhaseKey.IMAGE_PULL else 0.0)
+
+        _report(PhaseKey.CONNECT, message=f"Provisioning trainer on remote server '{self._server.name}'")
+        try:
+            async with get_async_db_session_ctx() as session:
+                provisioning_service = SshProvisioningService(JobProvisioningRepository(session), self._settings)
+                trainer = await provisioning_service.provision(
+                    self._job_id,
+                    self._server,
+                    protocol_version=self._protocol_version,
+                    snapshot_size_bytes=snapshot_size_bytes,
+                    on_gpu_wait=_on_gpu_wait,
+                    on_phase=_on_phase,
+                )
+        except BaseException:
+            _report(current_phase, state=PhaseState.FAILED, sub_progress=None)
+            raise
 
         await self._run_and_teardown(context, trainer)
 
@@ -125,25 +206,35 @@ class SshTrainingBackend:
         The one exception is `TrainingSuspendedError`: the studio is shutting
         down, and the whole point of that path is to leave the container (and
         therefore the trainer job) running so a restart can reattach.
+
+        `context.progress` is swapped for a phase-tagging wrapper for the
+        duration of the delegated call, then restored, so `RemoteTrainingBackend`
+        never has to know an SSH phase table exists while its own upload/train/
+        download progress still lands in the right slice of the SSH stepper.
         """
         remote_backend = RemoteTrainingBackend(
             trainer.base_url,
             trainer_name=self._server.name,
             device=TrainingDevice(type=self._server.device_type, index=_INDEXED_DEVICE_INDEX),
         )
+        original_progress = context.progress
+        context.progress = _PhaseTaggingProgress(original_progress)
         try:
-            await remote_backend.train(context)
-        except TrainingSuspendedError:
-            logger.info(
-                "Studio shutting down; leaving SSH-provisioned trainer container '{}' running for reattach",
-                trainer.container_name,
-            )
-            raise
-        except BaseException:
-            await self._teardown(trainer)
-            raise
-        else:
-            await self._teardown(trainer)
+            try:
+                await remote_backend.train(context)
+            except TrainingSuspendedError:
+                logger.info(
+                    "Studio shutting down; leaving SSH-provisioned trainer container '{}' running for reattach",
+                    trainer.container_name,
+                )
+                raise
+            except BaseException:
+                await self._teardown(trainer)
+                raise
+            else:
+                await self._teardown(trainer)
+        finally:
+            context.progress = original_progress
 
     async def _teardown(self, trainer: ProvisionedTrainer) -> None:
         """Tear down the tunnel/container and drop the provisioning record."""

--- a/application/backend/src/services/training_backends/ssh.py
+++ b/application/backend/src/services/training_backends/ssh.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSH-provisioned training backend.
+
+Provisions a per-job trainer container on a configured remote server, then
+delegates dataset transfer, progress mirroring, and model ingestion to
+:class:`~services.training_backends.remote.RemoteTrainingBackend` over the SSH
+tunnel `services.ssh.provisioning` opened. The container and tunnel are always
+torn down before this backend returns or raises, except when the studio is
+shutting down (`TrainingSuspendedError`): that path deliberately leaves the
+container running so a restart can reattach to it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from loguru import logger
+
+from db import get_async_db_session_ctx
+from repositories.job_provisioning_repo import JobProvisioningRepository
+from schemas.job import TrainingDevice
+from services.ssh.preflight import DEFAULT_PROTOCOL_VERSION
+from services.ssh.provisioning import ProvisionedTrainer, SshProvisioningService
+from services.training_backends.base import TrainingCanceledError, TrainingSuspendedError
+from services.training_backends.remote import RemoteTrainingBackend, RemoteTrainingError
+from settings import get_settings
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from schemas.remote_server import RemoteServer
+    from services.training_backends.base import TrainingContext
+
+# Trainer containers only ever run on cuda/xpu servers (see
+# `schemas.remote_server.SSH_SERVER_DEVICE_TYPES`), so the accelerator always
+# needs an index.
+_INDEXED_DEVICE_INDEX: Final = 0
+
+
+def _directory_size_bytes(path: Path) -> int:
+    """Sum the size of every regular file under ``path`` (blocking)."""
+    if not path.exists():
+        return 0
+    return sum(entry.stat().st_size for entry in path.rglob("*") if entry.is_file())
+
+
+class SshTrainingBackend:
+    """Provision an SSH trainer container for one job, then train through it."""
+
+    def __init__(
+        self,
+        job_id: UUID,
+        server: RemoteServer,
+        *,
+        protocol_version: int = DEFAULT_PROTOCOL_VERSION,
+    ) -> None:
+        self._job_id = job_id
+        self._server = server
+        self._protocol_version = protocol_version
+        self._settings = get_settings()
+
+    async def train(self, context: TrainingContext) -> None:
+        """Provision (or reattach), then train through the provisioned trainer.
+
+        When ``context.remote_job_id`` is set, a previous run already
+        provisioned a container for this job; reattach to it instead of
+        provisioning a fresh one.
+        """
+        if context.remote_job_id:
+            await self._reattach_and_train(context)
+            return
+        await self._provision_and_train(context)
+
+    async def _provision_and_train(self, context: TrainingContext) -> None:
+        snapshot_size_bytes = 0
+        if context.snapshot is not None:
+            snapshot_size_bytes = await asyncio.to_thread(_directory_size_bytes, Path(context.snapshot.path))
+
+        async def _on_gpu_wait(elapsed_s: float) -> None:
+            if context.should_stop():
+                raise TrainingCanceledError("Training canceled while waiting for a busy remote GPU")
+            context.progress(
+                0,
+                message=f"Waiting for GPU to free up on remote server '{self._server.name}'",
+                extra_info={"phase": {"key": "waiting", "elapsed_s": round(elapsed_s)}},
+            )
+
+        context.progress(0, message=f"Provisioning trainer on remote server '{self._server.name}'")
+        async with get_async_db_session_ctx() as session:
+            provisioning_service = SshProvisioningService(JobProvisioningRepository(session), self._settings)
+            trainer = await provisioning_service.provision(
+                self._job_id,
+                self._server,
+                protocol_version=self._protocol_version,
+                snapshot_size_bytes=snapshot_size_bytes,
+                on_gpu_wait=_on_gpu_wait,
+            )
+
+        await self._run_and_teardown(context, trainer)
+
+    async def _reattach_and_train(self, context: TrainingContext) -> None:
+        async with get_async_db_session_ctx() as session:
+            repository = JobProvisioningRepository(session)
+            job_provisioning = await repository.get_by_job_id(self._job_id)
+            if job_provisioning is None:
+                raise RemoteTrainingError(f"No provisioning record found for job {self._job_id} to reattach to")
+            provisioning_service = SshProvisioningService(repository, self._settings)
+            trainer = await provisioning_service.reattach(job_provisioning, self._server)
+
+        if trainer is None:
+            raise RemoteTrainingError(
+                f"Trainer container for job {self._job_id} on remote server '{self._server.name}' is no longer "
+                "running; it cannot be reattached to."
+            )
+
+        await self._run_and_teardown(context, trainer)
+
+    async def _run_and_teardown(self, context: TrainingContext, trainer: ProvisionedTrainer) -> None:
+        """Delegate training over the tunnel, then always tear down.
+
+        The one exception is `TrainingSuspendedError`: the studio is shutting
+        down, and the whole point of that path is to leave the container (and
+        therefore the trainer job) running so a restart can reattach.
+        """
+        remote_backend = RemoteTrainingBackend(
+            trainer.base_url,
+            trainer_name=self._server.name,
+            device=TrainingDevice(type=self._server.device_type, index=_INDEXED_DEVICE_INDEX),
+        )
+        try:
+            await remote_backend.train(context)
+        except TrainingSuspendedError:
+            logger.info(
+                "Studio shutting down; leaving SSH-provisioned trainer container '{}' running for reattach",
+                trainer.container_name,
+            )
+            raise
+        except BaseException:
+            await self._teardown(trainer)
+            raise
+        else:
+            await self._teardown(trainer)
+
+    async def _teardown(self, trainer: ProvisionedTrainer) -> None:
+        """Tear down the tunnel/container and drop the provisioning record."""
+        await trainer.teardown()
+        async with get_async_db_session_ctx() as session:
+            await JobProvisioningRepository(session).delete_by_job_id(self._job_id)
+
+
+__all__ = ["SshTrainingBackend"]

--- a/application/backend/src/workers/training_worker.py
+++ b/application/backend/src/workers/training_worker.py
@@ -218,7 +218,7 @@ class TrainingWorker(BaseProcessWorker):
                 should_cancel_job=lambda: bool(self.job_interrupt_flags.get(str(job.id), False)),
             )
 
-            backend = get_training_backend(payload)
+            backend = await get_training_backend(payload, job.id)
             await backend.train(context)
             # The local backend stops cooperatively without raising; treat a
             # completed-but-interrupted run as a cancellation, not a success.

--- a/application/backend/tests/services/ssh/test_provisioning.py
+++ b/application/backend/tests/services/ssh/test_provisioning.py
@@ -34,6 +34,7 @@ from services.ssh.docker_ops import JOB_LABEL, LIBRARY_VERSION_LABEL, MANAGED_LA
 from services.ssh.preflight import PROTOCOL_LABEL
 from services.ssh.provisioning import SshProvisioningService
 from services.ssh.transport import CommandResult
+from services.training_backends.phase import PhaseKey
 from settings import Settings
 
 if TYPE_CHECKING:
@@ -270,6 +271,30 @@ async def test_provision_waits_out_a_busy_gpu(_patch_transport_and_tunnel, repos
     )
 
     assert waited == [1.0]
+
+
+async def test_provision_reports_phases_in_verify_pull_start_order(_patch_transport_and_tunnel, repository) -> None:
+    """`on_phase` fires image_verify before image_pull before trainer_start,
+    matching the order the image is actually verified then pulled (never
+    pulling an unverified image) then the container is launched."""
+    _set_script(_patch_transport_and_tunnel, _healthy_script())
+    service = SshProvisioningService(repository)
+    reported: list[PhaseKey] = []
+
+    async def fake_ready(base_url, server_name):
+        return {"protocol_version": _PROTOCOL_VERSION, "library_version": "1.0.0"}
+
+    service._await_ready = fake_ready  # type: ignore[method-assign]
+
+    await service.provision(
+        uuid4(),
+        _server(),
+        protocol_version=_PROTOCOL_VERSION,
+        snapshot_size_bytes=1,
+        on_phase=reported.append,
+    )
+
+    assert reported == [PhaseKey.IMAGE_VERIFY, PhaseKey.IMAGE_PULL, PhaseKey.TRAINER_START]
 
 
 async def test_provision_cleans_up_container_on_protocol_mismatch(_patch_transport_and_tunnel, repository) -> None:

--- a/application/backend/tests/services/test_ssh_training_backend.py
+++ b/application/backend/tests/services/test_ssh_training_backend.py
@@ -19,6 +19,7 @@ from schemas.hardware import DeviceType
 from schemas.job import TrainingDevice
 from schemas.remote_server import RemoteServer
 from services.training_backends.base import TrainingCanceledError, TrainingSuspendedError
+from services.training_backends.phase import PhaseKey
 from services.training_backends.ssh import SshTrainingBackend
 
 MODULE = "services.training_backends.ssh"
@@ -205,6 +206,126 @@ async def test_reattach_raises_when_container_gone() -> None:
             assert "no longer running" in str(error)
         else:
             raise AssertionError("expected an error when the container is gone")
+
+
+async def test_provision_and_train_reports_connect_and_delegates_on_phase() -> None:
+    """The backend reports `connect` itself, then forwards `on_phase` so
+    `SshProvisioningService` can drive the rest of the provisioning stepper."""
+    server = _server()
+    trainer = MagicMock()
+    trainer.base_url = "http://127.0.0.1:54321"
+    trainer.container_name = "physicalai-trainer-abc"
+    trainer.teardown = AsyncMock()
+
+    remote_backend = MagicMock()
+    remote_backend.train = AsyncMock()
+
+    captured_phase_callback = {}
+
+    async def _provision(*_args, **kwargs):
+        captured_phase_callback["on_phase"] = kwargs["on_phase"]
+        return trainer
+
+    service = MagicMock()
+    service.provision = AsyncMock(side_effect=_provision)
+    repo = MagicMock()
+    repo.delete_by_job_id = AsyncMock()
+
+    with (
+        patch(f"{MODULE}.get_async_db_session_ctx", _session_scope),
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=repo),
+        patch(f"{MODULE}.SshProvisioningService", return_value=service),
+        patch(f"{MODULE}.RemoteTrainingBackend", return_value=remote_backend),
+    ):
+        backend = SshTrainingBackend(uuid4(), server)
+        context = _context()
+        await backend.train(context)
+
+    # `connect` is reported once, synchronously, before provisioning starts.
+    first_call = context.progress.call_args_list[0]
+    assert first_call.kwargs["extra_info"]["phase"]["key"] == "connect"
+
+    # The provisioning service got a callback it can drive further phases with.
+    captured_phase_callback["on_phase"](PhaseKey.IMAGE_PULL)
+    last_call = context.progress.call_args_list[-1]
+    assert last_call.kwargs["extra_info"]["phase"]["key"] == "image_pull"
+    assert last_call.kwargs["extra_info"]["phase"]["indeterminate"] is True
+
+
+async def test_provision_failure_marks_the_in_flight_phase_failed() -> None:
+    server = _server()
+    service = MagicMock()
+
+    async def _provision(*_args, **kwargs):
+        kwargs["on_phase"](PhaseKey.IMAGE_PULL)
+        raise RuntimeError("pull failed")
+
+    service.provision = AsyncMock(side_effect=_provision)
+    repo = MagicMock()
+
+    with (
+        patch(f"{MODULE}.get_async_db_session_ctx", _session_scope),
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=repo),
+        patch(f"{MODULE}.SshProvisioningService", return_value=service),
+    ):
+        backend = SshTrainingBackend(uuid4(), server)
+        context = _context()
+        try:
+            await backend.train(context)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("expected RuntimeError to propagate")
+
+    last_call = context.progress.call_args_list[-1]
+    assert last_call.kwargs["extra_info"]["phase"]["key"] == "image_pull"
+    assert last_call.kwargs["extra_info"]["phase"]["state"] == "failed"
+
+
+async def test_remote_training_progress_is_tagged_with_upload_train_download_phases() -> None:
+    """`context.progress` is swapped for a phase-tagging wrapper only for the
+    duration of the delegated `RemoteTrainingBackend.train` call."""
+    server = _server()
+    trainer = MagicMock()
+    trainer.base_url = "http://127.0.0.1:54321"
+    trainer.container_name = "physicalai-trainer-abc"
+    trainer.teardown = AsyncMock()
+
+    service = _patched_provisioning_service(trainer)
+    repo = MagicMock()
+    repo.delete_by_job_id = AsyncMock()
+
+    reported: list[tuple[int, dict | None]] = []
+
+    async def _train(ctx) -> None:
+        # Simulate RemoteTrainingBackend reporting its own plain 0-100 progress.
+        ctx.progress(5, message="Uploading dataset snapshot")
+        ctx.progress(50, message="Training")
+        ctx.progress(100, message="Model downloaded")
+
+    remote_backend = MagicMock()
+    remote_backend.train = AsyncMock(side_effect=_train)
+
+    with (
+        patch(f"{MODULE}.get_async_db_session_ctx", _session_scope),
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=repo),
+        patch(f"{MODULE}.SshProvisioningService", return_value=service),
+        patch(f"{MODULE}.RemoteTrainingBackend", return_value=remote_backend),
+    ):
+        backend = SshTrainingBackend(uuid4(), server)
+        context = _context()
+
+        def _capture(progress, *, message=None, extra_info=None):
+            reported.append((progress, extra_info))
+
+        context.progress = MagicMock(side_effect=_capture)
+        await backend.train(context)
+
+    # The wrapper is removed again once training delegation returns.
+    assert context.progress.side_effect is _capture
+
+    phases = [extra_info["phase"]["key"] for _, extra_info in reported if extra_info and "phase" in extra_info]
+    assert phases == ["connect", "upload", "train", "download"]
 
 
 async def test_gpu_wait_callback_raises_when_canceled() -> None:

--- a/application/backend/tests/services/test_ssh_training_backend.py
+++ b/application/backend/tests/services/test_ssh_training_backend.py
@@ -1,0 +1,234 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the SSH-provisioned training backend.
+
+`SshProvisioningService` and `RemoteTrainingBackend` are faked: this proves the
+*orchestration* SshTrainingBackend adds on top of them (provision-vs-reattach
+dispatch, device injection, and teardown-on-every-path-but-suspend), not their
+own already-tested internals.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from schemas.hardware import DeviceType
+from schemas.job import TrainingDevice
+from schemas.remote_server import RemoteServer
+from services.training_backends.base import TrainingCanceledError, TrainingSuspendedError
+from services.training_backends.ssh import SshTrainingBackend
+
+MODULE = "services.training_backends.ssh"
+
+
+def _server() -> RemoteServer:
+    return RemoteServer(id=uuid4(), name="Lab GPU box", ssh_host_alias="gpu-box", device_type=DeviceType.CUDA)
+
+
+def _context(*, remote_job_id=None, should_stop=False) -> MagicMock:
+    context = MagicMock()
+    context.remote_job_id = remote_job_id
+    context.snapshot = None
+    context.should_stop = MagicMock(return_value=should_stop)
+    context.on_remote_job_id = AsyncMock()
+    return context
+
+
+@asynccontextmanager
+async def _session_scope():
+    yield MagicMock()
+
+
+def _patched_provisioning_service(provisioned_trainer):
+    service = MagicMock()
+    service.provision = AsyncMock(return_value=provisioned_trainer)
+    service.reattach = AsyncMock(return_value=provisioned_trainer)
+    return service
+
+
+async def test_train_provisions_and_tears_down_on_success() -> None:
+    server = _server()
+    trainer = MagicMock()
+    trainer.base_url = "http://127.0.0.1:54321"
+    trainer.container_name = "physicalai-trainer-abc"
+    trainer.teardown = AsyncMock()
+
+    remote_backend = MagicMock()
+    remote_backend.train = AsyncMock()
+
+    service = _patched_provisioning_service(trainer)
+    repo = MagicMock()
+    repo.delete_by_job_id = AsyncMock()
+
+    with (
+        patch(f"{MODULE}.get_async_db_session_ctx", _session_scope),
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=repo),
+        patch(f"{MODULE}.SshProvisioningService", return_value=service),
+        patch(f"{MODULE}.RemoteTrainingBackend", return_value=remote_backend) as MockRemote,
+    ):
+        backend = SshTrainingBackend(uuid4(), server)
+        context = _context()
+        await backend.train(context)
+
+    service.provision.assert_awaited_once()
+    remote_backend.train.assert_awaited_once_with(context)
+    trainer.teardown.assert_awaited_once()
+    repo.delete_by_job_id.assert_awaited_once()
+    # The server's own configured device is injected, not probed live.
+    _, kwargs = MockRemote.call_args
+    assert kwargs["device"] == TrainingDevice(type=DeviceType.CUDA, index=0)
+
+
+async def test_train_tears_down_on_failure() -> None:
+    server = _server()
+    trainer = MagicMock()
+    trainer.base_url = "http://127.0.0.1:54321"
+    trainer.container_name = "physicalai-trainer-abc"
+    trainer.teardown = AsyncMock()
+
+    remote_backend = MagicMock()
+    remote_backend.train = AsyncMock(side_effect=RuntimeError("boom"))
+
+    service = _patched_provisioning_service(trainer)
+    repo = MagicMock()
+    repo.delete_by_job_id = AsyncMock()
+
+    with (
+        patch(f"{MODULE}.get_async_db_session_ctx", _session_scope),
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=repo),
+        patch(f"{MODULE}.SshProvisioningService", return_value=service),
+        patch(f"{MODULE}.RemoteTrainingBackend", return_value=remote_backend),
+    ):
+        backend = SshTrainingBackend(uuid4(), server)
+        context = _context()
+        try:
+            await backend.train(context)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("expected RuntimeError to propagate")
+
+    trainer.teardown.assert_awaited_once()
+    repo.delete_by_job_id.assert_awaited_once()
+
+
+async def test_train_leaves_container_running_on_suspend() -> None:
+    """A TrainingSuspendedError must not tear anything down - it's for reattach."""
+    server = _server()
+    trainer = MagicMock()
+    trainer.base_url = "http://127.0.0.1:54321"
+    trainer.container_name = "physicalai-trainer-abc"
+    trainer.teardown = AsyncMock()
+
+    remote_backend = MagicMock()
+    remote_backend.train = AsyncMock(side_effect=TrainingSuspendedError("shutting down"))
+
+    service = _patched_provisioning_service(trainer)
+    repo = MagicMock()
+    repo.delete_by_job_id = AsyncMock()
+
+    with (
+        patch(f"{MODULE}.get_async_db_session_ctx", _session_scope),
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=repo),
+        patch(f"{MODULE}.SshProvisioningService", return_value=service),
+        patch(f"{MODULE}.RemoteTrainingBackend", return_value=remote_backend),
+    ):
+        backend = SshTrainingBackend(uuid4(), server)
+        context = _context()
+        try:
+            await backend.train(context)
+        except TrainingSuspendedError:
+            pass
+        else:
+            raise AssertionError("expected TrainingSuspendedError to propagate")
+
+    trainer.teardown.assert_not_called()
+    repo.delete_by_job_id.assert_not_called()
+
+
+async def test_reattach_uses_persisted_provisioning_row() -> None:
+    server = _server()
+    job_id = uuid4()
+    job_provisioning = MagicMock()
+
+    trainer = MagicMock()
+    trainer.base_url = "http://127.0.0.1:54321"
+    trainer.container_name = "physicalai-trainer-abc"
+    trainer.teardown = AsyncMock()
+
+    remote_backend = MagicMock()
+    remote_backend.train = AsyncMock()
+
+    service = _patched_provisioning_service(trainer)
+    repo = MagicMock()
+    repo.get_by_job_id = AsyncMock(return_value=job_provisioning)
+    repo.delete_by_job_id = AsyncMock()
+
+    with (
+        patch(f"{MODULE}.get_async_db_session_ctx", _session_scope),
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=repo),
+        patch(f"{MODULE}.SshProvisioningService", return_value=service),
+        patch(f"{MODULE}.RemoteTrainingBackend", return_value=remote_backend),
+    ):
+        backend = SshTrainingBackend(job_id, server)
+        context = _context(remote_job_id=uuid4())
+        await backend.train(context)
+
+    service.reattach.assert_awaited_once_with(job_provisioning, server)
+    remote_backend.train.assert_awaited_once_with(context)
+    trainer.teardown.assert_awaited_once()
+
+
+async def test_reattach_raises_when_container_gone() -> None:
+    server = _server()
+    job_id = uuid4()
+    job_provisioning = MagicMock()
+
+    service = _patched_provisioning_service(None)
+    service.reattach = AsyncMock(return_value=None)
+    repo = MagicMock()
+    repo.get_by_job_id = AsyncMock(return_value=job_provisioning)
+
+    with (
+        patch(f"{MODULE}.get_async_db_session_ctx", _session_scope),
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=repo),
+        patch(f"{MODULE}.SshProvisioningService", return_value=service),
+    ):
+        backend = SshTrainingBackend(job_id, server)
+        context = _context(remote_job_id=uuid4())
+        try:
+            await backend.train(context)
+        except Exception as error:
+            assert "no longer running" in str(error)
+        else:
+            raise AssertionError("expected an error when the container is gone")
+
+
+async def test_gpu_wait_callback_raises_when_canceled() -> None:
+    """A cancellation requested while waiting for a busy GPU aborts the wait."""
+    server = _server()
+    service = MagicMock()
+
+    async def _provision(*_args, **kwargs):
+        await kwargs["on_gpu_wait"](5.0)
+        raise AssertionError("on_gpu_wait should have raised before provision continued")
+
+    service.provision = AsyncMock(side_effect=_provision)
+    repo = MagicMock()
+
+    with (
+        patch(f"{MODULE}.get_async_db_session_ctx", _session_scope),
+        patch(f"{MODULE}.JobProvisioningRepository", return_value=repo),
+        patch(f"{MODULE}.SshProvisioningService", return_value=service),
+    ):
+        backend = SshTrainingBackend(uuid4(), server)
+        context = _context(should_stop=True)
+        try:
+            await backend.train(context)
+        except TrainingCanceledError:
+            pass
+        else:
+            raise AssertionError("expected TrainingCanceledError")

--- a/application/backend/tests/services/test_ssh_training_backend.py
+++ b/application/backend/tests/services/test_ssh_training_backend.py
@@ -29,10 +29,13 @@ def _server() -> RemoteServer:
     return RemoteServer(id=uuid4(), name="Lab GPU box", ssh_host_alias="gpu-box", device_type=DeviceType.CUDA)
 
 
-def _context(*, remote_job_id=None, should_stop=False) -> MagicMock:
+def _context(*, remote_job_id=None, should_stop=False, snapshot_path: str | None = "/tmp") -> MagicMock:
     context = MagicMock()
     context.remote_job_id = remote_job_id
-    context.snapshot = None
+    if snapshot_path is None:
+        context.snapshot = None
+    else:
+        context.snapshot = MagicMock(path=snapshot_path)
     context.should_stop = MagicMock(return_value=should_stop)
     context.on_remote_job_id = AsyncMock()
     return context
@@ -148,6 +151,20 @@ async def test_train_leaves_container_running_on_suspend() -> None:
 
     trainer.teardown.assert_not_called()
     repo.delete_by_job_id.assert_not_called()
+
+
+async def test_provision_and_train_raises_without_a_snapshot() -> None:
+    """A fresh provision must fail fast rather than upload nothing."""
+    server = _server()
+    backend = SshTrainingBackend(uuid4(), server)
+    context = _context(snapshot_path=None)
+
+    try:
+        await backend.train(context)
+    except ValueError as error:
+        assert "dataset snapshot" in str(error)
+    else:
+        raise AssertionError("expected a ValueError when no snapshot is provided")
 
 
 async def test_reattach_uses_persisted_provisioning_row() -> None:

--- a/application/backend/tests/services/test_training_backends.py
+++ b/application/backend/tests/services/test_training_backends.py
@@ -9,12 +9,22 @@ import multiprocessing as mp
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import pytest
 from loguru import logger
 
-from schemas.job import LocalTrainJobPayload, RemoteTrainJobPayload, TrainJobPayload
+from schemas.hardware import DeviceType
+from schemas.job import (
+    LocalTrainJobPayload,
+    RemoteTrainJobPayload,
+    SshTrainJobPayload,
+    TrainingTarget,
+    TrainJobPayload,
+)
+from schemas.remote_server import RemoteServer
 from services.training_backends import get_training_backend
 from services.training_backends.local import LocalTrainingBackend
 from services.training_backends.remote import SNAPSHOT_UPLOAD_PROGRESS, TRAINING_PROGRESS_END, RemoteTrainingBackend
+from services.training_backends.ssh import SshTrainingBackend
 from services.training_service import TrainingTrackingDispatcher
 
 
@@ -24,39 +34,45 @@ def _settings() -> MagicMock:
     return settings
 
 
-def _local_payload() -> TrainJobPayload:
-    return LocalTrainJobPayload(
+def _payload(target: TrainingTarget) -> TrainJobPayload:
+    if target is TrainingTarget.LOCAL:
+        return LocalTrainJobPayload(
+            project_id=uuid4(),
+            dataset_id=uuid4(),
+            policy="act",
+            model_name="model",
+        )
+    if target is TrainingTarget.REMOTE:
+        return RemoteTrainJobPayload(
+            project_id=uuid4(),
+            dataset_id=uuid4(),
+            policy="act",
+            model_name="model",
+            remote_trainer_id=uuid4(),
+            remote_trainer_url="https://trainer.test",
+            remote_trainer_name="gpu-box-1",
+        )
+    return SshTrainJobPayload(
         project_id=uuid4(),
         dataset_id=uuid4(),
         policy="act",
         model_name="model",
+        remote_server_id=uuid4(),
     )
 
 
-def _remote_payload() -> TrainJobPayload:
-    return RemoteTrainJobPayload(
-        project_id=uuid4(),
-        dataset_id=uuid4(),
-        policy="act",
-        model_name="model",
-        remote_trainer_id=uuid4(),
-        remote_trainer_url="https://trainer.test",
-        remote_trainer_name="gpu-box-1",
-    )
-
-
-def test_get_training_backend_returns_local_for_local_job() -> None:
-    backend = get_training_backend(_local_payload())
+async def test_get_training_backend_returns_local_for_local_job() -> None:
+    backend = await get_training_backend(_payload(TrainingTarget.LOCAL), uuid4())
     assert isinstance(backend, LocalTrainingBackend)
 
 
-def test_get_training_backend_returns_remote_for_remote_job() -> None:
+async def test_get_training_backend_returns_remote_for_remote_job() -> None:
     settings = _settings()
     with (
         patch("settings.get_settings", return_value=settings),
         patch("services.training_backends.remote.get_settings", return_value=settings),
     ):
-        backend = get_training_backend(_remote_payload())
+        backend = await get_training_backend(_payload(TrainingTarget.REMOTE), uuid4())
     assert isinstance(backend, RemoteTrainingBackend)
 
     # The pinned trainer name reaches the backend, so its job logs are attributable.
@@ -67,6 +83,28 @@ def test_get_training_backend_returns_remote_for_remote_job() -> None:
     finally:
         logger.remove(sink_id)
     assert messages == ["[gpu-box-1] check"]
+
+
+async def test_get_training_backend_returns_ssh_for_ssh_job() -> None:
+    payload = _payload(TrainingTarget.SSH)
+    assert payload.remote_server_id is not None
+    server = RemoteServer(
+        id=payload.remote_server_id,
+        name="gpu-box-1",
+        ssh_host_alias="gpu-box",
+        device_type=DeviceType.CUDA,
+    )
+    with patch("services.remote_server_service.RemoteServerService.get_remote_server", AsyncMock(return_value=server)):
+        backend = await get_training_backend(payload, uuid4())
+    assert isinstance(backend, SshTrainingBackend)
+    assert backend._server is server
+
+
+async def test_get_training_backend_raises_without_remote_server_id() -> None:
+    payload = _payload(TrainingTarget.SSH).model_copy(update={"remote_server_id": None})
+    with pytest.raises(ValueError, match="remote server"):
+        await get_training_backend(payload, uuid4())
+
 
 
 def test_dispatcher_report_enqueues_progress_tuple() -> None:

--- a/application/backend/tests/services/test_training_backends.py
+++ b/application/backend/tests/services/test_training_backends.py
@@ -13,13 +13,7 @@ import pytest
 from loguru import logger
 
 from schemas.hardware import DeviceType
-from schemas.job import (
-    LocalTrainJobPayload,
-    RemoteTrainJobPayload,
-    SshTrainJobPayload,
-    TrainingTarget,
-    TrainJobPayload,
-)
+from schemas.job import LocalTrainJobPayload, RemoteTrainJobPayload, SshTrainJobPayload, TrainingTarget, TrainJobPayload
 from schemas.remote_server import RemoteServer
 from services.training_backends import get_training_backend
 from services.training_backends.local import LocalTrainingBackend
@@ -104,7 +98,6 @@ async def test_get_training_backend_raises_without_remote_server_id() -> None:
     payload = _payload(TrainingTarget.SSH).model_copy(update={"remote_server_id": None})
     with pytest.raises(ValueError, match="remote server"):
         await get_training_backend(payload, uuid4())
-
 
 
 def test_dispatcher_report_enqueues_progress_tuple() -> None:

--- a/application/backend/tests/services/training_backends/test_phase.py
+++ b/application/backend/tests/services/training_backends/test_phase.py
@@ -26,6 +26,21 @@ def test_ssh_phase_windows_are_contiguous_and_span_0_to_100() -> None:
         assert previous.end == current.start
 
 
+def test_ssh_phase_windows_verify_before_pull_before_trainer_start() -> None:
+    """Windows follow the real provisioning order: verify an image's signature
+    before ever pulling it, then launch the container."""
+    keys = [window.key for window in SSH_PHASE_WINDOWS]
+    assert keys == [
+        PhaseKey.CONNECT,
+        PhaseKey.IMAGE_VERIFY,
+        PhaseKey.IMAGE_PULL,
+        PhaseKey.TRAINER_START,
+        PhaseKey.UPLOAD,
+        PhaseKey.TRAIN,
+        PhaseKey.DOWNLOAD,
+    ]
+
+
 def test_phase_window_rejects_an_inverted_range() -> None:
     with pytest.raises(ValueError, match="Invalid phase window"):
         PhaseWindow(PhaseKey.CONNECT, "Connect", start=10, end=5)

--- a/application/backend/tests/workers/test_training_worker.py
+++ b/application/backend/tests/workers/test_training_worker.py
@@ -190,7 +190,7 @@ class TestTraining:
 
         with (
             patch(f"{MODULE}.get_settings", return_value=_make_settings(tmp_path)),
-            patch(f"{MODULE}.get_training_backend", return_value=backend),
+            patch(f"{MODULE}.get_training_backend", AsyncMock(return_value=backend)),
             patch(f"{MODULE}.TrainingTrackingDispatcher", return_value=dispatcher),
             patch(f"{MODULE}.JobService") as MockJobService,
             patch(f"{MODULE}.ModelService"),
@@ -228,7 +228,7 @@ class TestTraining:
 
         with (
             patch(f"{MODULE}.get_settings", return_value=_make_settings(tmp_path)),
-            patch(f"{MODULE}.get_training_backend", return_value=backend),
+            patch(f"{MODULE}.get_training_backend", AsyncMock(return_value=backend)),
             patch(f"{MODULE}.TrainingTrackingDispatcher", return_value=dispatcher),
             patch(f"{MODULE}.JobService") as MockJobService,
             patch(f"{MODULE}.ModelService") as MockModelService,
@@ -267,7 +267,7 @@ class TestTraining:
 
         with (
             patch(f"{MODULE}.get_settings", return_value=_make_settings(tmp_path)),
-            patch(f"{MODULE}.get_training_backend", return_value=backend),
+            patch(f"{MODULE}.get_training_backend", AsyncMock(return_value=backend)),
             patch(f"{MODULE}.TrainingTrackingDispatcher", return_value=dispatcher),
             patch(f"{MODULE}.JobService") as MockJobService,
             patch(f"{MODULE}.ModelService") as MockModelService,
@@ -303,7 +303,7 @@ class TestTraining:
 
         with (
             patch(f"{MODULE}.get_settings", return_value=_make_settings(tmp_path)),
-            patch(f"{MODULE}.get_training_backend", return_value=backend),
+            patch(f"{MODULE}.get_training_backend", AsyncMock(return_value=backend)),
             patch(f"{MODULE}.TrainingTrackingDispatcher", return_value=dispatcher),
             patch(f"{MODULE}.JobService") as MockJobService,
             patch(f"{MODULE}.ModelService") as MockModelService,
@@ -341,7 +341,7 @@ class TestTraining:
 
         with (
             patch(f"{MODULE}.get_settings", return_value=_make_settings(tmp_path)),
-            patch(f"{MODULE}.get_training_backend", return_value=backend),
+            patch(f"{MODULE}.get_training_backend", AsyncMock(return_value=backend)),
             patch(f"{MODULE}.TrainingTrackingDispatcher", return_value=dispatcher),
             patch(f"{MODULE}.JobService") as MockJobService,
             patch(f"{MODULE}.ModelService") as MockModelService,
@@ -381,7 +381,7 @@ class TestTraining:
 
         with (
             patch(f"{MODULE}.get_settings", return_value=_make_settings(tmp_path)),
-            patch(f"{MODULE}.get_training_backend", return_value=backend),
+            patch(f"{MODULE}.get_training_backend", AsyncMock(return_value=backend)),
             patch(f"{MODULE}.TrainingTrackingDispatcher", return_value=dispatcher),
             patch(f"{MODULE}.JobService") as MockJobService,
             patch(f"{MODULE}.ModelService") as MockModelService,
@@ -426,7 +426,7 @@ class TestTraining:
 
         with (
             patch(f"{MODULE}.get_settings", return_value=_make_settings(tmp_path)),
-            patch(f"{MODULE}.get_training_backend", return_value=backend),
+            patch(f"{MODULE}.get_training_backend", AsyncMock(return_value=backend)),
             patch(f"{MODULE}.TrainingTrackingDispatcher", return_value=dispatcher),
             patch(f"{MODULE}.JobService") as MockJobService,
             patch(f"{MODULE}.ModelService") as MockModelService,


### PR DESCRIPTION
Everything needed to run a job over SSH now exists, but nothing connects it: a `remote_server_id` is storable and validated yet never selects a backend. This is the switch that makes a chosen server actually run the job.

## What changed

- `get_training_backend` resolves `SshTrainingBackend` for SSH jobs; precedence is `SSH` → provisioning, `REMOTE` → pinned-URL, otherwise local.
- `SshTrainingBackend` provisions/reattaches via `SshProvisioningService`, delegates dataset transfer and progress to `RemoteTrainingBackend` over the tunnel, injects the server's configured device instead of a live `/devices` probe, and tears the container down on every path **except** `TrainingSuspendedError`, where it's left running for reattach.
- `GET /api/remote-servers` (read-only listing) so the UI can select SSH targets.
- Backend and UI test coverage for the new paths.

## Design notes

A `remote_server_id` never takes the direct-URL `remote_trainer_url` path, transfers are forced through the tunnel, and cancellation or failure always triggers teardown.

> The plan places the unified target selector in this PR, but the train-dialog and jobs-table work was consolidated into #946 so all user-facing UI ships and reviews together.

---

**Plan:** [PR 8 — Enable server-aware training execution](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md#pr-8--enable-server-aware-training-execution) · [backend plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-plan.md) · [full PR plan](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/docs/feature_plans/remote-ssh-trainer-pr-plan.md)
