### PR TITLE
fix: show live training logs from remote trainers #1009

### DIFF
--- a/application/backend/src/api/job.py
+++ b/application/backend/src/api/job.py
@@ -85,6 +85,9 @@ async def get_model_job_metrics(
 ) -> EventSourceResponse:
     """Get model running metrics if job is a model job"""
     job = await job_service.get_job_by_id(job_id)
+    metrics_path = await model_metrics_service.get_model_job_metrics_path(job)
+    if metrics_path.exists():
+        return EventSourceResponse(model_metrics_service.tail_csv_file(metrics_path))
     if (
         isinstance(job, TrainJob)
         and job.payload.training_target is TrainingTarget.REMOTE
@@ -94,9 +97,6 @@ async def get_model_job_metrics(
         return EventSourceResponse(
             model_metrics_service.tail_remote_csv_file(job.payload.remote_trainer_url, str(job.payload.remote_job_id))
         )
-    metrics_path = await model_metrics_service.get_model_job_metrics_path(job)
-    if metrics_path.exists():
-        return EventSourceResponse(model_metrics_service.tail_csv_file(metrics_path))
     return EventSourceResponse(model_metrics_service.empty_metrics_stream())
 
 

--- a/application/backend/src/api/job.py
+++ b/application/backend/src/api/job.py
@@ -17,7 +17,7 @@ from core.scheduler import Scheduler
 from exceptions import ResourceNotFoundError, ResourceType
 from schemas import Job
 from schemas.base_job import JobStatus
-from schemas.job import TrainJobPayload
+from schemas.job import TrainingTarget, TrainJob, TrainJobPayload
 from services import JobService, ModelMetricsService
 from services.event_processor import EventProcessor, EventType
 
@@ -85,6 +85,15 @@ async def get_model_job_metrics(
 ) -> EventSourceResponse:
     """Get model running metrics if job is a model job"""
     job = await job_service.get_job_by_id(job_id)
+    if (
+        isinstance(job, TrainJob)
+        and job.payload.training_target is TrainingTarget.REMOTE
+        and job.payload.remote_trainer_url is not None
+        and job.payload.remote_job_id is not None
+    ):
+        return EventSourceResponse(
+            model_metrics_service.tail_remote_csv_file(job.payload.remote_trainer_url, str(job.payload.remote_job_id))
+        )
     metrics_path = await model_metrics_service.get_model_job_metrics_path(job)
     if metrics_path.exists():
         return EventSourceResponse(model_metrics_service.tail_csv_file(metrics_path))

--- a/application/backend/src/services/model_metrics_service.py
+++ b/application/backend/src/services/model_metrics_service.py
@@ -67,6 +67,10 @@ class ModelMetricsService:
                         yield ServerSentEvent(data=line.removeprefix("data:").lstrip())
         except httpx.HTTPError as exc:
             logger.warning("Remote metrics stream failed for {}: {}", remote_job_id, exc)
+        except asyncio.CancelledError:
+            logger.debug("Remote metrics stream cancelled for {}", remote_job_id)
+        except GeneratorExit:
+            logger.debug("Remote metrics stream closed for {}", remote_job_id)
 
     @staticmethod
     async def empty_metrics_stream() -> AsyncGenerator[ServerSentEvent]:

--- a/application/backend/src/services/model_metrics_service.py
+++ b/application/backend/src/services/model_metrics_service.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 
 import anyio
+import httpx
 from loguru import logger
 from sse_starlette import ServerSentEvent
 
@@ -49,6 +50,23 @@ class ModelMetricsService:
             logger.debug(f"SSE log stream cancelled for {path}")
         except GeneratorExit:
             logger.debug(f"SSE log stream closed for {path}")
+
+    @staticmethod
+    async def tail_remote_csv_file(base_url: str, remote_job_id: str) -> AsyncGenerator[ServerSentEvent]:
+        """Relay metric SSE events from a remote trainer without exposing it to clients."""
+        url = f"{base_url.rstrip('/')}/jobs/{remote_job_id}/metrics"
+        timeout = httpx.Timeout(connect=10.0, read=None, write=10.0, pool=10.0)
+        try:
+            async with (
+                httpx.AsyncClient(timeout=timeout) as client,
+                client.stream("GET", url, headers={"Accept": "text/event-stream"}) as response,
+            ):
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if line.startswith("data:"):
+                        yield ServerSentEvent(data=line.removeprefix("data:").lstrip())
+        except httpx.HTTPError as exc:
+            logger.warning("Remote metrics stream failed for {}: {}", remote_job_id, exc)
 
     @staticmethod
     async def empty_metrics_stream() -> AsyncGenerator[ServerSentEvent]:

--- a/application/backend/src/trainer/api.py
+++ b/application/backend/src/trainer/api.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 from uuid import UUID  # noqa: TC003
 
+import anyio
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import FileResponse
 from loguru import logger
@@ -326,12 +327,12 @@ async def job_metrics(job_id: ResolvedJob, request: Request) -> EventSourceRespo
                 return
             await asyncio.sleep(0.5)
 
-        with path.open(encoding="utf-8") as metrics_file:
+        async with await anyio.open_file(path, encoding="utf-8") as metrics_file:
             header_line = ""
             while not header_line:
                 if await request.is_disconnected():
                     return
-                header_line = metrics_file.readline()
+                header_line = await metrics_file.readline()
                 if header_line:
                     break
                 state = manager.store.get(job_id.id)
@@ -342,7 +343,7 @@ async def job_metrics(job_id: ResolvedJob, request: Request) -> EventSourceRespo
             while True:
                 if await request.is_disconnected():
                     return
-                line = metrics_file.readline()
+                line = await metrics_file.readline()
                 if line:
                     row = next(csv.reader([line]))
                     data = {key: _parse_metric_value(value) for key, value in zip(headers, row, strict=False)}

--- a/application/backend/src/trainer/api.py
+++ b/application/backend/src/trainer/api.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import asyncio
+import csv
+import json
 import re
 import shutil
 from dataclasses import dataclass
@@ -24,7 +26,7 @@ from physicalai.data.archive_safety import (
     check_disk_headroom,
     flatten_single_root_directory,
 )
-from sse_starlette.sse import EventSourceResponse
+from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 
 from trainer.schemas import (
     CancelResponse,
@@ -51,6 +53,15 @@ class _ChunkedFileResponse(FileResponse):
     """FileResponse with a larger streaming chunk size for large artifacts."""
 
     chunk_size = _ARTIFACT_CHUNK_SIZE
+
+
+def _parse_metric_value(value: str) -> int | float | str | None:
+    """Match the Studio CSV metric value representation."""
+    try:
+        parsed = float(value)
+        return int(parsed) if parsed.is_integer() else parsed
+    except ValueError:
+        return None if value == "" else value
 
 
 def _manager(request: Request) -> QueueManager:
@@ -292,6 +303,57 @@ async def job_events(job_id: ResolvedJob, request: Request) -> EventSourceRespon
             await asyncio.sleep(1.0)
 
     return EventSourceResponse(_event_stream())
+
+
+@router.get("/{job_id}/metrics")
+async def job_metrics(job_id: ResolvedJob, request: Request) -> EventSourceResponse:
+    """Stream Lightning CSV metrics while a remote job is running."""
+    manager = job_id.manager
+    cache_path = get_settings().storage_dir / "cache" / job_id.id / "version_0" / "metrics.csv"
+    model_path = get_settings().models_dir / job_id.id / "version_0" / "metrics.csv"
+
+    async def _metric_stream():
+        path = cache_path
+        while not path.exists():
+            if await request.is_disconnected():
+                return
+            state = manager.store.get(job_id.id)
+            if state is None or state.status in _TERMINAL:
+                # A completed run moves the cache into the model directory.
+                if model_path.exists():
+                    path = model_path
+                    break
+                return
+            await asyncio.sleep(0.5)
+
+        with path.open(encoding="utf-8") as metrics_file:
+            header_line = ""
+            while not header_line:
+                if await request.is_disconnected():
+                    return
+                header_line = metrics_file.readline()
+                if header_line:
+                    break
+                state = manager.store.get(job_id.id)
+                if state is None or state.status in _TERMINAL:
+                    return
+                await asyncio.sleep(0.5)
+            headers = [header.replace("/", "_") for header in next(csv.reader([header_line]))]
+            while True:
+                if await request.is_disconnected():
+                    return
+                line = metrics_file.readline()
+                if line:
+                    row = next(csv.reader([line]))
+                    data = {key: _parse_metric_value(value) for key, value in zip(headers, row, strict=False)}
+                    yield ServerSentEvent(data=json.dumps(data))
+                    continue
+                state = manager.store.get(job_id.id)
+                if state is None or state.status in _TERMINAL:
+                    return
+                await asyncio.sleep(0.5)
+
+    return EventSourceResponse(_metric_stream())
 
 
 @router.get("/{job_id}/artifact")

--- a/application/backend/tests/trainer/test_api_metrics.py
+++ b/application/backend/tests/trainer/test_api_metrics.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the trainer's live Lightning metrics stream."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from trainer import api as api_module
+from trainer.schemas import JobState, TrainerJobStatus
+
+
+def test_metrics_stream_uses_studio_csv_shape(tmp_path, monkeypatch) -> None:
+    job_id = str(uuid4())
+    state = JobState(remote_job_id=job_id, status=TrainerJobStatus.COMPLETED)
+    store = MagicMock()
+    store.get.return_value = state
+    settings = MagicMock()
+    settings.storage_dir = tmp_path / "storage"
+    settings.models_dir = tmp_path / "models"
+    metrics_path = settings.models_dir / job_id / "version_0" / "metrics.csv"
+    metrics_path.parent.mkdir(parents=True)
+    metrics_path.write_text("epoch,step,train/loss\n0,4,0.25\n", encoding="utf-8")
+    monkeypatch.setattr(api_module, "get_settings", lambda: settings)
+
+    app = FastAPI()
+    app.include_router(api_module.router)
+    app.state.queue_manager = SimpleNamespace(store=store)
+
+    response = TestClient(app).get(f"/jobs/{job_id}/metrics")
+
+    assert response.status_code == 200
+    assert 'data: {"epoch": 0, "step": 4, "train_loss": 0.25}' in response.text

--- a/application/backend/tests/trainer/test_api_metrics.py
+++ b/application/backend/tests/trainer/test_api_metrics.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -36,4 +37,5 @@ def test_metrics_stream_uses_studio_csv_shape(tmp_path, monkeypatch) -> None:
     response = TestClient(app).get(f"/jobs/{job_id}/metrics")
 
     assert response.status_code == 200
-    assert 'data: {"epoch": 0, "step": 4, "train_loss": 0.25}' in response.text
+    data = next(line.removeprefix("data: ") for line in response.text.splitlines() if line.startswith("data: "))
+    assert json.loads(data) == {"epoch": 0, "step": 4, "train_loss": 0.25}


### PR DESCRIPTION
Fixes #1009 by adding a new `job_metrics` endpoint which gets consumed by the hosts' job metrics endpoints when dealing with a remote training job.