### PR TITLE
feat: Sync model metrics cursor

### DIFF
--- a/application/ui/src/api/batch-async-iterable.test.ts
+++ b/application/ui/src/api/batch-async-iterable.test.ts
@@ -1,20 +1,12 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { vi } from 'vitest';
+
 import { batchAsyncIterable } from './batch-async-iterable';
 
-const collect = async <T>(iterable: AsyncIterable<T>): Promise<T[]> => {
-    const results: T[] = [];
-
-    for await (const item of iterable) {
-        results.push(item);
-    }
-
-    return results;
-};
-
 // A source that yields items with delays so we can control when they land
-// relative to the batching interval.
+// relative to the batching interval. Delays are relative to the previous item.
 async function* timedSource<T>(items: Array<{ value: T; delayMs: number }>): AsyncGenerator<T> {
     for (const { value, delayMs } of items) {
         if (delayMs > 0) {
@@ -24,7 +16,34 @@ async function* timedSource<T>(items: Array<{ value: T; delayMs: number }>): Asy
     }
 }
 
+/**
+ * Starts consuming `iterable` without awaiting it, then drives the fake clock
+ * forward by `elapsedMs` so the buffered timers resolve deterministically.
+ */
+const collectWhileAdvancing = async <T>(iterable: AsyncIterable<T>, elapsedMs: number): Promise<T[]> => {
+    const results: T[] = [];
+
+    const consumed = (async () => {
+        for await (const item of iterable) {
+            results.push(item);
+        }
+    })();
+
+    await vi.advanceTimersByTimeAsync(elapsedMs);
+    await consumed;
+
+    return results;
+};
+
 describe('batchAsyncIterable', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('groups items produced within one interval window into a single batch', async () => {
         const source = timedSource([
             { value: 1, delayMs: 0 },
@@ -32,19 +51,21 @@ describe('batchAsyncIterable', () => {
             { value: 3, delayMs: 0 },
         ]);
 
-        const batches = await collect(batchAsyncIterable(source, 50));
+        const batches = await collectWhileAdvancing(batchAsyncIterable(source, 100), 300);
 
         expect(batches).toEqual([[1, 2, 3]]);
     });
 
     it('produces a separate batch per interval window when items are spread out over time', async () => {
+        // Items land at t=0, t=250 and t=450, so each falls into a different
+        // 100ms window and none collides with a window boundary.
         const source = timedSource([
             { value: 1, delayMs: 0 },
-            { value: 2, delayMs: 60 },
-            { value: 3, delayMs: 60 },
+            { value: 2, delayMs: 250 },
+            { value: 3, delayMs: 200 },
         ]);
 
-        const batches = await collect(batchAsyncIterable(source, 20));
+        const batches = await collectWhileAdvancing(batchAsyncIterable(source, 100), 1000);
 
         expect(batches).toEqual([[1], [2], [3]]);
     });
@@ -55,7 +76,7 @@ describe('batchAsyncIterable', () => {
             { value: 2, delayMs: 0 },
         ]);
 
-        const batches = await collect(batchAsyncIterable(source, 1000));
+        const batches = await collectWhileAdvancing(batchAsyncIterable(source, 1000), 2000);
 
         expect(batches).toEqual([[1, 2]]);
     });
@@ -63,7 +84,7 @@ describe('batchAsyncIterable', () => {
     it('yields nothing for a source that produces no items', async () => {
         const source = timedSource<number>([]);
 
-        const batches = await collect(batchAsyncIterable(source, 20));
+        const batches = await collectWhileAdvancing(batchAsyncIterable(source, 100), 300);
 
         expect(batches).toEqual([]);
     });
@@ -76,15 +97,15 @@ describe('batchAsyncIterable', () => {
         })();
 
         const batches: number[][] = [];
-        const iterator = batchAsyncIterable(source, 1000);
+        const consumed = (async () => {
+            for await (const batch of batchAsyncIterable(source, 100)) {
+                batches.push(batch);
+            }
+        })();
+        const assertion = expect(consumed).rejects.toThrow('stream failed');
 
-        await expect(
-            (async () => {
-                for await (const batch of iterator) {
-                    batches.push(batch);
-                }
-            })()
-        ).rejects.toThrow('stream failed');
+        await vi.advanceTimersByTimeAsync(300);
+        await assertion;
 
         expect(batches).toEqual([[1, 2]]);
     });

--- a/application/ui/src/api/batch-async-iterable.test.ts
+++ b/application/ui/src/api/batch-async-iterable.test.ts
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { batchAsyncIterable } from './batch-async-iterable';
+
+const collect = async <T>(iterable: AsyncIterable<T>): Promise<T[]> => {
+    const results: T[] = [];
+
+    for await (const item of iterable) {
+        results.push(item);
+    }
+
+    return results;
+};
+
+// A source that yields items with delays so we can control when they land
+// relative to the batching interval.
+async function* timedSource<T>(items: Array<{ value: T; delayMs: number }>): AsyncGenerator<T> {
+    for (const { value, delayMs } of items) {
+        if (delayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+        yield value;
+    }
+}
+
+describe('batchAsyncIterable', () => {
+    it('groups items produced within one interval window into a single batch', async () => {
+        const source = timedSource([
+            { value: 1, delayMs: 0 },
+            { value: 2, delayMs: 0 },
+            { value: 3, delayMs: 0 },
+        ]);
+
+        const batches = await collect(batchAsyncIterable(source, 50));
+
+        expect(batches).toEqual([[1, 2, 3]]);
+    });
+
+    it('produces a separate batch per interval window when items are spread out over time', async () => {
+        const source = timedSource([
+            { value: 1, delayMs: 0 },
+            { value: 2, delayMs: 60 },
+            { value: 3, delayMs: 60 },
+        ]);
+
+        const batches = await collect(batchAsyncIterable(source, 20));
+
+        expect(batches).toEqual([[1], [2], [3]]);
+    });
+
+    it('flushes any items buffered right before the source completes', async () => {
+        const source = timedSource([
+            { value: 1, delayMs: 0 },
+            { value: 2, delayMs: 0 },
+        ]);
+
+        const batches = await collect(batchAsyncIterable(source, 1000));
+
+        expect(batches).toEqual([[1, 2]]);
+    });
+
+    it('yields nothing for a source that produces no items', async () => {
+        const source = timedSource<number>([]);
+
+        const batches = await collect(batchAsyncIterable(source, 20));
+
+        expect(batches).toEqual([]);
+    });
+
+    it('propagates an error from the source after flushing already-buffered items', async () => {
+        const source = (async function* () {
+            yield 1;
+            yield 2;
+            throw new Error('stream failed');
+        })();
+
+        const batches: number[][] = [];
+        const iterator = batchAsyncIterable(source, 1000);
+
+        await expect(
+            (async () => {
+                for await (const batch of iterator) {
+                    batches.push(batch);
+                }
+            })()
+        ).rejects.toThrow('stream failed');
+
+        expect(batches).toEqual([[1, 2]]);
+    });
+});

--- a/application/ui/src/api/batch-async-iterable.ts
+++ b/application/ui/src/api/batch-async-iterable.ts
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Wraps an async iterable so that items are buffered and re-emitted as
+ * arrays ("batches") on a fixed cadence, instead of one at a time.
+ *
+ * This is used to protect the UI from high-frequency sources (e.g. an SSE
+ * stream tailing a file with hundreds of thousands of rows) where consuming
+ * every single item individually would trigger one state update/render per
+ * item. Batching bounds the number of downstream updates to roughly
+ * `sourceDurationMs / intervalMs`, regardless of how many items the source
+ * produces or how bursty it is.
+ *
+ * Any items still buffered when the source completes are flushed as a
+ * final batch. Errors from the source are propagated once, after any
+ * already-buffered items have been flushed.
+ */
+export function batchAsyncIterable<T>(source: AsyncIterable<T>, intervalMs: number): AsyncIterable<T[]> {
+    return {
+        async *[Symbol.asyncIterator](): AsyncGenerator<T[]> {
+            let buffer: T[] = [];
+            let sourceDone = false;
+            let sourceError: unknown;
+
+            const pump = (async () => {
+                try {
+                    for await (const item of source) {
+                        buffer.push(item);
+                    }
+                } catch (error) {
+                    sourceError = error;
+                } finally {
+                    sourceDone = true;
+                }
+            })();
+
+            const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+            try {
+                while (!sourceDone) {
+                    await sleep(intervalMs);
+
+                    if (buffer.length > 0) {
+                        const batch = buffer;
+                        buffer = [];
+                        yield batch;
+                    }
+                }
+
+                if (buffer.length > 0) {
+                    const batch = buffer;
+                    buffer = [];
+                    yield batch;
+                }
+
+                if (sourceError) {
+                    throw sourceError;
+                }
+            } finally {
+                // Ensure the source's own cleanup (e.g. closing an EventSource) has
+                // run before we consider this generator fully done.
+                await pump;
+            }
+        },
+    };
+}

--- a/application/ui/src/features/models/metrics/merge-metrics-by-step.test.ts
+++ b/application/ui/src/features/models/metrics/merge-metrics-by-step.test.ts
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { mergeMetricsByStep } from './merge-metrics-by-step';
+import { MetricsEntry } from './types';
+
+const entry = (overrides: Partial<MetricsEntry>): MetricsEntry => ({
+    step: 0,
+    epoch: null,
+    train_loss: null,
+    val_loss: null,
+    'lr-AdamW': null,
+    ...overrides,
+});
+
+describe('mergeMetricsByStep', () => {
+    it('returns an empty array for empty input', () => {
+        expect(mergeMetricsByStep([])).toEqual([]);
+    });
+
+    it('returns a single entry unchanged', () => {
+        const single = entry({ step: 1, train_loss: 0.5 });
+
+        expect(mergeMetricsByStep([single])).toEqual([single]);
+    });
+
+    it('sorts entries by step ascending', () => {
+        const result = mergeMetricsByStep([entry({ step: 3 }), entry({ step: 1 }), entry({ step: 2 })]);
+
+        expect(result.map((e) => e.step)).toEqual([1, 2, 3]);
+    });
+
+    it('merges multiple entries for the same step into one', () => {
+        const result = mergeMetricsByStep([entry({ step: 1, train_loss: 0.5 }), entry({ step: 1, val_loss: 0.3 })]);
+
+        expect(result).toHaveLength(1);
+    });
+
+    it('fills a null field on an earlier entry with a later non-null value for the same step', () => {
+        const result = mergeMetricsByStep([
+            entry({ step: 1, train_loss: 0.5, val_loss: null }),
+            entry({ step: 1, train_loss: null, val_loss: 0.3 }),
+        ]);
+
+        expect(result[0]).toMatchObject({ train_loss: 0.5, val_loss: 0.3 });
+    });
+
+    it('lets a later non-null value overwrite an earlier value for the same field', () => {
+        const result = mergeMetricsByStep([entry({ step: 1, train_loss: 0.5 }), entry({ step: 1, train_loss: 0.9 })]);
+
+        expect(result[0].train_loss).toBe(0.9);
+    });
+
+    it('keeps the earlier value when the later entry has null/undefined for that field', () => {
+        const result = mergeMetricsByStep([
+            entry({ step: 1, train_loss: 0.5 }),
+            entry({ step: 1, train_loss: undefined }),
+        ]);
+
+        expect(result[0].train_loss).toBe(0.5);
+    });
+
+    it('normalizes a missing field to null when never provided across merged entries', () => {
+        const result = mergeMetricsByStep([
+            entry({ step: 1, epoch: null, train_loss: null, val_loss: null, 'lr-AdamW': null }),
+        ]);
+
+        expect(result[0]).toEqual({ step: 1, epoch: null, train_loss: null, val_loss: null, 'lr-AdamW': null });
+    });
+
+    it('keeps distinct steps as separate entries', () => {
+        const result = mergeMetricsByStep([entry({ step: 1, train_loss: 0.5 }), entry({ step: 2, train_loss: 0.4 })]);
+
+        expect(result).toHaveLength(2);
+        expect(result.map((e) => e.step)).toEqual([1, 2]);
+    });
+});

--- a/application/ui/src/features/models/metrics/merge-metrics-by-step.test.ts
+++ b/application/ui/src/features/models/metrics/merge-metrics-by-step.test.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { mergeMetricsByStep } from './merge-metrics-by-step';
+import { foldMetricsBatch, sortMetricsByStep } from './merge-metrics-by-step';
 import { MetricsEntry } from './types';
 
 const entry = (overrides: Partial<MetricsEntry>): MetricsEntry => ({
@@ -13,31 +13,36 @@ const entry = (overrides: Partial<MetricsEntry>): MetricsEntry => ({
     ...overrides,
 });
 
-describe('mergeMetricsByStep', () => {
+// Convenience for tests that only care about the end result of merging a flat
+// list of raw entries in one go (as opposed to across multiple batches).
+const mergeAllAtOnce = (entries: MetricsEntry[]): MetricsEntry[] =>
+    sortMetricsByStep(foldMetricsBatch(new Map(), entries));
+
+describe('foldMetricsBatch + sortMetricsByStep (merging a full list at once)', () => {
     it('returns an empty array for empty input', () => {
-        expect(mergeMetricsByStep([])).toEqual([]);
+        expect(mergeAllAtOnce([])).toEqual([]);
     });
 
     it('returns a single entry unchanged', () => {
         const single = entry({ step: 1, train_loss: 0.5 });
 
-        expect(mergeMetricsByStep([single])).toEqual([single]);
+        expect(mergeAllAtOnce([single])).toEqual([single]);
     });
 
     it('sorts entries by step ascending', () => {
-        const result = mergeMetricsByStep([entry({ step: 3 }), entry({ step: 1 }), entry({ step: 2 })]);
+        const result = mergeAllAtOnce([entry({ step: 3 }), entry({ step: 1 }), entry({ step: 2 })]);
 
         expect(result.map((e) => e.step)).toEqual([1, 2, 3]);
     });
 
     it('merges multiple entries for the same step into one', () => {
-        const result = mergeMetricsByStep([entry({ step: 1, train_loss: 0.5 }), entry({ step: 1, val_loss: 0.3 })]);
+        const result = mergeAllAtOnce([entry({ step: 1, train_loss: 0.5 }), entry({ step: 1, val_loss: 0.3 })]);
 
         expect(result).toHaveLength(1);
     });
 
     it('fills a null field on an earlier entry with a later non-null value for the same step', () => {
-        const result = mergeMetricsByStep([
+        const result = mergeAllAtOnce([
             entry({ step: 1, train_loss: 0.5, val_loss: null }),
             entry({ step: 1, train_loss: null, val_loss: 0.3 }),
         ]);
@@ -46,22 +51,19 @@ describe('mergeMetricsByStep', () => {
     });
 
     it('lets a later non-null value overwrite an earlier value for the same field', () => {
-        const result = mergeMetricsByStep([entry({ step: 1, train_loss: 0.5 }), entry({ step: 1, train_loss: 0.9 })]);
+        const result = mergeAllAtOnce([entry({ step: 1, train_loss: 0.5 }), entry({ step: 1, train_loss: 0.9 })]);
 
         expect(result[0].train_loss).toBe(0.9);
     });
 
     it('keeps the earlier value when the later entry has null/undefined for that field', () => {
-        const result = mergeMetricsByStep([
-            entry({ step: 1, train_loss: 0.5 }),
-            entry({ step: 1, train_loss: undefined }),
-        ]);
+        const result = mergeAllAtOnce([entry({ step: 1, train_loss: 0.5 }), entry({ step: 1, train_loss: undefined })]);
 
         expect(result[0].train_loss).toBe(0.5);
     });
 
     it('normalizes a missing field to null when never provided across merged entries', () => {
-        const result = mergeMetricsByStep([
+        const result = mergeAllAtOnce([
             entry({ step: 1, epoch: null, train_loss: null, val_loss: null, 'lr-AdamW': null }),
         ]);
 
@@ -69,9 +71,61 @@ describe('mergeMetricsByStep', () => {
     });
 
     it('keeps distinct steps as separate entries', () => {
-        const result = mergeMetricsByStep([entry({ step: 1, train_loss: 0.5 }), entry({ step: 2, train_loss: 0.4 })]);
+        const result = mergeAllAtOnce([entry({ step: 1, train_loss: 0.5 }), entry({ step: 2, train_loss: 0.4 })]);
 
         expect(result).toHaveLength(2);
         expect(result.map((e) => e.step)).toEqual([1, 2]);
+    });
+});
+
+describe('foldMetricsBatch', () => {
+    it('does not mutate the map passed in', () => {
+        const initial = new Map<number, MetricsEntry>();
+
+        foldMetricsBatch(initial, [entry({ step: 1, train_loss: 0.5 })]);
+
+        expect(initial.size).toBe(0);
+    });
+
+    it('folds a new batch into an existing map without reprocessing prior entries', () => {
+        const afterFirstBatch = foldMetricsBatch(new Map(), [entry({ step: 1, train_loss: 0.5 })]);
+        const afterSecondBatch = foldMetricsBatch(afterFirstBatch, [entry({ step: 2, train_loss: 0.4 })]);
+
+        expect(afterSecondBatch.size).toBe(2);
+        expect(afterSecondBatch.get(1)).toMatchObject({ train_loss: 0.5 });
+        expect(afterSecondBatch.get(2)).toMatchObject({ train_loss: 0.4 });
+    });
+
+    it('merges a later batch for the same step into the existing entry, coalescing null fields', () => {
+        const afterFirstBatch = foldMetricsBatch(new Map(), [entry({ step: 1, train_loss: 0.5, val_loss: null })]);
+        const afterSecondBatch = foldMetricsBatch(afterFirstBatch, [
+            entry({ step: 1, train_loss: null, val_loss: 0.3 }),
+        ]);
+
+        expect(afterSecondBatch.size).toBe(1);
+        expect(afterSecondBatch.get(1)).toMatchObject({ train_loss: 0.5, val_loss: 0.3 });
+    });
+
+    it('returns a new map reference each call so reference-equality consumers detect the update', () => {
+        const initial = new Map<number, MetricsEntry>();
+        const result = foldMetricsBatch(initial, [entry({ step: 1 })]);
+
+        expect(result).not.toBe(initial);
+    });
+});
+
+describe('sortMetricsByStep', () => {
+    it('returns an empty array for an empty map', () => {
+        expect(sortMetricsByStep(new Map())).toEqual([]);
+    });
+
+    it('sorts entries by step ascending regardless of insertion order', () => {
+        const byStep = new Map<number, MetricsEntry>([
+            [3, entry({ step: 3 })],
+            [1, entry({ step: 1 })],
+            [2, entry({ step: 2 })],
+        ]);
+
+        expect(sortMetricsByStep(byStep).map((e) => e.step)).toEqual([1, 2, 3]);
     });
 });

--- a/application/ui/src/features/models/metrics/merge-metrics-by-step.test.ts
+++ b/application/ui/src/features/models/metrics/merge-metrics-by-step.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { foldMetricsBatch, sortMetricsByStep } from './merge-metrics-by-step';
-import { MetricsEntry } from './types';
+import type { MetricsEntry } from './types';
 
 const entry = (overrides: Partial<MetricsEntry>): MetricsEntry => ({
     step: 0,

--- a/application/ui/src/features/models/metrics/merge-metrics-by-step.ts
+++ b/application/ui/src/features/models/metrics/merge-metrics-by-step.ts
@@ -15,20 +15,34 @@ const mergeFields = (current: MetricsEntry, incoming: MetricsEntry): MergedField
     'lr-AdamW': coalesce(current['lr-AdamW'], incoming['lr-AdamW']),
 });
 
-export const mergeMetricsByStep = (entries: MetricsEntry[]): MetricsEntry[] => {
-    const byStep = new Map<number, MetricsEntry>();
+/**
+ * Folds a batch of raw metric entries into an existing step -> entry map,
+ * without reprocessing entries that were already folded in on a previous
+ * call. Always returns a new `Map` (never mutates `byStep`) so that callers
+ * relying on referential equality to detect changes (e.g. TanStack Query)
+ * observe the update.
+ */
+export const foldMetricsBatch = (
+    byStep: ReadonlyMap<number, MetricsEntry>,
+    batch: readonly MetricsEntry[]
+): Map<number, MetricsEntry> => {
+    const next = new Map(byStep);
 
-    for (const entry of entries) {
-        const current = byStep.get(entry.step);
+    for (const entry of batch) {
+        const current = next.get(entry.step);
 
-        byStep.set(entry.step, {
+        next.set(entry.step, {
             step: entry.step,
             ...mergeFields(current ?? entry, entry),
         });
     }
 
-    return byStep
+    return next;
+};
+
+/** Converts a step -> entry map into an array sorted by step, ascending. */
+export const sortMetricsByStep = (byStep: ReadonlyMap<number, MetricsEntry>): MetricsEntry[] =>
+    byStep
         .values()
         .toArray()
         .toSorted((a, b) => a.step - b.step);
-};

--- a/application/ui/src/features/models/metrics/merge-metrics-by-step.ts
+++ b/application/ui/src/features/models/metrics/merge-metrics-by-step.ts
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { MetricsEntry } from './types';
+
+type MergedFields = Required<Omit<MetricsEntry, 'step'>>;
+
+const coalesce = <T>(current: T | null | undefined, incoming: T | null | undefined): T | null =>
+    incoming ?? current ?? null;
+
+const mergeFields = (current: MetricsEntry, incoming: MetricsEntry): MergedFields => ({
+    epoch: coalesce(current.epoch, incoming.epoch),
+    train_loss: coalesce(current.train_loss, incoming.train_loss),
+    val_loss: coalesce(current.val_loss, incoming.val_loss),
+    'lr-AdamW': coalesce(current['lr-AdamW'], incoming['lr-AdamW']),
+});
+
+export const mergeMetricsByStep = (entries: MetricsEntry[]): MetricsEntry[] => {
+    const byStep = new Map<number, MetricsEntry>();
+
+    for (const entry of entries) {
+        const current = byStep.get(entry.step);
+
+        byStep.set(entry.step, {
+            step: entry.step,
+            ...mergeFields(current ?? entry, entry),
+        });
+    }
+
+    return byStep
+        .values()
+        .toArray()
+        .toSorted((a, b) => a.step - b.step);
+};

--- a/application/ui/src/features/models/metrics/metric-graph.tsx
+++ b/application/ui/src/features/models/metrics/metric-graph.tsx
@@ -126,7 +126,6 @@ export const MetricGraph = ({
                                     fill={`url(#${gradientId})`}
                                     dot={false}
                                     connectNulls
-                                    isAnimationActive={false}
                                 />
                                 <Tooltip
                                     filterNull={false}

--- a/application/ui/src/features/models/metrics/metric-graph.tsx
+++ b/application/ui/src/features/models/metrics/metric-graph.tsx
@@ -1,14 +1,53 @@
 import { useId } from 'react';
 
-import { Flex, View } from '@geti-ui/ui';
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Flex, Text, View } from '@geti-ui/ui';
+import {
+    Area,
+    AreaChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    TooltipContentProps,
+    XAxis,
+    YAxis,
+} from 'recharts';
 
 import { Box } from '../shared/box';
 import { MetricsEntry } from './types';
 
-export type MetricGraphPoint = {
-    x: number;
-    y: number;
+type CustomTooltipContentProps = Partial<TooltipContentProps> & {
+    xAxisLabel?: string;
+    yAxisLabel?: string;
+};
+
+const CustomTooltipContent = ({ active, payload, label, xAxisLabel, yAxisLabel }: CustomTooltipContentProps) => {
+    if (!active || !payload?.length) {
+        return null;
+    }
+
+    const value = payload[0].value;
+
+    return (
+        <View
+            padding={'size-200'}
+            backgroundColor={'gray-50'}
+            borderRadius={'regular'}
+            borderWidth={'thin'}
+            borderColor={'gray-400'}
+            UNSAFE_style={{
+                padding: 'var(--spectrum-global-dimension-size-100)',
+                color: 'var(--spectrum-global-color-gray-900)',
+                fontSize: 'var(--spectrum-global-dimension-font-size-75)',
+            }}
+        >
+            <div>
+                {xAxisLabel}: {label}
+            </div>
+            <Text UNSAFE_style={{ color: 'var(--metric-graph-color)' }}>
+                {yAxisLabel}: {value ?? 'Not available'}
+            </Text>
+        </View>
+    );
 };
 
 type MetricGraphProps = {
@@ -90,39 +129,9 @@ export const MetricGraph = ({
                                 />
                                 <Tooltip
                                     filterNull={false}
-                                    labelFormatter={(label) => `${xAxisLabel}: ${label}`}
-                                    content={({ active, payload, label }) => {
-                                        console.log({ payload });
-                                        if (active && payload && payload.length) {
-                                            const value = payload[0].value;
-                                            return (
-                                                <div
-                                                    style={{
-                                                        padding: 'var(--spectrum-global-dimension-size-100)',
-                                                        color: 'var(--spectrum-global-color-gray-900)',
-                                                        fontSize: 'var(--spectrum-global-dimension-font-size-75)',
-                                                        backgroundColor: 'var(--spectrum-global-color-gray-50)',
-                                                        borderColor: 'var(--color-border-2)',
-                                                        borderRadius: 'var(--spectrum-alias-border-radius-regular)',
-                                                    }}
-                                                >
-                                                    <div>
-                                                        {xAxisLabel}: {label}
-                                                    </div>
-                                                    <div>
-                                                        {yAxisLabel}: {value}
-                                                    </div>
-                                                </div>
-                                            );
-                                        }
-                                    }}
+                                    content={<CustomTooltipContent xAxisLabel={xAxisLabel} yAxisLabel={yAxisLabel} />}
                                     cursor={{
                                         stroke: 'var(--metric-graph-color)',
-                                    }}
-                                    contentStyle={{
-                                        backgroundColor: 'var(--spectrum-global-color-gray-50)',
-                                        borderColor: 'var(--color-border-2)',
-                                        borderRadius: 'var(--spectrum-alias-border-radius-regular)',
                                     }}
                                 />
                             </AreaChart>

--- a/application/ui/src/features/models/metrics/metric-graph.tsx
+++ b/application/ui/src/features/models/metrics/metric-graph.tsx
@@ -13,7 +13,7 @@ import {
 } from 'recharts';
 
 import { Box } from '../shared/box';
-import { MetricsEntry } from './types';
+import type { MetricsEntry } from './types';
 
 type CustomTooltipContentProps = Partial<TooltipContentProps> & {
     xAxisLabel?: string;

--- a/application/ui/src/features/models/metrics/metric-graph.tsx
+++ b/application/ui/src/features/models/metrics/metric-graph.tsx
@@ -126,6 +126,7 @@ export const MetricGraph = ({
                                     fill={`url(#${gradientId})`}
                                     dot={false}
                                     connectNulls
+                                    isAnimationActive={false}
                                 />
                                 <Tooltip
                                     filterNull={false}

--- a/application/ui/src/features/models/metrics/metric-graph.tsx
+++ b/application/ui/src/features/models/metrics/metric-graph.tsx
@@ -4,6 +4,7 @@ import { Flex, View } from '@geti-ui/ui';
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 import { Box } from '../shared/box';
+import { MetricsEntry } from './types';
 
 export type MetricGraphPoint = {
     x: number;
@@ -11,21 +12,27 @@ export type MetricGraphPoint = {
 };
 
 type MetricGraphProps = {
+    syncId?: string;
     title: string;
-    data?: MetricGraphPoint[];
+    data?: MetricsEntry[];
     xAxisLabel?: string;
     yAxisLabel: string;
     color?: string;
+    getX: (metricsEntry: MetricsEntry) => number;
+    getY: (metricsEntry: MetricsEntry) => number | null | undefined;
 };
 
 const X_AXIS_TICK_COUNT = 8;
 const Y_AXIS_TICK_COUNT = 4;
 
 export const MetricGraph = ({
+    syncId,
     title,
     data,
     xAxisLabel,
     yAxisLabel,
+    getY,
+    getX,
     color = 'var(--energy-blue)',
 }: MetricGraphProps) => {
     const gradientId = useId();
@@ -45,6 +52,7 @@ export const MetricGraph = ({
                     <View backgroundColor={'gray-50'} minHeight={'size-3000'}>
                         <ResponsiveContainer width='100%' height={300} style={{ userSelect: 'none' }}>
                             <AreaChart
+                                syncId={syncId}
                                 style={{ aspectRatio: 1.6 }}
                                 data={data}
                                 margin={{ top: 35, bottom: 35, left: 35, right: 35 }}
@@ -57,7 +65,7 @@ export const MetricGraph = ({
                                 </defs>
                                 <CartesianGrid />
                                 <XAxis
-                                    dataKey='x'
+                                    dataKey={getX}
                                     type='number'
                                     domain={[0, 'dataMax']}
                                     label={{ value: xAxisLabel ?? 'x', position: 'bottom', fill: '#666', offset: 12 }}
@@ -72,15 +80,42 @@ export const MetricGraph = ({
                                 />
                                 <Area
                                     type='linear'
-                                    dataKey='y'
+                                    dataKey={getY}
                                     name={yAxisLabel}
                                     stroke='var(--metric-graph-color)'
                                     strokeWidth={2}
                                     fill={`url(#${gradientId})`}
                                     dot={false}
+                                    connectNulls
                                 />
                                 <Tooltip
+                                    filterNull={false}
                                     labelFormatter={(label) => `${xAxisLabel}: ${label}`}
+                                    content={({ active, payload, label }) => {
+                                        console.log({ payload });
+                                        if (active && payload && payload.length) {
+                                            const value = payload[0].value;
+                                            return (
+                                                <div
+                                                    style={{
+                                                        padding: 'var(--spectrum-global-dimension-size-100)',
+                                                        color: 'var(--spectrum-global-color-gray-900)',
+                                                        fontSize: 'var(--spectrum-global-dimension-font-size-75)',
+                                                        backgroundColor: 'var(--spectrum-global-color-gray-50)',
+                                                        borderColor: 'var(--color-border-2)',
+                                                        borderRadius: 'var(--spectrum-alias-border-radius-regular)',
+                                                    }}
+                                                >
+                                                    <div>
+                                                        {xAxisLabel}: {label}
+                                                    </div>
+                                                    <div>
+                                                        {yAxisLabel}: {value}
+                                                    </div>
+                                                </div>
+                                            );
+                                        }
+                                    }}
                                     cursor={{
                                         stroke: 'var(--metric-graph-color)',
                                     }}

--- a/application/ui/src/features/models/metrics/metrics-view.test.tsx
+++ b/application/ui/src/features/models/metrics/metrics-view.test.tsx
@@ -1,0 +1,71 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen } from '@testing-library/react';
+
+import { render } from '../../../test-utils/render';
+import { MetricSeries, MetricsView } from './metrics';
+import { MetricsEntry } from './types';
+
+const entry = (overrides: Partial<MetricsEntry>): MetricsEntry => ({
+    step: 0,
+    epoch: null,
+    train_loss: null,
+    val_loss: null,
+    'lr-AdamW': null,
+    ...overrides,
+});
+
+const buildSeries = (title: string, getY: MetricSeries['getY'], data: MetricsEntry[]): MetricSeries => ({
+    title,
+    xLabel: 'Step',
+    yLabel: 'Loss',
+    data,
+    getX: (metricsEntry) => metricsEntry.step,
+    getY,
+});
+
+describe('MetricsView', () => {
+    it('shows a loading indicator while loading, regardless of series content', () => {
+        render(<MetricsView series={[]} isLoading />);
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('shows the empty state when no series has any data points', () => {
+        render(<MetricsView series={[]} isLoading={false} />);
+
+        expect(screen.getByText('No metrics available yet')).toBeInTheDocument();
+    });
+
+    it('shows the empty state when every series has entries but all values are null', () => {
+        const data = [entry({ step: 1 }), entry({ step: 2 })];
+        const series = [buildSeries('Training loss', (e) => e.train_loss, data)];
+
+        render(<MetricsView series={series} isLoading={false} />);
+
+        expect(screen.getByText('No metrics available yet')).toBeInTheDocument();
+    });
+
+    it('renders a chart for a series that has at least one non-null value', () => {
+        const data = [entry({ step: 1, train_loss: 0.5 })];
+        const series = [buildSeries('Training loss', (e) => e.train_loss, data)];
+
+        render(<MetricsView series={series} isLoading={false} />);
+
+        expect(screen.getByText('Training loss')).toBeInTheDocument();
+    });
+
+    it('hides a chart whose values are all null while still rendering charts that have data', () => {
+        const data = [entry({ step: 1, train_loss: 0.5, val_loss: null })];
+        const series = [
+            buildSeries('Training loss', (e) => e.train_loss, data),
+            buildSeries('Validation loss', (e) => e.val_loss, data),
+        ];
+
+        render(<MetricsView series={series} isLoading={false} />);
+
+        expect(screen.getByText('Training loss')).toBeInTheDocument();
+        expect(screen.queryByText('Validation loss')).not.toBeInTheDocument();
+    });
+});

--- a/application/ui/src/features/models/metrics/metrics-view.test.tsx
+++ b/application/ui/src/features/models/metrics/metrics-view.test.tsx
@@ -5,7 +5,7 @@ import { screen } from '@testing-library/react';
 
 import { render } from '../../../test-utils/render';
 import { MetricSeries, MetricsView } from './metrics';
-import { MetricsEntry } from './types';
+import type { MetricsEntry } from './types';
 
 const entry = (overrides: Partial<MetricsEntry>): MetricsEntry => ({
     step: 0,

--- a/application/ui/src/features/models/metrics/metrics.tsx
+++ b/application/ui/src/features/models/metrics/metrics.tsx
@@ -7,6 +7,7 @@ import { fetchClient } from '../../../api/client';
 import { fetchSSE } from '../../../api/fetch-sse';
 import { getQueryKey } from '../../../query-client/query-client.interface';
 import { ReactComponent as EmptyIllustration } from './../../../assets/illustration.svg';
+import { mergeMetricsByStep } from './merge-metrics-by-step';
 import { MetricGraph } from './metric-graph';
 import { MetricsEntry } from './types';
 
@@ -81,7 +82,7 @@ const useJobMetrics = (jobId: string) => {
                 return fetchSSE<MetricsEntry>(url, { signal: context.signal });
             },
         }),
-
+        select: mergeMetricsByStep,
         staleTime: Infinity,
     });
 };
@@ -99,7 +100,7 @@ export const JobMetricsContent = ({ jobId }: { jobId: string }) => {
             yLabel: 'Loss',
             data: metricsData,
             getX: (entry) => entry.step,
-            getY: (entry) => entry.train_loss ?? entry.train_loss_step,
+            getY: (entry) => entry.train_loss,
             color: 'var(--moss-tint-1)'
         },
         {
@@ -136,6 +137,7 @@ const useModelMetrics = (modelId: string) => {
                 return fetchSSE<MetricsEntry>(url, { signal: context.signal });
             },
         }),
+        select: mergeMetricsByStep,
         staleTime: Infinity,
     });
 };
@@ -155,7 +157,7 @@ export const MetricsContent = ({ modelId }: { modelId: string }) => {
             data: metricsData,
             color: 'var(--moss-tint-1)',
             getX: (entry) => entry.step,
-            getY: (entry) => entry.train_loss ?? entry.train_loss_step,
+            getY: (entry) => entry.train_loss,
         },
         {
             title: 'Validation loss',

--- a/application/ui/src/features/models/metrics/metrics.tsx
+++ b/application/ui/src/features/models/metrics/metrics.tsx
@@ -20,7 +20,7 @@ const NoMetricsAvailable = () => {
     );
 };
 
-interface MetricSeries {
+export interface MetricSeries {
     title: string;
     xLabel: string;
     yLabel: string;
@@ -35,14 +35,14 @@ interface MetricsViewProps {
     isLoading: boolean;
 }
 
-const MetricsView = ({ series, isLoading }: MetricsViewProps) => {
+export const MetricsView = ({ series, isLoading }: MetricsViewProps) => {
     const syncId = useId();
 
     if (isLoading) {
         return <Loading mode='inline' />;
     }
 
-    const seriesReadyToRender = series.filter((metric) => metric.data.length > 0);
+    const seriesReadyToRender = series.filter((metric) => metric.data.some((entry) => metric.getY(entry) != null));
 
     if (seriesReadyToRender.length === 0) {
         return <NoMetricsAvailable />;

--- a/application/ui/src/features/models/metrics/metrics.tsx
+++ b/application/ui/src/features/models/metrics/metrics.tsx
@@ -3,11 +3,12 @@ import { useId, useMemo } from 'react';
 import { Grid, Heading, IllustratedMessage, Loading } from '@geti-ui/ui';
 import { experimental_streamedQuery as streamedQuery, useQuery } from '@tanstack/react-query';
 
+import { batchAsyncIterable } from '../../../api/batch-async-iterable';
 import { fetchClient } from '../../../api/client';
 import { fetchSSE } from '../../../api/fetch-sse';
 import { getQueryKey } from '../../../query-client/query-client.interface';
 import { ReactComponent as EmptyIllustration } from './../../../assets/illustration.svg';
-import { mergeMetricsByStep } from './merge-metrics-by-step';
+import { foldMetricsBatch, sortMetricsByStep } from './merge-metrics-by-step';
 import { MetricGraph } from './metric-graph';
 import { MetricsEntry } from './types';
 
@@ -70,6 +71,11 @@ export const MetricsView = ({ series, isLoading }: MetricsViewProps) => {
     );
 };
 
+// Flush interval for batching incoming SSE metric rows into a single query-data
+// update, so the UI re-renders/re-merges on a bounded cadence (regardless of how
+// many rows a job/model produced) instead of once per raw row.
+const METRICS_BATCH_INTERVAL_MS = 200;
+
 const useJobMetrics = (jobId: string) => {
     return useQuery({
         queryKey: getQueryKey(['get', '/api/jobs/{job_id}/model_metrics', { params: { path: { job_id: jobId } } }]),
@@ -79,10 +85,15 @@ const useJobMetrics = (jobId: string) => {
                     params: { path: { job_id: jobId } },
                 });
 
-                return fetchSSE<MetricsEntry>(url, { signal: context.signal });
+                return batchAsyncIterable(
+                    fetchSSE<MetricsEntry>(url, { signal: context.signal }),
+                    METRICS_BATCH_INTERVAL_MS
+                );
             },
+            reducer: foldMetricsBatch,
+            initialValue: new Map<number, MetricsEntry>(),
         }),
-        select: mergeMetricsByStep,
+        select: sortMetricsByStep,
         staleTime: Infinity,
     });
 };
@@ -101,7 +112,7 @@ export const JobMetricsContent = ({ jobId }: { jobId: string }) => {
             data: metricsData,
             getX: (entry) => entry.step,
             getY: (entry) => entry.train_loss,
-            color: 'var(--moss-tint-1)'
+            color: 'var(--moss-tint-1)',
         },
         {
             title: 'Validation loss',
@@ -134,10 +145,15 @@ const useModelMetrics = (modelId: string) => {
                     params: { path: { model_id: modelId } },
                 });
 
-                return fetchSSE<MetricsEntry>(url, { signal: context.signal });
+                return batchAsyncIterable(
+                    fetchSSE<MetricsEntry>(url, { signal: context.signal }),
+                    METRICS_BATCH_INTERVAL_MS
+                );
             },
+            reducer: foldMetricsBatch,
+            initialValue: new Map<number, MetricsEntry>(),
         }),
-        select: mergeMetricsByStep,
+        select: sortMetricsByStep,
         staleTime: Infinity,
     });
 };

--- a/application/ui/src/features/models/metrics/metrics.tsx
+++ b/application/ui/src/features/models/metrics/metrics.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 
 import { Grid, Heading, IllustratedMessage, Loading } from '@geti-ui/ui';
 import { experimental_streamedQuery as streamedQuery, useQuery } from '@tanstack/react-query';
@@ -7,7 +7,8 @@ import { fetchClient } from '../../../api/client';
 import { fetchSSE } from '../../../api/fetch-sse';
 import { getQueryKey } from '../../../query-client/query-client.interface';
 import { ReactComponent as EmptyIllustration } from './../../../assets/illustration.svg';
-import { MetricGraph, type MetricGraphPoint } from './metric-graph';
+import { MetricGraph } from './metric-graph';
+import { MetricsEntry } from './types';
 
 const NoMetricsAvailable = () => {
     return (
@@ -22,8 +23,10 @@ interface MetricSeries {
     title: string;
     xLabel: string;
     yLabel: string;
-    data: MetricGraphPoint[];
+    data: MetricsEntry[];
     color?: string;
+    getX: (metricsEntry: MetricsEntry) => number;
+    getY: (metricsEntry: MetricsEntry) => number | null | undefined;
 }
 
 interface MetricsViewProps {
@@ -32,6 +35,8 @@ interface MetricsViewProps {
 }
 
 const MetricsView = ({ series, isLoading }: MetricsViewProps) => {
+    const syncId = useId();
+
     if (isLoading) {
         return <Loading mode='inline' />;
     }
@@ -47,40 +52,21 @@ const MetricsView = ({ series, isLoading }: MetricsViewProps) => {
             columns='repeat(auto-fit, minmax(min(100%, var(--spectrum-global-dimension-size-6000)), 1fr))'
             gap='size-200'
         >
-            {seriesReadyToRender.map(({ title, xLabel, yLabel, data, color }) => (
+            {seriesReadyToRender.map(({ title, xLabel, yLabel, data, color, getX, getY }) => (
                 <MetricGraph
                     key={title}
+                    syncId={syncId}
                     title={title}
                     yAxisLabel={yLabel}
                     xAxisLabel={xLabel}
                     data={data}
                     color={color}
+                    getX={getX}
+                    getY={getY}
                 />
             ))}
         </Grid>
     );
-};
-
-interface MetricsEntry {
-    epoch: number | null;
-    step: number;
-    train_loss: number | null | undefined;
-    train_loss_step: number | null | undefined;
-    'lr-AdamW': number | null | undefined;
-    val_loss: number | null | undefined;
-}
-
-const selectSeries = (
-    data: MetricsEntry[] | undefined,
-    getX: (metricsEntry: MetricsEntry) => number,
-    getY: (metricsEntry: MetricsEntry) => number | null | undefined
-) => {
-    if (data == null) return [];
-
-    return data.flatMap((entry) => {
-        const y = getY(entry);
-        return y == null ? [] : [{ x: getX(entry), y }];
-    });
 };
 
 const useJobMetrics = (jobId: string) => {
@@ -95,47 +81,44 @@ const useJobMetrics = (jobId: string) => {
                 return fetchSSE<MetricsEntry>(url, { signal: context.signal });
             },
         }),
+
         staleTime: Infinity,
     });
 };
 
 export const JobMetricsContent = ({ jobId }: { jobId: string }) => {
     const query = useJobMetrics(jobId);
-
-    const lossStepMetrics = useMemo(() => {
-        return selectSeries(
-            query.data,
-            (entry) => entry.step,
-            (entry) => entry.train_loss ?? entry.train_loss_step
-        );
+    const metricsData = useMemo(() => {
+        return query.data ?? [];
     }, [query.data]);
 
-    const validationLossStepMetrics = useMemo(() => {
-        return selectSeries(
-            query.data,
-            (entry) => entry.step,
-            (entry) => entry.val_loss
-        );
-    }, [query.data]);
-
-    const learningRateStepMetrics = useMemo(() => {
-        return selectSeries(
-            query.data,
-            (entry) => entry.step,
-            (entry) => entry['lr-AdamW']
-        );
-    }, [query.data]);
-
-    const metrics = [
-        { title: 'Training loss', xLabel: 'Step', yLabel: 'Loss', data: lossStepMetrics, color: 'var(--moss-tint-1)' },
+    const metrics: MetricSeries[] = [
+        {
+            title: 'Training loss',
+            xLabel: 'Step',
+            yLabel: 'Loss',
+            data: metricsData,
+            getX: (entry) => entry.step,
+            getY: (entry) => entry.train_loss ?? entry.train_loss_step,
+            color: 'var(--moss-tint-1)'
+        },
         {
             title: 'Validation loss',
             xLabel: 'Step',
             yLabel: 'Loss',
-            data: validationLossStepMetrics,
+            data: metricsData,
+            getX: (entry) => entry.step,
+            getY: (entry) => entry.val_loss,
             color: 'var(--coral)',
         },
-        { title: 'Learning rate', xLabel: 'Step', yLabel: 'Learning rate', data: learningRateStepMetrics },
+        {
+            title: 'Learning rate',
+            xLabel: 'Step',
+            yLabel: 'Learning rate',
+            data: metricsData,
+            getX: (entry) => entry.step,
+            getY: (entry) => entry['lr-AdamW'],
+        },
     ];
 
     return <MetricsView series={metrics} isLoading={query.isLoading} />;
@@ -160,40 +143,37 @@ const useModelMetrics = (modelId: string) => {
 export const MetricsContent = ({ modelId }: { modelId: string }) => {
     const query = useModelMetrics(modelId);
 
-    const lossStepMetrics = useMemo(() => {
-        return selectSeries(
-            query.data,
-            (entry) => entry.step,
-            (entry) => entry.train_loss ?? entry.train_loss_step
-        );
+    const metricsData = useMemo(() => {
+        return query.data ?? [];
     }, [query.data]);
 
-    const validationLossStepMetrics = useMemo(() => {
-        return selectSeries(
-            query.data,
-            (entry) => entry.step,
-            (entry) => entry.val_loss
-        );
-    }, [query.data]);
-
-    const learningRateStepMetrics = useMemo(() => {
-        return selectSeries(
-            query.data,
-            (entry) => entry.step,
-            (entry) => entry['lr-AdamW']
-        );
-    }, [query.data]);
-
-    const metrics = [
-        { title: 'Training loss', xLabel: 'Step', yLabel: 'Loss', data: lossStepMetrics, color: 'var(--moss-tint-1)' },
+    const metrics: MetricSeries[] = [
+        {
+            title: 'Training loss',
+            xLabel: 'Step',
+            yLabel: 'Loss',
+            data: metricsData,
+            color: 'var(--moss-tint-1)',
+            getX: (entry) => entry.step,
+            getY: (entry) => entry.train_loss ?? entry.train_loss_step,
+        },
         {
             title: 'Validation loss',
             xLabel: 'Step',
             yLabel: 'Loss',
-            data: validationLossStepMetrics,
+            data: metricsData,
             color: 'var(--coral)',
+            getX: (entry) => entry.step,
+            getY: (entry) => entry.val_loss,
         },
-        { title: 'Learning rate', xLabel: 'Step', yLabel: 'Learning rate', data: learningRateStepMetrics },
+        {
+            title: 'Learning rate',
+            xLabel: 'Step',
+            yLabel: 'Learning rate',
+            data: metricsData,
+            getX: (entry) => entry.step,
+            getY: (entry) => entry['lr-AdamW'],
+        },
     ];
 
     return <MetricsView series={metrics} isLoading={query.isLoading} />;

--- a/application/ui/src/features/models/metrics/metrics.tsx
+++ b/application/ui/src/features/models/metrics/metrics.tsx
@@ -10,7 +10,7 @@ import { getQueryKey } from '../../../query-client/query-client.interface';
 import { ReactComponent as EmptyIllustration } from './../../../assets/illustration.svg';
 import { foldMetricsBatch, sortMetricsByStep } from './merge-metrics-by-step';
 import { MetricGraph } from './metric-graph';
-import { MetricsEntry } from './types';
+import type { MetricsEntry } from './types';
 
 const NoMetricsAvailable = () => {
     return (

--- a/application/ui/src/features/models/metrics/types.ts
+++ b/application/ui/src/features/models/metrics/types.ts
@@ -2,7 +2,6 @@ export interface MetricsEntry {
     epoch: number | null;
     step: number;
     train_loss: number | null | undefined;
-    train_loss_step: number | null | undefined;
     'lr-AdamW': number | null | undefined;
     val_loss: number | null | undefined;
 }

--- a/application/ui/src/features/models/metrics/types.ts
+++ b/application/ui/src/features/models/metrics/types.ts
@@ -1,0 +1,8 @@
+export interface MetricsEntry {
+    epoch: number | null;
+    step: number;
+    train_loss: number | null | undefined;
+    train_loss_step: number | null | undefined;
+    'lr-AdamW': number | null | undefined;
+    val_loss: number | null | undefined;
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->

1. Sync metrics cursors so hovering over one chart shows respectively values for another charts. 
To do so all charts need to share the same values for X axis. In case of validation loss, the chart has lots of null values - this is a thing we need to take a look to improve.
2. Add batching - we don't want to redraw the chart for each new data point, we will do it in batches. It improves the performance of the charts and generally the UX.

<img width="1240" height="959" alt="image" src="https://github.com/user-attachments/assets/6cbb532a-8fa7-4e6b-9cf8-54279e611a67" />

## Related Issues

<!-- Fixes #123 -->
Part 4 of #961 
