### PR TITLE
feat: add unavailable robot response

### DIFF
--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -107,13 +107,16 @@ def get_robot_manager_service(request: HTTPConnection) -> RobotConnectionManager
 RobotConnectionManagerDep = Annotated[RobotConnectionManager, Depends(get_robot_manager_service)]
 
 
-def get_robot_client_factory(robot_manager: RobotConnectionManagerDep) -> RobotClientFactory:
+def get_robot_client_factory(
+    robot_manager: RobotConnectionManagerDep,
+    catalog_service: RobotCatalogServiceDep,
+) -> RobotClientFactory:
     """Provide a RobotClientFactory bound to the application robot manager.
 
     Request scoped: the factory is a thin wrapper around the shared
     RobotConnectionManager and is the seam used to fake robot hardware in tests.
     """
-    return RobotClientFactory(robot_manager=robot_manager)
+    return RobotClientFactory(robot_manager=robot_manager, catalog_registry=catalog_service.registry)
 
 
 RobotClientFactoryDep = Annotated[RobotClientFactory, Depends(get_robot_client_factory)]

--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -77,9 +77,18 @@ def get_remote_trainer_service(session: AsyncSessionDep) -> RemoteTrainerService
 RemoteTrainerServiceDep = Annotated[RemoteTrainerService, Depends(get_remote_trainer_service)]
 
 
-def get_robot_service(session: AsyncSessionDep) -> RobotService:
+@lru_cache
+def get_robot_catalog_service() -> RobotCatalogService:
+    """Provide a RobotCatalogService instance for the robot catalog."""
+    return RobotCatalogService()
+
+
+RobotCatalogServiceDep = Annotated[RobotCatalogService, Depends(get_robot_catalog_service)]
+
+
+def get_robot_service(session: AsyncSessionDep, catalog_service: RobotCatalogServiceDep) -> RobotService:
     """Provide a RobotService instance for managing robots in a project."""
-    return RobotService(session)
+    return RobotService(session, catalog_service.registry)
 
 
 RobotServiceDep = Annotated[RobotService, Depends(get_robot_service)]
@@ -110,26 +119,17 @@ def get_robot_client_factory(robot_manager: RobotConnectionManagerDep) -> RobotC
 RobotClientFactoryDep = Annotated[RobotClientFactory, Depends(get_robot_client_factory)]
 
 
-@lru_cache
-def get_robot_catalog_service() -> RobotCatalogService:
-    """Provide a RobotCatalogService instance for the robot catalog."""
-    return RobotCatalogService()
-
-
-RobotCatalogServiceDep = Annotated[RobotCatalogService, Depends(get_robot_catalog_service)]
-
-
-def get_camera_service(session: AsyncSessionDep) -> ProjectCameraService:
+def get_camera_service(session: AsyncSessionDep, catalog_service: RobotCatalogServiceDep) -> ProjectCameraService:
     """Provide a ProjectCameraService instance for managing cameras in a project."""
-    return ProjectCameraService(session)
+    return ProjectCameraService(session, catalog_service.registry)
 
 
 ProjectCameraServiceDep = Annotated[ProjectCameraService, Depends(get_camera_service)]
 
 
-def get_environment_service(session: AsyncSessionDep) -> EnvironmentService:
+def get_environment_service(session: AsyncSessionDep, catalog_service: RobotCatalogServiceDep) -> EnvironmentService:
     """Provide a EnvironmentService instance for managing environments in a project."""
-    return EnvironmentService(session)
+    return EnvironmentService(session, catalog_service.registry)
 
 
 EnvironmentServiceDep = Annotated[EnvironmentService, Depends(get_environment_service)]

--- a/application/backend/src/api/robot_control.py
+++ b/application/backend/src/api/robot_control.py
@@ -9,6 +9,8 @@ from loguru import logger
 
 from api.dependencies import RobotClientFactoryDep, SchedulerDep, get_project_id, get_robot_id, get_robot_service
 from exceptions import BaseException as AppBaseException
+from exceptions import RobotPluginUnavailableError
+from schemas.robot import ReadableRobot, UnavailableRobot
 from services import RobotService
 from workers.base import run_at_frequency
 from workers.teleoperate_worker import TeleoperateWorker
@@ -36,6 +38,11 @@ async def robot_websocket_openapi(project_id: UUID) -> Response:  # noqa: ARG001
 
 def _build_robot_control_state(worker: TeleoperateWorker) -> dict:
     return {"connected": worker.loaded_event.is_set(), "follower_source": worker.get_action_read_state()}
+
+
+def _ensure_robot_available(robot: ReadableRobot) -> None:
+    if isinstance(robot, UnavailableRobot):
+        raise RobotPluginUnavailableError(robot.name, robot.type)
 
 
 async def handle_outgoing(
@@ -98,10 +105,12 @@ async def robot_websocket(
         settings = await websocket.receive_json("text")
         follower_id = get_robot_id(settings["follower_id"])
         follower = await robot_service.get_robot_by_id(project_id, follower_id)
+        _ensure_robot_available(follower)
         leader = None
         if "leader_id" in settings:
             leader_id = get_robot_id(settings["leader_id"])
             leader = await robot_service.get_robot_by_id(project_id, leader_id)
+            _ensure_robot_available(leader)
 
         # Create worker
         worker = TeleoperateWorker(

--- a/application/backend/src/api/robots.py
+++ b/application/backend/src/api/robots.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, status
 
 from api.dependencies import get_project_id, get_robot_id, get_robot_service
-from schemas.robot import Robot, RobotWithConnectionState
+from schemas.robot import Robot, RobotWithConnectionState, UnavailableRobot, UnavailableRobotWithConnectionState
 from services import RobotService
 
 router = APIRouter(prefix="/api/projects/{project_id}/robots", tags=["Project Robots"])
@@ -16,7 +16,7 @@ ProjectID = Annotated[UUID, Depends(get_project_id)]
 async def list_project_robots(
     project_id: ProjectID,
     robot_service: Annotated[RobotService, Depends(get_robot_service)],
-) -> list[Robot]:
+) -> list[Robot | UnavailableRobot]:
     """Fetch all robots."""
     return await robot_service.get_robot_list(project_id)
 
@@ -25,7 +25,7 @@ async def list_project_robots(
 async def list_online_project_robots(
     project_id: ProjectID,
     robot_service: Annotated[RobotService, Depends(get_robot_service)],
-) -> list[RobotWithConnectionState]:
+) -> list[RobotWithConnectionState | UnavailableRobotWithConnectionState]:
     """Fetch all robots."""
     return await robot_service.find_online_robots(project_id)
 
@@ -45,7 +45,7 @@ async def get_project_robot(
     project_id: Annotated[UUID, Depends(get_project_id)],
     robot_id: Annotated[UUID, Depends(get_robot_id)],
     robot_service: Annotated[RobotService, Depends(get_robot_service)],
-) -> Robot:
+) -> Robot | UnavailableRobot:
     """Get robot by id."""
     return await robot_service.get_robot_by_id(project_id, robot_id)
 

--- a/application/backend/src/api/robots.py
+++ b/application/backend/src/api/robots.py
@@ -4,7 +4,13 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, status
 
 from api.dependencies import get_project_id, get_robot_id, get_robot_service
-from schemas.robot import Robot, RobotWithConnectionState, UnavailableRobot, UnavailableRobotWithConnectionState
+from schemas.robot import (
+    ReadableRobot,
+    Robot,
+    RobotWithConnectionState,
+    UnavailableRobot,
+    UnavailableRobotWithConnectionState,
+)
 from services import RobotService
 
 router = APIRouter(prefix="/api/projects/{project_id}/robots", tags=["Project Robots"])
@@ -16,7 +22,7 @@ ProjectID = Annotated[UUID, Depends(get_project_id)]
 async def list_project_robots(
     project_id: ProjectID,
     robot_service: Annotated[RobotService, Depends(get_robot_service)],
-) -> list[Robot | UnavailableRobot]:
+) -> list[ReadableRobot]:
     """Fetch all robots."""
     return await robot_service.get_robot_list(project_id)
 

--- a/application/backend/src/control/environment_integration.py
+++ b/application/backend/src/control/environment_integration.py
@@ -12,10 +12,12 @@ from physicalai.capture import SharedCamera
 from physicalai.capture.errors import CaptureError
 from physicalai.data import Observation
 
+from exceptions import RobotPluginUnavailableError
 from robots.robot_client import RobotClient
 from robots.robot_client_factory import RobotClientFactory
 from schemas.environment import EnvironmentWithRelations, TeleoperatorRobotWithRobot
 from schemas.project_camera import Camera
+from schemas.robot import UnavailableRobot
 from utils.camera_factory import build_shared_camera
 from utils.jpeg import encode_jpeg_rgb
 
@@ -48,6 +50,7 @@ class EnvironmentIntegration:
 
     async def setup(self) -> None:
         try:
+            self._ensure_robots_available()
             robot = self.environment.robots[0]  # TODO: Handle multiple robots?
 
             self.follower = await self.robot_client_factory.build(robot.robot)
@@ -83,6 +86,19 @@ class EnvironmentIntegration:
         except Exception:
             await self.teardown()
             raise
+
+    def _ensure_robots_available(self) -> None:
+        for robot_with_teleoperator in self.environment.robots:
+            robots = [robot_with_teleoperator.robot]
+            if (
+                isinstance(robot_with_teleoperator.tele_operator, TeleoperatorRobotWithRobot)
+                and robot_with_teleoperator.tele_operator.robot is not None
+            ):
+                robots.append(robot_with_teleoperator.tele_operator.robot)
+
+            for robot in robots:
+                if isinstance(robot, UnavailableRobot):
+                    raise RobotPluginUnavailableError(robot.name, robot.type)
 
     def build_lerobot_dataset_features(self, use_videos: bool = True) -> dict:
         """Build lerobot dataset features."""

--- a/application/backend/src/exceptions.py
+++ b/application/backend/src/exceptions.py
@@ -75,6 +75,20 @@ class ResourceInUseError(BaseException):
         )
 
 
+class RobotPluginUnavailableError(BaseException):
+    """Raised when a robot's catalog plugin is not installed."""
+
+    def __init__(self, robot_name: str, robot_type: str) -> None:
+        super().__init__(
+            message=(
+                f"Robot '{robot_name}' requires unavailable plugin type '{robot_type}'. "
+                "Reinstall the plugin before connecting."
+            ),
+            error_code="robot_plugin_unavailable",
+            http_status=http.HTTPStatus.CONFLICT,
+        )
+
+
 class ResourceAlreadyExistsError(BaseException):
     """
     Exception raised when a resource already exists.

--- a/application/backend/src/repositories/mappers/project_robot_mapper.py
+++ b/application/backend/src/repositories/mappers/project_robot_mapper.py
@@ -1,7 +1,7 @@
 from db.schema import ProjectRobotDB
 from repositories.mappers.base_mapper_interface import IBaseMapper
 from robots.catalog.registry import RobotCatalogRegistry
-from schemas.robot import Robot, RobotAdapter, UnavailableRobot
+from schemas.robot import Robot, UnavailableRobot
 
 
 class ProjectRobotMapper(IBaseMapper[ProjectRobotDB, Robot | UnavailableRobot]):
@@ -34,4 +34,4 @@ class ProjectRobotMapper(IBaseMapper[ProjectRobotDB, Robot | UnavailableRobot]):
         }
         if catalog_registry.get_definition(model.type) is None:
             return UnavailableRobot.model_validate(robot)
-        return RobotAdapter.validate_python(robot)
+        return catalog_registry.get_robot_adapter().validate_python(robot)

--- a/application/backend/src/repositories/mappers/project_robot_mapper.py
+++ b/application/backend/src/repositories/mappers/project_robot_mapper.py
@@ -1,6 +1,7 @@
 from db.schema import ProjectRobotDB
 from repositories.mappers.base_mapper_interface import IBaseMapper
-from schemas.robot import Robot, RobotAdapter
+from robots.catalog.registry import RobotCatalogRegistry
+from schemas.robot import Robot, RobotAdapter, UnavailableRobot
 
 
 class ProjectRobotMapper(IBaseMapper):
@@ -17,15 +18,16 @@ class ProjectRobotMapper(IBaseMapper):
         )
 
     @staticmethod
-    def from_schema(model: ProjectRobotDB) -> Robot:
+    def from_schema(model: ProjectRobotDB, catalog_registry: RobotCatalogRegistry) -> Robot | UnavailableRobot:
         """Convert Robot db entity to schema."""
-        return RobotAdapter.validate_python(
-            {
-                "id": model.id,
-                "name": model.name,
-                "type": model.type,
-                "payload": model.payload,
-                "created_at": model.created_at,
-                "updated_at": model.updated_at,
-            }
-        )
+        robot = {
+            "id": model.id,
+            "name": model.name,
+            "type": model.type,
+            "payload": model.payload,
+            "created_at": model.created_at,
+            "updated_at": model.updated_at,
+        }
+        if catalog_registry.get_definition(model.type) is None:
+            return UnavailableRobot.model_validate(robot)
+        return RobotAdapter.validate_python(robot)

--- a/application/backend/src/repositories/mappers/project_robot_mapper.py
+++ b/application/backend/src/repositories/mappers/project_robot_mapper.py
@@ -4,7 +4,7 @@ from robots.catalog.registry import RobotCatalogRegistry
 from schemas.robot import Robot, RobotAdapter, UnavailableRobot
 
 
-class ProjectRobotMapper(IBaseMapper):
+class ProjectRobotMapper(IBaseMapper[ProjectRobotDB, Robot | UnavailableRobot]):
     """Mapper for Robot schema entity <-> DB entity conversions."""
 
     @staticmethod
@@ -18,8 +18,12 @@ class ProjectRobotMapper(IBaseMapper):
         )
 
     @staticmethod
-    def from_schema(model: ProjectRobotDB, catalog_registry: RobotCatalogRegistry) -> Robot | UnavailableRobot:
+    def from_schema(
+        model: ProjectRobotDB,
+        catalog_registry: RobotCatalogRegistry | None = None,
+    ) -> Robot | UnavailableRobot:
         """Convert Robot db entity to schema."""
+        catalog_registry = catalog_registry or RobotCatalogRegistry()
         robot = {
             "id": model.id,
             "name": model.name,

--- a/application/backend/src/repositories/project_environment_repo.py
+++ b/application/backend/src/repositories/project_environment_repo.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio.session import AsyncSession
 from db.schema import EnvironmentCameraDB, EnvironmentRobotDB, ProjectEnvironmentDB
 from repositories.base import ProjectBaseRepository
 from repositories.mappers import ProjectCameraMapper, ProjectEnvironmentMapper, ProjectRobotMapper
+from robots.catalog.registry import RobotCatalogRegistry
 from schemas.environment import (
     Environment,
     EnvironmentWithRelations,
@@ -18,8 +19,9 @@ from schemas.environment import (
 
 
 class ProjectEnvironmentRepository(ProjectBaseRepository[Environment, ProjectEnvironmentDB]):
-    def __init__(self, db: AsyncSession, project_id: UUID):
+    def __init__(self, db: AsyncSession, project_id: UUID, catalog_registry: RobotCatalogRegistry):
         super().__init__(db, project_id, ProjectEnvironmentDB)
+        self.catalog_registry = catalog_registry
 
     @property
     def to_schema(self) -> Callable[[Environment], ProjectEnvironmentDB]:
@@ -91,8 +93,8 @@ class ProjectEnvironmentRepository(ProjectBaseRepository[Environment, ProjectEnv
             updated_at=env.updated_at,
         )
 
-    @staticmethod
     def _build_robots_with_teleoperators(
+        self,
         environment_id: UUID,
         robot_links: list[EnvironmentRobotDB],
     ) -> list[RobotWithTeleoperator]:
@@ -107,7 +109,7 @@ class ProjectEnvironmentRepository(ProjectBaseRepository[Environment, ProjectEnv
                 )
                 continue
 
-            robot = ProjectRobotMapper.from_schema(link.robot)
+            robot = ProjectRobotMapper.from_schema(link.robot, self.catalog_registry)
 
             if link.tele_operator_type == "robot" and link.tele_operator_robot_id is not None:
                 if link.tele_operator_robot is None:
@@ -125,7 +127,7 @@ class ProjectEnvironmentRepository(ProjectBaseRepository[Environment, ProjectEnv
                 else:
                     tele_operator = TeleoperatorRobotWithRobot(
                         robot_id=UUID(link.tele_operator_robot_id),
-                        robot=ProjectRobotMapper.from_schema(link.tele_operator_robot),
+                        robot=ProjectRobotMapper.from_schema(link.tele_operator_robot, self.catalog_registry),
                     )
             elif link.tele_operator_type == "robot":
                 logger.warning(

--- a/application/backend/src/repositories/project_robot_repo.py
+++ b/application/backend/src/repositories/project_robot_repo.py
@@ -6,17 +6,19 @@ from sqlalchemy.ext.asyncio.session import AsyncSession
 from db.schema import ProjectRobotDB
 from repositories.base import ProjectBaseRepository
 from repositories.mappers import ProjectRobotMapper
-from schemas.robot import Robot
+from robots.catalog.registry import RobotCatalogRegistry
+from schemas.robot import Robot, UnavailableRobot
 
 
 class ProjectRobotRepository(ProjectBaseRepository):
-    def __init__(self, db: AsyncSession, project_id: UUID):
+    def __init__(self, db: AsyncSession, project_id: UUID, catalog_registry: RobotCatalogRegistry):
         super().__init__(db, project_id, ProjectRobotDB)
+        self.catalog_registry = catalog_registry
 
     @property
     def to_schema(self) -> Callable[[Robot], ProjectRobotDB]:
         return ProjectRobotMapper.to_schema
 
     @property
-    def from_schema(self) -> Callable[[ProjectRobotDB], Robot]:
-        return ProjectRobotMapper.from_schema
+    def from_schema(self) -> Callable[[ProjectRobotDB], Robot | UnavailableRobot]:
+        return lambda model: ProjectRobotMapper.from_schema(model, self.catalog_registry)

--- a/application/backend/src/robots/robot_client_factory.py
+++ b/application/backend/src/robots/robot_client_factory.py
@@ -2,11 +2,12 @@ from physicalai.config import to_config
 from physicalai.robot import SharedRobot
 from physicalai_studio_plugin import shared_robot_name
 
+from exceptions import RobotPluginUnavailableError
 from robots.catalog.registry import RobotCatalogRegistry
 from robots.physicalai_adapter import PhysicalAIRobotAdapter, PhysicalAIRobotAdapterConfig
 from robots.robot_client import RobotClient
 from schemas import SerialPortInfo
-from schemas.robot import Robot
+from schemas.robot import ReadableRobot, UnavailableRobot
 from utils.serial_robot_tools import RobotConnectionManager
 
 
@@ -22,7 +23,10 @@ class RobotClientFactory:
         self.robot_manager = robot_manager
         self.catalog_registry = catalog_registry or RobotCatalogRegistry()
 
-    async def build(self, robot: Robot) -> RobotClient:
+    async def build(self, robot: ReadableRobot) -> RobotClient:
+        if isinstance(robot, UnavailableRobot):
+            raise RobotPluginUnavailableError(robot.name, robot.type)
+
         definition = self.catalog_registry.get_definition(robot.type)
 
         if definition is None:

--- a/application/backend/src/robots/robot_service.py
+++ b/application/backend/src/robots/robot_service.py
@@ -7,33 +7,44 @@ from exceptions import ResourceInUseError, ResourceNotFoundError, ResourceType
 from repositories.project_environment_repo import ProjectEnvironmentRepository
 from repositories.project_robot_repo import ProjectRobotRepository
 from robots.catalog.registry import RobotCatalogRegistry
-from schemas.robot import Robot, RobotWithConnectionState, RobotWithConnectionStateAdapter
+from schemas.robot import (
+    Robot,
+    RobotWithConnectionState,
+    RobotWithConnectionStateAdapter,
+    UnavailableRobot,
+    UnavailableRobotWithConnectionState,
+)
 from utils.serial_robot_tools import RobotConnectionManager
 
 
 class RobotService:
-    def __init__(self, session: AsyncSession) -> None:
+    def __init__(self, session: AsyncSession, catalog_registry: RobotCatalogRegistry) -> None:
         self.session = session
+        self.catalog_registry = catalog_registry
 
     def _repo(self, project_id: UUID) -> ProjectRobotRepository:
-        return ProjectRobotRepository(self.session, project_id)
+        return ProjectRobotRepository(self.session, project_id, self.catalog_registry)
 
-    async def get_robot_list(self, project_id: UUID) -> list[Robot]:
+    async def get_robot_list(self, project_id: UUID) -> list[Robot | UnavailableRobot]:
         return await self._repo(project_id).get_all()
 
-    async def find_online_robots(self, project_id: UUID) -> list[RobotWithConnectionState]:
+    async def find_online_robots(
+        self, project_id: UUID
+    ) -> list[RobotWithConnectionState | UnavailableRobotWithConnectionState]:
         robots = await self.get_robot_list(project_id)
 
         # Single serial port scan shared across all probes
         manager = RobotConnectionManager()
         await manager.find_robots()
 
-        registry = RobotCatalogRegistry()
-
-        results: list[RobotWithConnectionState] = []
+        results: list[RobotWithConnectionState | UnavailableRobotWithConnectionState] = []
 
         for robot in robots:
-            definition = registry.get_definition(robot.type)
+            if isinstance(robot, UnavailableRobot):
+                results.append(UnavailableRobotWithConnectionState(**robot.model_dump()))
+                continue
+
+            definition = self.catalog_registry.get_definition(robot.type)
             is_online = False
             if definition is not None and definition.probe is not None:
                 is_online = await definition.probe.is_online(robot.payload, manager)
@@ -49,7 +60,7 @@ class RobotService:
 
         return results
 
-    async def get_robot_by_id(self, project_id: UUID, robot_id: UUID) -> Robot:
+    async def get_robot_by_id(self, project_id: UUID, robot_id: UUID) -> Robot | UnavailableRobot:
         robot = await self._repo(project_id).get_by_id(robot_id)
 
         if robot is None:
@@ -74,7 +85,7 @@ class RobotService:
             await repo.delete_by_id(robot_id)
         except IntegrityError as e:
             await self.session.rollback()
-            env_repo = ProjectEnvironmentRepository(self.session, project_id)
+            env_repo = ProjectEnvironmentRepository(self.session, project_id, self.catalog_registry)
             environment_names = await env_repo.find_environment_names_using_robot(robot_id)
             if environment_names:
                 raise ResourceInUseError(

--- a/application/backend/src/schemas/environment.py
+++ b/application/backend/src/schemas/environment.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from schemas.project_camera import Camera
-from schemas.robot import Robot
+from schemas.robot import ReadableRobot
 
 
 class TeleoperatorRobot(BaseModel):
@@ -109,7 +109,7 @@ class TeleoperatorRobotWithRobot(BaseModel):
 
     type: Literal["robot"] = "robot"
     robot_id: UUID = Field(..., description="ID of the robot acting as teleoperator")
-    robot: Robot | None = Field(None, description="Eager-loaded robot object")
+    robot: ReadableRobot | None = Field(None, description="Eager-loaded robot object")
 
 
 class TeleoperatorNoneWithRobot(BaseModel):
@@ -124,7 +124,7 @@ TeleoperatorWithRobot = Annotated[TeleoperatorRobotWithRobot | TeleoperatorNoneW
 class RobotWithTeleoperator(BaseModel):
     """Robot configuration with eager-loaded robot and teleoperator."""
 
-    robot: Robot = Field(..., description="The robot in this environment")
+    robot: ReadableRobot = Field(..., description="The robot in this environment")
     tele_operator: TeleoperatorWithRobot = Field(..., description="Teleoperator configuration with eager-loaded data")
 
     model_config = ConfigDict(

--- a/application/backend/src/schemas/robot.py
+++ b/application/backend/src/schemas/robot.py
@@ -5,9 +5,10 @@ from pydantic import Field, TypeAdapter, create_model
 from robots.catalog.registry import RobotCatalogRegistry
 from robots.catalog.so101 import SO101Robot
 from robots.catalog.widowxai import TrossenBimanualRobot, TrossenSingleArmRobot
-from schemas.robot_type import RobotType
+from schemas.robot_type import BaseRobot, RobotType
 
 __all__ = [
+    "ReadableRobot",
     "Robot",
     "RobotAdapter",
     "RobotType",
@@ -16,6 +17,8 @@ __all__ = [
     "SO101Robot",
     "TrossenBimanualRobot",
     "TrossenSingleArmRobot",
+    "UnavailableRobot",
+    "UnavailableRobotWithConnectionState",
 ]
 
 # ============================================================================
@@ -25,6 +28,17 @@ __all__ = [
 _registry = RobotCatalogRegistry()
 Robot = _registry.make_robot_type()
 RobotAdapter: TypeAdapter = _registry.get_robot_adapter()
+
+
+class UnavailableRobot(BaseRobot):
+    """A persisted robot whose catalog plugin is not currently installed."""
+
+    type: str
+    payload: dict[str, Any]
+    unavailable: Literal[True] = True
+
+
+ReadableRobot = Robot | UnavailableRobot
 
 
 # ============================================================================
@@ -52,3 +66,7 @@ def _with_connection_status(robot_model: type) -> type:
 _connection_state_models = [_with_connection_status(model) for model in _registry.get_robot_types()]
 RobotWithConnectionState: Any = Annotated[_build_union(_connection_state_models), Field(discriminator="type")]
 RobotWithConnectionStateAdapter: TypeAdapter[Any] = TypeAdapter(RobotWithConnectionState)
+
+
+class UnavailableRobotWithConnectionState(UnavailableRobot):
+    connection_status: Literal["unknown"] = "unknown"

--- a/application/backend/src/services/environment_service.py
+++ b/application/backend/src/services/environment_service.py
@@ -4,15 +4,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from exceptions import ResourceNotFoundError, ResourceType
 from repositories.project_environment_repo import ProjectEnvironmentRepository
+from robots.catalog.registry import RobotCatalogRegistry
 from schemas.environment import Environment, EnvironmentWithRelations
 
 
 class EnvironmentService:
-    def __init__(self, session: AsyncSession) -> None:
+    def __init__(self, session: AsyncSession, catalog_registry: RobotCatalogRegistry) -> None:
         self.session = session
+        self.catalog_registry = catalog_registry
 
     def _repo(self, project_id: UUID) -> ProjectEnvironmentRepository:
-        return ProjectEnvironmentRepository(self.session, project_id)
+        return ProjectEnvironmentRepository(self.session, project_id, self.catalog_registry)
 
     async def get_environment_list(self, project_id: UUID) -> list[Environment]:
         return await self._repo(project_id).get_all()

--- a/application/backend/src/services/project_camera_service.py
+++ b/application/backend/src/services/project_camera_service.py
@@ -6,12 +6,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from exceptions import ResourceInUseError, ResourceNotFoundError, ResourceType
 from repositories.project_camera_repo import ProjectCameraRepository
 from repositories.project_environment_repo import ProjectEnvironmentRepository
+from robots.catalog.registry import RobotCatalogRegistry
 from schemas.project_camera import Camera
 
 
 class ProjectCameraService:
-    def __init__(self, session: AsyncSession) -> None:
+    def __init__(self, session: AsyncSession, catalog_registry: RobotCatalogRegistry) -> None:
         self.session = session
+        self.catalog_registry = catalog_registry
 
     def _repo(self, project_id: UUID) -> ProjectCameraRepository:
         return ProjectCameraRepository(self.session, str(project_id))
@@ -48,7 +50,7 @@ class ProjectCameraService:
             await repo.delete_by_id(camera_id)
         except IntegrityError as e:
             await self.session.rollback()
-            env_repo = ProjectEnvironmentRepository(self.session, project_id)
+            env_repo = ProjectEnvironmentRepository(self.session, project_id, self.catalog_registry)
             environment_names = await env_repo.find_environment_names_using_camera(camera_id)
             if environment_names:
                 raise ResourceInUseError(

--- a/application/backend/src/services/robot_catalog_service.py
+++ b/application/backend/src/services/robot_catalog_service.py
@@ -8,6 +8,11 @@ class RobotCatalogService:
     def __init__(self) -> None:
         self._registry: RobotCatalogRegistry = RobotCatalogRegistry()
 
+    @property
+    def registry(self) -> RobotCatalogRegistry:
+        """Return the process-wide catalog registry."""
+        return self._registry
+
     def list_entries(self) -> list[RobotCatalogDefinition]:
         return self._registry.list_definitions()
 

--- a/application/backend/tests/api/test_dependencies.py
+++ b/application/backend/tests/api/test_dependencies.py
@@ -16,6 +16,7 @@ from api.record import robot_control_websocket
 from api.robot_control import robot_websocket
 from robots.robot_client_factory import RobotClientFactory
 from services.job_service import JobService
+from services.robot_catalog_service import RobotCatalogService
 from settings import Settings
 from utils.serial_robot_tools import RobotConnectionManager
 
@@ -28,11 +29,13 @@ def _dependency_calls(endpoint: Callable[..., object]) -> set[Callable[..., obje
 
 def test_robot_client_factory_uses_provided_manager() -> None:
     robot_manager = MagicMock(spec=RobotConnectionManager)
+    catalog_service = MagicMock(spec=RobotCatalogService)
 
-    factory = get_robot_client_factory(robot_manager)
+    factory = get_robot_client_factory(robot_manager, catalog_service)
 
     assert isinstance(factory, RobotClientFactory)
     assert factory.robot_manager is robot_manager
+    assert factory.catalog_registry is catalog_service.registry
 
 
 def test_model_metrics_service_uses_injected_settings() -> None:

--- a/application/backend/tests/control/test_environment_integration.py
+++ b/application/backend/tests/control/test_environment_integration.py
@@ -1,5 +1,6 @@
 import asyncio
 from unittest.mock import MagicMock, Mock, patch
+from uuid import uuid4
 
 import numpy as np
 import pytest
@@ -7,6 +8,9 @@ import torch
 from physicalai.capture import SharedCamera
 
 from control.environment_integration import EnvironmentIntegration, sanitize_camera_name
+from exceptions import RobotPluginUnavailableError
+from schemas.environment import EnvironmentWithRelations, RobotWithTeleoperator, TeleoperatorNoneWithRobot
+from schemas.robot import UnavailableRobot
 
 
 def test_sanitize_camera_name():
@@ -62,6 +66,30 @@ def inference_environment_integration(event_loop, mock_robot_client_factory, moc
 
 
 class TestInferenceEnvironmentIntegration:
+    def test_setup_rejects_environment_with_unavailable_robot(self, mock_robot_client_factory, event_loop):
+        unavailable_robot = UnavailableRobot(
+            id=uuid4(),
+            name="Missing MuJoCo robot",
+            type="MuJoCo_SO101_Follower",
+            payload={"port": "/dev/ttyACM0"},
+        )
+        environment = EnvironmentWithRelations(
+            id=uuid4(),
+            name="Unavailable robot environment",
+            robots=[
+                RobotWithTeleoperator(
+                    robot=unavailable_robot,
+                    tele_operator=TeleoperatorNoneWithRobot(),
+                )
+            ],
+        )
+        subject = EnvironmentIntegration(environment, mock_robot_client_factory)
+
+        with pytest.raises(RobotPluginUnavailableError, match="MuJoCo_SO101_Follower"):
+            event_loop.run_until_complete(subject.setup())
+
+        mock_robot_client_factory.build.assert_not_called()
+
     def test_get_observation(self, inference_environment_integration: EnvironmentIntegration, event_loop):
         observation = event_loop.run_until_complete(inference_environment_integration.get_observation())
         assert observation is not None

--- a/application/backend/tests/repositories/mappers/test_project_robot_mapper_bimanual.py
+++ b/application/backend/tests/repositories/mappers/test_project_robot_mapper_bimanual.py
@@ -10,7 +10,9 @@ from uuid import uuid4
 import pytest
 
 from repositories.mappers.project_robot_mapper import ProjectRobotMapper
+from robots.catalog.registry import RobotCatalogRegistry
 from robots.catalog.widowxai import TrossenBimanualPayload, TrossenBimanualRobot
+from schemas.robot import UnavailableRobot
 
 
 def _make_bimanual_db_model(robot_type: str):
@@ -37,7 +39,7 @@ class TestProjectRobotMapperBimanual:
     )
     def test_from_schema_returns_bimanual_robot(self, robot_type):
         db_model = _make_bimanual_db_model(robot_type)
-        result = ProjectRobotMapper.from_schema(db_model)
+        result = ProjectRobotMapper.from_schema(db_model, RobotCatalogRegistry())
 
         assert result.type == robot_type
         assert isinstance(result.payload, TrossenBimanualPayload)
@@ -73,7 +75,17 @@ class TestProjectRobotMapperBimanual:
         db_model.created_at = None
         db_model.updated_at = None
 
-        restored = ProjectRobotMapper.from_schema(db_model)
+        restored = ProjectRobotMapper.from_schema(db_model, RobotCatalogRegistry())
 
         assert restored.payload.connection_string_left == "192.168.10.1"
         assert restored.payload.connection_string_right == "192.168.10.2"
+
+    def test_from_schema_preserves_robot_from_unavailable_plugin(self):
+        db_model = _make_bimanual_db_model("MuJoCo_SO101_Follower")
+
+        result = ProjectRobotMapper.from_schema(db_model, RobotCatalogRegistry())
+
+        assert isinstance(result, UnavailableRobot)
+        assert result.type == "MuJoCo_SO101_Follower"
+        assert result.unavailable is True
+        assert result.payload == db_model.payload

--- a/application/backend/tests/repositories/mappers/test_project_robot_mapper_bimanual.py
+++ b/application/backend/tests/repositories/mappers/test_project_robot_mapper_bimanual.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
+from physicalai_studio_plugin import RobotCatalogDefinition
+from pydantic import BaseModel
 
 from repositories.mappers.project_robot_mapper import ProjectRobotMapper
 from robots.catalog.registry import RobotCatalogRegistry
@@ -89,3 +91,24 @@ class TestProjectRobotMapperBimanual:
         assert result.type == "MuJoCo_SO101_Follower"
         assert result.unavailable is True
         assert result.payload == db_model.payload
+
+    def test_from_schema_uses_the_injected_registry_adapter(self):
+        class PluginPayload(BaseModel):
+            connection_string: str
+
+        registry = RobotCatalogRegistry()
+        registry.register_robot(
+            RobotCatalogDefinition(
+                type="Test_Plugin_Robot",
+                display_name="Test Plugin Robot",
+                role="follower",
+                robot_payload=PluginPayload,
+            )
+        )
+        db_model = _make_bimanual_db_model("Test_Plugin_Robot")
+        db_model.payload = {"connection_string": "test://robot"}
+
+        result = ProjectRobotMapper.from_schema(db_model, registry)
+
+        assert result.type == "Test_Plugin_Robot"
+        assert result.payload.connection_string == "test://robot"

--- a/application/backend/tests/repositories/test_project_environment_repo.py
+++ b/application/backend/tests/repositories/test_project_environment_repo.py
@@ -57,8 +57,10 @@ def test_build_robots_with_teleoperators_skips_missing_robot_and_logs_warning() 
     valid_link.tele_operator_robot_id = None
     valid_link.tele_operator_robot = None
 
+    repo = ProjectEnvironmentRepository(MagicMock(), uuid4(), RobotCatalogRegistry())
+
     with patch("repositories.project_environment_repo.logger.warning") as warning_mock:
-        robots = ProjectEnvironmentRepository._build_robots_with_teleoperators(
+        robots = repo._build_robots_with_teleoperators(
             environment_id,
             [dangling_link, valid_link],
         )
@@ -80,8 +82,10 @@ def test_build_robots_with_teleoperators_keeps_teleoperator_id_when_eager_robot_
     link.tele_operator_robot_id = str(teleop_robot_id)
     link.tele_operator_robot = None
 
+    repo = ProjectEnvironmentRepository(MagicMock(), uuid4(), RobotCatalogRegistry())
+
     with patch("repositories.project_environment_repo.logger.warning") as warning_mock:
-        robots = ProjectEnvironmentRepository._build_robots_with_teleoperators(environment_id, [link])
+        robots = repo._build_robots_with_teleoperators(environment_id, [link])
 
     assert len(robots) == 1
     assert robots[0].robot.name == "Follower"

--- a/application/backend/tests/repositories/test_project_environment_repo.py
+++ b/application/backend/tests/repositories/test_project_environment_repo.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 from repositories.project_environment_repo import ProjectEnvironmentRepository
+from robots.catalog.registry import RobotCatalogRegistry
 
 
 def _make_robot_db_model(*, robot_id: UUID | None = None, name: str = "Robot") -> MagicMock:
@@ -117,7 +118,7 @@ def test_get_by_id_with_relations_skips_missing_camera_and_logs_warning() -> Non
     db_session = MagicMock()
     db_session.execute = AsyncMock(return_value=execute_result)
 
-    repo = ProjectEnvironmentRepository(db_session, project_id)
+    repo = ProjectEnvironmentRepository(db_session, project_id, RobotCatalogRegistry())
 
     with patch("repositories.project_environment_repo.logger.warning") as warning_mock:
         environment = asyncio.run(repo.get_by_id_with_relations(environment_id))

--- a/application/backend/tests/repositories/test_project_environment_repo.py
+++ b/application/backend/tests/repositories/test_project_environment_repo.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 
 from repositories.project_environment_repo import ProjectEnvironmentRepository
 from robots.catalog.registry import RobotCatalogRegistry
+from schemas.robot import RobotAdapter
 
 
 def _make_robot_db_model(*, robot_id: UUID | None = None, name: str = "Robot") -> MagicMock:
@@ -57,7 +58,10 @@ def test_build_robots_with_teleoperators_skips_missing_robot_and_logs_warning() 
     valid_link.tele_operator_robot_id = None
     valid_link.tele_operator_robot = None
 
-    repo = ProjectEnvironmentRepository(MagicMock(), uuid4(), RobotCatalogRegistry())
+    catalog_registry = MagicMock(spec=RobotCatalogRegistry)
+    catalog_registry.get_definition.return_value = MagicMock()
+    catalog_registry.get_robot_adapter.return_value = RobotAdapter
+    repo = ProjectEnvironmentRepository(MagicMock(), uuid4(), catalog_registry)
 
     with patch("repositories.project_environment_repo.logger.warning") as warning_mock:
         robots = repo._build_robots_with_teleoperators(
@@ -82,7 +86,10 @@ def test_build_robots_with_teleoperators_keeps_teleoperator_id_when_eager_robot_
     link.tele_operator_robot_id = str(teleop_robot_id)
     link.tele_operator_robot = None
 
-    repo = ProjectEnvironmentRepository(MagicMock(), uuid4(), RobotCatalogRegistry())
+    catalog_registry = MagicMock(spec=RobotCatalogRegistry)
+    catalog_registry.get_definition.return_value = MagicMock()
+    catalog_registry.get_robot_adapter.return_value = RobotAdapter
+    repo = ProjectEnvironmentRepository(MagicMock(), uuid4(), catalog_registry)
 
     with patch("repositories.project_environment_repo.logger.warning") as warning_mock:
         robots = repo._build_robots_with_teleoperators(environment_id, [link])

--- a/application/ui/src/features/datasets/episodes/robot-cell.component.tsx
+++ b/application/ui/src/features/datasets/episodes/robot-cell.component.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from 'react';
 
 import { View } from '@geti-ui/ui';
 
-import { RobotViewer } from '../../robots/controller/robot-viewer';
+import { RobotViewer, UnavailableRobotViewer } from '../../robots/controller/robot-viewer';
 import { RobotModelsProvider } from '../../robots/robot-models-context';
+import { isUnavailableRobot } from '../../robots/robot-types';
 import { useEpisodeViewer } from './episode-viewer-provider.component';
 
 const InnerCell = ({ robotId }: { robotId: string }) => {
@@ -23,6 +24,10 @@ const InnerCell = ({ robotId }: { robotId: string }) => {
     const robot = environment.robots?.find((r) => r.robot.id === robotId)?.robot;
     if (robot === undefined) {
         return <></>;
+    }
+
+    if (isUnavailableRobot(robot)) {
+        return <UnavailableRobotViewer robotType={robot.type} />;
     }
 
     return (

--- a/application/ui/src/features/robots/controller/robot-viewer.module.css
+++ b/application/ui/src/features/robots/controller/robot-viewer.module.css
@@ -5,6 +5,8 @@
 
 .canvas {
     position: relative;
+    width: 100%;
+    height: 100%;
     overflow: hidden;
 }
 

--- a/application/ui/src/features/robots/controller/robot-viewer.tsx
+++ b/application/ui/src/features/robots/controller/robot-viewer.tsx
@@ -105,7 +105,7 @@ interface RobotViewerProps {
 export const UnavailableRobotViewer = ({ robotType }: { robotType: string }) => (
     <div className={classes.viewer}>
         <div className={classes.canvas}>
-            <div className={classes.unavailableOverlay}>
+            <div className={classes.errorOverlay}>
                 <span>
                     Plugin unavailable: reinstall <strong>{robotType}</strong> to view or interact with this robot.
                 </span>

--- a/application/ui/src/features/robots/controller/robot-viewer.tsx
+++ b/application/ui/src/features/robots/controller/robot-viewer.tsx
@@ -101,6 +101,19 @@ interface RobotViewerProps {
     featureValues?: number[];
     featureNames?: string[];
 }
+
+export const UnavailableRobotViewer = ({ robotType }: { robotType: string }) => (
+    <div className={classes.viewer}>
+        <div className={classes.canvas}>
+            <div className={classes.unavailableOverlay}>
+                <span>
+                    Plugin unavailable: reinstall <strong>{robotType}</strong> to view or interact with this robot.
+                </span>
+            </div>
+        </div>
+    </div>
+);
+
 export const RobotViewer = ({ robot = { type: 'SO101_Follower' }, featureValues, featureNames }: RobotViewerProps) => {
     const angle = degToRad(-45);
     const isTrossen = robot.type.toLowerCase().includes('trossen');

--- a/application/ui/src/features/robots/controller/robot-viewer.tsx
+++ b/application/ui/src/features/robots/controller/robot-viewer.tsx
@@ -105,7 +105,7 @@ interface RobotViewerProps {
 export const UnavailableRobotViewer = ({ robotType }: { robotType: string }) => (
     <div className={classes.viewer}>
         <div className={classes.canvas}>
-            <div className={classes.errorOverlay}>
+            <div className={classes.errorOverlay} role='alert'>
                 <span>
                     Plugin unavailable: reinstall <strong>{robotType}</strong> to view or interact with this robot.
                 </span>

--- a/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
+++ b/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
@@ -2,8 +2,9 @@ import { Flex, ProgressCircle, Switch, View } from '@geti-ui/ui';
 
 import { $api } from '../../../../api/client';
 import { getRobotConnectionErrorTitle } from '../../../../api/errors';
+import { SchemaRobot } from '../../../../api/openapi-spec';
 import { useProjectId } from '../../../projects/use-project';
-import { RobotViewer } from '../../controller/robot-viewer';
+import { RobotViewer, UnavailableRobotViewer } from '../../controller/robot-viewer';
 import { RobotModelsProvider } from '../../robot-models-context';
 import { InlineAlert } from '../../setup-wizard/shared/inline-alert';
 import { RobotActionReadState, useJointState, useSynchronizeModelJoints } from '../../use-joint-state';
@@ -14,8 +15,26 @@ const InnerCell = ({ follower_id, leader_id }: { follower_id: string; leader_id?
     const { data: robot } = $api.useSuspenseQuery('get', '/api/projects/{project_id}/robots/{robot_id}', {
         params: { path: { project_id, robot_id: follower_id } },
     });
+    const isUnavailable = 'unavailable' in robot && robot.unavailable;
 
-    const { joints, state, error, errorCode, setFollowerSource } = useJointState(project_id, follower_id, leader_id);
+    if (isUnavailable) {
+        return <UnavailableRobotViewer robotType={robot.type} />;
+    }
+
+    return <AvailableRobotCell robot={robot} followerId={follower_id} leaderId={leader_id} />;
+};
+
+const AvailableRobotCell = ({
+    robot,
+    followerId,
+    leaderId,
+}: {
+    robot: SchemaRobot;
+    followerId: string;
+    leaderId?: string;
+}) => {
+    const { project_id } = useProjectId();
+    const { joints, state, error, errorCode, setFollowerSource } = useJointState(project_id, followerId, leaderId);
     useSynchronizeModelJoints(joints, robot.type);
 
     const isTeleoperating = state.follower_source === RobotActionReadState.Teleoperation;
@@ -52,7 +71,7 @@ const InnerCell = ({ follower_id, leader_id }: { follower_id: string; leader_id?
             position={'relative'}
         >
             <RobotViewer robot={robot} />
-            {leader_id !== undefined && (
+            {leaderId !== undefined && (
                 <View position={'absolute'} right={0} top={0}>
                     <Switch
                         isSelected={isTeleoperating}

--- a/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
+++ b/application/ui/src/features/robots/environment-form/cells/robot-cell.tsx
@@ -2,34 +2,19 @@ import { Flex, ProgressCircle, Switch, View } from '@geti-ui/ui';
 
 import { $api } from '../../../../api/client';
 import { getRobotConnectionErrorTitle } from '../../../../api/errors';
-import { SchemaRobot } from '../../../../api/openapi-spec';
 import { useProjectId } from '../../../projects/use-project';
 import { RobotViewer, UnavailableRobotViewer } from '../../controller/robot-viewer';
 import { RobotModelsProvider } from '../../robot-models-context';
+import { AvailableSchemaRobot, isUnavailableRobot } from '../../robot-types';
 import { InlineAlert } from '../../setup-wizard/shared/inline-alert';
 import { RobotActionReadState, useJointState, useSynchronizeModelJoints } from '../../use-joint-state';
-
-const InnerCell = ({ follower_id, leader_id }: { follower_id: string; leader_id?: string }) => {
-    const { project_id } = useProjectId();
-
-    const { data: robot } = $api.useSuspenseQuery('get', '/api/projects/{project_id}/robots/{robot_id}', {
-        params: { path: { project_id, robot_id: follower_id } },
-    });
-    const isUnavailable = 'unavailable' in robot && robot.unavailable;
-
-    if (isUnavailable) {
-        return <UnavailableRobotViewer robotType={robot.type} />;
-    }
-
-    return <AvailableRobotCell robot={robot} followerId={follower_id} leaderId={leader_id} />;
-};
 
 const AvailableRobotCell = ({
     robot,
     followerId,
     leaderId,
 }: {
-    robot: SchemaRobot;
+    robot: AvailableSchemaRobot;
     followerId: string;
     leaderId?: string;
 }) => {
@@ -88,9 +73,18 @@ const AvailableRobotCell = ({
 };
 
 export const RobotCell = ({ follower_id, leader_id }: { follower_id: string; leader_id?: string }) => {
+    const { project_id } = useProjectId();
+
+    const { data: robot } = $api.useSuspenseQuery('get', '/api/projects/{project_id}/robots/{robot_id}', {
+        params: { path: { project_id, robot_id: follower_id } },
+    });
+    if (isUnavailableRobot(robot)) {
+        return <UnavailableRobotViewer robotType={robot.type} />;
+    }
+
     return (
         <RobotModelsProvider>
-            <InnerCell follower_id={follower_id} leader_id={leader_id} />
+            <AvailableRobotCell robot={robot} followerId={follower_id} leaderId={leader_id} />
         </RobotModelsProvider>
     );
 };

--- a/application/ui/src/features/robots/environment-form/robot-form.tsx
+++ b/application/ui/src/features/robots/environment-form/robot-form.tsx
@@ -6,6 +6,7 @@ import { Add, Close } from '@geti-ui/ui/icons';
 import { $api } from '../../../api/client';
 import { useProjectId } from '../../../features/projects/use-project';
 import { useIsRobotRole } from '../robot-catalog.hooks';
+import { isUnavailableRobot } from '../robot-types';
 import { RobotConfiguration, useEnvironmentForm, useSetEnvironmentForm } from './provider';
 
 import classes from './form.module.css';
@@ -74,6 +75,10 @@ export const AddRobotForm = ({
     const environment = useEnvironmentForm();
 
     const availableRobots = robotsQuery.data.filter((robot) => {
+        if (isUnavailableRobot(robot)) {
+            return false;
+        }
+
         return (
             environment.robots.some(({ robot_id, teleoperator }) => {
                 if (robot_id === robot.id) {

--- a/application/ui/src/features/robots/robot-control/robot-cell.component.tsx
+++ b/application/ui/src/features/robots/robot-control/robot-cell.component.tsx
@@ -3,6 +3,7 @@ import { View } from '@geti-ui/ui';
 import { RobotViewer, UnavailableRobotViewer } from '../controller/robot-viewer';
 import { Observation, useRobotControl } from '../robot-control-provider';
 import { RobotModelsProvider } from '../robot-models-context';
+import { isUnavailableRobot } from '../robot-types';
 
 const getActionObservationSource = (observation?: Observation): { [joint: string]: number } | undefined => {
     if (observation === undefined) {
@@ -14,7 +15,7 @@ const getActionObservationSource = (observation?: Observation): { [joint: string
     return observation.state;
 };
 
-const InnerCell = ({ robot_id }: { robot_id: string }) => {
+export const RobotCell = ({ robot_id }: { robot_id: string }) => {
     const { observation, environment } = useRobotControl();
 
     const observation_source = getActionObservationSource(observation.current);
@@ -27,26 +28,20 @@ const InnerCell = ({ robot_id }: { robot_id: string }) => {
     const environmentRobot = environment.robots.find((robot) => robot.robot.id === robot_id)?.robot;
     if (environmentRobot === undefined) return <></>;
 
-    if ('unavailable' in environmentRobot && environmentRobot.unavailable) {
+    if (isUnavailableRobot(environmentRobot)) {
         return <UnavailableRobotViewer robotType={environmentRobot.type} />;
     }
 
     return (
-        <View minWidth='size-4000' minHeight='size-4000' width='100%' height='100%' backgroundColor={'gray-600'}>
-            <RobotViewer
-                key={robot_id}
-                featureValues={action_values}
-                featureNames={action_keys}
-                robot={environmentRobot}
-            />
-        </View>
-    );
-};
-
-export const RobotCell = ({ robot_id }: { robot_id: string }) => {
-    return (
         <RobotModelsProvider>
-            <InnerCell robot_id={robot_id} />
+            <View minWidth='size-4000' minHeight='size-4000' width='100%' height='100%' backgroundColor={'gray-600'}>
+                <RobotViewer
+                    key={robot_id}
+                    featureValues={action_values}
+                    featureNames={action_keys}
+                    robot={environmentRobot}
+                />
+            </View>
         </RobotModelsProvider>
     );
 };

--- a/application/ui/src/features/robots/robot-control/robot-cell.component.tsx
+++ b/application/ui/src/features/robots/robot-control/robot-cell.component.tsx
@@ -1,6 +1,6 @@
 import { View } from '@geti-ui/ui';
 
-import { RobotViewer } from '../controller/robot-viewer';
+import { RobotViewer, UnavailableRobotViewer } from '../controller/robot-viewer';
 import { Observation, useRobotControl } from '../robot-control-provider';
 import { RobotModelsProvider } from '../robot-models-context';
 
@@ -24,13 +24,20 @@ const InnerCell = ({ robot_id }: { robot_id: string }) => {
         return <></>;
     }
 
+    const environmentRobot = environment.robots.find((robot) => robot.robot.id === robot_id)?.robot;
+    if (environmentRobot === undefined) return <></>;
+
+    if ('unavailable' in environmentRobot && environmentRobot.unavailable) {
+        return <UnavailableRobotViewer robotType={environmentRobot.type} />;
+    }
+
     return (
         <View minWidth='size-4000' minHeight='size-4000' width='100%' height='100%' backgroundColor={'gray-600'}>
             <RobotViewer
                 key={robot_id}
                 featureValues={action_values}
                 featureNames={action_keys}
-                robot={environment.robots[0].robot}
+                robot={environmentRobot}
             />
         </View>
     );

--- a/application/ui/src/features/robots/robot-form/catalog/so101.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/so101.tsx
@@ -3,7 +3,7 @@ import { Flex, Item, Picker, Text } from '@geti-ui/ui';
 import { getApiErrorMessage, isSerialPermissionDeniedError } from '../../../../api/errors';
 import type { SchemaSo101RobotPayload } from '../../../../api/openapi-spec';
 import { useCatalogIdentifyMutation, useDiscoverRobotsQuery } from '../../robot-catalog.hooks';
-import type { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
+import type { AvailableSchemaRobot, ConfigurableRobotType, SchemaRobotInput } from '../../robot-types';
 import { InlineAlert } from '../../setup-wizard/shared/inline-alert';
 import { PermissionDeniedError } from '../../setup-wizard/so101/diagnostics-step-error';
 import { useRobotFormFields } from '../provider';
@@ -14,7 +14,7 @@ export interface SO101FormData {
     payload: SchemaSo101RobotPayload;
 }
 
-export const getInitialSO101FormData = (robot?: SchemaRobot): SO101FormData => ({
+export const getInitialSO101FormData = (robot?: AvailableSchemaRobot): SO101FormData => ({
     name: robot?.name ?? '',
     payload:
         robot && (robot.type === 'SO101_Follower' || robot.type === 'SO101_Leader')
@@ -24,7 +24,7 @@ export const getInitialSO101FormData = (robot?: SchemaRobot): SO101FormData => (
 
 export const buildSO101Body = (
     formData: SO101FormData,
-    schemaType: SchemaRobotType,
+    schemaType: ConfigurableRobotType,
     robot_id: string
 ): SchemaRobotInput | null => {
     if (!formData.payload.serial_number && !formData.payload.connection_string) {

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai-bimanual.tsx
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { SchemaTrossenBimanualPayload } from '../../../../api/openapi-spec';
 import { useCatalogIdentifyMutation } from '../../robot-catalog.hooks';
-import type { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
+import type { AvailableSchemaRobot, ConfigurableRobotType, SchemaRobotInput } from '../../robot-types';
 import { useRobotFormFields } from '../provider';
 import { IdentifyRobot } from './actions';
 import { buildWidowxBody } from './widowxai';
@@ -13,7 +13,7 @@ export interface BimanualFormData {
     payload: SchemaTrossenBimanualPayload;
 }
 
-export const getInitialBimanualFormData = (robot?: SchemaRobot): BimanualFormData => ({
+export const getInitialBimanualFormData = (robot?: AvailableSchemaRobot): BimanualFormData => ({
     name: robot?.name ?? '',
     payload:
         robot && 'connection_string_left' in robot.payload
@@ -23,7 +23,7 @@ export const getInitialBimanualFormData = (robot?: SchemaRobot): BimanualFormDat
 
 export const buildBimanualBody = (
     formData: BimanualFormData,
-    schemaType: SchemaRobotType,
+    schemaType: ConfigurableRobotType,
     robot_id: string
 ): SchemaRobotInput | null => {
     if (!formData.payload.connection_string_left || !formData.payload.connection_string_right) {

--- a/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
+++ b/application/ui/src/features/robots/robot-form/catalog/widowxai.tsx
@@ -2,7 +2,7 @@ import { Flex, TextField } from '@geti-ui/ui';
 
 import type { SchemaTrossenSingleArmPayload } from '../../../../api/openapi-spec';
 import { useCatalogIdentifyMutation } from '../../robot-catalog.hooks';
-import type { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../../robot-types';
+import type { AvailableSchemaRobot, ConfigurableRobotType, SchemaRobotInput } from '../../robot-types';
 import { useRobotFormFields } from '../provider';
 import { IdentifyRobot } from './actions';
 
@@ -11,14 +11,14 @@ export interface WidowxFormData {
     payload: SchemaTrossenSingleArmPayload;
 }
 
-export const getInitialWidowxFormData = (robot?: SchemaRobot): WidowxFormData => ({
+export const getInitialWidowxFormData = (robot?: AvailableSchemaRobot): WidowxFormData => ({
     name: robot?.name ?? '',
     payload: robot && 'connection_string' in robot.payload ? robot.payload : { connection_string: '' },
 });
 
 export const buildWidowxBody = (
     formData: WidowxFormData,
-    schemaType: SchemaRobotType,
+    schemaType: ConfigurableRobotType,
     robot_id: string
 ): SchemaRobotInput | null => {
     if (!formData.payload.connection_string) {

--- a/application/ui/src/features/robots/robot-form/form.tsx
+++ b/application/ui/src/features/robots/robot-form/form.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft } from '@geti-ui/ui/icons';
 import { useProjectId } from '../../../features/projects/use-project';
 import { paths } from '../../../router';
 import { useRobotCatalogQuery } from '../robot-catalog.hooks';
-import { SchemaRobotType } from '../robot-types';
+import { ConfigurableRobotType } from '../robot-types';
 import { SO101FormFields } from './catalog/so101';
 import { WidowxAIFormFields } from './catalog/widowxai';
 import { BiManualWidowxAIFormFields } from './catalog/widowxai-bimanual';
@@ -23,7 +23,7 @@ export const RobotType = () => {
             selectedKey={activeType}
             onSelectionChange={(selected) => {
                 if (selected !== null) {
-                    setActiveType(selected as SchemaRobotType);
+                    setActiveType(selected as ConfigurableRobotType);
                 }
             }}
         >

--- a/application/ui/src/features/robots/robot-form/provider.tsx
+++ b/application/ui/src/features/robots/robot-form/provider.tsx
@@ -1,13 +1,13 @@
 import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 
-import { SchemaRobot, SchemaRobotInput, SchemaRobotType } from '../robot-types';
+import { AvailableSchemaRobot, ConfigurableRobotType, SchemaRobotInput } from '../robot-types';
 import { getInitialSO101FormData } from './catalog/so101';
 import { getInitialWidowxFormData } from './catalog/widowxai';
 import { getInitialBimanualFormData } from './catalog/widowxai-bimanual';
 import { buildRobotBody, type AnyRobotFormData, type FormDataForSchema } from './form-data';
 
 type RobotFormState = {
-    activeType: SchemaRobotType;
+    activeType: ConfigurableRobotType;
     SO101_Follower: FormDataForSchema['SO101_Follower'];
     SO101_Leader: FormDataForSchema['SO101_Leader'];
     Trossen_WidowXAI_Follower: FormDataForSchema['Trossen_WidowXAI_Follower'];
@@ -19,8 +19,8 @@ type RobotFormState = {
 const RobotFormContext = createContext<RobotFormState | null>(null);
 
 type SetRobotFormContextType = {
-    setActiveType: (type: SchemaRobotType) => void;
-    updateFormData: <K extends SchemaRobotType>(
+    setActiveType: (type: ConfigurableRobotType) => void;
+    updateFormData: <K extends ConfigurableRobotType>(
         schemaType: K,
         update: Partial<FormDataForSchema[K]> | ((prev: FormDataForSchema[K]) => FormDataForSchema[K])
     ) => void;
@@ -28,7 +28,7 @@ type SetRobotFormContextType = {
 
 const SetRobotFormContext = createContext<SetRobotFormContextType | null>(null);
 
-const FORM_DATA_FAMILY: Record<SchemaRobotType, string> = {
+const FORM_DATA_FAMILY: Record<ConfigurableRobotType, string> = {
     SO101_Follower: 'so101',
     SO101_Leader: 'so101',
     Trossen_WidowXAI_Follower: 'widowx',
@@ -37,7 +37,7 @@ const FORM_DATA_FAMILY: Record<SchemaRobotType, string> = {
     Trossen_Bimanual_WidowXAI_Leader: 'bimanual',
 };
 
-const getInitialState = (robot?: SchemaRobot): RobotFormState => ({
+const getInitialState = (robot?: AvailableSchemaRobot): RobotFormState => ({
     activeType: robot?.type ?? 'SO101_Follower',
     SO101_Follower: getInitialSO101FormData(robot?.type === 'SO101_Follower' ? robot : undefined),
     SO101_Leader: getInitialSO101FormData(robot?.type === 'SO101_Leader' ? robot : undefined),
@@ -53,10 +53,10 @@ const getInitialState = (robot?: SchemaRobot): RobotFormState => ({
     ),
 });
 
-export const RobotFormProvider = ({ children, robot }: { children: ReactNode; robot?: SchemaRobot }) => {
+export const RobotFormProvider = ({ children, robot }: { children: ReactNode; robot?: AvailableSchemaRobot }) => {
     const [state, setState] = useState(() => getInitialState(robot));
 
-    const setActiveType = useCallback(<T extends SchemaRobotType>(type: T) => {
+    const setActiveType = useCallback(<T extends ConfigurableRobotType>(type: T) => {
         setState((prev) => {
             if (prev.activeType === type) return prev;
 
@@ -72,7 +72,7 @@ export const RobotFormProvider = ({ children, robot }: { children: ReactNode; ro
     }, []);
 
     const updateFormData = useCallback(
-        <K extends SchemaRobotType>(
+        <K extends ConfigurableRobotType>(
             schemaType: K,
             update: Partial<FormDataForSchema[K]> | ((prev: FormDataForSchema[K]) => FormDataForSchema[K])
         ) => {
@@ -98,11 +98,11 @@ export const RobotFormProvider = ({ children, robot }: { children: ReactNode; ro
     );
 };
 
-export function useRobotForm(): { activeType: SchemaRobotType; robotForm: AnyRobotFormData };
-export function useRobotForm<K extends SchemaRobotType>(
+export function useRobotForm(): { activeType: ConfigurableRobotType; robotForm: AnyRobotFormData };
+export function useRobotForm<K extends ConfigurableRobotType>(
     schemaType: K
-): { activeType: SchemaRobotType; robotForm: FormDataForSchema[K] };
-export function useRobotForm(schemaType?: SchemaRobotType) {
+): { activeType: ConfigurableRobotType; robotForm: FormDataForSchema[K] };
+export function useRobotForm(schemaType?: ConfigurableRobotType) {
     const context = useContext(RobotFormContext);
 
     if (context === null) {

--- a/application/ui/src/features/robots/robot-types.ts
+++ b/application/ui/src/features/robots/robot-types.ts
@@ -1,4 +1,4 @@
-import type { operations } from '../../api/openapi-spec';
+import type { operations, SchemaUnavailableRobot } from '../../api/openapi-spec';
 
 type ListProjectRobotsOperation = operations['list_project_robots_api_projects__project_id__robots_get'];
 type CreateProjectRobotOperation = operations['create_project_robot_api_projects__project_id__robots_post'];
@@ -13,4 +13,13 @@ export type SchemaRobotInput = CreateProjectRobotOperation['requestBody']['conte
 export type SchemaRobotCreateResponse = CreateProjectRobotOperation['responses'][201]['content']['application/json'];
 
 /** All possible robot type discriminators. */
+export type AvailableSchemaRobot = Exclude<SchemaRobot, SchemaUnavailableRobot>;
+
+/** All robot type discriminators, including persisted types from unavailable plugins. */
 export type SchemaRobotType = SchemaRobot['type'];
+
+/** Robot type discriminators that are currently installed and can be configured. */
+export type ConfigurableRobotType = AvailableSchemaRobot['type'];
+
+export const isUnavailableRobot = (robot: SchemaRobot): robot is SchemaUnavailableRobot =>
+    'unavailable' in robot && robot.unavailable;

--- a/application/ui/src/features/robots/robots-list.test.tsx
+++ b/application/ui/src/features/robots/robots-list.test.tsx
@@ -125,4 +125,26 @@ describe('RobotsList', () => {
         expect(click).toHaveBeenCalledOnce();
         expect(revokeObjectUrl).toHaveBeenCalledWith('blob:calibration');
     });
+
+    it('shows unavailable robots without treating their status as loading', async () => {
+        const unavailableRobot = {
+            id: 'unavailable-id',
+            name: 'Removed plugin robot',
+            type: 'Removed_Plugin_Robot',
+            payload: { connection_string: '/dev/ttyUSB0' },
+            unavailable: true as const,
+        };
+        server.use(
+            http.get(ROBOTS_PATH, () => HttpResponse.json([unavailableRobot])),
+            http.get(ONLINE_ROBOTS_PATH, () =>
+                HttpResponse.json([{ ...unavailableRobot, connection_status: 'unknown' as const }])
+            )
+        );
+
+        renderRobotsList();
+
+        expect(await screen.findByText('Unavailable')).toBeInTheDocument();
+        expect(screen.getByText(/plugin unavailable/)).toBeInTheDocument();
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
 });

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -107,7 +107,7 @@ export const ConnectionStatus = ({
 
     return (
         <StatusLight
-            variant={status === 'online' ? 'positive' : status == 'unknown' ? 'notice' : 'negative'}
+            variant={status === 'online' ? 'positive' : status === 'unknown' ? 'notice' : 'negative'}
             UNSAFE_className={classes.connectionStatus}
         >
             {isUnavailable ? (

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -40,6 +40,7 @@ const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
 
     const editPath = paths.project.robots.edit({ project_id, robot_id: robot.id });
     const isSO101 = robot.type === 'SO101_Follower' || robot.type === 'SO101_Leader';
+    const isUnavailable = 'unavailable' in robot && robot.unavailable;
 
     return (
         <MenuTrigger>
@@ -81,9 +82,11 @@ const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
                     }
                 }}
             >
-                <Item key='edit' href={editPath}>
-                    Edit
-                </Item>
+                {isUnavailable ? null : (
+                    <Item key='edit' href={editPath}>
+                        Edit
+                    </Item>
+                )}
                 {isSO101 ? <Item key='export-calibration'>Export calibration</Item> : null}
                 <Item key='delete'>Delete</Item>
             </Menu>
@@ -122,6 +125,7 @@ const RobotListItem = ({
             ? `${payload.connection_string_left} | ${payload.connection_string_right}`
             : undefined);
     const serialNumber = 'serial_number' in robot.payload ? robot.payload.serial_number : undefined;
+    const isUnavailable = 'unavailable' in robot && robot.unavailable;
 
     return (
         <View
@@ -141,6 +145,7 @@ const RobotListItem = ({
                     </Heading>
                     <View gridArea='type' UNSAFE_style={{ fontSize: '14px' }}>
                         {robot.type.replaceAll('_', ' ')}
+                        {isUnavailable ? ' (plugin unavailable)' : ''}
                     </View>
                     <View gridArea='status'>
                         <ConnectionStatus status={status} />

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -9,7 +9,7 @@ import { getApiErrorMessage, isResourceInUseError } from '../../api/errors';
 import { paths } from '../../router';
 import { useProjectId } from '../projects/use-project';
 import RobotArm from './../../assets/robot-arm.webp';
-import { SchemaRobot } from './robot-types';
+import { isUnavailableRobot, SchemaRobot } from './robot-types';
 
 import classes from './robots-list.module.css';
 
@@ -40,7 +40,7 @@ const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
 
     const editPath = paths.project.robots.edit({ project_id, robot_id: robot.id });
     const isSO101 = robot.type === 'SO101_Follower' || robot.type === 'SO101_Leader';
-    const isUnavailable = 'unavailable' in robot && robot.unavailable;
+    const isUnavailable = isUnavailableRobot(robot);
 
     return (
         <MenuTrigger>
@@ -94,7 +94,13 @@ const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
     );
 };
 
-export const ConnectionStatus = ({ status }: { status: 'online' | 'offline' | 'unknown' }) => {
+export const ConnectionStatus = ({
+    status,
+    isUnavailable = false,
+}: {
+    status: 'online' | 'offline' | 'unknown';
+    isUnavailable?: boolean;
+}) => {
     const Capitalize = (str: string) => {
         return str.charAt(0).toUpperCase() + str.slice(1);
     };
@@ -104,7 +110,13 @@ export const ConnectionStatus = ({ status }: { status: 'online' | 'offline' | 'u
             variant={status === 'online' ? 'positive' : status == 'unknown' ? 'notice' : 'negative'}
             UNSAFE_className={classes.connectionStatus}
         >
-            {status === 'unknown' ? <View>Loading...</View> : <View>{Capitalize(status)}</View>}
+            {isUnavailable ? (
+                <View>Unavailable</View>
+            ) : status === 'unknown' ? (
+                <View>Loading...</View>
+            ) : (
+                <View>{Capitalize(status)}</View>
+            )}
         </StatusLight>
     );
 };
@@ -118,14 +130,14 @@ const RobotListItem = ({
     status: 'online' | 'offline' | 'unknown';
     isActive: boolean;
 }) => {
-    const payload = robot.payload;
-    const connectionString =
-        ('connection_string' in payload ? payload.connection_string : undefined) ??
-        ('connection_string_left' in payload && 'connection_string_right' in payload
-            ? `${payload.connection_string_left} | ${payload.connection_string_right}`
-            : undefined);
-    const serialNumber = 'serial_number' in robot.payload ? robot.payload.serial_number : undefined;
-    const isUnavailable = 'unavailable' in robot && robot.unavailable;
+    const isUnavailable = isUnavailableRobot(robot);
+    const connectionString = isUnavailable
+        ? undefined
+        : (('connection_string' in robot.payload ? robot.payload.connection_string : undefined) ??
+          ('connection_string_left' in robot.payload && 'connection_string_right' in robot.payload
+              ? `${robot.payload.connection_string_left} | ${robot.payload.connection_string_right}`
+              : undefined));
+    const serialNumber = !isUnavailable && 'serial_number' in robot.payload ? robot.payload.serial_number : undefined;
 
     return (
         <View
@@ -148,7 +160,7 @@ const RobotListItem = ({
                         {isUnavailable ? ' (plugin unavailable)' : ''}
                     </View>
                     <View gridArea='status'>
-                        <ConnectionStatus status={status} />
+                        <ConnectionStatus status={status} isUnavailable={isUnavailable} />
                     </View>
                 </Grid>
                 <Flex direction={'row'} justifyContent={'space-between'}>

--- a/application/ui/src/routes/robots/edit.tsx
+++ b/application/ui/src/routes/robots/edit.tsx
@@ -1,12 +1,18 @@
 import { FormPreviewLayout } from '../../components/form-preview-layout';
+import { UnavailableRobotViewer } from '../../features/robots/controller/robot-viewer';
 import { Preview } from '../../features/robots/robot-form/preview';
 import { RobotFormProvider } from '../../features/robots/robot-form/provider';
 import { UpdateRobotForm } from '../../features/robots/robot-form/update-form';
 import { RobotModelsProvider } from '../../features/robots/robot-models-context';
+import { isUnavailableRobot } from '../../features/robots/robot-types';
 import { useRobot } from '../../features/robots/use-robot';
 
 export const Edit = () => {
     const robot = useRobot();
+
+    if (isUnavailableRobot(robot)) {
+        return <UnavailableRobotViewer robotType={robot.type} />;
+    }
 
     return (
         <RobotModelsProvider>

--- a/application/ui/src/routes/robots/robot.tsx
+++ b/application/ui/src/routes/robots/robot.tsx
@@ -6,17 +6,19 @@ import { JointControls } from '../../features/robots/controller/joint-controls';
 import { RobotViewer, UnavailableRobotViewer } from '../../features/robots/controller/robot-viewer';
 import { useCatalogIdentifyMutation } from '../../features/robots/robot-catalog.hooks';
 import { RobotModelsProvider } from '../../features/robots/robot-models-context';
+import { AvailableSchemaRobot, isUnavailableRobot } from '../../features/robots/robot-types';
 import { useRobot } from '../../features/robots/use-robot';
 
 export const Robot = () => {
     const robot = useRobot();
-    const isUnavailable = 'unavailable' in robot && robot.unavailable;
-
-    return isUnavailable ? <UnavailableRobotViewer robotType={robot.type} /> : <AvailableRobot />;
+    return isUnavailableRobot(robot) ? (
+        <UnavailableRobotViewer robotType={robot.type} />
+    ) : (
+        <AvailableRobot robot={robot} />
+    );
 };
 
-const AvailableRobot = () => {
-    const robot = useRobot();
+const AvailableRobot = ({ robot }: { robot: AvailableSchemaRobot }) => {
     const identifyMutation = useCatalogIdentifyMutation();
 
     const onIdentify = identifyMutation.isPending

--- a/application/ui/src/routes/robots/robot.tsx
+++ b/application/ui/src/routes/robots/robot.tsx
@@ -3,14 +3,20 @@ import { useState } from 'react';
 import { Button, ButtonGroup, Flex, Grid, View } from '@geti-ui/ui';
 
 import { JointControls } from '../../features/robots/controller/joint-controls';
-import { RobotViewer } from '../../features/robots/controller/robot-viewer';
+import { RobotViewer, UnavailableRobotViewer } from '../../features/robots/controller/robot-viewer';
 import { useCatalogIdentifyMutation } from '../../features/robots/robot-catalog.hooks';
 import { RobotModelsProvider } from '../../features/robots/robot-models-context';
 import { useRobot } from '../../features/robots/use-robot';
 
 export const Robot = () => {
     const robot = useRobot();
+    const isUnavailable = 'unavailable' in robot && robot.unavailable;
 
+    return isUnavailable ? <UnavailableRobotViewer robotType={robot.type} /> : <AvailableRobot />;
+};
+
+const AvailableRobot = () => {
+    const robot = useRobot();
     const identifyMutation = useCatalogIdentifyMutation();
 
     const onIdentify = identifyMutation.isPending


### PR DESCRIPTION
> This PR is extracted from https://github.com/open-edge-platform/physical-ai-studio/pull/1003

With the new robot plugin setup it will be possible for users to have robots stored in their database that may no longer be available (due to the plugin being uninstalled).
Before the backend would throw a validatoin error from `RobotAdapter.validate_python`, with this PR we are being more lenient: if the robot type is unknown then we return an `UnavailableRobot`.

The UI is updated to show some very basic error messages: I expect that the issue this PR addresses will mainly be seen by developers working on plugins, so for now we won't invest too much time yet on tihs.

| **Dataset recording** | **Dataset viewing** |
|------------|-----------|
|  <img width="1920" height="1200" alt="screenshot-2026-08-20_12-53-21" src="https://github.com/user-attachments/assets/c64840bd-9103-450b-ad54-21183e08861d" />          | <img width="1920" height="1200" alt="screenshot-2026-08-20_12-53-08" src="https://github.com/user-attachments/assets/92cef28f-a17b-4cb5-b051-4222be4cf453" />          |
| **Environment**   | **Robot list**  |
|  <img width="1920" height="1200" alt="screenshot-2026-08-20_12-52-57" src="https://github.com/user-attachments/assets/13e1df23-27c9-4337-8b37-6f3609a0be17" />          |  <img width="1920" height="1200" alt="screenshot-2026-08-20_12-52-44" src="https://github.com/user-attachments/assets/6acb5461-84e7-423f-8e90-42eeeb3f0bb0" />         |
