### PR TITLE
feat: include application footer in app layout

### DIFF
--- a/application/ui/src/components/app-footer/app-footer.tsx
+++ b/application/ui/src/components/app-footer/app-footer.tsx
@@ -4,13 +4,10 @@ import { Manifest } from '@geti-ui/ui/icons';
 import { JobStatus } from '../../features/jobs/footer/job-status';
 import { LogsDialog } from '../../features/logs/logs-dialog';
 
-export const AppFooter = ({ gridArea = 'footer', compact = false }: { gridArea?: string; compact?: boolean }) => {
+export const AppFooter = ({ gridArea = 'footer' }: { gridArea?: string }) => {
     return (
         <View
             gridArea={gridArea}
-            height='size-400'
-            minHeight='size-400'
-            maxHeight='size-400'
             borderTopColor={'gray-300'}
             borderTopWidth={'thin'}
             borderBottomColor={'gray-75'}
@@ -19,27 +16,25 @@ export const AppFooter = ({ gridArea = 'footer', compact = false }: { gridArea?:
             paddingX='size-100'
             paddingY='size-0'
         >
-            <Flex alignItems='center' justifyContent='space-between' gap='size-100' height='100%'>
-                <Flex alignItems={'center'} height='100%' gap='size-100' flex={1} minWidth={0}>
-                    <View overflow={'hidden'}>
-                        <DialogTrigger type='fullscreen'>
-                            <ActionButton
-                                isQuiet
-                                UNSAFE_style={{
-                                    paddingRight: 'var(--spectrum-global-dimension-size-100)',
-                                }}
-                            >
-                                <Icon>
-                                    <Manifest />
-                                </Icon>
-                                Logs
-                            </ActionButton>
-                            {(close) => <LogsDialog close={close} />}
-                        </DialogTrigger>
-                    </View>
-                    <Divider orientation='vertical' size='S' />
-                    <JobStatus />
-                </Flex>
+            <Flex alignItems={'center'} height='100%' gap='size-100' minWidth={0}>
+                <View overflow={'hidden'}>
+                    <DialogTrigger type='fullscreen'>
+                        <ActionButton
+                            isQuiet
+                            UNSAFE_style={{
+                                paddingRight: 'var(--spectrum-global-dimension-size-100)',
+                            }}
+                        >
+                            <Icon>
+                                <Manifest />
+                            </Icon>
+                            Logs
+                        </ActionButton>
+                        {(close) => <LogsDialog close={close} />}
+                    </DialogTrigger>
+                </View>
+                <Divider orientation='vertical' size='S' />
+                <JobStatus />
             </Flex>
         </View>
     );

--- a/application/ui/src/components/app-footer/app-footer.tsx
+++ b/application/ui/src/components/app-footer/app-footer.tsx
@@ -1,0 +1,46 @@
+import { ActionButton, DialogTrigger, Divider, Flex, Icon, View } from '@geti-ui/ui';
+import { Manifest } from '@geti-ui/ui/icons';
+
+import { JobStatus } from '../../features/jobs/footer/job-status';
+import { LogsDialog } from '../../features/logs/logs-dialog';
+
+export const AppFooter = ({ gridArea = 'footer', compact = false }: { gridArea?: string; compact?: boolean }) => {
+    return (
+        <View
+            gridArea={gridArea}
+            height='size-400'
+            minHeight='size-400'
+            maxHeight='size-400'
+            borderTopColor={'gray-300'}
+            borderTopWidth={'thin'}
+            borderBottomColor={'gray-75'}
+            borderBottomWidth={'thin'}
+            backgroundColor={'gray-75'}
+            paddingX='size-100'
+            paddingY='size-0'
+        >
+            <Flex alignItems='center' justifyContent='space-between' gap='size-100' height='100%'>
+                <Flex alignItems={'center'} height='100%' gap='size-100' flex={1} minWidth={0}>
+                    <View overflow={'hidden'}>
+                        <DialogTrigger type='fullscreen'>
+                            <ActionButton
+                                isQuiet
+                                UNSAFE_style={{
+                                    paddingRight: 'var(--spectrum-global-dimension-size-100)',
+                                }}
+                            >
+                                <Icon>
+                                    <Manifest />
+                                </Icon>
+                                Logs
+                            </ActionButton>
+                            {(close) => <LogsDialog close={close} />}
+                        </DialogTrigger>
+                    </View>
+                    <Divider orientation='vertical' size='S' />
+                    <JobStatus />
+                </Flex>
+            </Flex>
+        </View>
+    );
+};

--- a/application/ui/src/routes/app/app.layout.module.css
+++ b/application/ui/src/routes/app/app.layout.module.css
@@ -19,13 +19,15 @@
         &[class*='is-selected'] {
             background-color: var(--spectrum-global-color-gray-300);
 
-            .sidebarListItemIcon {
-                fill: var(--energy-blue);
+            .sidebarListItemIcon,
+            .sidebarListItemIcon path {
+                fill: var(--energy-blue) !important;
             }
         }
     }
 }
 
-.sidebarListItemIcon {
-    fill: var(--spectrum-global-color-gray-700);
+.sidebarListItemIcon,
+.sidebarListItemIcon path {
+    fill: var(--spectrum-global-color-gray-700) !important;
 }

--- a/application/ui/src/routes/app/app.layout.test.tsx
+++ b/application/ui/src/routes/app/app.layout.test.tsx
@@ -1,11 +1,16 @@
 import { ThemeProvider } from '@geti-ui/ui';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render as rtlRender, screen } from '@testing-library/react';
+import { vi } from 'vitest';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import { createQueryClient } from '../../query-client/query-client';
 import { render } from '../../test-utils/render';
 import { AppLayout } from './app.layout';
+
+vi.mock('../../features/jobs/footer/job-status', () => ({
+    JobStatus: () => null,
+}));
 
 describe('AppLayout', () => {
     it('renders the logo, linking to the projects page', () => {

--- a/application/ui/src/routes/app/app.layout.test.tsx
+++ b/application/ui/src/routes/app/app.layout.test.tsx
@@ -1,8 +1,8 @@
 import { ThemeProvider } from '@geti-ui/ui';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render as rtlRender, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 import { createMemoryRouter, RouterProvider } from 'react-router';
+import { vi } from 'vitest';
 
 import { createQueryClient } from '../../query-client/query-client';
 import { render } from '../../test-utils/render';

--- a/application/ui/src/routes/app/app.layout.tsx
+++ b/application/ui/src/routes/app/app.layout.tsx
@@ -51,7 +51,7 @@ export const AppLayout = () => {
                         <Outlet />
                     </Suspense>
                 </View>
-                <AppFooter compact />
+                <AppFooter />
             </Grid>
         </Tabs>
     );

--- a/application/ui/src/routes/app/app.layout.tsx
+++ b/application/ui/src/routes/app/app.layout.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 import { Grid, Loading, Tabs, View } from '@geti-ui/ui';
 import { Outlet, useLocation } from 'react-router';
 
+import { AppFooter } from '../../components/app-footer/app-footer';
 import { AppSidebar } from './app-sidebar';
 import { disabledNavItemKeys } from './nav-items';
 
@@ -30,8 +31,8 @@ export const AppLayout = () => {
             width={'100%'}
         >
             <Grid
-                areas={['sidebar content']}
-                rows={['minmax(0, 1fr)']}
+                areas={['sidebar content', 'footer footer']}
+                rows={['minmax(0, 1fr)', 'var(--spectrum-global-dimension-size-400)']}
                 columns={['size-3000', 'minmax(0, 1fr)']}
                 minHeight={0}
                 height='100%'
@@ -50,6 +51,7 @@ export const AppLayout = () => {
                         <Outlet />
                     </Suspense>
                 </View>
+                <AppFooter compact />
             </Grid>
         </Tabs>
     );

--- a/application/ui/src/routes/projects/project.layout.tsx
+++ b/application/ui/src/routes/projects/project.layout.tsx
@@ -1,24 +1,10 @@
 import { Suspense } from 'react';
 
-import {
-    ActionButton,
-    DialogTrigger,
-    Divider,
-    Flex,
-    Grid,
-    Icon,
-    Item,
-    Loading,
-    TabList,
-    Tabs,
-    View,
-} from '@geti-ui/ui';
-import { Manifest } from '@geti-ui/ui/icons';
+import { Flex, Grid, Item, Loading, TabList, Tabs, View } from '@geti-ui/ui';
 import { Outlet, useLocation } from 'react-router';
 
+import { AppFooter } from '../../components/app-footer/app-footer';
 import { AppLogo } from '../../components/app-logo/app-logo';
-import { JobStatus } from '../../features/jobs/footer/job-status';
-import { LogsDialog } from '../../features/logs/logs-dialog';
 import { ProjectMenu } from '../../features/projects/menu/project-menu.component';
 import { useProject, useProjectId } from '../../features/projects/use-project';
 import { paths } from '../../router';
@@ -68,41 +54,6 @@ const Header = ({ project_id }: { project_id: string }) => {
     );
 };
 
-const Footer = () => {
-    return (
-        <View
-            gridArea={'footer'}
-            borderTopColor={'gray-300'}
-            borderTopWidth={'thin'}
-            borderBottomColor={'gray-75'}
-            borderBottomWidth={'thin'}
-            paddingX='size-100'
-            paddingY='size-25'
-        >
-            <Flex alignItems={'center'} height='100%' gap='size-100'>
-                <View overflow={'hidden'}>
-                    <DialogTrigger type='fullscreen'>
-                        <ActionButton
-                            isQuiet
-                            UNSAFE_style={{
-                                paddingRight: 'var(--spectrum-global-dimension-size-100)',
-                            }}
-                        >
-                            <Icon>
-                                <Manifest />
-                            </Icon>
-                            Logs
-                        </ActionButton>
-                        {(close) => <LogsDialog close={close} />}
-                    </DialogTrigger>
-                </View>
-                <Divider orientation='vertical' size='S' />
-                <JobStatus />
-            </Flex>
-        </View>
-    );
-};
-
 export const ProjectLayout = () => {
     const { project_id } = useProjectId();
     const { pathname } = useLocation();
@@ -138,7 +89,7 @@ export const ProjectLayout = () => {
                         <Outlet />
                     </Suspense>
                 </View>
-                <Footer />
+                <AppFooter />
             </Grid>
         </Tabs>
     );


### PR DESCRIPTION
> This PR is extracted from https://github.com/open-edge-platform/physical-ai-studio/pull/1003

Having the footer been shown in the application layout allows users to see training jobs without being inside of a project.

We will later also extend this footer with an option to warn the user that they need to reboot their server after installing a new plugin.

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/2726b215-532a-4ae3-b870-7f3eeb4b4111" />
