### PR TITLE
fix: fix height of footer row

### DIFF
--- a/application/ui/src/routes/app/app.layout.tsx
+++ b/application/ui/src/routes/app/app.layout.tsx
@@ -32,7 +32,7 @@ export const AppLayout = () => {
         >
             <Grid
                 areas={['sidebar content', 'footer footer']}
-                rows={['minmax(0, 1fr)', 'var(--spectrum-global-dimension-size-400)']}
+                rows={['minmax(0, 1fr)', 'size-400']}
                 columns={['size-3000', 'minmax(0, 1fr)']}
                 minHeight={0}
                 height='100%'


### PR DESCRIPTION
Fix a regression from #1025 where if the page content would be small (during loading time or when you don't have many projects) the footer would grow in size.