### PR TITLE
chore: allow overwriting ui proxy target

### DIFF
--- a/application/ui/README.md
+++ b/application/ui/README.md
@@ -88,20 +88,22 @@ ui/src/
 
 Create `.env.local` for custom configuration:
 
-| Variable                          | Description                                    | Default                 |
-| --------------------------------- | ----------------------------------------------- | ----------------------- |
-| `PUBLIC_API_BASE_URL`             | Backend API base URL                            | `http://localhost:3000` |
+| Variable                  | Description                                     | Default                 |
+| ------------------------- | ----------------------------------------------- | ----------------------- |
+| `PUBLIC_API_BASE_URL`     | Backend API base URL                            | `http://localhost:3000` |
+| `PUBLIC_API_PROXY_TARGET` | Backend target for the development `/api` proxy | `http://localhost:7860` |
 
 ### Development Proxy
 
-The dev server proxies `/api` requests to the backend:
+The dev server proxies `/api` requests to `PUBLIC_API_PROXY_TARGET` (or
+`http://localhost:7860` by default):
 
 ```typescript
 // rsbuild.config.ts
 server: {
   proxy: {
     '/api': {
-      target: 'http://localhost:7860',  // Backend server
+      target: 'http://localhost:7860',  // Default backend server
       changeOrigin: true,
       ws: true,  // WebSocket support
     },
@@ -109,7 +111,7 @@ server: {
 }
 ```
 
-This allows the UI to make API calls to `/api/*` which are automatically forwarded to the backend at `http://localhost:7860`.
+This allows the UI to make API calls to `/api/*` which are automatically forwarded to the configured backend.
 
 ## See Also
 

--- a/application/ui/rsbuild.config.ts
+++ b/application/ui/rsbuild.config.ts
@@ -3,8 +3,8 @@ import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 
-const { publicVars } = loadEnv({ prefixes: ['PUBLIC_'] });
-const apiProxyTarget = process.env.PUBLIC_API_PROXY_TARGET ?? 'http://localhost:7860';
+const { publicVars, rawPublicVars } = loadEnv({ prefixes: ['PUBLIC_'] });
+const apiProxyTarget = rawPublicVars.PUBLIC_API_PROXY_TARGET ?? 'http://localhost:7860';
 
 export default defineConfig({
     plugins: [

--- a/application/ui/rsbuild.config.ts
+++ b/application/ui/rsbuild.config.ts
@@ -4,6 +4,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 
 const { publicVars } = loadEnv({ prefixes: ['PUBLIC_'] });
+const apiProxyTarget = process.env.PUBLIC_API_PROXY_TARGET ?? 'http://localhost:7860';
 
 export default defineConfig({
     plugins: [
@@ -50,8 +51,7 @@ export default defineConfig({
     server: {
         proxy: {
             '/api': {
-                target: 'http://localhost:7860',
-                //target: 'http://192.168.2.117:7860',
+                target: apiProxyTarget,
                 changeOrigin: true,
                 ws: true,
                 //pathRewrite: { '^/api': '' }, // strip the /api prefix


### PR DESCRIPTION
This allows users and developers to more easily overwrite the ports the ui and backend are running at,

```
uv run --extra xpu physicalai-studio serve --host 127.0.0.1 --port 8000

PUBLIC_API_PROXY_TARGET=http://localhost:8000 npm run start
```

the main use case for this is if you'd want to use say Geti and PhysicalAI Studio or any other self hosted service at the same time and don't want to spend time on setting up a reverse proxy like nginx or traefik.