### PR TITLE
feat: configure hugging face token and remote trainer in settings page

### DIFF
--- a/application/backend/.env.example
+++ b/application/backend/.env.example
@@ -63,6 +63,5 @@ no_proxy=localhost,127.0.0.1,::1
 # User-configurable settings file. Defaults to the platform app-data directory.
 # SETTINGS_FILE=
 
-# Hugging Face token, used by the remote training backend to authenticate
-# dataset/model uploads. Never commit a real token to source control.
-HF_TOKEN=
+# Hugging Face authentication is configured in the `huggingface` group of
+# settings.json. HF_TOKEN remains available to direct Hub downloads.

--- a/application/backend/.env.example
+++ b/application/backend/.env.example
@@ -16,11 +16,8 @@ ENVIRONMENT=dev
 # DATA_IMPORT_MIN_FREE_BYTES=1073741824
 
 # Remote training (studio side): submitting jobs to a trainer registered in
-# the Studio UI/API.
-# Seconds to wait for trainer HTTP requests (excludes long-poll/SSE streams).
-# TRAINER_REQUEST_TIMEOUT_S=30.0
-# Seconds to wait between chunks while streaming the model artifact.
-# TRAINER_DOWNLOAD_READ_TIMEOUT_S=120.0
+# the Studio UI/API. Client timeouts are configured in the `trainer` group of
+# settings.json, not via environment variables.
 
 # Server
 HOST=0.0.0.0
@@ -62,6 +59,9 @@ ALLOW_UNKNOWN_DB_REVISION=false
 
 # Proxy settings
 no_proxy=localhost,127.0.0.1,::1
+
+# User-configurable settings file. Defaults to the platform app-data directory.
+# SETTINGS_FILE=
 
 # Hugging Face token, used by the remote training backend to authenticate
 # dataset/model uploads. Never commit a real token to source control.

--- a/application/backend/src/api/settings.py
+++ b/application/backend/src/api/settings.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""User-configurable application settings API."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from settings import HuggingFaceSettings, Settings, TrainerClientSettings, get_settings, merge_user_settings
+
+router = APIRouter(prefix="/api/settings", tags=["Settings"])
+
+
+class UserSettingsResponse(BaseModel):
+    """Effective user-configurable settings, with secrets masked."""
+
+    trainer: TrainerClientSettings
+    huggingface: HuggingFaceSettings
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> "UserSettingsResponse":
+        return cls(
+            trainer=settings.trainer,
+            huggingface=settings.huggingface,
+        )
+
+
+class SettingsUpdate(BaseModel):
+    """Partial update for user-configurable application settings."""
+
+    trainer: TrainerClientSettings | None = None
+    huggingface: HuggingFaceSettings | None = None
+
+
+@router.get("")
+async def get_user_settings() -> UserSettingsResponse:
+    """Get the effective user-configurable settings."""
+    return UserSettingsResponse.from_settings(get_settings())
+
+
+@router.patch("")
+async def update_user_settings(update: SettingsUpdate) -> UserSettingsResponse:
+    """Persist the supplied fields and return effective settings."""
+    merge_user_settings(update.model_dump(exclude_unset=True))
+    return UserSettingsResponse.from_settings(get_settings())

--- a/application/backend/src/cli/serve.py
+++ b/application/backend/src/cli/serve.py
@@ -27,8 +27,7 @@ def _configure_packaged_runtime() -> None:
     os.environ.setdefault("ALEMBIC_CONFIG_PATH", str(package_root / "alembic.ini"))
     os.environ.setdefault("ALEMBIC_SCRIPT_LOCATION", str(package_root / "alembic"))
 
-    # Refresh cached settings so downstream DB/migration modules observe packaged paths.
-    get_settings.cache_clear()
+    # Settings are resolved for each call, so downstream modules observe these paths.
 
 
 def start_server(host: str, port: int) -> None:

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -26,6 +26,7 @@ from api.robot_catalog import router as robot_catalog_router
 from api.robot_control import router as robot_control_router
 from api.robot_setup import router as robot_setup_router
 from api.robots import router as project_robots_router
+from api.settings import router as settings_router
 from api.system import system_router
 from api.webui import SPAStaticFiles
 from core.lifecycle import lifespan
@@ -55,6 +56,7 @@ app.include_router(camera_router)
 app.include_router(dataset_router)
 app.include_router(record_router)
 app.include_router(remote_trainers_router)
+app.include_router(settings_router)
 app.include_router(models_router)
 app.include_router(policies_router)
 app.include_router(job_router)

--- a/application/backend/src/services/training_backends/local.py
+++ b/application/backend/src/services/training_backends/local.py
@@ -22,6 +22,7 @@ from loguru import logger
 
 from schemas.job import _DEFAULT_MAX_EPOCHS
 from services.training_backends._log_format import render_progress_log
+from settings import get_settings
 
 if TYPE_CHECKING:
     from physicalai.train.callbacks import ReportFn
@@ -35,20 +36,24 @@ class LocalTrainingBackend:
 
     async def train(self, context: TrainingContext) -> None:
         """Run Lightning training, save, and export into the model directory."""
-        from training import run_training_job
+        from training import RunOptions, run_training_job
 
         if context.snapshot is None:
             raise ValueError("Local training requires a dataset snapshot")
 
+        spec = build_spec(context)
+        spec.run_options = RunOptions(
+            resume_from=_resume_checkpoint(context),
+            hf_token=get_settings().huggingface.hf_token,
+        )
         await asyncio.to_thread(
             run_training_job,
-            build_spec(context),
+            spec,
             dataset_root=context.snapshot.path,
             output_dir=context.output_dir,
             cache_dir=context.cache_dir,
             report=self._reporter(context),
             should_stop=context.should_stop,
-            resume_from=_resume_checkpoint(context),
         )
 
     @staticmethod

--- a/application/backend/src/services/training_backends/local.py
+++ b/application/backend/src/services/training_backends/local.py
@@ -15,10 +15,12 @@ module can be imported in environments without the `[train]` extra installed.
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
+from pydantic import SecretStr
 
 from schemas.job import _DEFAULT_MAX_EPOCHS
 from services.training_backends._log_format import render_progress_log
@@ -42,9 +44,15 @@ class LocalTrainingBackend:
             raise ValueError("Local training requires a dataset snapshot")
 
         spec = build_spec(context)
+        hf_token = get_settings().huggingface.hf_token
+        # Fallback to Environment Variable based hf token if settings hasn't been set
+        if (hf_token is None or not hf_token.get_secret_value()) and (
+            legacy_hf_token := os.environ.get("HF_TOKEN", "")
+        ):
+            hf_token = SecretStr(legacy_hf_token)
         spec.run_options = RunOptions(
             resume_from=_resume_checkpoint(context),
-            hf_token=get_settings().huggingface.hf_token,
+            hf_token=hf_token,
         )
         await asyncio.to_thread(
             run_training_job,

--- a/application/backend/src/services/training_backends/remote.py
+++ b/application/backend/src/services/training_backends/remote.py
@@ -322,7 +322,7 @@ class RemoteTrainingBackend:
 
         spec = build_spec(context).model_copy(update={"device_type": None, "device_index": None})
         body: dict[str, Any] = {
-            "spec": spec.model_dump(mode="json"),
+            "spec": spec.model_dump(mode="json", exclude={"run_options"}),
             "dataset_transfer": "http",
         }
         async with await self._client() as client:

--- a/application/backend/src/services/training_backends/remote.py
+++ b/application/backend/src/services/training_backends/remote.py
@@ -80,7 +80,7 @@ class RemoteTrainingBackend:
     def __init__(self, base_url: str, *, trainer_name: str | None = None) -> None:
         settings = get_settings()
         self._base_url = base_url.rstrip("/")
-        self._timeout = settings.trainer_request_timeout_s
+        self._timeout = settings.trainer.request_timeout_s
         # Resolved once by _resolve_trust_env(): True honors proxy env vars,
         # False bypasses them. None means "not yet probed".
         self._trust_env: bool | None = None
@@ -245,7 +245,7 @@ class RemoteTrainingBackend:
 
         settings = get_settings()
         # A large upload must not trip the short request timeout; guard stalls with a per-write gap.
-        stream_timeout = httpx.Timeout(self._timeout, write=settings.trainer_download_read_timeout_s)
+        stream_timeout = httpx.Timeout(self._timeout, write=settings.trainer.download_read_timeout_s)
         offset = await self._get_upload_offset(remote_job_id, total, stream_timeout)
         for attempt in range(_TRANSFER_RETRY_LIMIT + 1):
             if offset == total:
@@ -347,12 +347,12 @@ class RemoteTrainingBackend:
         dropped stream is recoverable: we reconnect with exponential backoff, and
         also poll the plain job endpoint as a fallback for middleboxes that break
         long-lived SSE (see :meth:`_poll_state`). We only abandon the job once the
-        trainer has been continuously unreachable for ``trainer_stream_reconnect_max_s``
+        trainer has been continuously unreachable for ``trainer.stream_reconnect_max_s``
         seconds.
         """
         settings = get_settings()
-        unreachable_budget_s = settings.trainer_stream_reconnect_max_s
-        max_backoff_s = settings.trainer_stream_reconnect_backoff_max_s
+        unreachable_budget_s = settings.trainer.stream_reconnect_max_s
+        max_backoff_s = settings.trainer.stream_reconnect_backoff_max_s
         backoff_s = _RECONNECT_BACKOFF_S
         # Monotonic timestamp of the last successful contact with the trainer
         # (an event received, or a successful poll). Resets the outage budget.
@@ -552,7 +552,7 @@ class RemoteTrainingBackend:
         """Stream the model archive and extract it into the model directory."""
         settings = get_settings()
         tmp_archive = Path(tempfile.gettempdir()) / f"remote-model-{uuid.uuid4().hex}.zip"
-        stream_timeout = httpx.Timeout(self._timeout, read=settings.trainer_download_read_timeout_s)
+        stream_timeout = httpx.Timeout(self._timeout, read=settings.trainer.download_read_timeout_s)
         self._log.info("Downloading trained model artifact from trainer job {}", remote_job_id)
         started = time.monotonic()
         try:

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, JsonConfigSettingsSource, PydanticBaseSettingsSource, SettingsConfigDict
 
 
@@ -51,7 +51,13 @@ class TrainerClientSettings(BaseModel):
     stream_reconnect_backoff_max_s: float = Field(default=30.0)
 
 
-_USER_CONFIG_GROUPS: tuple[str, ...] = ("trainer",)
+class HuggingFaceSettings(BaseModel):
+    """Hugging Face credentials for authenticated training downloads."""
+
+    hf_token: SecretStr | None = Field(default=None)
+
+
+_USER_CONFIG_GROUPS: tuple[str, ...] = ("trainer", "huggingface")
 
 
 class UserConfigSettingsSource(JsonConfigSettingsSource):
@@ -142,6 +148,8 @@ class Settings(BaseSettings):
 
     # User-configurable client-side remote trainer timeouts.
     trainer: TrainerClientSettings = TrainerClientSettings()
+    # User-configurable Hugging Face credentials.
+    huggingface: HuggingFaceSettings = HuggingFaceSettings()
 
     # Server
     host: str = Field(default="0.0.0.0", alias="HOST")  # noqa: S104 # nosec B104
@@ -196,7 +204,7 @@ def write_user_settings(data: dict[str, Any]) -> None:
     fd, tmp_path = tempfile.mkstemp(dir=path.parent, prefix="settings.", suffix=".json.tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
-            json.dump(filtered, tmp_file, indent=2)
+            json.dump(filtered, tmp_file, indent=2, default=_plain_secret_str)
             tmp_file.write("\n")
             tmp_file.flush()
             os.fsync(tmp_file.fileno())
@@ -207,6 +215,13 @@ def write_user_settings(data: dict[str, Any]) -> None:
         except OSError:
             pass
         raise
+
+
+def _plain_secret_str(value: Any) -> Any:
+    """Serialize SecretStr values as plaintext in the local settings file."""
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    return value
 
 
 def load_user_settings_file() -> dict[str, Any]:

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -56,6 +56,14 @@ class HuggingFaceSettings(BaseModel):
 
     hf_token: SecretStr | None = Field(default=None)
 
+    @field_validator("hf_token", mode="before")
+    @classmethod
+    def empty_token_is_unset(cls, value: str | None) -> str | None:
+        """Treat an empty form submission as removal of the stored token."""
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
+
 
 _USER_CONFIG_GROUPS: tuple[str, ...] = ("trainer", "huggingface")
 

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -1,16 +1,17 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Application configuration management"""
+"""Application configuration management."""
 
+import json
 import os
 import sys
-from functools import lru_cache
+import tempfile
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseModel, Field, field_validator
+from pydantic_settings import BaseSettings, JsonConfigSettingsSource, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 def get_default_storage_dir() -> Path:
@@ -31,6 +32,34 @@ def get_default_storage_dir() -> Path:
             return xdg_data_home_path / "physicalai"
 
     return Path("~/.local/share/physicalai").expanduser()
+
+
+def get_settings_file_path() -> Path:
+    """Return the user-configurable settings file path."""
+    override = os.environ.get("SETTINGS_FILE")
+    if override:
+        return Path(override).expanduser()
+    return get_default_storage_dir() / "settings.json"
+
+
+class TrainerClientSettings(BaseModel):
+    """Client-side timeouts for talking to a remote trainer service."""
+
+    request_timeout_s: float = Field(default=30.0)
+    download_read_timeout_s: float = Field(default=120.0)
+    stream_reconnect_max_s: float = Field(default=900.0)
+    stream_reconnect_backoff_max_s: float = Field(default=30.0)
+
+
+_USER_CONFIG_GROUPS: tuple[str, ...] = ("trainer",)
+
+
+class UserConfigSettingsSource(JsonConfigSettingsSource):
+    """JSON settings source restricted to user-configurable groups."""
+
+    def __call__(self) -> dict[str, Any]:
+        data: dict[str, Any] = super().__call__()
+        return {key: value for key, value in data.items() if key in _USER_CONFIG_GROUPS}
 
 
 class Settings(BaseSettings):
@@ -111,17 +140,8 @@ class Settings(BaseSettings):
         """Storage directory for logs."""
         return self.storage_dir / "logs"
 
-    # Remote training
-    # Seconds to wait for trainer HTTP requests (excludes long-poll/SSE streams).
-    trainer_request_timeout_s: float = Field(default=30.0, alias="TRAINER_REQUEST_TIMEOUT_S")
-    # Seconds to wait between chunks while streaming the model artifact. A stalled
-    # transfer (e.g. a proxy holding the connection open) must fail instead of
-    # hanging the job forever; this is a per-read gap, not a total transfer cap.
-    trainer_download_read_timeout_s: float = Field(default=120.0, alias="TRAINER_DOWNLOAD_READ_TIMEOUT_S")
-    # Stop reconnecting after this continuous trainer outage.
-    trainer_stream_reconnect_max_s: float = Field(default=900.0, alias="TRAINER_STREAM_RECONNECT_MAX_S")
-    # Upper bound on the exponential backoff between event-stream reconnect attempts.
-    trainer_stream_reconnect_backoff_max_s: float = Field(default=30.0, alias="TRAINER_STREAM_RECONNECT_BACKOFF_MAX_S")
+    # User-configurable client-side remote trainer timeouts.
+    trainer: TrainerClientSettings = TrainerClientSettings()
 
     # Server
     host: str = Field(default="0.0.0.0", alias="HOST")  # noqa: S104 # nosec B104
@@ -149,8 +169,73 @@ class Settings(BaseSettings):
         """Get synchronous database URL"""
         return f"sqlite:///{self.data_dir / self.database_file}"
 
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Resolve init kwargs, user JSON, environment, then .env."""
+        return (
+            init_settings,
+            UserConfigSettingsSource(settings_cls, json_file=get_settings_file_path()),
+            env_settings,
+            dotenv_settings,
+            file_secret_settings,
+        )
 
-@lru_cache
+
+def write_user_settings(data: dict[str, Any]) -> None:
+    """Atomically persist allowed user-configurable settings."""
+    path = get_settings_file_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    filtered = {key: value for key, value in data.items() if key in _USER_CONFIG_GROUPS and value is not None}
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, prefix="settings.", suffix=".json.tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            json.dump(filtered, tmp_file, indent=2)
+            tmp_file.write("\n")
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_user_settings_file() -> dict[str, Any]:
+    """Return the raw user settings JSON, or an empty mapping."""
+    path = get_settings_file_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open(encoding="utf-8") as settings_file:
+            data = json.load(settings_file)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def merge_user_settings(patch: dict[str, Any]) -> None:
+    """Apply a partial patch without overwriting omitted fields."""
+    current = load_user_settings_file()
+    for group in _USER_CONFIG_GROUPS:
+        if group not in patch:
+            continue
+        value = patch[group]
+        if value is None:
+            current.pop(group, None)
+        elif isinstance(value, dict):
+            current.setdefault(group, {}).update(value)
+    write_user_settings(current)
+
+
 def get_settings() -> Settings:
-    """Get cached application settings"""
+    """Return settings freshly resolved from their sources."""
     return Settings()

--- a/application/backend/src/training/__init__.py
+++ b/application/backend/src/training/__init__.py
@@ -9,9 +9,10 @@ the full contract.
 """
 
 from .device import resolve_accelerator, resolve_devices, resolve_strategy
-from .job import TrainingJobSpec, run_training_job
+from .job import RunOptions, TrainingJobSpec, run_training_job
 
 __all__ = [
+    "RunOptions",
     "TrainingJobSpec",
     "resolve_accelerator",
     "resolve_devices",

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -31,11 +31,12 @@ from __future__ import annotations
 
 import gc
 import logging
+import os
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 if TYPE_CHECKING:
     from physicalai.policies.base import Policy
@@ -63,6 +64,13 @@ _WEIGHTS_ONLY_RESUME_POLICIES = frozenset({"pi0"})
 
 _COMPILED_EXPORT_RELOAD_POLICIES = frozenset({"act", "smolvla"})
 """Policies that cannot be exported while ``torch.compile``d, so are reloaded first."""
+
+
+class RunOptions(BaseModel):
+    """Runtime-only controls which are not part of the training payload."""
+
+    resume_from: Path | str | None = None
+    hf_token: SecretStr | None = None
 
 
 class TrainingJobSpec(BaseModel):
@@ -103,6 +111,7 @@ class TrainingJobSpec(BaseModel):
         ge=0,
         description="Zero-based index of the accelerator to train on. None lets Lightning pick one.",
     )
+    run_options: RunOptions = Field(default_factory=RunOptions)
 
 
 def build_policy(spec: TrainingJobSpec, *, resume_from: Path | str | None = None) -> Policy:
@@ -138,7 +147,6 @@ def run_training_job(
     cache_dir: Path | str,
     report: ReportFn,
     should_stop: StopFn,
-    resume_from: Path | str | None = None,
 ) -> None:
     """Train one policy end to end: fit, checkpoint, and export.
 
@@ -173,8 +181,6 @@ def run_training_job(
             moved to ``output_dir`` on success.
         report: Telemetry sink, called with ``(progress, message, extra_info)``.
         should_stop: Cooperative cancellation probe.
-        resume_from: Checkpoint to continue training from, e.g. a previously
-            trained model's ``model.ckpt``. None trains from scratch.
     """
     from lightning.pytorch.callbacks import ModelCheckpoint
     from lightning.pytorch.loggers import CSVLogger
@@ -184,6 +190,8 @@ def run_training_job(
 
     from training.device import resolve_accelerator, resolve_devices, resolve_strategy
 
+    if spec.run_options.hf_token is not None:
+        os.environ["HF_TOKEN"] = spec.run_options.hf_token.get_secret_value()
     accelerator = resolve_accelerator(spec.device_type)
     output_dir, cache_dir = Path(output_dir), Path(cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -195,7 +203,7 @@ def run_training_job(
         num_workers=spec.num_workers,
         val_split=spec.val_split,
     )
-    policy = build_policy(spec, resume_from=resume_from)
+    policy = build_policy(spec, resume_from=spec.run_options.resume_from)
 
     trainer = Trainer(
         logger=CSVLogger(cache_dir.parent, name=cache_dir.stem),

--- a/application/backend/tests/api/test_user_settings_api.py
+++ b/application/backend/tests/api/test_user_settings_api.py
@@ -46,3 +46,14 @@ def test_patch_settings_clears_huggingface_token(monkeypatch, tmp_path: Path) ->
 
     assert response.status_code == 200
     assert get_settings().huggingface.hf_token is None
+
+
+def test_patch_empty_huggingface_token_clears_setting(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+    write_user_settings({"huggingface": {"hf_token": "super-secret"}})
+
+    with TestClient(app) as client:
+        response = client.patch("/api/settings", json={"huggingface": {"hf_token": ""}})
+
+    assert response.status_code == 200
+    assert get_settings().huggingface.hf_token is None

--- a/application/backend/tests/api/test_user_settings_api.py
+++ b/application/backend/tests/api/test_user_settings_api.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the user-configurable settings API."""
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from main import app
+from settings import get_settings, write_user_settings
+
+
+def test_get_settings_masks_huggingface_token(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+    write_user_settings({"huggingface": {"hf_token": "super-secret"}})
+
+    with TestClient(app) as client:
+        response = client.get("/api/settings")
+
+    assert response.status_code == 200
+    assert "super-secret" not in response.text
+    assert response.json()["huggingface"]["hf_token"] is not None
+
+
+def test_patch_settings_preserves_omitted_fields(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+    write_user_settings({"huggingface": {"hf_token": "super-secret"}})
+
+    with TestClient(app) as client:
+        response = client.patch("/api/settings", json={"trainer": {"request_timeout_s": 45.0}})
+
+    assert response.status_code == 200
+    assert response.json()["trainer"]["request_timeout_s"] == 45.0
+    assert "super-secret" not in response.text
+    assert get_settings().huggingface.hf_token is not None
+    assert get_settings().huggingface.hf_token.get_secret_value() == "super-secret"
+
+
+def test_patch_settings_clears_huggingface_token(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+    write_user_settings({"huggingface": {"hf_token": "super-secret"}})
+
+    with TestClient(app) as client:
+        response = client.patch("/api/settings", json={"huggingface": {"hf_token": None}})
+
+    assert response.status_code == 200
+    assert get_settings().huggingface.hf_token is None

--- a/application/backend/tests/cli/test_serve.py
+++ b/application/backend/tests/cli/test_serve.py
@@ -9,17 +9,14 @@ serve_module = importlib.import_module("cli.serve")
 
 
 @pytest.fixture(autouse=True)
-def _clear_settings_cache() -> Iterator[None]:
-    settings_module = importlib.import_module("settings")
+def _clear_packaged_runtime_environment() -> Iterator[None]:
     os.environ.pop("ALEMBIC_CONFIG_PATH", None)
     os.environ.pop("ALEMBIC_SCRIPT_LOCATION", None)
     os.environ.pop("STATIC_FILES_DIR", None)
-    settings_module.get_settings.cache_clear()
     yield
     os.environ.pop("ALEMBIC_CONFIG_PATH", None)
     os.environ.pop("ALEMBIC_SCRIPT_LOCATION", None)
     os.environ.pop("STATIC_FILES_DIR", None)
-    settings_module.get_settings.cache_clear()
 
 
 def test_sync_missing_robot_assets_skips_when_available(monkeypatch) -> None:
@@ -66,9 +63,8 @@ def test_sync_missing_robot_assets_exits_when_sync_fails(monkeypatch) -> None:
         serve_module._sync_missing_robot_assets()
 
 
-def test_configure_packaged_runtime_refreshes_cached_settings(monkeypatch) -> None:
+def test_configure_packaged_runtime_updates_settings(monkeypatch) -> None:
     settings_module = importlib.import_module("settings")
-    settings_module.get_settings.cache_clear()
 
     stale_settings = settings_module.get_settings()
     assert stale_settings.alembic_script_location == "src/alembic"

--- a/application/backend/tests/services/test_local_training_backend.py
+++ b/application/backend/tests/services/test_local_training_backend.py
@@ -174,6 +174,26 @@ class TestLocalTrainingBackend:
         assert token.get_secret_value() == "hf-secret"
 
     @pytest.mark.anyio
+    @pytest.mark.parametrize("configured_token", [None, SecretStr("")])
+    async def test_train_falls_back_to_huggingface_token_environment_variable(
+        self, tmp_path, monkeypatch, configured_token
+    ):
+        context = _context(tmp_path, _payload())
+        settings = MagicMock()
+        settings.huggingface.hf_token = configured_token
+        monkeypatch.setenv("HF_TOKEN", "hf-legacy")
+
+        with (
+            patch("training.run_training_job") as mock_run,
+            patch(f"{LOCAL}.get_settings", return_value=settings),
+        ):
+            await LocalTrainingBackend().train(context)
+
+        token = mock_run.call_args.args[0].run_options.hf_token
+        assert token is not None
+        assert token.get_secret_value() == "hf-legacy"
+
+    @pytest.mark.anyio
     async def test_train_without_a_snapshot_is_rejected(self, tmp_path):
         context = _context(tmp_path, _payload())
         context.snapshot = None

--- a/application/backend/tests/services/test_local_training_backend.py
+++ b/application/backend/tests/services/test_local_training_backend.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from pydantic import SecretStr
 
 from schemas.dataset import Snapshot
 from schemas.job import _DEFAULT_MAX_EPOCHS, TrainingDevice, TrainingPrecision, TrainJobPayload
@@ -138,11 +139,11 @@ class TestLocalTrainingBackend:
 
         mock_run.assert_called_once()
         spec, kwargs = mock_run.call_args.args[0], mock_run.call_args.kwargs
-        assert spec == build_spec(context)
+        assert spec.model_dump(exclude={"run_options"}) == build_spec(context).model_dump(exclude={"run_options"})
         assert kwargs["dataset_root"] == context.snapshot.path
         assert kwargs["output_dir"] == context.output_dir
         assert kwargs["cache_dir"] == context.cache_dir
-        assert kwargs["resume_from"] is None
+        assert spec.run_options.resume_from is None
 
     @pytest.mark.anyio
     async def test_train_resumes_from_the_base_models_checkpoint(self, tmp_path):
@@ -154,7 +155,23 @@ class TestLocalTrainingBackend:
         with patch("training.run_training_job") as mock_run:
             await LocalTrainingBackend().train(context)
 
-        assert mock_run.call_args.kwargs["resume_from"] == base_dir / CHECKPOINT_NAME
+        assert mock_run.call_args.args[0].run_options.resume_from == base_dir / CHECKPOINT_NAME
+
+    @pytest.mark.anyio
+    async def test_train_passes_the_persisted_huggingface_token(self, tmp_path):
+        context = _context(tmp_path, _payload())
+        settings = MagicMock()
+        settings.huggingface.hf_token = SecretStr("hf-secret")
+
+        with (
+            patch("training.run_training_job") as mock_run,
+            patch(f"{LOCAL}.get_settings", return_value=settings),
+        ):
+            await LocalTrainingBackend().train(context)
+
+        token = mock_run.call_args.args[0].run_options.hf_token
+        assert token is not None
+        assert token.get_secret_value() == "hf-secret"
 
     @pytest.mark.anyio
     async def test_train_without_a_snapshot_is_rejected(self, tmp_path):

--- a/application/backend/tests/services/test_remote_training_backend.py
+++ b/application/backend/tests/services/test_remote_training_backend.py
@@ -202,10 +202,10 @@ class _FakeClient:
 def _settings() -> MagicMock:
     settings = MagicMock()
     settings.trainer_url = "https://trainer.test"
-    settings.trainer_request_timeout_s = 5.0
-    settings.trainer_download_read_timeout_s = 120.0
-    settings.trainer_stream_reconnect_max_s = 900.0
-    settings.trainer_stream_reconnect_backoff_max_s = 30.0
+    settings.trainer.request_timeout_s = 5.0
+    settings.trainer.download_read_timeout_s = 120.0
+    settings.trainer.stream_reconnect_max_s = 900.0
+    settings.trainer.stream_reconnect_backoff_max_s = 30.0
     settings.data_import_max_uncompressed_bytes = 10 * 1024 * 1024
     settings.data_import_min_free_bytes = 0
     return settings
@@ -474,8 +474,8 @@ class TestRemoteTrainingBackend:
         """Persistent unreachability past the reconnect budget aborts the job."""
         settings = _settings()
         # Zero budget: the first failed reconnect+poll cycle exhausts it.
-        settings.trainer_stream_reconnect_max_s = 0.0
-        settings.trainer_stream_reconnect_backoff_max_s = 0.0
+        settings.trainer.stream_reconnect_max_s = 0.0
+        settings.trainer.stream_reconnect_backoff_max_s = 0.0
         context = _context(tmp_path)
         controller = _Controller(states=[])
         controller.raise_connection_error = True

--- a/application/backend/tests/services/test_remote_training_backend.py
+++ b/application/backend/tests/services/test_remote_training_backend.py
@@ -316,6 +316,12 @@ class TestRemoteTrainingBackend:
         assert max(reported) == 100
 
     @pytest.mark.anyio
+    async def test_submit_excludes_local_run_options_from_trainer_payload(self, tmp_path):
+        body = await _submitted_body(_settings(), _context(tmp_path))
+
+        assert "run_options" not in body["spec"]
+
+    @pytest.mark.anyio
     async def test_completion_deletes_remote_job_artifacts(self, tmp_path):
         """After a successful download, the trainer's copy of the job is cleaned up."""
         settings = _settings()
@@ -655,7 +661,7 @@ class TestHttpDatasetTransfer:
 
         body = await _submitted_body(settings, context)
 
-        assert body["spec"] == build_spec(context).model_dump(mode="json") | {
+        assert body["spec"] == build_spec(context).model_dump(mode="json", exclude={"run_options"}) | {
             "device_type": None,
             "device_index": None,
         }

--- a/application/backend/tests/services/test_training_backends.py
+++ b/application/backend/tests/services/test_training_backends.py
@@ -20,7 +20,7 @@ from services.training_service import TrainingTrackingDispatcher
 
 def _settings() -> MagicMock:
     settings = MagicMock()
-    settings.trainer_request_timeout_s = 5.0
+    settings.trainer.request_timeout_s = 5.0
     return settings
 
 

--- a/application/backend/tests/services/test_training_log_format.py
+++ b/application/backend/tests/services/test_training_log_format.py
@@ -20,7 +20,9 @@ REMOTE = "services.training_backends.remote"
 
 
 def _backend() -> RemoteTrainingBackend:
-    with patch(f"{REMOTE}.get_settings", return_value=MagicMock(trainer_request_timeout_s=5.0)):
+    settings = MagicMock()
+    settings.trainer.request_timeout_s = 5.0
+    with patch(f"{REMOTE}.get_settings", return_value=settings):
         return RemoteTrainingBackend("https://trainer.test", trainer_name="trainer")
 
 

--- a/application/backend/tests/test_settings.py
+++ b/application/backend/tests/test_settings.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import settings as settings_module
-from settings import Settings, get_default_storage_dir
+from settings import Settings, get_default_storage_dir, merge_user_settings
 
 
 def test_default_storage_dir_uses_xdg_data_home(monkeypatch, tmp_path: Path) -> None:
@@ -42,3 +42,25 @@ def test_data_dir_is_storage_backed_even_with_data_dir_env(monkeypatch, tmp_path
     settings = Settings(STORAGE_DIR="~/custom-storage")
 
     assert settings.data_dir == tmp_path / "custom-storage" / "data"
+
+
+def test_trainer_settings_are_loaded_from_json(monkeypatch, tmp_path: Path) -> None:
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setenv("SETTINGS_FILE", str(settings_file))
+
+    merge_user_settings({"trainer": {"request_timeout_s": 5.0}})
+
+    settings = Settings()
+    assert settings.trainer.request_timeout_s == 5.0
+    assert settings.trainer.download_read_timeout_s == 120.0
+
+
+def test_trainer_settings_patch_keeps_omitted_values(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+
+    merge_user_settings({"trainer": {"request_timeout_s": 5.0}})
+    merge_user_settings({"trainer": {"download_read_timeout_s": 10.0}})
+
+    settings = Settings()
+    assert settings.trainer.request_timeout_s == 5.0
+    assert settings.trainer.download_read_timeout_s == 10.0

--- a/application/backend/tests/test_settings.py
+++ b/application/backend/tests/test_settings.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import settings as settings_module
-from settings import Settings, get_default_storage_dir, merge_user_settings
+from settings import Settings, get_default_storage_dir, load_user_settings_file, merge_user_settings
 
 
 def test_default_storage_dir_uses_xdg_data_home(monkeypatch, tmp_path: Path) -> None:
@@ -64,3 +64,14 @@ def test_trainer_settings_patch_keeps_omitted_values(monkeypatch, tmp_path: Path
     settings = Settings()
     assert settings.trainer.request_timeout_s == 5.0
     assert settings.trainer.download_read_timeout_s == 10.0
+
+
+def test_huggingface_token_is_loaded_from_json(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+
+    merge_user_settings({"huggingface": {"hf_token": "hf_example"}})
+
+    settings = Settings()
+    assert settings.huggingface.hf_token is not None
+    assert settings.huggingface.hf_token.get_secret_value() == "hf_example"
+    assert load_user_settings_file() == {"huggingface": {"hf_token": "hf_example"}}

--- a/application/backend/tests/training/test_job.py
+++ b/application/backend/tests/training/test_job.py
@@ -13,15 +13,16 @@ is mocked out; it is not under test.
 from __future__ import annotations
 
 import gc
+import os
 import weakref
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from physicalai.export import ExportablePolicyMixin, ExportBackend
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
-from training import TrainingJobSpec
+from training import RunOptions, TrainingJobSpec
 from training.job import CHECKPOINT_NAME, EXPORTS_DIRNAME, PRETRAINED_BASE_CHECKPOINTS, build_policy, run_training_job
 
 JOB = "training.job"
@@ -183,6 +184,14 @@ def _run(
 
 
 class TestRunTrainingJob:
+    def test_run_options_export_huggingface_token(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        spec = TrainingJobSpec(policy="act", run_options=RunOptions(hf_token=SecretStr("hf-secret")))
+
+        _run(spec, tmp_path)
+
+        assert os.environ["HF_TOKEN"] == "hf-secret"
+
     def test_trainer_is_configured_from_the_spec(self, tmp_path: Path) -> None:
         spec = TrainingJobSpec(
             policy="act",

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
@@ -55,7 +55,20 @@ const mockProjectWithRemoteTrainer = () => {
         http.get('/api/system/devices/training', () =>
             HttpResponse.json({ mode: 'local', remote_available: true, devices: [] })
         ),
-        http.get('/api/remote-trainers', () => HttpResponse.json([remoteTrainer]))
+        http.get('/api/remote-trainers', () => HttpResponse.json([remoteTrainer])),
+        http.get('/api/settings', () =>
+            HttpResponse.json({
+                streaming: { vcodec: 'auto', encoder_queue_maxsize: 60 },
+                trainer: {
+                    request_timeout_s: 30,
+                    download_read_timeout_s: 120,
+                    stream_reconnect_max_s: 900,
+                    stream_reconnect_backoff_max_s: 30,
+                },
+                huggingface: { hf_token: null },
+                logger: { providers: ['csv'] },
+            })
+        )
     );
 };
 
@@ -122,5 +135,30 @@ describe('TrainModelDialog', () => {
 
         expect(await screen.findByRole('option', { name: /this machine \(local\)/i })).toBeInTheDocument();
         expect(screen.queryByRole('option', { name: remoteTrainer.name })).not.toBeInTheDocument();
+    });
+
+    it('warns when SmolVLA is selected without a Hugging Face token', async () => {
+        const user = userEvent.setup();
+        mockProjectWithRemoteTrainer();
+
+        renderDialog();
+
+        await user.click(await screen.findByLabelText('Select SmolVLA policy'));
+
+        expect(screen.getByText(/SmolVLA downloads pretrained assets from Hugging Face/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Pi0.5 requires a Hugging Face token/i)).not.toBeInTheDocument();
+    });
+
+    it('blocks Pi0.5 training without a Hugging Face token', async () => {
+        const user = userEvent.setup();
+        mockProjectWithRemoteTrainer();
+
+        renderDialog();
+        await user.click(await screen.findByRole('button', { name: /select…/i }));
+        await user.click(await screen.findByRole('option', { name: 'Test dataset' }));
+        await user.click(screen.getByLabelText('Select Pi0.5 policy'));
+
+        expect(screen.getByText(/Pi0.5 requires a Hugging Face token/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Train' })).toBeDisabled();
     });
 });

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
@@ -58,7 +58,6 @@ const mockProjectWithRemoteTrainer = () => {
         http.get('/api/remote-trainers', () => HttpResponse.json([remoteTrainer])),
         http.get('/api/settings', () =>
             HttpResponse.json({
-                streaming: { vcodec: 'auto', encoder_queue_maxsize: 60 },
                 trainer: {
                     request_timeout_s: 30,
                     download_read_timeout_s: 120,
@@ -66,7 +65,6 @@ const mockProjectWithRemoteTrainer = () => {
                     stream_reconnect_backoff_max_s: 30,
                 },
                 huggingface: { hf_token: null },
-                logger: { providers: ['csv'] },
             })
         )
     );

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.tsx
@@ -16,9 +16,11 @@ import {
     Picker,
     Text,
 } from '@geti-ui/ui';
+import { Link } from 'react-router';
 
 import { $api } from '../../../api/client';
 import { SchemaTrainJob as SchemaJob, SchemaModel } from '../../../api/openapi-spec';
+import { paths } from '../../../router';
 import { useProject } from '../../projects/use-project';
 import { useRemoteTrainerHealth } from '../../remote-trainers/use-remote-trainer-health';
 import { InlineAlert } from '../../robots/setup-wizard/shared/inline-alert';
@@ -48,6 +50,7 @@ type TrainingTargetOption = {
 export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: TrainModelDialogProps) => {
     const bestDevice = useBestTrainingDevice();
     const { data: remoteTrainers = [] } = $api.useQuery('get', '/api/remote-trainers');
+    const { data: settings } = $api.useQuery('get', '/api/settings');
     // Continuing an existing model needs its checkpoint, which only this machine
     // has: the trainer protocol can receive a dataset but not a base checkpoint.
     // So a resumed run offers local training only.
@@ -83,6 +86,9 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
         checkHealth: checkRemoteTrainerHealth,
     } = useRemoteTrainerHealth(isRemoteTarget ? (remoteTrainerId?.toString() ?? null) : null);
     const remoteUnavailable = isRemoteTarget && remoteTrainerHealth?.status === 'unreachable';
+    const hasHuggingFaceToken = settings?.huggingface.hf_token != null;
+    const smolVlaMissingToken = selectedPolicy === 'smolvla' && !hasHuggingFaceToken;
+    const pi05MissingToken = selectedPolicy === 'pi05' && !hasHuggingFaceToken;
     const bestRemoteDevice = useMemo(() => pickBestDevice(remoteTrainerHealth?.devices ?? []), [remoteTrainerHealth]);
     // The device actually driving this job: the local GPU when training locally,
     // or the remote trainer's reported GPU once its health check resolves. Auto
@@ -196,6 +202,28 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
                         isDisabled={baseModel !== undefined}
                         trainingDevice={activeDevice}
                     />
+                    {smolVlaMissingToken && (
+                        <InlineAlert variant='warning'>
+                            <Flex direction='column' gap='size-100'>
+                                <span>
+                                    SmolVLA downloads pretrained assets from Hugging Face. Configure a token in Settings
+                                    to avoid download failures.
+                                </span>
+                                <Link to={paths.settings.index.pattern}>Open Settings</Link>
+                            </Flex>
+                        </InlineAlert>
+                    )}
+                    {pi05MissingToken && (
+                        <InlineAlert variant='error'>
+                            <Flex direction='column' gap='size-100'>
+                                <span>
+                                    Pi0.5 requires a Hugging Face token to download its gated base model. Configure one
+                                    in Settings before training.
+                                </span>
+                                <Link to={paths.settings.index.pattern}>Open Settings</Link>
+                            </Flex>
+                        </InlineAlert>
+                    )}
 
                     <Disclosure
                         isQuiet
@@ -234,7 +262,13 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
                 <Button
                     variant='accent'
                     onPress={save}
-                    isDisabled={!selectedDataset || !selectedPolicy || remoteTrainerId === null || remoteUnavailable}
+                    isDisabled={
+                        !selectedDataset ||
+                        !selectedPolicy ||
+                        remoteTrainerId === null ||
+                        remoteUnavailable ||
+                        pi05MissingToken
+                    }
                 >
                     Train
                 </Button>

--- a/application/ui/src/features/settings/general/general-settings.module.css
+++ b/application/ui/src/features/settings/general/general-settings.module.css
@@ -1,0 +1,25 @@
+.section {
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: var(--spectrum-global-dimension-size-75);
+    margin-block: var(--spectrum-global-dimension-size-300);
+}
+
+.description {
+    display: block;
+    margin-top: var(--spectrum-global-dimension-size-50);
+    color: var(--spectrum-global-color-gray-700);
+}
+
+.fields {
+    margin-top: var(--spectrum-global-dimension-size-200);
+}
+
+.error {
+    display: block;
+    margin-top: var(--spectrum-global-dimension-size-100);
+    color: var(--spectrum-red-600);
+}
+
+.saved {
+    color: var(--spectrum-global-color-gray-700);
+}

--- a/application/ui/src/features/settings/general/general-settings.tsx
+++ b/application/ui/src/features/settings/general/general-settings.tsx
@@ -1,0 +1,18 @@
+import { Heading, Text, View } from '@geti-ui/ui';
+
+import { $api } from '../../../api/client';
+import { HuggingFaceSettingsForm } from './huggingface-settings-form';
+import { TrainerSettingsForm } from './trainer-settings-form';
+
+export const GeneralSettings = () => {
+    const { data: settings } = $api.useSuspenseQuery('get', '/api/settings');
+
+    return (
+        <View padding='size-400' height='100%' maxWidth='240ch' marginX='auto'>
+            <Heading level={1}>General</Heading>
+            <Text>Configure trainer and Hugging Face defaults.</Text>
+            <HuggingFaceSettingsForm huggingface={settings.huggingface} />
+            <TrainerSettingsForm trainer={settings.trainer} />
+        </View>
+    );
+};

--- a/application/ui/src/features/settings/general/huggingface-settings-form.tsx
+++ b/application/ui/src/features/settings/general/huggingface-settings-form.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+import { SchemaHuggingFaceSettings, SchemaSettingsUpdate } from '../../../api/openapi-spec';
+import { SecretChange, SecretField } from './secret-field';
+import { SettingsSection } from './settings-section';
+import { useSettingsPatch } from './use-settings-patch';
+
+type HuggingFaceSettingsFormProps = { huggingface: SchemaHuggingFaceSettings };
+
+export const HuggingFaceSettingsForm = ({ huggingface }: HuggingFaceSettingsFormProps) => {
+    const patchMutation = useSettingsPatch();
+    const [token, setToken] = useState<SecretChange>({ draft: '', remove: false });
+    const [saved, setSaved] = useState(false);
+    const dirty = token.draft !== '' || token.remove;
+
+    const save = () => {
+        const body: SchemaSettingsUpdate = {
+            huggingface: {
+                hf_token: token.remove ? null : token.draft === '' ? undefined : token.draft,
+            },
+        };
+        patchMutation.mutate(
+            { body },
+            {
+                onSuccess: () => {
+                    setToken({ draft: '', remove: false });
+                    setSaved(true);
+                },
+            }
+        );
+    };
+
+    return (
+        <SettingsSection
+            title='Hugging Face'
+            description='Token used to authenticate downloads of pretrained training assets.'
+            isDirty={dirty}
+            isPending={patchMutation.isPending}
+            saved={saved}
+            error={patchMutation.error}
+            onSave={save}
+        >
+            <SecretField label='Hugging Face token' isSet={huggingface.hf_token != null} onChange={setToken} />
+        </SettingsSection>
+    );
+};

--- a/application/ui/src/features/settings/general/huggingface-settings-form.tsx
+++ b/application/ui/src/features/settings/general/huggingface-settings-form.tsx
@@ -49,7 +49,7 @@ export const HuggingFaceSettingsForm = ({ huggingface }: HuggingFaceSettingsForm
                     <TextField
                         label='Hugging Face token'
                         value={'hf_**********************************'}
-                        isReadOnly
+                        isDisabled
                         width='100%'
                     />
                     <ActionButton
@@ -61,6 +61,14 @@ export const HuggingFaceSettingsForm = ({ huggingface }: HuggingFaceSettingsForm
                         <Icon>
                             <Close />
                         </Icon>
+                        <span
+                            style={{
+                                paddingLeft: 'var(--spectrum-global-dimension-size-100)',
+                                paddingRight: 'var(--spectrum-global-dimension-size-200)',
+                            }}
+                        >
+                            Clear
+                        </span>
                     </ActionButton>
                 </Flex>
             ) : (

--- a/application/ui/src/features/settings/general/huggingface-settings-form.tsx
+++ b/application/ui/src/features/settings/general/huggingface-settings-form.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
+import { ActionButton, Flex, Icon, TextField } from '@geti-ui/ui';
+import { Close } from '@geti-ui/ui/icons';
+
 import { SchemaHuggingFaceSettings, SchemaSettingsUpdate } from '../../../api/openapi-spec';
-import { SecretChange, SecretField } from './secret-field';
 import { SettingsSection } from './settings-section';
 import { useSettingsPatch } from './use-settings-patch';
 
@@ -9,38 +11,73 @@ type HuggingFaceSettingsFormProps = { huggingface: SchemaHuggingFaceSettings };
 
 export const HuggingFaceSettingsForm = ({ huggingface }: HuggingFaceSettingsFormProps) => {
     const patchMutation = useSettingsPatch();
-    const [token, setToken] = useState<SecretChange>({ draft: '', remove: false });
+    const [token, setToken] = useState('');
     const [saved, setSaved] = useState(false);
-    const dirty = token.draft !== '' || token.remove;
+    const isSet = huggingface.hf_token != null;
 
     const save = () => {
         const body: SchemaSettingsUpdate = {
-            huggingface: {
-                hf_token: token.remove ? null : token.draft === '' ? undefined : token.draft,
-            },
+            huggingface: { hf_token: token },
         };
         patchMutation.mutate(
             { body },
             {
                 onSuccess: () => {
-                    setToken({ draft: '', remove: false });
+                    setToken('');
                     setSaved(true);
                 },
             }
         );
     };
 
+    const clear = () => {
+        patchMutation.mutate({ body: { huggingface: { hf_token: null } } }, { onSuccess: () => setSaved(true) });
+    };
+
     return (
         <SettingsSection
             title='Hugging Face'
             description='Token used to authenticate downloads of pretrained training assets.'
-            isDirty={dirty}
+            isDirty={!isSet && token !== ''}
             isPending={patchMutation.isPending}
             saved={saved}
             error={patchMutation.error}
             onSave={save}
         >
-            <SecretField label='Hugging Face token' isSet={huggingface.hf_token != null} onChange={setToken} />
+            {isSet ? (
+                <Flex alignItems='end' gap='size-100'>
+                    <TextField
+                        label='Hugging Face token'
+                        value={'hf_**********************************'}
+                        isReadOnly
+                        width='100%'
+                    />
+                    <ActionButton
+                        aria-label='Clear Hugging Face token'
+                        isQuiet
+                        onPress={clear}
+                        isDisabled={patchMutation.isPending}
+                    >
+                        <Icon>
+                            <Close />
+                        </Icon>
+                    </ActionButton>
+                </Flex>
+            ) : (
+                <TextField
+                    label='Hugging Face token'
+                    type='password'
+                    value={token}
+                    onChange={setToken}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                            event.preventDefault();
+                            save();
+                        }
+                    }}
+                    width='100%'
+                />
+            )}
         </SettingsSection>
     );
 };

--- a/application/ui/src/features/settings/general/secret-field.tsx
+++ b/application/ui/src/features/settings/general/secret-field.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+import { Flex, Switch, TextField } from '@geti-ui/ui';
+
+export type SecretChange = { draft: string; remove: boolean };
+
+type SecretFieldProps = {
+    label: string;
+    isSet: boolean;
+    onChange: (change: SecretChange) => void;
+};
+
+export const SecretField = ({ label, isSet, onChange }: SecretFieldProps) => {
+    const [draft, setDraft] = useState('');
+    const [remove, setRemove] = useState(false);
+
+    const update = (nextDraft: string, nextRemove: boolean) => {
+        setDraft(nextDraft);
+        setRemove(nextRemove);
+        onChange({ draft: nextDraft, remove: nextRemove });
+    };
+
+    return (
+        <Flex direction='column' gap='size-100'>
+            <TextField
+                type='password'
+                label={label}
+                value={draft}
+                onChange={(value) => update(value, remove)}
+                placeholder={isSet ? 'Leave empty to keep the configured value' : undefined}
+                width='100%'
+            />
+            {isSet && (
+                <Switch isSelected={remove} onChange={(selected) => update(draft, selected)}>
+                    Remove the configured value
+                </Switch>
+            )}
+        </Flex>
+    );
+};

--- a/application/ui/src/features/settings/general/settings-section.tsx
+++ b/application/ui/src/features/settings/general/settings-section.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from 'react';
+
+import { Button, Flex, Heading, Text, View } from '@geti-ui/ui';
+
+import { getApiErrorMessage } from '../../../api/errors';
+
+import classes from './general-settings.module.css';
+
+type SettingsSectionProps = {
+    title: string;
+    description: string;
+    isDirty: boolean;
+    isPending: boolean;
+    saved: boolean;
+    error?: unknown;
+    onSave: () => void;
+    children: ReactNode;
+};
+
+export const SettingsSection = ({
+    title,
+    description,
+    isDirty,
+    isPending,
+    saved,
+    error,
+    onSave,
+    children,
+}: SettingsSectionProps) => {
+    const errorMessage = error
+        ? (getApiErrorMessage(error) ?? 'The settings could not be saved. Try again.')
+        : undefined;
+
+    return (
+        <View UNSAFE_className={classes.section} padding='size-300'>
+            <Heading level={3}>{title}</Heading>
+            <Text UNSAFE_className={classes.description}>{description}</Text>
+            <Flex direction='column' gap='size-200' UNSAFE_className={classes.fields}>
+                {children}
+            </Flex>
+            {errorMessage !== undefined && <Text UNSAFE_className={classes.error}>{errorMessage}</Text>}
+            <Flex alignItems='center' gap='size-200' marginTop='size-200'>
+                <Button variant='accent' onPress={onSave} isDisabled={!isDirty || isPending} isPending={isPending}>
+                    Save
+                </Button>
+                {saved && !isDirty && <Text UNSAFE_className={classes.saved}>Saved</Text>}
+            </Flex>
+        </View>
+    );
+};

--- a/application/ui/src/features/settings/general/trainer-settings-form.tsx
+++ b/application/ui/src/features/settings/general/trainer-settings-form.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+
+import { NumberField } from '@geti-ui/ui';
+
+import { SchemaSettingsUpdate, SchemaTrainerClientSettings } from '../../../api/openapi-spec';
+import { SettingsSection } from './settings-section';
+import { useSettingsPatch } from './use-settings-patch';
+
+type TrainerSettingsFormProps = { trainer: SchemaTrainerClientSettings };
+
+export const TrainerSettingsForm = ({ trainer }: TrainerSettingsFormProps) => {
+    const patchMutation = useSettingsPatch();
+    const [requestTimeoutS, setRequestTimeoutS] = useState(trainer.request_timeout_s);
+    const [downloadReadTimeoutS, setDownloadReadTimeoutS] = useState(trainer.download_read_timeout_s);
+    const [streamReconnectMaxS, setStreamReconnectMaxS] = useState(trainer.stream_reconnect_max_s);
+    const [streamReconnectBackoffMaxS, setStreamReconnectBackoffMaxS] = useState(
+        trainer.stream_reconnect_backoff_max_s
+    );
+    const [dirty, setDirty] = useState(false);
+    const [saved, setSaved] = useState(false);
+
+    const update = (setValue: (value: number) => void, value: number) => {
+        if (!Number.isNaN(value)) {
+            setValue(value);
+            setDirty(true);
+            setSaved(false);
+        }
+    };
+
+    const save = () => {
+        const body: SchemaSettingsUpdate = {
+            trainer: {
+                request_timeout_s: requestTimeoutS,
+                download_read_timeout_s: downloadReadTimeoutS,
+                stream_reconnect_max_s: streamReconnectMaxS,
+                stream_reconnect_backoff_max_s: streamReconnectBackoffMaxS,
+            },
+        };
+        patchMutation.mutate(
+            { body },
+            {
+                onSuccess: () => {
+                    setDirty(false);
+                    setSaved(true);
+                },
+            }
+        );
+    };
+
+    return (
+        <SettingsSection
+            title='Trainer'
+            description='Client timeouts for talking to a remote trainer service.'
+            isDirty={dirty}
+            isPending={patchMutation.isPending}
+            saved={saved}
+            error={patchMutation.error}
+            onSave={save}
+        >
+            <NumberField
+                label='Request timeout (s)'
+                value={requestTimeoutS}
+                onChange={(value) => update(setRequestTimeoutS, value)}
+                width='100%'
+            />
+            <NumberField
+                label='Artifact download read timeout (s)'
+                value={downloadReadTimeoutS}
+                onChange={(value) => update(setDownloadReadTimeoutS, value)}
+                width='100%'
+            />
+            <NumberField
+                label='Stream reconnect budget (s)'
+                value={streamReconnectMaxS}
+                onChange={(value) => update(setStreamReconnectMaxS, value)}
+                width='100%'
+            />
+            <NumberField
+                label='Stream reconnect backoff max (s)'
+                value={streamReconnectBackoffMaxS}
+                onChange={(value) => update(setStreamReconnectBackoffMaxS, value)}
+                width='100%'
+            />
+        </SettingsSection>
+    );
+};

--- a/application/ui/src/features/settings/general/use-settings-patch.ts
+++ b/application/ui/src/features/settings/general/use-settings-patch.ts
@@ -1,0 +1,6 @@
+import { $api } from '../../../api/client';
+
+export const useSettingsPatch = () =>
+    $api.useMutation('patch', '/api/settings', {
+        meta: { invalidates: [['get', '/api/settings']] },
+    });

--- a/application/ui/src/features/settings/settings.tsx
+++ b/application/ui/src/features/settings/settings.tsx
@@ -1,10 +1,11 @@
-import { ReactNode } from 'react';
+import { ReactNode, Suspense } from 'react';
 
-import { Item, TabList, TabPanels, Tabs } from '@geti-ui/ui';
+import { Item, Loading, TabList, TabPanels, Tabs } from '@geti-ui/ui';
 import { useMatch } from 'react-router';
 
 import { paths } from '../../router';
 import { Compute } from './compute';
+import { GeneralSettings } from './general/general-settings';
 
 type TabItem = {
     key: string;
@@ -16,19 +17,23 @@ type TabItem = {
 const useActiveTab = () => {
     const match = useMatch(paths.settings.index.path(':activeTab').pattern);
 
-    return match?.params?.activeTab ?? 'compute';
+    return match?.params?.activeTab ?? 'general';
 };
 
 export const SettingsView = () => {
     const activeTab = useActiveTab();
 
     const tabs: TabItem[] = [
-        /*{
+        {
             key: 'general',
             name: 'General',
             href: paths.settings.index.pattern,
-            content: <></>,
-        },*/
+            content: (
+                <Suspense fallback={<Loading />}>
+                    <GeneralSettings />
+                </Suspense>
+            ),
+        },
         {
             key: 'compute',
             name: 'Compute',


### PR DESCRIPTION
Add a new "General settings" page where users can configure remote trainer options and add their Hugging Face token.
The train model dialog now warns when selecting SmolVLA without a Hugging Face token and disables the form when selecting Pi05 when the user hasn't configured a Hugging Face token yet.

> [!IMPORTANT]
> Settings are stored in `~/.local/share/physicalai/settings.json`, and are not encrypted. The **Hugging Face Token is stored in plaintext**. Before we told users to add their token as an environment variable where most users add it in plain text to `.env`.

| **Settings**                                                                                                                                                  | **SmolVLA**                                                                                                                                                   | **Pi05**                                                                                                                                                      |
|---------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1920" height="1200" alt="screenshot-2026-08-21_08-41-15" src="https://github.com/user-attachments/assets/eda50c77-ca59-4ab3-bf8e-5f455cc10b79" /> | <img width="1920" height="1200" alt="screenshot-2026-08-21_08-41-31" src="https://github.com/user-attachments/assets/25e58ce4-1662-41f6-968b-d0587097f3da" /> | <img width="1920" height="1200" alt="screenshot-2026-08-21_08-41-38" src="https://github.com/user-attachments/assets/e921d5fc-0162-411e-a49f-4fb8ef5a440c" /> |
|                                                                                                                                                               |                                                                                                                                                               |                                                                                                                                                               |
