### PR TITLE
feat: extend health endpoint and add system restart

### DIFF
--- a/application/backend/src/api/dependencies.py
+++ b/application/backend/src/api/dependencies.py
@@ -26,6 +26,7 @@ from services import (
 from services.dataset_import.service import DatasetImportService
 from services.environment_service import EnvironmentService
 from services.event_processor import EventProcessor
+from services.health_service import HealthService
 from services.job_service import JobService
 from services.log_service import LogService
 from services.robot_catalog_service import RobotCatalogService
@@ -59,6 +60,17 @@ def get_system_service() -> SystemService:
 
 
 SystemServiceDep = Annotated[SystemService, Depends(get_system_service)]
+
+
+def get_health_service(request: HTTPConnection) -> HealthService:
+    """Provide the process-local health service initialized during application startup."""
+    health_service = getattr(request.app.state, "health_service", None)
+    if health_service is None:
+        raise RuntimeError("Health service not initialized")
+    return cast("HealthService", health_service)
+
+
+HealthServiceDep = Annotated[HealthService, Depends(get_health_service)]
 
 
 def get_project_service(session: AsyncSessionDep) -> ProjectService:

--- a/application/backend/src/api/system.py
+++ b/application/backend/src/api/system.py
@@ -5,49 +5,20 @@
 
 import os
 import signal
-import sys
-import threading
-import time
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
-from loguru import logger
+from fastapi import APIRouter, BackgroundTasks, Depends, status
 
-from api.dependencies import get_system_service
+from api.dependencies import HealthServiceDep, get_system_service
 from schemas.hardware import InferenceDeviceInfo, TrainingDevices
 from services.system_service import SystemService
 
 system_router = APIRouter(prefix="/api/system", tags=["System"])
 
 
-def _restart_argv_candidates() -> list[list[str]]:
-    """Build candidate argv lists for in-place process restart."""
-    candidates: list[list[str]] = []
-
-    orig_argv = list(getattr(sys, "orig_argv", []) or [])
-    if orig_argv and orig_argv[0]:
-        candidates.append(orig_argv)
-
-    python_argv = [sys.executable, *sys.argv]
-    if python_argv[0] and python_argv not in candidates:
-        candidates.append(python_argv)
-
-    return candidates
-
-
-def _restart_process() -> bool:
-    """Try to replace the current process image in-place."""
-    for argv in _restart_argv_candidates():
-        executable = argv[0]
-        try:
-            if os.path.sep in executable:
-                os.execv(executable, argv)
-            else:
-                os.execvp(executable, argv)
-            return True
-        except OSError:
-            logger.exception("Restart exec failed for argv={}", argv)
-    return False
+def _stop_process() -> None:
+    """Request graceful shutdown so the process supervisor can restart the server."""
+    os.kill(os.getpid(), signal.SIGTERM)
 
 
 @system_router.get("/devices/inference")
@@ -72,19 +43,12 @@ async def get_training_devices(
 
 
 @system_router.post("/restart", status_code=status.HTTP_202_ACCEPTED)
-async def restart_server() -> dict[str, str]:
+async def restart_server(background_tasks: BackgroundTasks, health_service: HealthServiceDep) -> dict[str, str]:
     """Gracefully restart the server to activate plugin changes.
 
-    Schedules a delayed self-reexec so the response is flushed first. If reexec
-    fails, falls back to SIGTERM so an external supervisor can restart it.
+    The shutdown signal is sent after the response is flushed, allowing the
+    FastAPI lifespan to stop workers before the process supervisor restarts it.
     """
-
-    def _schedule_restart() -> None:
-        time.sleep(1.0)
-        if _restart_process():
-            return
-        logger.warning("Self-restart failed; falling back to SIGTERM")
-        os.kill(os.getpid(), signal.SIGTERM)
-
-    threading.Thread(target=_schedule_restart, daemon=True).start()
+    health_service.mark_plugin_restart_required()
+    background_tasks.add_task(_stop_process)
     return {"status": "restarting"}

--- a/application/backend/src/api/system.py
+++ b/application/backend/src/api/system.py
@@ -3,15 +3,51 @@
 
 """System information endpoints for hardware discovery."""
 
+import os
+import signal
+import sys
+import threading
+import time
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
+from loguru import logger
 
 from api.dependencies import get_system_service
 from schemas.hardware import InferenceDeviceInfo, TrainingDevices
 from services.system_service import SystemService
 
 system_router = APIRouter(prefix="/api/system", tags=["System"])
+
+
+def _restart_argv_candidates() -> list[list[str]]:
+    """Build candidate argv lists for in-place process restart."""
+    candidates: list[list[str]] = []
+
+    orig_argv = list(getattr(sys, "orig_argv", []) or [])
+    if orig_argv and orig_argv[0]:
+        candidates.append(orig_argv)
+
+    python_argv = [sys.executable, *sys.argv]
+    if python_argv[0] and python_argv not in candidates:
+        candidates.append(python_argv)
+
+    return candidates
+
+
+def _restart_process() -> bool:
+    """Try to replace the current process image in-place."""
+    for argv in _restart_argv_candidates():
+        executable = argv[0]
+        try:
+            if os.path.sep in executable:
+                os.execv(executable, argv)
+            else:
+                os.execvp(executable, argv)
+            return True
+        except OSError:
+            logger.exception("Restart exec failed for argv={}", argv)
+    return False
 
 
 @system_router.get("/devices/inference")
@@ -33,3 +69,22 @@ async def get_training_devices(
     are returned so the UI can block training instead of falling back to local CPU.
     """
     return await system_service.get_available_training_devices()
+
+
+@system_router.post("/restart", status_code=status.HTTP_202_ACCEPTED)
+async def restart_server() -> dict[str, str]:
+    """Gracefully restart the server to activate plugin changes.
+
+    Schedules a delayed self-reexec so the response is flushed first. If reexec
+    fails, falls back to SIGTERM so an external supervisor can restart it.
+    """
+
+    def _schedule_restart() -> None:
+        time.sleep(1.0)
+        if _restart_process():
+            return
+        logger.warning("Self-restart failed; falling back to SIGTERM")
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    threading.Thread(target=_schedule_restart, daemon=True).start()
+    return {"status": "restarting"}

--- a/application/backend/src/core/lifecycle.py
+++ b/application/backend/src/core/lifecycle.py
@@ -6,6 +6,7 @@ from loguru import logger
 
 from core.logging import setup_logging, setup_uvicorn_logging
 from services.event_processor import EventProcessor
+from services.health_service import HealthService
 from settings import get_settings
 from utils.multiprocessing import ensure_spawn_start_method
 from utils.serial_robot_tools import RobotConnectionManager
@@ -23,6 +24,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     settings = get_settings()
     app.state.settings = settings
+    app.state.health_service = HealthService()
 
     # Camera fingerprints locked by an active recording/teleop session.
     # Mutated by the robot_control WS handler; checked by camera CRUD and

--- a/application/backend/src/core/lifecycle.py
+++ b/application/backend/src/core/lifecycle.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -13,6 +15,34 @@ from utils.serial_robot_tools import RobotConnectionManager
 from workers.model_worker_registry import ModelWorkerRegistry
 
 from .scheduler import Scheduler
+
+
+def _restart_argv_candidates() -> list[list[str]]:
+    """Build candidate argv lists for re-executing the current server process."""
+    candidates: list[list[str]] = []
+
+    orig_argv = list(getattr(sys, "orig_argv", []) or [])
+    if orig_argv and orig_argv[0]:
+        candidates.append(orig_argv)
+
+    python_argv = [sys.executable, *sys.argv]
+    if python_argv[0] and python_argv not in candidates:
+        candidates.append(python_argv)
+
+    return candidates
+
+
+def _restart_process() -> None:
+    """Replace this process image after graceful application shutdown."""
+    for argv in _restart_argv_candidates():
+        executable = argv[0]
+        try:
+            if os.path.sep in executable:
+                os.execv(executable, argv)  # noqa: S606
+            else:
+                os.execvp(executable, argv)  # noqa: S606
+        except OSError:
+            logger.exception("Restart exec failed for argv={}", argv)
 
 
 @asynccontextmanager
@@ -61,3 +91,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     app_scheduler.shutdown()
     app.state.event_processor.shutdown()
     logger.info("Application shutdown completed")
+
+    if app.state.health_service.plugin_restart_required:
+        _restart_process()

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -12,6 +12,7 @@ from starlette.middleware.base import RequestResponseEndpoint
 from api.camera import router as camera_router
 from api.dataset import router as dataset_router
 from api.dataset_import import router as imports_router
+from api.dependencies import HealthServiceDep
 from api.environments import router as project_environments_router
 from api.hardware import router as hardware_router
 from api.job import router as job_router
@@ -71,10 +72,13 @@ async def _upload_size_guard(request: Request, call_next: RequestResponseEndpoin
 
 
 @app.get("/api/health")
-async def health_check() -> dict:
+async def health_check(response: Response, health_service: HealthServiceDep) -> dict[str, str | bool]:
     """Health check endpoint."""
+    response.headers["Cache-Control"] = "no-store"
     return {
         "status": "healthy",
+        "instance_id": health_service.instance_id,
+        "restart_required": health_service.plugin_restart_required,
     }
 
 

--- a/application/backend/src/main.py
+++ b/application/backend/src/main.py
@@ -75,6 +75,7 @@ async def _upload_size_guard(request: Request, call_next: RequestResponseEndpoin
 async def health_check(response: Response, health_service: HealthServiceDep) -> dict[str, str | bool]:
     """Health check endpoint."""
     response.headers["Cache-Control"] = "no-store"
+    health_service.refresh_plugin_restart_required()
     return {
         "status": "healthy",
         "instance_id": health_service.instance_id,

--- a/application/backend/src/services/health_service.py
+++ b/application/backend/src/services/health_service.py
@@ -1,7 +1,20 @@
 """Process-local backend health and restart state."""
 
 from dataclasses import dataclass, field
+from importlib.metadata import entry_points
 from uuid import uuid4
+
+CATALOG_PLUGIN_ENTRYPOINT_GROUP = "physicalai.studio.catalog_plugins"
+
+
+def _installed_catalog_plugins() -> set[tuple[str, str, str]]:
+    """Return the installed catalog plugin entry points and distribution versions."""
+    plugins: set[tuple[str, str, str]] = set()
+    for plugin in entry_points(group=CATALOG_PLUGIN_ENTRYPOINT_GROUP):
+        distribution = plugin.dist
+        distribution_version = distribution.version if distribution is not None else "unknown"
+        plugins.add((plugin.name, plugin.value, distribution_version))
+    return plugins
 
 
 @dataclass
@@ -10,6 +23,12 @@ class HealthService:
 
     instance_id: str = field(default_factory=lambda: str(uuid4()))
     plugin_restart_required: bool = False
+    _installed_catalog_plugins: set[tuple[str, str, str]] = field(default_factory=_installed_catalog_plugins)
+
+    def refresh_plugin_restart_required(self) -> None:
+        """Record catalog plugin installation or version changes after startup."""
+        if _installed_catalog_plugins() != self._installed_catalog_plugins:
+            self.mark_plugin_restart_required()
 
     def mark_plugin_restart_required(self) -> None:
         """Record that installed plugin changes require process replacement."""

--- a/application/backend/src/services/health_service.py
+++ b/application/backend/src/services/health_service.py
@@ -1,0 +1,16 @@
+"""Process-local backend health and restart state."""
+
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+
+@dataclass
+class HealthService:
+    """Expose the current server instance and pending plugin restart state."""
+
+    instance_id: str = field(default_factory=lambda: str(uuid4()))
+    plugin_restart_required: bool = False
+
+    def mark_plugin_restart_required(self) -> None:
+        """Record that installed plugin changes require process replacement."""
+        self.plugin_restart_required = True

--- a/application/backend/tests/api/test_system.py
+++ b/application/backend/tests/api/test_system.py
@@ -1,0 +1,16 @@
+from fastapi import BackgroundTasks
+
+from api.system import _stop_process, restart_server
+from services.health_service import HealthService
+
+
+async def test_restart_server_marks_restart_required_and_schedules_shutdown() -> None:
+    background_tasks = BackgroundTasks()
+    health_service = HealthService()
+
+    response = await restart_server(background_tasks, health_service)
+
+    assert response == {"status": "restarting"}
+    assert health_service.plugin_restart_required is True
+    assert len(background_tasks.tasks) == 1
+    assert background_tasks.tasks[0].func is _stop_process

--- a/application/backend/tests/services/test_health_service.py
+++ b/application/backend/tests/services/test_health_service.py
@@ -1,0 +1,23 @@
+from services import health_service
+from services.health_service import HealthService
+
+
+def test_health_service_marks_restart_when_catalog_plugins_change(monkeypatch) -> None:
+    initial_plugins = {("plugin", "package:register", "1.0.0")}
+    updated_plugins = {("plugin", "package:register", "2.0.0")}
+    service = HealthService(_installed_catalog_plugins=initial_plugins)
+
+    monkeypatch.setattr(health_service, "_installed_catalog_plugins", lambda: updated_plugins)
+    service.refresh_plugin_restart_required()
+
+    assert service.plugin_restart_required is True
+
+
+def test_health_service_ignores_unchanged_catalog_plugins(monkeypatch) -> None:
+    installed_plugins = {("plugin", "package:register", "1.0.0")}
+    service = HealthService(_installed_catalog_plugins=installed_plugins)
+    monkeypatch.setattr(health_service, "_installed_catalog_plugins", lambda: installed_plugins)
+
+    service.refresh_plugin_restart_required()
+
+    assert service.plugin_restart_required is False


### PR DESCRIPTION
After installing a new (robot) plugin the server often needs to restart so that it has access to new modules etc.
This PR adds a new `POST /api/system/restart` endpoint which restarts the server.

To help the UI in detecting that the server:
a) needs to restart
b) has been restarted

we now add a new `restart_required` boolean to the health endpoint and a `instance_id`. The instance id is a random id that gets assigned to the server at startup. The UI will know the server has rebooted when this id has changed.