### PR TITLE
feat(library): support LeRobot diffusion export metadata

### DIFF
--- a/library/src/physicalai/export/mixin_policy.py
+++ b/library/src/physicalai/export/mixin_policy.py
@@ -170,6 +170,11 @@ class ExportablePolicyMixin:
         """
         return {}
 
+    @property
+    def export_policy_name(self) -> str:
+        """Policy name used for exported artifacts and manifests."""
+        return self.__class__.__name__.lower()
+
     @contextmanager
     def _scoped_rtc(self, *, enable: bool) -> Generator[None, None, None]:
         """Temporarily set enable_rtc on the model, restoring the previous value on exit."""
@@ -204,7 +209,7 @@ class ExportablePolicyMixin:
             **extras: Additional keyword arguments to forward to the manifest.
         """
         policy_class = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        policy_name = self.__class__.__name__.lower()
+        policy_name = self.export_policy_name
         artifact_filename = f"{policy_name}{backend.extension}"
 
         if input_names is not None:
@@ -274,7 +279,7 @@ class ExportablePolicyMixin:
         # If path is a directory or doesn't have a valid extension, add filename
         if path.is_dir() or (not path.suffix or path.suffix not in valid_extensions):
             # Use policy name for filename
-            policy_name = self.__class__.__name__.lower()
+            policy_name = self.export_policy_name
             path /= f"{policy_name}{extension}"
 
         # Create parent directory

--- a/library/src/physicalai/inference/adapters/pytorch.py
+++ b/library/src/physicalai/inference/adapters/pytorch.py
@@ -14,6 +14,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+import numpy as np
 import torch
 from physicalai.config import import_class
 from physicalai.inference.adapters.base import RuntimeAdapter
@@ -26,12 +27,25 @@ from physicalai.export.backends import TorchExportParameters
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import numpy as np
-
     from physicalai.policies.base import Policy
 
 
 logger = logging.getLogger(__name__)
+
+
+def _to_torch_input(value: object, device: str) -> object:
+    """Recursively convert numpy arrays to torch tensors.
+
+    Returns:
+        The converted input value.
+    """
+    if isinstance(value, dict):
+        return {key: _to_torch_input(item, device) for key, item in value.items()}
+    if isinstance(value, np.ndarray):
+        return torch.from_numpy(value).to(device)
+    if isinstance(value, torch.Tensor):
+        return value.to(device)
+    return value
 
 
 @adapter_registry.register("torch", extensions=(".ckpt", ".pt"))
@@ -159,6 +173,12 @@ class TorchAdapter(RuntimeAdapter):
         try:
             # Build Observation from numpy dict and convert to torch tensors on device
             observation = Observation.from_dict(inputs).to_torch(self.device)
+            extra_inputs = self._extra_inputs(inputs)
+            if extra_inputs:
+                observation.extra = {
+                    **(observation.extra or {}),
+                    **extra_inputs,
+                }
 
             torch_outputs = self._policy(observation)
             return self._convert_outputs_to_numpy(torch_outputs)
@@ -166,6 +186,17 @@ class TorchAdapter(RuntimeAdapter):
         except Exception as e:
             msg = f"Inference failed: {e}"
             raise RuntimeError(msg) from e
+
+    def _extra_inputs(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Return inputs that do not map to first-class ``Observation`` fields."""
+        observation_fields = set(Observation.keys())
+        extras = {}
+        for key, value in inputs.items():
+            head = key.split(".", 1)[0]
+            if key in observation_fields or head in observation_fields:
+                continue
+            extras[key] = _to_torch_input(value, self.device)
+        return extras
 
     def _convert_outputs_to_numpy(self, torch_outputs: torch.Tensor | dict | list | tuple) -> dict[str, np.ndarray]:
         """Convert model outputs to numpy format.

--- a/library/src/physicalai/policies/lerobot/policy.py
+++ b/library/src/physicalai/policies/lerobot/policy.py
@@ -29,10 +29,14 @@ from typing import IO, TYPE_CHECKING, Any, ClassVar, cast
 import torch
 from lightning_utilities import module_available
 from physicalai.config.serializable import dataclass_to_dict, dict_to_dataclass
+from physicalai.inference.data import InferenceFeature, InferenceFeatureDtype, InferenceFeatureType
+from physicalai.inference.manifest import ComponentSpec
 
 from physicalai.data import Observation
 from physicalai.data.lerobot import FormatConverter
 from physicalai.data.lerobot.dataset import _LeRobotDatasetAdapter  # noqa: PLC2701
+from physicalai.data.observation import ACTION, IMAGES, STATE, TASK
+from physicalai.export.backends import ExportParameters, TorchExportParameters
 from physicalai.export.mixin_policy import CONFIG_KEY, DATASET_STATS_KEY, POLICY_NAME_KEY, ExportablePolicyMixin
 from physicalai.policies.base import Policy
 from physicalai.policies.lerobot.mixin import LeRobotFromConfig
@@ -157,6 +161,67 @@ def _warn_if_unsupported_policy(policy_name: str) -> None:
         UserWarning,
         stacklevel=3,
     )
+
+
+def _feature_type_name(feature: object) -> str:
+    """Normalize a LeRobot feature type name.
+
+    Returns:
+        Uppercase LeRobot feature type name, or an empty string when absent.
+    """
+    value = feature.get("type") if isinstance(feature, dict) else getattr(feature, "type", None)
+    if value is None:
+        return ""
+    if hasattr(value, "value"):
+        return str(value.value)
+    return str(value).rsplit(".", 1)[-1].upper()
+
+
+def _feature_shape(feature: object) -> tuple[int, ...] | None:
+    """Normalize a LeRobot feature shape as a tuple.
+
+    Returns:
+        Feature shape tuple, or ``None`` when the feature has no shape.
+    """
+    shape = feature.get("shape") if isinstance(feature, dict) else getattr(feature, "shape", None)
+    if shape is None:
+        return None
+    if isinstance(shape, int):
+        return (shape,)
+    return tuple(int(dim) for dim in shape)
+
+
+def _runtime_input_name(feature_id: str, feature_type: str) -> str | None:
+    """Map LeRobot feature keys to Runtime observation input names.
+
+    Returns:
+        Runtime input name, or ``None`` when the feature type is unsupported.
+    """
+    if feature_type == "STATE":
+        return STATE
+    if feature_type == "VISUAL":
+        images_prefix = "observation.images."
+        if feature_id.startswith(images_prefix):
+            return f"{IMAGES}.{feature_id.removeprefix(images_prefix)}"
+        return IMAGES
+    if feature_type == "LANGUAGE":
+        return TASK
+    if feature_type == "ENV":
+        return feature_id
+    return None
+
+
+def _action_chunk_size(config: object) -> int:
+    """Resolve the executable action chunk size for a LeRobot config.
+
+    Returns:
+        Number of action steps produced by the policy.
+    """
+    for attr in ("n_action_steps", "chunk_size"):
+        value = getattr(config, attr, None)
+        if value is not None:
+            return int(value)
+    return 1
 
 
 class LeRobotPolicy(ExportablePolicyMixin, LeRobotFromConfig, Policy):
@@ -832,7 +897,7 @@ class LeRobotPolicy(ExportablePolicyMixin, LeRobotFromConfig, Policy):
         """
         del batch_idx  # Unused argument
 
-        total_loss, loss_dict = self(batch)
+        total_loss, loss_dict = self._compute_lerobot_loss(batch)
 
         # Log individual loss components if available (skip non-scalar values and 'loss' key)
         if loss_dict is not None:
@@ -849,20 +914,63 @@ class LeRobotPolicy(ExportablePolicyMixin, LeRobotFromConfig, Policy):
         self.log("train/loss", total_loss, prog_bar=True)
         return total_loss
 
-    def validation_step(self, batch: Gym, batch_idx: int) -> dict[str, float]:
+    def validation_step(
+        self,
+        batch: Gym | Observation | dict[str, torch.Tensor],
+        batch_idx: int,
+    ) -> dict[str, float] | torch.Tensor:
         """Validation step for Lightning.
 
-        Runs gym-based validation by executing rollouts in the environment.
-        The DataModule's val_dataloader returns Gym environment instances directly.
+        Supports both eval-loss validation on data batches and gym-based
+        rollout validation.
 
         Args:
-            batch: Gym environment to evaluate.
+            batch: Observation/LeRobot-format batch or Gym environment.
             batch_idx: Batch index.
 
         Returns:
-            Metrics dict from gym rollout evaluation.
+            Eval-loss tensor for data batches, or metrics dict from gym rollout evaluation.
         """
+        if isinstance(batch, (Observation, dict)):
+            loss, loss_dict = self.compute_val_loss(batch)
+            for key, value in loss_dict.items():
+                if key == "loss":
+                    continue
+                if isinstance(value, (int, float, torch.Tensor)) and (
+                    not isinstance(value, torch.Tensor) or value.numel() == 1
+                ):
+                    self.log(f"val/{key}", value, prog_bar=False, on_step=False, on_epoch=True, sync_dist=True)
+
+            self.log("val/loss", loss_dict["loss"], prog_bar=True, on_step=False, on_epoch=True, sync_dist=True)
+            return loss
+
         return self.evaluate_gym(batch, batch_idx, stage="val")
+
+    def compute_val_loss(
+        self,
+        batch: Observation | dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor | float]]:
+        """Compute validation loss on a LeRobot data batch.
+
+        LeRobot policies compute supervised losses through their regular
+        policy forward pass. This method keeps the wrapper in eval mode while
+        still calling the underlying LeRobot loss path directly, so validation
+        batches can produce ``val/loss`` without being mistaken for action
+        inference.
+
+        Args:
+            batch: PhysicalAI Observation or native LeRobot dictionary batch.
+
+        Returns:
+            Tuple of total loss and a loss dictionary containing at least
+            ``"loss"``.
+        """
+        loss, loss_dict = self._compute_lerobot_loss(batch)
+        if loss_dict is None:
+            return loss, {"loss": loss}
+        if "loss" not in loss_dict:
+            return loss, {**loss_dict, "loss": loss}
+        return loss, loss_dict
 
     def test_step(self, batch: Gym, batch_idx: int) -> dict[str, float]:
         """Test step for Lightning.
@@ -882,39 +990,44 @@ class LeRobotPolicy(ExportablePolicyMixin, LeRobotFromConfig, Policy):
     def forward(  # type: ignore[override]
         self,
         batch: Observation | dict[str, torch.Tensor],
-    ) -> torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor] | None]:
+    ) -> torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor | float] | None]:
         """Forward pass for the LeRobot policy.
 
         Handles both training and inference modes:
         - Training: Returns (loss, loss_dict) for backpropagation
-        - Inference: Returns denormalized actions for prediction/export
+        - Inference: Returns denormalized action chunks for prediction/export
 
         Args:
             batch: Input batch (Observation or LeRobot dict).
 
         Returns:
             - Training mode: Tuple of (loss, loss_dict or None)
-            - Inference mode: Action tensor
+            - Inference mode: Action chunk tensor
         """
-        # Convert to LeRobot format if needed
-        batch_dict = FormatConverter.to_lerobot_dict(batch) if isinstance(batch, Observation) else batch
-
-        # Apply preprocessor for normalization, padding to max_action_dim, etc.
-        # This is required for policies like Groot that expect padded actions
-        batch_dict = self._preprocessor(batch_dict)
-
         if self.training:
             # Training mode: compute loss
-            output = self.lerobot_policy(batch_dict)
+            return self._compute_lerobot_loss(batch)
+        return self.predict_action_chunk(batch)
 
-            # Handle different return formats (some policies return tuple, some just loss)
-            if isinstance(output, tuple):
-                return output
-            return output, None
+    def _compute_lerobot_loss(
+        self,
+        batch: Observation | dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor | float] | None]:
+        """Run the wrapped LeRobot policy's supervised loss path.
 
-        # Inference mode: predict actions and denormalize
-        action = self.lerobot_policy.select_action(batch_dict)
-        return self._postprocessor(action)
+        Returns:
+            Total loss and an optional LeRobot loss dictionary.
+        """
+        batch_dict = FormatConverter.to_lerobot_dict(batch) if isinstance(batch, Observation) else batch
+        batch_dict = self._preprocessor(batch_dict)
+        output = self.lerobot_policy(batch_dict)
+
+        # Handle different return formats: some policies return
+        # ``(loss, loss_dict)``, while diffusion-style policies return only loss.
+        if isinstance(output, tuple):
+            loss, loss_dict = output
+            return cast("torch.Tensor", loss), cast("dict[str, torch.Tensor | float] | None", loss_dict)
+        return cast("torch.Tensor", output), None
 
     def predict_action_chunk(self, batch: Observation | dict[str, torch.Tensor]) -> torch.Tensor:
         """Predict full action chunk using the wrapped LeRobot policy.
@@ -968,6 +1081,79 @@ class LeRobotPolicy(ExportablePolicyMixin, LeRobotFromConfig, Policy):
         """
         super().reset()
         self.lerobot_policy.reset()
+
+    @property
+    def export_policy_name(self) -> str:
+        """LeRobot registry name used for exported artifacts."""
+        return self.policy_name.lower()
+
+    @property
+    def inputs_schema(self) -> list[InferenceFeature] | None:
+        """Describe the policy's expected Runtime inputs for export metadata."""
+        if self._config is None:
+            return None
+
+        schema: list[InferenceFeature] = []
+        for feature_id, feature in self._config.input_features.items():
+            feature_type = _feature_type_name(feature)
+            name = _runtime_input_name(feature_id, feature_type)
+            shape = _feature_shape(feature)
+            if name is None or shape is None:
+                continue
+
+            if feature_type == "STATE":
+                inference_type = InferenceFeatureType.STATE
+            elif feature_type == "VISUAL":
+                inference_type = InferenceFeatureType.VISUAL
+            elif feature_type == "LANGUAGE":
+                inference_type = InferenceFeatureType.LANGUAGE
+            else:
+                inference_type = InferenceFeatureType.COMMON
+
+            schema.append(
+                InferenceFeature(
+                    ftype=inference_type,
+                    shape=shape,
+                    name=name,
+                    dtype=InferenceFeatureDtype.STRING
+                    if inference_type is InferenceFeatureType.LANGUAGE
+                    else InferenceFeatureDtype.FLOAT32,
+                ),
+            )
+
+        return schema
+
+    @property
+    def outputs_schema(self) -> list[InferenceFeature] | None:
+        """Describe the policy's action chunk output for export metadata."""
+        if self._config is None:
+            return None
+
+        for feature in self._config.output_features.values():
+            if _feature_type_name(feature) != "ACTION":
+                continue
+            shape = _feature_shape(feature)
+            if shape is None:
+                continue
+            return [
+                InferenceFeature(
+                    ftype=InferenceFeatureType.ACTION,
+                    shape=(_action_chunk_size(self._config), *shape),
+                    name=ACTION,
+                    dtype=InferenceFeatureDtype.FLOAT32,
+                ),
+            ]
+
+        return None
+
+    @property
+    def extra_export_args(self) -> dict[str, ExportParameters]:
+        """Torch Runtime export metadata for LeRobot policies."""
+        return {
+            "torch": TorchExportParameters(
+                preprocessors_specs=[ComponentSpec(type="to_float_tensor")],
+            ),
+        }
 
     @property
     def config(self) -> PreTrainedConfig:

--- a/library/tests/integration/test_lerobot_wrapper_equivalence.py
+++ b/library/tests/integration/test_lerobot_wrapper_equivalence.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import copy
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -707,6 +708,21 @@ def _make_training_batch(config: Any, device: torch.device) -> dict[str, torch.T
     return batch
 
 
+def _make_single_observation_batch(
+    batch: dict[str, torch.Tensor],
+    config: Any,
+) -> dict[str, torch.Tensor]:
+    """Drop temporal observation windows for LeRobot ``select_action`` calls."""
+    single: dict[str, torch.Tensor] = {}
+    for key, value in batch.items():
+        feature = config.input_features.get(key)
+        if feature is not None and value.ndim == len(feature.shape) + 2:
+            single[key] = value[:, -1]
+        else:
+            single[key] = value
+    return single
+
+
 @pytest.fixture(scope="module")
 def pusht_dataset() -> Any:
     """Load pusht dataset once per module for inference-equivalence tests."""
@@ -904,6 +920,45 @@ class TestTrainingForwardContract:
         _, loss_dict = policy(batch)
 
         assert loss_dict is None
+
+    def test_diffusion_validation_step_produces_loss(self, training_policy_and_batch):
+        policy, batch, policy_name = training_policy_and_batch
+        if policy_name != "diffusion":
+            pytest.skip("Diffusion-specific: validation contract")
+
+        policy.eval()
+        with torch.no_grad(), patch.object(policy, "log") as log:
+            loss = policy.validation_step(_clone_batch(batch), batch_idx=0)
+
+        assert isinstance(loss, torch.Tensor)
+        assert loss.ndim == 0
+        logged_names = [call.args[0] for call in log.call_args_list]
+        assert "val/loss" in logged_names
+
+    def test_diffusion_inference_shapes_and_reset(self, training_policy_and_batch):
+        policy, batch, policy_name = training_policy_and_batch
+        if policy_name != "diffusion":
+            pytest.skip("Diffusion-specific: inference contract")
+
+        policy.eval()
+        infer_batch = {k: v for k, v in batch.items() if k not in {"action", "action_is_pad"}}
+        action_dim = policy._config.output_features["action"].shape[0]
+
+        policy.reset()
+        with torch.no_grad():
+            chunk = policy.predict_action_chunk(_clone_batch(infer_batch))
+
+        assert chunk.dim() == 3, f"Expected 3D tensor, got shape {chunk.shape}"
+        assert chunk.shape[0] == 1
+        assert chunk.shape[1] == policy._config.n_action_steps
+        assert chunk.shape[2] == action_dim
+
+        policy.reset()
+        single_step_batch = _make_single_observation_batch(infer_batch, policy._config)
+        with torch.no_grad():
+            action = policy.select_action(_clone_batch(single_step_batch))
+
+        assert action.shape == (1, action_dim)
 
     def test_gradient_flows_through_wrapper(self, training_policy_and_batch):
         policy, batch, _ = training_policy_and_batch

--- a/library/tests/unit/inference/test_adapters.py
+++ b/library/tests/unit/inference/test_adapters.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from physicalai.inference.model import InferenceModel
 
 from physicalai.data.observation import Observation
 from physicalai.export.backends import TorchExportParameters
@@ -24,6 +25,42 @@ from physicalai.export.mixin_policy import ExportBackend
 from physicalai.inference.adapters import get_adapter
 from physicalai.inference.adapters.executorch import ExecuTorchAdapter
 from physicalai.inference.adapters.pytorch import TorchAdapter
+
+
+class _TinyLeRobotRuntimePolicy(torch.nn.Module):
+    """Minimal LeRobot-like module for Torch export/load contract tests."""
+
+    config_class: type | None = None
+
+    def __init__(self, config: object, action_chunk: torch.Tensor | None = None) -> None:
+        super().__init__()
+        self.config = config
+        if action_chunk is None:
+            action_feature = config.output_features["action"]  # type: ignore[attr-defined]
+            action_shape = action_feature["shape"] if isinstance(action_feature, dict) else action_feature.shape
+            action_chunk = torch.zeros(
+                1,
+                int(config.n_action_steps),  # type: ignore[attr-defined]
+                int(action_shape[0]),
+            )
+        self.register_buffer("action_chunk", action_chunk.clone())
+        self.last_batch: dict[str, torch.Tensor] | None = None
+
+    def forward(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
+        self.last_batch = batch
+        return torch.tensor(0.0, device=self.action_chunk.device)
+
+    def predict_action_chunk(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
+        self.last_batch = batch
+        env_state = batch.get("observation.environment_state")
+        device = env_state.device if isinstance(env_state, torch.Tensor) else self.action_chunk.device
+        return self.action_chunk.to(device)
+
+    def select_action(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
+        return self.predict_action_chunk(batch)[:, 0, :]
+
+    def reset(self) -> None:
+        self.last_batch = None
 
 
 class TestGetAdapter:
@@ -226,6 +263,64 @@ class TestTorchAdapter:
 
             adapter.load(model_path)
             assert mock_load.call_args.kwargs["compile_model"] is True
+
+    def test_lerobot_diffusion_torch_export_loads_with_inference_model(self, tmp_path: Path) -> None:
+        """Torch export for LeRobot diffusion loads through Runtime InferenceModel."""
+        pytest.importorskip("lerobot")
+        from lerobot.configs.types import FeatureType, PolicyFeature  # noqa: PLC0415
+        from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig  # noqa: PLC0415
+
+        from physicalai.policies.lerobot import LeRobotPolicy  # noqa: PLC0415
+
+        _TinyLeRobotRuntimePolicy.config_class = DiffusionConfig
+        config = DiffusionConfig(
+            input_features={
+                "observation.environment_state": PolicyFeature(type=FeatureType.ENV, shape=(2,)),
+            },
+            output_features={
+                "action": PolicyFeature(type=FeatureType.ACTION, shape=(2,)),
+            },
+            horizon=8,
+            n_action_steps=3,
+            num_inference_steps=1,
+        )
+        expected_chunk = torch.tensor([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]])
+
+        export_policy = LeRobotPolicy(policy_name="diffusion")
+        export_policy._config = config
+        export_policy._preprocessor = torch.nn.Identity()
+        export_policy._postprocessor = torch.nn.Identity()
+        export_policy._lerobot_policy = _TinyLeRobotRuntimePolicy(config, expected_chunk)
+
+        export_policy.to_torch(tmp_path)
+
+        manifest = json.loads((tmp_path / "manifest.json").read_text())
+        assert (tmp_path / "diffusion.pt").exists()
+        assert manifest["policy"]["name"] == "diffusion"
+        assert manifest["model"]["artifacts"]["torch"] == "diffusion.pt"
+        assert manifest["model"]["input_features"][0]["init_args"]["name"] == "observation.environment_state"
+        assert manifest["model"]["input_features"][0]["init_args"]["shape"] == [2]
+        assert manifest["model"]["output_features"][0]["init_args"]["name"] == "action"
+        assert manifest["model"]["output_features"][0]["init_args"]["shape"] == [3, 2]
+
+        with (
+            patch("physicalai.policies.lerobot.policy.get_policy_class", return_value=_TinyLeRobotRuntimePolicy),
+            patch(
+                "physicalai.policies.lerobot.policy.make_pre_post_processors",
+                return_value=(torch.nn.Identity(), torch.nn.Identity()),
+            ),
+        ):
+            model = InferenceModel(tmp_path, backend="torch", device="cpu")
+
+        chunk = model.predict_action_chunk({
+            "observation.environment_state": np.zeros((1, 2), dtype=np.float32),
+        })
+
+        assert chunk.shape == (3, 2)
+        np.testing.assert_allclose(chunk, expected_chunk.numpy()[0])
+        loaded_policy = model.adapter._policy
+        assert loaded_policy is not None
+        assert "observation.environment_state" in loaded_policy.lerobot_policy.last_batch
 
 
 class TestExecuTorchAdapter:

--- a/library/tests/unit/policies/test_lerobot.py
+++ b/library/tests/unit/policies/test_lerobot.py
@@ -17,6 +17,8 @@ import torch
 # Skip all tests if lerobot not installed
 pytest.importorskip("lerobot", reason="LeRobot not installed")
 
+from physicalai.data import Observation  # noqa: E402
+
 
 # Module-level fixtures for expensive operations (shared across all tests)
 @pytest.fixture(scope="module")
@@ -24,6 +26,7 @@ def lerobot_imports():
     """Import LeRobot modules once per test module."""
     pytest.importorskip("lerobot")
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
     from physicalai.policies.lerobot import LeRobotPolicy
 
     return {"LeRobotPolicy": LeRobotPolicy, "LeRobotDataset": LeRobotDataset}
@@ -41,6 +44,47 @@ def pusht_act_policy(lerobot_imports, pusht_dataset):
     """Create ACT policy from pusht dataset once per module."""
     LeRobotPolicy = lerobot_imports["LeRobotPolicy"]
     return LeRobotPolicy.from_dataset("act", pusht_dataset)
+
+
+class _FakeLeRobotPolicy(torch.nn.Module):
+    """Minimal LeRobot-like policy used to exercise wrapper dispatch."""
+
+    def __init__(
+        self,
+        loss_output: torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor | float] | None],
+    ) -> None:
+        super().__init__()
+        self.loss_output = loss_output
+        self.loss_batches: list[dict[str, torch.Tensor]] = []
+        self.predict_action_chunk_calls = 0
+        self.select_action_calls = 0
+        self.reset_calls = 0
+
+    def forward(
+        self,
+        batch: dict[str, torch.Tensor],
+    ) -> torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor | float] | None]:
+        self.loss_batches.append(batch)
+        return self.loss_output
+
+    def predict_action_chunk(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
+        self.predict_action_chunk_calls += 1
+        return torch.ones(1, 3, 2, device=batch["observation.state"].device)
+
+    def select_action(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
+        self.select_action_calls += 1
+        return torch.ones(1, 2, device=batch["observation.state"].device)
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+
+
+def _attach_fake_lerobot_policy(lerobot_policy: Any, fake_policy: _FakeLeRobotPolicy) -> Any:  # noqa: ANN401
+    """Attach a fake initialized LeRobot module without invoking LeRobot factories."""
+    lerobot_policy._preprocessor = torch.nn.Identity()
+    lerobot_policy._postprocessor = torch.nn.Identity()
+    lerobot_policy._lerobot_policy = fake_policy
+    return lerobot_policy
 
 
 class TestLeRobotPolicyLazyInit:
@@ -155,6 +199,71 @@ class TestLeRobotPolicyMethods:
         assert hasattr(policy, "training_step")
         assert callable(policy.training_step)
 
+    def test_compute_val_loss_adds_loss_key_for_diffusion_style_loss(self, lerobot_imports):
+        """Diffusion-style LeRobot losses may return only a scalar loss tensor."""
+        LeRobotPolicy = lerobot_imports["LeRobotPolicy"]
+        loss = torch.tensor(1.25)
+        fake_policy = _FakeLeRobotPolicy(loss)
+        policy = _attach_fake_lerobot_policy(LeRobotPolicy(policy_name="diffusion"), fake_policy)
+        batch = {"observation.state": torch.zeros(1, 2)}
+
+        val_loss, loss_dict = policy.compute_val_loss(batch)
+
+        assert val_loss is loss
+        assert loss_dict["loss"] is loss
+        assert fake_policy.loss_batches[-1] is batch
+
+    def test_validation_step_logs_observation_loss(self, lerobot_imports):
+        """Observation validation batches should log val/loss like first-party policies."""
+        LeRobotPolicy = lerobot_imports["LeRobotPolicy"]
+        policy = LeRobotPolicy(policy_name="diffusion")
+        batch = Observation(action=torch.zeros(1, 2))
+        loss = torch.tensor(2.0)
+        aux_loss = torch.tensor(0.5)
+
+        with (
+            patch.object(policy, "compute_val_loss", return_value=(loss, {"loss": loss, "aux": aux_loss})),
+            patch.object(policy, "log") as log,
+        ):
+            result = policy.validation_step(batch, 0)
+
+        assert result is loss
+        logged_names = [call.args[0] for call in log.call_args_list]
+        assert "val/loss" in logged_names
+        assert "val/aux" in logged_names
+
+    def test_validation_step_preserves_gym_rollout_path(self, lerobot_imports):
+        """Non-data validation batches should still use gym rollout evaluation."""
+        LeRobotPolicy = lerobot_imports["LeRobotPolicy"]
+        policy = LeRobotPolicy(policy_name="diffusion")
+        gym = object()
+        metrics = {"val/gym/success_rate": 1.0}
+
+        with patch.object(policy, "evaluate_gym", return_value=metrics) as evaluate_gym:
+            result = policy.validation_step(gym, 3)
+
+        assert result == metrics
+        evaluate_gym.assert_called_once_with(gym, 3, stage="val")
+
+    def test_diffusion_action_methods_dispatch_to_lerobot_policy(self, lerobot_imports):
+        """Diffusion wrapper keeps chunk prediction, single-action selection, and reset wired."""
+        LeRobotPolicy = lerobot_imports["LeRobotPolicy"]
+        fake_policy = _FakeLeRobotPolicy(torch.tensor(0.0))
+        policy = _attach_fake_lerobot_policy(LeRobotPolicy(policy_name="diffusion"), fake_policy)
+        batch = {"observation.state": torch.zeros(1, 2)}
+
+        policy.train()
+        chunk = policy.predict_action_chunk(batch)
+        action = policy.select_action(batch)
+        policy.reset()
+
+        assert chunk.shape == (1, 3, 2)
+        assert action.shape == (1, 2)
+        assert fake_policy.predict_action_chunk_calls == 1
+        assert fake_policy.select_action_calls == 1
+        assert fake_policy.reset_calls == 1
+        assert policy.training
+
 
 class TestLeRobotPolicyConfigureOptimizers:
     """Tests for optimizer configuration using LeRobot presets."""
@@ -230,6 +339,16 @@ class TestLeRobotPolicyUniversalWrapper:
         LeRobotPolicy = lerobot_imports["LeRobotPolicy"]
 
         policy = LeRobotPolicy.from_dataset("diffusion", pusht_dataset)
+        assert policy._config is not None
+        assert "diffusion" in policy._config.__class__.__name__.lower()
+
+    def test_supports_diffusion_policy_from_repo_id_metadata(self, lerobot_imports):
+        """Test Diffusion construction from lightweight dataset metadata."""
+        LeRobotPolicy = lerobot_imports["LeRobotPolicy"]
+
+        policy = LeRobotPolicy.from_dataset("diffusion", "lerobot/pusht")
+
+        assert policy.policy_name == "diffusion"
         assert policy._config is not None
         assert "diffusion" in policy._config.__class__.__name__.lower()
 
@@ -854,8 +973,9 @@ class TestCheckpointConverter:
         """ValueError when policy_name is None and config has no 'type' field."""
         import json
 
-        from physicalai.policies.lerobot.utils.checkpoint_converter import lerobot_to_lightning
         from safetensors.torch import save_file
+
+        from physicalai.policies.lerobot.utils.checkpoint_converter import lerobot_to_lightning
 
         no_type_dir = tmp_path / "no_type"
         no_type_dir.mkdir()


### PR DESCRIPTION
## Description

- Adds policy-specific export naming for LeRobot policies so diffusion exports as `diffusion.pt`
- Adds LeRobot input/output manifest metadata for Torch Runtime export
- Preserves flat LeRobot runtime inputs
- Adds diffusion validation-loss handling and action-chunk inference coverage

## Related Issues

N/A

## Author
Hirad Emamialagha - [LinkedIn](https://www.linkedin.com/in/hirad-alagha)