### PR TITLE
feat: add VLA Adapter first party model

### DIFF
--- a/library/configs/physicalai/vla_adapter.yaml
+++ b/library/configs/physicalai/vla_adapter.yaml
@@ -1,0 +1,78 @@
+# VLA-Adapter Policy Training Configuration
+#
+# Usage:
+#   physicalai fit --config configs/physicalai/vla_adapter.yaml
+#
+# VLA-Adapter freezes a Prismatic VLM (fused DINOv2 + SigLIP towers feeding
+# Qwen2.5-0.5B) and trains only a Bridge-Attention head, the visual projector,
+# the action queries and the proprio projector — roughly 125M of ~1.2B
+# parameters. The per-component split is logged when the model is built.
+
+model:
+  class_path: physicalai.policies.VLAAdapter
+  init_args:
+    # Backbone weights. The towers and the language model are frozen, so
+    # leaving this false would train the head against random features.
+    load_pretrained_backbone: true
+
+    # Trainability of the two large pretrained backbones. Everything else
+    # (visual projector, action queries, action head, proprio projector)
+    # always trains.
+    train_vision_backbone: false
+    train_llm: false
+
+    # LIBERO preset: 8-step chunks of 7-DoF actions, 8-dim proprioception.
+    chunk_size: 8
+    n_action_steps: 8
+    max_action_dim: 7
+    max_state_dim: 8
+
+    # Two cameras (third-person + wrist). The dataset's `images.image` and
+    # `images.image2` sort into slots 0 and 1, matching upstream's
+    # full_image / wrist_image order, so no remapping is needed.
+    num_images_in_input: 2
+    image_key_reorder_map: {}
+    num_cameras: 0
+
+    # Fixed token length keeps exported graphs statically shaped.
+    tokenizer_max_length: 48
+
+data:
+  class_path: physicalai.data.lerobot.LeRobotDataModule
+  init_args:
+    # 1693 episodes / 273k frames / 10 fps / ~35 GB.
+    # For a quick smoke run, restrict it on the CLI instead of editing here:
+    #   --data.episodes=[0,1,2]
+    repo_id: "HuggingFaceVLA/libero"
+    data_format: "physicalai"
+
+    # Batch size 1: the frozen backbone is ~1.2B params in fp32, and
+    # `output_hidden_states=True` retains 25 x 576 x 896 floats per sample.
+    # Raise this on a machine with real GPU memory.
+    train_batch_size: 1
+
+    # Eval-loss validation on a held-out 5% of episodes. Gym-based validation
+    # (`val_gym: physicalai.gyms.libero.LiberoGym`) is the alternative, but it
+    # needs the `libero` extra and is far more expensive; benchmark separately
+    # with `physicalai benchmark` once weights are worth evaluating.
+    val_split: 0.05
+    val_split_seed: 42
+
+    # Optional augmentation, matching the other first-party configs:
+    # image_transforms:
+    #   class_path: torchvision.transforms.v2.Compose
+    #   init_args:
+    #     transforms:
+    #       - class_path: torchvision.transforms.v2.ColorJitter
+    #         init_args:
+    #           contrast: [0.8, 1.2]
+    #           brightness: [0.7, 1.3]
+
+trainer:
+  max_epochs: 100
+  accelerator: auto
+  devices: 1
+  precision: 32
+  log_every_n_steps: 50
+  check_val_every_n_epoch: 1
+  gradient_clip_val: 1.0

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -105,6 +105,16 @@ smolvla = [
     "safetensors>=0.4.3,<1.0.0",
 ]
 
+# VLA-Adapter tiny-scale VLA (Prismatic DINOv2+SigLIP -> Qwen2.5-0.5B + Bridge-Attention head)
+# The released checkpoints store their vision towers in timm layout, so timm is
+# required alongside transformers for the Qwen2 language model.
+vla_adapter = [
+    "transformers>=5.5.0,<5.6.0",
+    "timm>=1.0.0,<1.1.0",
+    "safetensors>=0.4.3,<1.0.0",
+    "Pillow>=10.0.0,<13.0.0",
+]
+
 # ExecuTorch runtime for edge/mobile deployment
 executorch = ["executorch>=1.1.0"]
 
@@ -119,6 +129,7 @@ all = [
     "physicalai-train[pi05]",
     "physicalai-train[groot]",
     "physicalai-train[smolvla]",
+    "physicalai-train[vla_adapter]",
 ]
 
 # Contribute Torch and ExecuTorch as inference backends to the registry

--- a/library/src/physicalai/policies/__init__.py
+++ b/library/src/physicalai/policies/__init__.py
@@ -13,6 +13,7 @@ from .lerobot import get_lerobot_policy
 from .pi0 import Pi0, Pi0Config, Pi0Model
 from .pi05 import Pi05, Pi05Config, Pi05Model
 from .smolvla import SmolVLA, SmolVLAConfig, SmolVLAModel
+from .vla_adapter import VLAAdapter, VLAAdapterConfig, VLAAdapterModel
 
 __all__ = [
     # ACT
@@ -36,6 +37,10 @@ __all__ = [
     "SmolVLA",
     "SmolVLAConfig",
     "SmolVLAModel",
+    # VLA-Adapter
+    "VLAAdapter",
+    "VLAAdapterConfig",
+    "VLAAdapterModel",
     # Utils
     "get_physicalai_policy_class",
     "get_policy",
@@ -51,7 +56,7 @@ def get_policy(policy_name: str, *, source: str = "physicalai", **kwargs) -> Pol
 
     Args:
         policy_name: Name of the policy to create. Supported values depend on source:
-            - physicalai: "act", "dummy", "groot", "pi0", "pi05", "smolvla"
+            - physicalai: "act", "dummy", "groot", "pi0", "pi05", "smolvla", "vla_adapter"
             - lerobot: "act", "diffusion", "smolvla", "pi0", "pi05", "pi0_fast", "groot", "xvla"
         source: Where the policy implementation comes from. Options:
             - "physicalai": First-party implementations (default)
@@ -139,5 +144,10 @@ def get_physicalai_policy_class(policy_name: str) -> type[Policy]:
         return Pi05
     if policy_name == "smolvla":
         return SmolVLA
-    msg = f"Unknown physicalai policy: {policy_name}. Supported policies: act, dummy, groot, pi0, pi05, smolvla"
+    if policy_name == "vla_adapter":
+        return VLAAdapter
+    msg = (
+        f"Unknown physicalai policy: {policy_name}. "
+        "Supported policies: act, dummy, groot, pi0, pi05, smolvla, vla_adapter"
+    )
     raise ValueError(msg)

--- a/library/src/physicalai/policies/vla_adapter/__init__.py
+++ b/library/src/physicalai/policies/vla_adapter/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""VLA-Adapter Policy - tiny-scale VLA with a Bridge-Attention action head."""
+
+from physicalai.policies.vla_adapter.config import VLAAdapterConfig
+from physicalai.policies.vla_adapter.model import VLAAdapterModel
+from physicalai.policies.vla_adapter.policy import VLAAdapter
+
+__all__ = ["VLAAdapter", "VLAAdapterConfig", "VLAAdapterModel"]

--- a/library/src/physicalai/policies/vla_adapter/components/__init__.py
+++ b/library/src/physicalai/policies/vla_adapter/components/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Building blocks for the VLA-Adapter policy.
+
+Split by role: :mod:`.vlm` is the perception stack, :mod:`.action_head` the
+policy head, and :mod:`.proprio` the state projector bridging them — the same
+separation upstream keeps between ``action_heads.py`` and ``projectors.py``.
+
+The split is by role, not by what trains: the VLM's visual projector and action
+queries train alongside the head, while its towers and language model stay
+frozen.
+"""
+
+from physicalai.policies.vla_adapter.components.action_head import L1RegressionActionHead, MLPResNet, MLPResNetBlock
+from physicalai.policies.vla_adapter.components.proprio import ProprioProjector
+from physicalai.policies.vla_adapter.components.vlm import VLM, PrismaticVisionBackbone, PrismaticVisualProjector
+
+__all__ = [
+    "VLM",
+    "L1RegressionActionHead",
+    "MLPResNet",
+    "MLPResNetBlock",
+    "PrismaticVisionBackbone",
+    "PrismaticVisualProjector",
+    "ProprioProjector",
+]

--- a/library/src/physicalai/policies/vla_adapter/components/action_head.py
+++ b/library/src/physicalai/policies/vla_adapter/components/action_head.py
@@ -1,0 +1,288 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Derived from https://github.com/OpenHelix-Team/VLA-Adapter
+# (prismatic/models/action_heads.py), Copyright (c) OpenHelix Team,
+# licensed under the MIT License.
+
+"""The VLA-Adapter "Policy" head — an MLP-ResNet driven by Bridge Attention.
+
+The paper's contribution. The head never sees the raw observation: its input is
+*all zeros*, and every bit of information arrives by cross-attention onto the
+frozen VLM's per-layer hidden states.
+
+Block ``i`` is conditioned on LLM layer ``i + 1`` — hence block count must equal
+LLM depth. Each layer's states split into the leading ``num_task_tokens``
+("task", ``h_t``) and the trailing action-query positions ("action", ``h_a``).
+With the projected proprio token ``p`` these form two cross-attention pathways
+whose relative strength is a learned, ``tanh``-squashed ``gating_factor`` — the
+"Bridge".
+
+Differences from upstream, all behaviour-preserving: shape constants are
+constructor args rather than ``sys.argv`` globals; ``phase="Training"`` becomes
+``nn.Module.training``; the hard-coded bfloat16 cast is dropped so the head runs
+on CPU and through export. Module *structure* is unchanged, so ``state_dict()``
+stays compatible with ``action_head--checkpoint.pt``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import nn
+
+# Standard deviation of the training-time input perturbation. Upstream builds a
+# fresh (unregistered, hence untrained) ``nn.Parameter`` on every forward pass,
+# which is equivalent to adding fixed-scale Gaussian noise. Keeping it
+# unregistered also keeps our ``state_dict`` compatible with the released
+# checkpoints, which contain no perturbation entry.
+_PERTURBATION_STD = 0.02
+
+
+class MLPResNetBlock(nn.Module):
+    """One residual block with fused self / task / adapter attention.
+
+    One set of Q/K/V projections serves three pathways whose scores are
+    concatenated *before* a single softmax, so they compete for one budget of
+    attention mass rather than being summed after:
+
+    1. **self** — the block's own token features,
+    2. **task** — ``cat(h_a, p)``, action-query and proprio features,
+    3. **adapter** — ``h_t``, the vision features, scaled by ``tanh(g)``.
+
+    Note:
+        The pathway names are upstream's and read inverted: ``task`` attends to
+        the *action* states, ``adapter`` to ``h_t``. Behaviour is preserved
+        verbatim; only the ``h_t`` pathway is gated.
+    """
+
+    def __init__(self, dim: int, num_heads: int = 8) -> None:
+        """Initialize the block.
+
+        Args:
+            dim: Hidden width. Must divide evenly by ``num_heads``, since
+                attention reshapes it into ``num_heads`` subspaces via ``view``.
+            num_heads: Attention heads, shared by all three pathways.
+
+        Raises:
+            ValueError: If ``dim`` is not divisible by ``num_heads``.
+        """
+        super().__init__()
+        if dim % num_heads != 0:
+            msg = f"Hidden width {dim} must be divisible by num_heads {num_heads}."
+            raise ValueError(msg)
+
+        self.dim = dim
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+
+        self.ffn = nn.Sequential(
+            nn.LayerNorm(dim),
+            nn.Linear(dim, dim),
+            nn.ReLU(),
+        )
+
+        self.q_proj = nn.Linear(dim, dim)
+        self.k_proj = nn.Linear(dim, dim)
+        self.v_proj = nn.Linear(dim, dim)
+        self.o_proj = nn.Linear(dim, dim)
+
+        self.gating_factor = nn.Parameter(torch.zeros(1))
+
+    def _split_heads(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Reshape ``(B, S, C)`` into ``(B, num_heads, S, head_dim)``.
+
+        Args:
+            tensor: Input ``(B, S, C)``.
+
+        Returns:
+            ``(B, num_heads, S, head_dim)``.
+        """
+        batch, seq, _ = tensor.shape
+        return tensor.view(batch, seq, self.num_heads, self.head_dim).transpose(1, 2)
+
+    def forward(  # noqa: PLR0914 - the fused three-pathway attention needs them
+        self,
+        x: torch.Tensor,
+        h_t: torch.Tensor,
+        h_a: torch.Tensor,
+        p: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run one Bridge-Attention residual block.
+
+        Args:
+            x: Token features ``(B, T, dim)``.
+            h_t: Task (vision) states ``(B, K_t, dim)``.
+            h_a: Action states ``(B, K_a, dim)``.
+            p: Optional proprio features ``(B, 1, dim)``.
+
+        Returns:
+            ``(B, T, dim)``.
+        """
+        ratio_g = torch.tanh(self.gating_factor)
+
+        conditions = [h_a] if p is None else [h_a, p]
+        cond = torch.cat(conditions, dim=1)
+
+        batch, seq, width = x.shape
+
+        query = self._split_heads(self.q_proj(x))
+        k_tokens = self._split_heads(self.k_proj(x))
+        v_tokens = self._split_heads(self.v_proj(x))
+        k_task = self._split_heads(self.k_proj(cond))
+        v_task = self._split_heads(self.v_proj(cond))
+        k_adapter = self._split_heads(self.k_proj(h_t))
+        v_adapter = self._split_heads(self.v_proj(h_t))
+
+        scores_tokens = torch.matmul(query, k_tokens.transpose(-2, -1))
+        scores_task = torch.matmul(query, k_task.transpose(-2, -1))
+        scores_adapter = torch.matmul(query, k_adapter.transpose(-2, -1)) * ratio_g
+
+        scores = torch.cat([scores_tokens, scores_task, scores_adapter], dim=-1)
+        scores /= math.sqrt(self.head_dim)
+        weights = torch.softmax(scores, dim=-1)
+
+        values = torch.cat([v_tokens, v_task, v_adapter], dim=2)
+        attended = torch.matmul(weights, values)
+
+        attended = attended.transpose(1, 2).contiguous().view(batch, seq, width)
+        attended = self.o_proj(attended)
+
+        return self.ffn(attended + x)
+
+
+class MLPResNet(nn.Module):
+    """Stack of :class:`MLPResNetBlock` with input and output projections."""
+
+    def __init__(
+        self,
+        num_blocks: int,
+        input_dim: int,
+        hidden_dim: int,
+        output_dim: int,
+        num_heads: int = 8,
+    ) -> None:
+        """Initialize the residual stack.
+
+        Args:
+            num_blocks: Residual blocks; must match LLM depth, since block ``i``
+                is conditioned on layer ``i + 1``.
+            input_dim: Flattened input width (``action_dim * hidden_dim``).
+            hidden_dim: Working width of the blocks.
+            output_dim: Per-step action dimension.
+            num_heads: Attention heads per block.
+        """
+        super().__init__()
+        self.layer_norm1 = nn.LayerNorm(input_dim)
+        self.fc1 = nn.Linear(input_dim, hidden_dim)
+        self.relu = nn.ReLU()
+        self.mlp_resnet_blocks = nn.ModuleList(
+            MLPResNetBlock(dim=hidden_dim, num_heads=num_heads) for _ in range(num_blocks)
+        )
+        self.layer_norm2 = nn.LayerNorm(hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        h_t: torch.Tensor,
+        h_a: torch.Tensor,
+        p: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run the stack.
+
+        Args:
+            x: Input features ``(B, chunk, input_dim)``.
+            h_t: Per-layer task states ``(B, L + 1, K_t, hidden_dim)``.
+            h_a: Per-layer action states ``(B, L + 1, K_a, hidden_dim)``.
+            p: Optional proprio features ``(B, 1, hidden_dim)``.
+
+        Returns:
+            ``(B, chunk, output_dim)``.
+        """
+        x = self.layer_norm1(x)
+        x = self.fc1(x)
+        x = self.relu(x)
+        # Block i reads layer i+1 of the backbone: index 0 is the embedding
+        # output, so the first transformer layer sits at index 1.
+        for i, block in enumerate(self.mlp_resnet_blocks):
+            x = block(x, h_t=h_t[:, i + 1], h_a=h_a[:, i + 1], p=p)
+        x = self.layer_norm2(x)
+        return self.fc2(x)
+
+
+class L1RegressionActionHead(nn.Module):
+    """Continuous action head trained with an L1 objective.
+
+    Produces the whole chunk in a **single forward pass** — no diffusion or
+    flow-matching loop — which keeps the exported graph static.
+    """
+
+    def __init__(
+        self,
+        input_dim: int = 896,
+        hidden_dim: int = 896,
+        action_dim: int = 7,
+        chunk_size: int = 8,
+        num_task_tokens: int = 512,
+        num_blocks: int = 24,
+        num_heads: int = 8,
+    ) -> None:
+        """Initialize the action head.
+
+        Args:
+            input_dim: Backbone (LLM) hidden width.
+            hidden_dim: Working width of the residual blocks.
+            action_dim: Per-step action dimension.
+            chunk_size: Action steps produced per call.
+            num_task_tokens: Leading positions treated as task features; the
+                rest are action-query features.
+            num_blocks: Residual blocks; must match the LLM depth.
+            num_heads: Attention heads per block.
+        """
+        super().__init__()
+        self.num_task_tokens = num_task_tokens
+        self.action_dim = action_dim
+        self.hidden_dim = hidden_dim
+        self.chunk_size = chunk_size
+        self.model = MLPResNet(
+            num_blocks=num_blocks,
+            input_dim=input_dim * action_dim,
+            hidden_dim=hidden_dim,
+            output_dim=action_dim,
+            num_heads=num_heads,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        proprio_features: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Predict an action chunk from stacked per-layer hidden states.
+
+        Args:
+            hidden_states: Layer-stacked states ``(B, L + 1, S, hidden_dim)``.
+            proprio_features: Optional proprio token ``(B, 1, hidden_dim)``.
+
+        Returns:
+            ``(B, chunk_size, action_dim)``.
+        """
+        batch = hidden_states.shape[0]
+
+        task_states = hidden_states[:, :, : self.num_task_tokens, :]
+        action_states = hidden_states[:, :, self.num_task_tokens :, :]
+
+        # The head's own input carries no information: it is a zero tensor of
+        # shape (B, chunk, action_dim * hidden_dim). Everything the head knows
+        # arrives through the cross-attention pathways below.
+        x = torch.zeros(
+            (batch, self.chunk_size, self.action_dim * self.hidden_dim),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+
+        if self.training:
+            x += torch.randn_like(x) * _PERTURBATION_STD
+
+        return self.model(x, h_t=task_states, h_a=action_states, p=proprio_features)

--- a/library/src/physicalai/policies/vla_adapter/components/action_head.py
+++ b/library/src/physicalai/policies/vla_adapter/components/action_head.py
@@ -10,19 +10,6 @@
 The paper's contribution. The head never sees the raw observation: its input is
 *all zeros*, and every bit of information arrives by cross-attention onto the
 frozen VLM's per-layer hidden states.
-
-Block ``i`` is conditioned on LLM layer ``i + 1`` — hence block count must equal
-LLM depth. Each layer's states split into the leading ``num_task_tokens``
-("task", ``h_t``) and the trailing action-query positions ("action", ``h_a``).
-With the projected proprio token ``p`` these form two cross-attention pathways
-whose relative strength is a learned, ``tanh``-squashed ``gating_factor`` — the
-"Bridge".
-
-Differences from upstream, all behaviour-preserving: shape constants are
-constructor args rather than ``sys.argv`` globals; ``phase="Training"`` becomes
-``nn.Module.training``; the hard-coded bfloat16 cast is dropped so the head runs
-on CPU and through export. Module *structure* is unchanged, so ``state_dict()``
-stays compatible with ``action_head--checkpoint.pt``.
 """
 
 from __future__ import annotations
@@ -34,9 +21,7 @@ from torch import nn
 
 # Standard deviation of the training-time input perturbation. Upstream builds a
 # fresh (unregistered, hence untrained) ``nn.Parameter`` on every forward pass,
-# which is equivalent to adding fixed-scale Gaussian noise. Keeping it
-# unregistered also keeps our ``state_dict`` compatible with the released
-# checkpoints, which contain no perturbation entry.
+# which is equivalent to adding fixed-scale Gaussian noise.
 _PERTURBATION_STD = 0.02
 
 

--- a/library/src/physicalai/policies/vla_adapter/components/proprio.py
+++ b/library/src/physicalai/policies/vla_adapter/components/proprio.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Derived from https://github.com/OpenHelix-Team/VLA-Adapter
+# (prismatic/models/projectors.py), Copyright (c) OpenHelix Team,
+# licensed under the MIT License.
+
+"""Projection of proprioceptive state into the action head's embedding space.
+
+*Proprioception* is the robot's own sense of its body configuration — for LIBERO
+an 8-vector: end-effector position (3), axis-angle orientation (3), gripper (2).
+Cameras do not substitute for it: actions are *relative*, so a correct delta
+needs the current pose, and a wrist camera cannot see its own gripper aperture
+while the third-person view is routinely occluded.
+
+In Studio terms this is just ``Observation.state`` (``FeatureType.STATE``), so
+it normalises through the usual path. Head-side counterpart to
+``PrismaticVisualProjector``, which feeds the backbone.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class ProprioProjector(nn.Module):
+    """Two-layer MLP lifting proprioceptive state to the backbone width.
+
+    Projecting rather than concatenating lets the state participate as a
+    first-class *token* in the head's cross-attention.
+    """
+
+    def __init__(self, llm_dim: int, proprio_dim: int) -> None:
+        """Initialize the projector.
+
+        Args:
+            llm_dim: Backbone hidden width to project into.
+            proprio_dim: Width of the raw proprioceptive vector.
+        """
+        super().__init__()
+        self.llm_dim = llm_dim
+        self.proprio_dim = proprio_dim
+
+        self.fc1 = nn.Linear(proprio_dim, llm_dim, bias=True)
+        self.fc2 = nn.Linear(llm_dim, llm_dim, bias=True)
+        self.act_fn1 = nn.GELU()
+
+    def forward(self, proprio: torch.Tensor) -> torch.Tensor:
+        """Project a proprioceptive state vector.
+
+        Args:
+            proprio: State tensor ``(B, proprio_dim)``.
+
+        Returns:
+            ``(B, llm_dim)``.
+        """
+        projected = self.fc1(proprio)
+        projected = self.act_fn1(projected)
+        return self.fc2(projected)

--- a/library/src/physicalai/policies/vla_adapter/components/vlm.py
+++ b/library/src/physicalai/policies/vla_adapter/components/vlm.py
@@ -1,0 +1,470 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# PrismaticVisionBackbone and PrismaticVisualProjector are vendored from the
+# `modeling_prismatic.py` that ships inside the released VLA-Adapter
+# checkpoints (https://huggingface.co/VLA-Adapter), itself derived from
+# OpenVLA (https://github.com/openvla/openvla). Copyright (c) OpenHelix Team
+# and the OpenVLA authors, licensed under the MIT License.
+
+r"""The Prismatic VLM: fused DINOv2 + SigLIP towers feeding a Qwen2 LLM.
+
+The vision modules are **vendored, not reimplemented**. Three checkpoint
+behaviours are easy to get wrong and all fail silently — shapes agree, the model
+runs, only the success rate suffers:
+
+1. Features come from the **second-to-last** block via
+   ``get_intermediate_layers(n={num_blocks - 2})``, not ``forward_features``.
+2. ``LayerScale`` params are renamed ``gamma`` -> ``scale_factor`` (HF overwrites
+   names containing ``gamma``). Without the patch, 48 tensors fail to load.
+3. Each image arrives as **six** channels, three normalised per tower.
+
+Upstream's ``prismatic`` package pins torch 2.2 / transformers 4.40 / timm 0.9,
+so it cannot be a dependency; the checkpoint-local ``modeling_prismatic.py``
+needs only timm + transformers and is the vendoring source.
+
+:class:`VLM` takes its API from upstream's ``PrismaticVLM`` but its module names
+from ``PrismaticForConditionalGeneration`` — the class the checkpoints export
+through — so ``VLM.state_dict()`` matches ``model.safetensors`` exactly (982
+tensors, no prefix surgery). Mostly frozen: towers and LLM stay fixed while the
+projector and ``action_queries`` train; see :attr:`VLM.trainable_module_keys`.
+
+``action_queries`` lives here, not with the head, because it is an *input* to
+the LLM. The head reads the hidden states produced *at* those positions, never
+the embeddings themselves.
+
+Sequence layout consumed by the action head::
+
+    [ 512 fused vision patches ][ prompt tokens ][ 64 action queries ]
+      \_____ "task" (h_t) _____/                  \__ "action" (h_a) __/
+
+Prompt tokens are not passed to the head; they shape the action-query states
+through attention inside the LLM. Hidden states from every layer are returned
+stacked, because head block ``i`` is conditioned on layer ``i + 1``. The LLM
+carries no ``lm_head`` — it is a feature extractor.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from functools import partial
+from typing import Any
+
+import timm
+import torch
+from torch import nn
+
+from physicalai.policies.vla_adapter.config import VLAAdapterConfig
+
+logger = logging.getLogger(__name__)
+
+# Channels per image once both towers' normalised copies are stacked.
+CHANNELS_PER_IMAGE = 6
+# Channels a single tower consumes.
+CHANNELS_PER_TOWER = 3
+# VLA-Adapter always fuses DINOv2 with SigLIP.
+NUM_VISION_TOWERS = 2
+
+
+def unpack_tuple(fn: Callable[[Any], tuple[Any]]) -> Callable[[Any], Any]:
+    """Unwrap a single-element sequence returned by a monkey-patched forward.
+
+    DEVIATION FROM UPSTREAM: upstream tests ``isinstance(result, tuple)``,
+    correct for timm 0.9. timm 1.0 returns a *list*, which a tuple-only check
+    passes straight through, handing the caller a list where a tensor is
+    expected.
+
+    Args:
+        fn: Function whose result should be unwrapped.
+
+    Returns:
+        Wrapper returning ``result[0]`` for a tuple or list.
+    """
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        result = fn(*args, **kwargs)
+        return result[0] if isinstance(result, (tuple, list)) else result
+
+    return wrapper
+
+
+def _ls_new_forward(self: nn.Module, x: torch.Tensor) -> torch.Tensor:
+    """Replacement ``LayerScale.forward`` reading ``scale_factor``.
+
+    Args:
+        self: The patched ``LayerScale`` module.
+        x: Input activations.
+
+    Returns:
+        Scaled activations.
+    """
+    return x.mul_(self.scale_factor) if self.inplace else x * self.scale_factor
+
+
+def ls_apply_patch(ls_module: nn.Module) -> None:
+    """Rename a ``LayerScale`` module's ``gamma`` parameter to ``scale_factor``.
+
+    The checkpoints store ``ls1.scale_factor``; without this, 48 tensors fail
+    to load.
+
+    Args:
+        ls_module: A timm ``LayerScale`` instance, patched in place.
+    """
+    from timm.models.vision_transformer import LayerScale  # noqa: PLC0415
+
+    ls_module.scale_factor = nn.Parameter(ls_module.gamma.clone())
+    ls_module.forward = _ls_new_forward.__get__(ls_module, LayerScale)
+    del ls_module.gamma
+
+
+class PrismaticVisionBackbone(nn.Module):
+    """Fused DINOv2 + SigLIP towers, vendored from the checkpoint modeling code.
+
+    Attribute names (``featurizer``, ``fused_featurizer``) mirror the
+    checkpoint's tensor keys.
+    """
+
+    def __init__(
+        self,
+        image_sizes: list[int],
+        timm_model_ids: list[str],
+        timm_override_act_layers: list[str | None],
+        *,
+        pretrained: bool = False,
+    ) -> None:
+        """Build both towers and apply the LayerScale patch.
+
+        Args:
+            image_sizes: Input resolution per tower.
+            timm_model_ids: timm identifiers for the DINOv2 and SigLIP towers.
+            timm_override_act_layers: Activation-layer override per tower.
+            pretrained: Fetch pretrained tower weights. The towers are frozen by
+                default, so leaving this False means the head reads noise.
+
+        Raises:
+            ValueError: If exactly two tower ids are not supplied.
+        """
+        super().__init__()
+        self.num_images_in_input = 1
+
+        if len(timm_model_ids) != NUM_VISION_TOWERS:
+            msg = f"VLA-Adapter always fuses exactly {NUM_VISION_TOWERS} vision towers, got {len(timm_model_ids)}."
+            raise ValueError(msg)
+
+        self.featurizer = self._create_featurizer(
+            model_id=timm_model_ids[0],
+            img_size=image_sizes[0],
+            act_layer=timm_override_act_layers[0],
+            pretrained=pretrained,
+        )
+        self.fused_featurizer = self._create_featurizer(
+            model_id=timm_model_ids[1],
+            img_size=image_sizes[1],
+            act_layer=timm_override_act_layers[1],
+            pretrained=pretrained,
+        )
+        self.embed_dim = self.featurizer.embed_dim + self.fused_featurizer.embed_dim
+
+        self._patch_layer_scales()
+
+    @staticmethod
+    def _create_featurizer(model_id: str, img_size: int, act_layer: str | None, *, pretrained: bool) -> nn.Module:
+        """Create a timm featurizer emitting second-to-last-block patches.
+
+        The monkey-patched ``forward`` is load-bearing: Prismatic reads block
+        ``num_blocks - 2``, and ``get_intermediate_layers`` already drops prefix
+        (CLS / register) tokens.
+
+        Args:
+            model_id: timm model identifier.
+            img_size: Square input resolution.
+            act_layer: Activation-layer override.
+            pretrained: Fetch pretrained weights.
+
+        Returns:
+            The configured featurizer.
+        """
+        featurizer = timm.create_model(
+            model_id,
+            pretrained=pretrained,
+            num_classes=0,
+            img_size=img_size,
+            act_layer=act_layer,
+        )
+
+        num_blocks = len(featurizer.blocks)
+        featurizer.forward = unpack_tuple(partial(featurizer.get_intermediate_layers, n={num_blocks - 2}))
+
+        return featurizer
+
+    def _patch_layer_scales(self) -> None:
+        """Patch every ``LayerScale`` module in both towers."""
+        from timm.models.vision_transformer import LayerScale  # noqa: PLC0415
+
+        for tower in (self.featurizer, self.fused_featurizer):
+            for module in tower.modules():
+                if isinstance(module, LayerScale):
+                    ls_apply_patch(module)
+
+    def get_num_patches(self) -> int:
+        """Count vision patches per image.
+
+        Returns:
+            Patch tokens per image, per tower.
+        """
+        return int(self.featurizer.patch_embed.num_patches)
+
+    def get_num_images_in_input(self) -> int:
+        """Report how many camera views the backbone expects.
+
+        Returns:
+            Images per sample.
+        """
+        return self.num_images_in_input
+
+    def set_num_images_in_input(self, num_images_in_input: int) -> None:
+        """Set how many camera views the backbone expects.
+
+        Args:
+            num_images_in_input: Images per sample.
+        """
+        self.num_images_in_input = num_images_in_input
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        """Encode channel-stacked camera views into fused patch tokens.
+
+        Args:
+            pixel_values: ``(B, 6 * num_images, H, W)`` — three channels per
+                tower, per image.
+
+        Returns:
+            ``(B, num_images * num_patches, embed_dim)``.
+        """
+        images = torch.split(pixel_values, [CHANNELS_PER_IMAGE] * self.num_images_in_input, dim=1)
+
+        all_patches = []
+        for img in images:
+            img_regular, img_fused = torch.split(img, [CHANNELS_PER_TOWER, CHANNELS_PER_TOWER], dim=1)
+            patches = self.featurizer(img_regular)
+            patches_fused = self.fused_featurizer(img_fused)
+            all_patches.append(torch.cat([patches, patches_fused], dim=2))
+
+        return torch.cat(all_patches, dim=1)
+
+
+class PrismaticVisualProjector(nn.Module):
+    """Projects fused *visual* patches into the LLM embedding space.
+
+    Vendored from upstream's ``PrismaticProjector``; renamed to distinguish it
+    from the head-side ``ProprioProjector``.
+
+    Applied **per token** — it changes width, never token count. The token count
+    grows earlier, when :class:`PrismaticVisionBackbone` concatenates views.
+    Vision only: text is already in the LLM's embedding space and is simply
+    concatenated alongside, never projected.
+
+    Always the ``fused-gelu-mlp`` variant recorded in the checkpoint's
+    ``arch_specifier``: 2176 -> 8704 -> 896 -> 896. Upstream's pretraining code
+    calls the same module ``FusedMLPProjector``; the ``fc1``/``fc2``/``fc3``
+    naming used here is the exported one the checkpoint keys carry.
+    """
+
+    def __init__(self, vision_dim: int, llm_dim: int) -> None:
+        """Build the three-layer projector.
+
+        Args:
+            vision_dim: Input (fused visual) width.
+            llm_dim: Output width, matching the LLM hidden size.
+        """
+        super().__init__()
+        self.vision_dim, self.llm_dim = vision_dim, llm_dim
+
+        initial_projection_dim = 4 * vision_dim
+        self.fc1 = nn.Linear(self.vision_dim, initial_projection_dim, bias=True)
+        self.fc2 = nn.Linear(initial_projection_dim, self.llm_dim, bias=True)
+        self.fc3 = nn.Linear(self.llm_dim, self.llm_dim, bias=True)
+        self.act_fn1 = nn.GELU()
+        self.act_fn2 = nn.GELU()
+
+    def forward(self, img_patches: torch.Tensor) -> torch.Tensor:
+        """Project visual patches into the LLM embedding space.
+
+        Args:
+            img_patches: Fused patches ``(B, S, vision_dim)``.
+
+        Returns:
+            ``(B, S, llm_dim)``.
+        """
+        projected_features = self.fc1(img_patches)
+        projected_features = self.act_fn1(projected_features)
+        projected_features = self.fc2(projected_features)
+        projected_features = self.act_fn2(projected_features)
+        return self.fc3(projected_features)
+
+
+class VLM(nn.Module):
+    """The Prismatic VLM, exposing per-layer hidden states to the action head.
+
+    Holds exactly the four submodules ``model.safetensors`` contains, so its
+    ``state_dict()`` matches that file key for key.
+    """
+
+    def __init__(self, config: VLAAdapterConfig) -> None:
+        """Assemble the towers, projector, language model and action queries.
+
+        Args:
+            config: Supplies backbone ids, LLM geometry and trainability flags.
+        """
+        super().__init__()
+
+        self.config = config
+        self.arch_specifier = config.arch_specifier
+
+        # init vision
+        self.vision_backbone = PrismaticVisionBackbone(
+            image_sizes=[config.image_size[0]] * NUM_VISION_TOWERS,
+            timm_model_ids=list(config.vision_backbone_ids),
+            timm_override_act_layers=[None, None],
+            pretrained=config.load_pretrained_backbone,
+        )
+        self.vision_backbone.set_num_images_in_input(config.num_images_in_input)
+
+        # init LLM
+        self.language_model = self._build_language_model()
+        self.llm_dim = self.language_model.config.hidden_size
+        self.num_layers = self.language_model.config.num_hidden_layers
+
+        # init projector
+        self.projector = PrismaticVisualProjector(
+            vision_dim=self.vision_backbone.embed_dim,
+            llm_dim=self.llm_dim,
+        )
+
+        # init action layer
+        self.action_queries = nn.Embedding(config.num_action_queries, self.llm_dim)
+        self.action_queries.weight.data.zero_()
+
+        self.all_module_keys = ["vision_backbone", "language_model", "projector", "action_queries"]
+        self.trainable_module_keys: list[str] = []
+        self.apply_trainability()
+
+    def _build_language_model(self) -> nn.Module:
+        """Build the Qwen2 language model, taking its geometry from the reference.
+
+        Geometry is never configured locally: it is read from
+        ``llm_model_name`` so the model and its tokenizer cannot disagree, and
+        so the action head's depth follows the LLM's automatically.
+
+        Weights are pretrained unless disabled. The LLM is frozen by default, so
+        a randomly initialised one would leave the head reading noise. They are
+        loaded as float32 because the published weights are bfloat16, which
+        would not match the float32 vision towers and head.
+
+        Returns:
+            A ``Qwen2Model`` with caching disabled.
+        """
+        from transformers import Qwen2Config, Qwen2Model  # noqa: PLC0415
+
+        name = self.config.llm_model_name
+        llm_config = Qwen2Config.from_pretrained(name)
+        llm_config.use_cache = False
+
+        if not self.config.load_pretrained_backbone:
+            return Qwen2Model(llm_config)
+
+        model = Qwen2Model.from_pretrained(name, dtype=torch.float32)
+        model.config.use_cache = False
+        return model
+
+    def apply_trainability(self) -> None:
+        """Apply the trainability flags and record the outcome.
+
+        Only the two large pretrained backbones are configurable. The visual
+        projector and action queries always train: absent a checkpoint the
+        projector is randomly initialised and the queries are zero, so freezing
+        either would leave the action head reading noise. Upstream agrees —
+        ``freeze_backbones`` trains the projector in every stage but
+        ``last-layer-finetune``, and ``finetune.py`` forces ``requires_grad``
+        on the action queries.
+        """
+        wants_grad = {
+            "vision_backbone": self.config.train_vision_backbone,
+            "language_model": self.config.train_llm,
+            "projector": True,
+            "action_queries": True,
+        }
+        for key, flag in wants_grad.items():
+            getattr(self, key).requires_grad_(requires_grad=flag)
+
+        self.trainable_module_keys = [key for key, flag in wants_grad.items() if flag]
+
+    @property
+    def num_vision_tokens(self) -> int:
+        """Total fused vision patch tokens across all camera views.
+
+        Returns:
+            ``num_patches * num_images_in_input``.
+        """
+        return self.vision_backbone.get_num_patches() * self.config.num_images_in_input
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run the VLM and return stacked per-layer hidden states.
+
+        Args:
+            pixel_values: Channel-stacked pixels ``(B, 6 * num_images, H, W)``.
+            input_ids: Prompt token ids ``(B, T_text)``.
+            attention_mask: Optional prompt mask ``(B, T_text)``.
+
+        Returns:
+            ``(B, num_layers + 1, num_vision_tokens + num_action_queries,
+            llm_dim)`` — only vision and action-query positions are kept.
+        """
+        batch = input_ids.shape[0]
+
+        vision_features = self.vision_backbone(pixel_values)
+        vision_embeds = self.projector(vision_features)
+
+        text_embeds = self.language_model.get_input_embeddings()(input_ids)
+        queries = self.action_queries.weight.unsqueeze(0).expand(batch, -1, -1)
+
+        inputs_embeds = torch.cat(
+            [vision_embeds, text_embeds.to(vision_embeds.dtype), queries.to(vision_embeds.dtype)],
+            dim=1,
+        )
+
+        if attention_mask is None:
+            attention_mask = torch.ones(input_ids.shape, dtype=torch.long, device=input_ids.device)
+        ones = partial(torch.ones, dtype=attention_mask.dtype, device=attention_mask.device)
+        full_mask = torch.cat(
+            [
+                ones((batch, vision_embeds.shape[1])),
+                attention_mask,
+                ones((batch, self.config.num_action_queries)),
+            ],
+            dim=1,
+        )
+
+        outputs = self.language_model(
+            inputs_embeds=inputs_embeds,
+            attention_mask=full_mask,
+            use_cache=False,
+            output_hidden_states=True,
+            return_dict=True,
+        )
+
+        num_vision = vision_embeds.shape[1]
+        num_queries = self.config.num_action_queries
+
+        # Keep only the task (vision) and action-query positions from every
+        # layer, stacked on a new layer axis for the head.
+        per_layer = [
+            torch.cat([state[:, :num_vision], state[:, -num_queries:]], dim=1).unsqueeze(1)
+            for state in outputs.hidden_states
+        ]
+        return torch.cat(per_layer, dim=1)

--- a/library/src/physicalai/policies/vla_adapter/components/vlm.py
+++ b/library/src/physicalai/policies/vla_adapter/components/vlm.py
@@ -9,25 +9,8 @@
 
 r"""The Prismatic VLM: fused DINOv2 + SigLIP towers feeding a Qwen2 LLM.
 
-The vision modules are **vendored, not reimplemented**. Three checkpoint
-behaviours are easy to get wrong and all fail silently — shapes agree, the model
-runs, only the success rate suffers:
-
-1. Features come from the **second-to-last** block via
-   ``get_intermediate_layers(n={num_blocks - 2})``, not ``forward_features``.
-2. ``LayerScale`` params are renamed ``gamma`` -> ``scale_factor`` (HF overwrites
-   names containing ``gamma``). Without the patch, 48 tensors fail to load.
-3. Each image arrives as **six** channels, three normalised per tower.
-
-Upstream's ``prismatic`` package pins torch 2.2 / transformers 4.40 / timm 0.9,
-so it cannot be a dependency; the checkpoint-local ``modeling_prismatic.py``
-needs only timm + transformers and is the vendoring source.
-
-:class:`VLM` takes its API from upstream's ``PrismaticVLM`` but its module names
-from ``PrismaticForConditionalGeneration`` — the class the checkpoints export
-through — so ``VLM.state_dict()`` matches ``model.safetensors`` exactly (982
-tensors, no prefix surgery). Mostly frozen: towers and LLM stay fixed while the
-projector and ``action_queries`` train; see :attr:`VLM.trainable_module_keys`.
+Mostly frozen: towers and LLM stay fixed while the projector and
+``action_queries`` train; see :attr:`VLM.trainable_module_keys`.
 
 ``action_queries`` lives here, not with the head, because it is an *input* to
 the LLM. The head reads the hidden states produced *at* those positions, never
@@ -62,7 +45,8 @@ from physicalai.policies.vla_adapter.config import (
 if TYPE_CHECKING:
     from timm.layers import LayerScale
     from timm.models import VisionTransformer
-    from transformers import Qwen2Model
+    from transformers import Qwen2Config, Qwen2Model
+    from transformers.modeling_outputs import BaseModelOutputWithPast
 
     from physicalai.policies.vla_adapter.config import VLAAdapterConfig
 
@@ -85,7 +69,7 @@ def _ls_new_forward(self: Any, x: torch.Tensor) -> torch.Tensor:  # noqa: ANN401
 def ls_apply_patch(ls_module: LayerScale) -> None:
     """Rename a ``LayerScale`` module's ``gamma`` parameter to ``scale_factor``.
 
-    The checkpoints store ``ls1.scale_factor``; without this, 48 tensors fail
+    The LIBERO-compatible weights store ``ls1.scale_factor``; without this, 48 tensors fail
     to load.
 
     Args:
@@ -101,15 +85,13 @@ def ls_apply_patch(ls_module: LayerScale) -> None:
 class PrismaticVisionBackbone(nn.Module):
     """Fused DINOv2 + SigLIP towers, vendored from the checkpoint modeling code.
 
-    ``primary_featurizer`` is DINOv2 (width 1024), ``secondary_featurizer`` is
-    SigLIP (width 1152). Upstream names these ``featurizer`` /
-    ``fused_featurizer``; the released checkpoints use those keys, so importing
-    one needs a name mapping (see Phase 3). Nothing in the train/save/load/export
-    path depends on it — our own checkpoints round-trip under these names.
+    ``featurizer`` is DINOv2 (width 1024), ``fused_featurizer`` is SigLIP
+    (width 1152). The names are upstream's, kept verbatim so the released
+    checkpoints load without remapping these tensors.
     """
 
-    primary_featurizer: VisionTransformer
-    secondary_featurizer: VisionTransformer
+    featurizer: VisionTransformer
+    fused_featurizer: VisionTransformer
     embed_dim: int
 
     def __init__(
@@ -133,19 +115,19 @@ class PrismaticVisionBackbone(nn.Module):
         super().__init__()
         self.num_images_in_input = 1
 
-        self.primary_featurizer = self._create_featurizer(
+        self.featurizer = self._create_featurizer(
             model_id=timm_model_ids[0],
             img_size=image_sizes[0],
             act_layer=timm_override_act_layers[0],
             pretrained=pretrained,
         )
-        self.secondary_featurizer = self._create_featurizer(
+        self.fused_featurizer = self._create_featurizer(
             model_id=timm_model_ids[1],
             img_size=image_sizes[1],
             act_layer=timm_override_act_layers[1],
             pretrained=pretrained,
         )
-        self.embed_dim = self.primary_featurizer.embed_dim + self.secondary_featurizer.embed_dim
+        self.embed_dim = self.featurizer.embed_dim + self.fused_featurizer.embed_dim
 
         self._patch_layer_scales()
 
@@ -205,7 +187,7 @@ class PrismaticVisionBackbone(nn.Module):
         """Patch every ``LayerScale`` module in both towers."""
         from timm.models.vision_transformer import LayerScale  # noqa: PLC0415
 
-        for tower in (self.primary_featurizer, self.secondary_featurizer):
+        for tower in (self.featurizer, self.fused_featurizer):
             for module in tower.modules():
                 if isinstance(module, LayerScale):
                     ls_apply_patch(module)
@@ -216,7 +198,7 @@ class PrismaticVisionBackbone(nn.Module):
         Returns:
             Patch tokens per image, per tower.
         """
-        return int(self.primary_featurizer.patch_embed.num_patches)
+        return int(self.featurizer.patch_embed.num_patches)
 
     def get_num_images_in_input(self) -> int:
         """Report how many camera views the backbone expects.
@@ -249,8 +231,8 @@ class PrismaticVisionBackbone(nn.Module):
         all_patches = []
         for img in images:
             img_regular, img_fused = torch.split(img, [CHANNELS_PER_TOWER, CHANNELS_PER_TOWER], dim=1)
-            patches = self.primary_featurizer(img_regular)
-            patches_fused = self.secondary_featurizer(img_fused)
+            patches = self.featurizer(img_regular)
+            patches_fused = self.fused_featurizer(img_fused)
             all_patches.append(torch.cat([patches, patches_fused], dim=2))
 
         return torch.cat(all_patches, dim=1)
@@ -306,18 +288,80 @@ class PrismaticVisualProjector(nn.Module):
         return self.fc3(projected_features)
 
 
+class LanguageModel(nn.Module):
+    """Model that wraps LLM transformer."""
+
+    model: Qwen2Model
+
+    def __init__(self, model_name: str, *, pretrained: bool = True) -> None:
+        """Build the Qwen2 transformer.
+
+        Args:
+            model_name: HuggingFace identifier supplying both geometry and weights.
+            pretrained: Boolean indicating whether to load published weights.
+        """
+        super().__init__()
+
+        from transformers import Qwen2Config, Qwen2Model  # noqa: PLC0415
+
+        if pretrained:
+            self.model = Qwen2Model.from_pretrained(model_name, dtype=torch.float32)
+        else:
+            self.model = Qwen2Model(Qwen2Config.from_pretrained(model_name))
+
+        # Every call is a single forward pass; a key/value cache would only add
+        # memory and break the static shapes export depends on.
+        self.model.config.use_cache = False
+
+    @property
+    def config(self) -> Qwen2Config:
+        """Configuration of the wrapped transformer.
+
+        Returns:
+            The Qwen2 configuration.
+        """
+        return self.model.config
+
+    def get_input_embeddings(self) -> nn.Module:
+        """Return the token embedding table.
+
+        Returns:
+            The wrapped transformer's input embeddings.
+        """
+        return self.model.get_input_embeddings()
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        *,
+        use_cache: bool = False,
+        output_hidden_states: bool = True,
+        return_dict: bool = True,
+    ) -> BaseModelOutputWithPast:
+        """Run the wrapped transformer.
+
+        Args:
+            inputs_embeds: Pre-embedded sequence ``(B, S, llm_dim)``.
+            attention_mask: Mask over the sequence.
+            use_cache: Retain key/value cache; off, as every call is one pass.
+            output_hidden_states: Return all per-layer hidden states.
+            return_dict: Return a dataclass rather than a tuple.
+
+        Returns:
+            The transformer output, carrying ``hidden_states``.
+        """
+        return self.model(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+
 class VLM(nn.Module):
-    """The Prismatic VLM, exposing per-layer hidden states to the action head.
-
-    Holds exactly the four submodules ``model.safetensors`` contains, so its
-    ``state_dict()`` matches that file key for key.
-    """
-
-    # Declared for the same reason as the vision towers: `.config` and friends
-    # are resolved dynamically by transformers.
-    language_model: Qwen2Model
-    llm_dim: int
-    num_layers: int
+    """The Prismatic VLM, exposing per-layer hidden states to the action head."""
 
     def __init__(self, config: VLAAdapterConfig) -> None:
         """Assemble the towers, projector, language model and action queries.
@@ -340,7 +384,10 @@ class VLM(nn.Module):
         self.vision_backbone.set_num_images_in_input(config.num_images_in_input)
 
         # init LLM
-        self.language_model = self._build_language_model()
+        self.language_model = LanguageModel(
+            config.llm_model_name,
+            pretrained=config.load_pretrained_backbone,
+        )
         self.llm_dim = self.language_model.config.hidden_size
         self.num_layers = self.language_model.config.num_hidden_layers
 
@@ -358,42 +405,11 @@ class VLM(nn.Module):
         self.trainable_module_keys: list[str] = []
         self.apply_trainability()
 
-    def _build_language_model(self) -> Qwen2Model:
-        """Build the Qwen2 language model, taking its geometry from the reference.
-
-        Geometry is never configured locally: it is read from
-        ``llm_model_name`` so the model and its tokenizer cannot disagree, and
-        so the action head's depth follows the LLM's automatically.
-
-        Weights are pretrained unless disabled. The LLM is frozen by default, so
-        a randomly initialised one would leave the head reading noise. They are
-        loaded as float32 because the published weights are bfloat16, which
-        would not match the float32 vision towers and head.
-
-        Returns:
-            A ``Qwen2Model`` with caching disabled.
-        """
-        from transformers import Qwen2Config, Qwen2Model  # noqa: PLC0415
-
-        if not self.config.load_pretrained_backbone:
-            llm_config = Qwen2Config.from_pretrained(self.config.llm_model_name)
-            llm_config.use_cache = False
-            return Qwen2Model(llm_config)
-
-        model = Qwen2Model.from_pretrained(self.config.llm_model_name, dtype=torch.float32)
-        model.config.use_cache = False
-        return model
-
     def apply_trainability(self) -> None:
         """Apply the trainability flags and record the outcome.
 
         Only the two large pretrained backbones are configurable. The visual
-        projector and action queries always train: absent a checkpoint the
-        projector is randomly initialised and the queries are zero, so freezing
-        either would leave the action head reading noise. Upstream agrees —
-        ``freeze_backbones`` trains the projector in every stage but
-        ``last-layer-finetune``, and ``finetune.py`` forces ``requires_grad``
-        on the action queries.
+        projector and action queries always train.
         """
         wants_grad = {
             "vision_backbone": self.config.train_vision_backbone,

--- a/library/src/physicalai/policies/vla_adapter/components/vlm.py
+++ b/library/src/physicalai/policies/vla_adapter/components/vlm.py
@@ -47,49 +47,29 @@ carries no ``lm_head`` — it is a feature extractor.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
 from functools import partial
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
-import timm
 import torch
 from torch import nn
 
-from physicalai.policies.vla_adapter.config import VLAAdapterConfig
+from physicalai.policies.vla_adapter.config import (
+    CHANNELS_PER_IMAGE,
+    CHANNELS_PER_TOWER,
+    NUM_VISION_TOWERS,
+)
+
+if TYPE_CHECKING:
+    from timm.layers import LayerScale
+    from timm.models import VisionTransformer
+    from transformers import Qwen2Model
+
+    from physicalai.policies.vla_adapter.config import VLAAdapterConfig
 
 logger = logging.getLogger(__name__)
 
-# Channels per image once both towers' normalised copies are stacked.
-CHANNELS_PER_IMAGE = 6
-# Channels a single tower consumes.
-CHANNELS_PER_TOWER = 3
-# VLA-Adapter always fuses DINOv2 with SigLIP.
-NUM_VISION_TOWERS = 2
 
-
-def unpack_tuple(fn: Callable[[Any], tuple[Any]]) -> Callable[[Any], Any]:
-    """Unwrap a single-element sequence returned by a monkey-patched forward.
-
-    DEVIATION FROM UPSTREAM: upstream tests ``isinstance(result, tuple)``,
-    correct for timm 0.9. timm 1.0 returns a *list*, which a tuple-only check
-    passes straight through, handing the caller a list where a tensor is
-    expected.
-
-    Args:
-        fn: Function whose result should be unwrapped.
-
-    Returns:
-        Wrapper returning ``result[0]`` for a tuple or list.
-    """
-
-    def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-        result = fn(*args, **kwargs)
-        return result[0] if isinstance(result, (tuple, list)) else result
-
-    return wrapper
-
-
-def _ls_new_forward(self: nn.Module, x: torch.Tensor) -> torch.Tensor:
+def _ls_new_forward(self: Any, x: torch.Tensor) -> torch.Tensor:  # noqa: ANN401
     """Replacement ``LayerScale.forward`` reading ``scale_factor``.
 
     Args:
@@ -102,7 +82,7 @@ def _ls_new_forward(self: nn.Module, x: torch.Tensor) -> torch.Tensor:
     return x.mul_(self.scale_factor) if self.inplace else x * self.scale_factor
 
 
-def ls_apply_patch(ls_module: nn.Module) -> None:
+def ls_apply_patch(ls_module: LayerScale) -> None:
     """Rename a ``LayerScale`` module's ``gamma`` parameter to ``scale_factor``.
 
     The checkpoints store ``ls1.scale_factor``; without this, 48 tensors fail
@@ -114,16 +94,23 @@ def ls_apply_patch(ls_module: nn.Module) -> None:
     from timm.models.vision_transformer import LayerScale  # noqa: PLC0415
 
     ls_module.scale_factor = nn.Parameter(ls_module.gamma.clone())
-    ls_module.forward = _ls_new_forward.__get__(ls_module, LayerScale)
+    ls_module.forward = _ls_new_forward.__get__(ls_module, LayerScale)  # type: ignore[method-assign]
     del ls_module.gamma
 
 
 class PrismaticVisionBackbone(nn.Module):
     """Fused DINOv2 + SigLIP towers, vendored from the checkpoint modeling code.
 
-    Attribute names (``featurizer``, ``fused_featurizer``) mirror the
-    checkpoint's tensor keys.
+    ``primary_featurizer`` is DINOv2 (width 1024), ``secondary_featurizer`` is
+    SigLIP (width 1152). Upstream names these ``featurizer`` /
+    ``fused_featurizer``; the released checkpoints use those keys, so importing
+    one needs a name mapping (see Phase 3). Nothing in the train/save/load/export
+    path depends on it — our own checkpoints round-trip under these names.
     """
+
+    primary_featurizer: VisionTransformer
+    secondary_featurizer: VisionTransformer
+    embed_dim: int
 
     def __init__(
         self,
@@ -142,34 +129,34 @@ class PrismaticVisionBackbone(nn.Module):
             pretrained: Fetch pretrained tower weights. The towers are frozen by
                 default, so leaving this False means the head reads noise.
 
-        Raises:
-            ValueError: If exactly two tower ids are not supplied.
         """
         super().__init__()
         self.num_images_in_input = 1
 
-        if len(timm_model_ids) != NUM_VISION_TOWERS:
-            msg = f"VLA-Adapter always fuses exactly {NUM_VISION_TOWERS} vision towers, got {len(timm_model_ids)}."
-            raise ValueError(msg)
-
-        self.featurizer = self._create_featurizer(
+        self.primary_featurizer = self._create_featurizer(
             model_id=timm_model_ids[0],
             img_size=image_sizes[0],
             act_layer=timm_override_act_layers[0],
             pretrained=pretrained,
         )
-        self.fused_featurizer = self._create_featurizer(
+        self.secondary_featurizer = self._create_featurizer(
             model_id=timm_model_ids[1],
             img_size=image_sizes[1],
             act_layer=timm_override_act_layers[1],
             pretrained=pretrained,
         )
-        self.embed_dim = self.featurizer.embed_dim + self.fused_featurizer.embed_dim
+        self.embed_dim = self.primary_featurizer.embed_dim + self.secondary_featurizer.embed_dim
 
         self._patch_layer_scales()
 
     @staticmethod
-    def _create_featurizer(model_id: str, img_size: int, act_layer: str | None, *, pretrained: bool) -> nn.Module:
+    def _create_featurizer(
+        model_id: str,
+        img_size: int,
+        act_layer: str | None,
+        *,
+        pretrained: bool,
+    ) -> VisionTransformer:
         """Create a timm featurizer emitting second-to-last-block patches.
 
         The monkey-patched ``forward`` is load-bearing: Prismatic reads block
@@ -185,16 +172,32 @@ class PrismaticVisionBackbone(nn.Module):
         Returns:
             The configured featurizer.
         """
-        featurizer = timm.create_model(
-            model_id,
-            pretrained=pretrained,
-            num_classes=0,
-            img_size=img_size,
-            act_layer=act_layer,
+        import timm  # noqa: PLC0415
+
+        # `create_model` is a factory keyed on a string, so it is declared
+        # `-> Module`. The concrete class here is the ViT we asked for, and the
+        # attributes used below (`blocks`, `embed_dim`, `patch_embed`,
+        # `get_intermediate_layers`) live on `VisionTransformer`, not `Module`.
+        featurizer = cast(
+            "VisionTransformer",
+            timm.create_model(
+                model_id,
+                pretrained=pretrained,
+                num_classes=0,
+                img_size=img_size,
+                act_layer=act_layer,
+            ),
         )
 
-        num_blocks = len(featurizer.blocks)
-        featurizer.forward = unpack_tuple(partial(featurizer.get_intermediate_layers, n={num_blocks - 2}))
+        second_to_last = [len(featurizer.blocks) - 2]
+
+        def _forward(x: torch.Tensor) -> torch.Tensor:
+            # A single requested index yields a one-element list.
+            # (Upstream passes a set here, which is outside the declared
+            #  signature; a one-element list is identical in effect.)
+            return featurizer.get_intermediate_layers(x, n=second_to_last)[0]
+
+        featurizer.forward = _forward  # type: ignore[method-assign,assignment]
 
         return featurizer
 
@@ -202,7 +205,7 @@ class PrismaticVisionBackbone(nn.Module):
         """Patch every ``LayerScale`` module in both towers."""
         from timm.models.vision_transformer import LayerScale  # noqa: PLC0415
 
-        for tower in (self.featurizer, self.fused_featurizer):
+        for tower in (self.primary_featurizer, self.secondary_featurizer):
             for module in tower.modules():
                 if isinstance(module, LayerScale):
                     ls_apply_patch(module)
@@ -213,7 +216,7 @@ class PrismaticVisionBackbone(nn.Module):
         Returns:
             Patch tokens per image, per tower.
         """
-        return int(self.featurizer.patch_embed.num_patches)
+        return int(self.primary_featurizer.patch_embed.num_patches)
 
     def get_num_images_in_input(self) -> int:
         """Report how many camera views the backbone expects.
@@ -246,8 +249,8 @@ class PrismaticVisionBackbone(nn.Module):
         all_patches = []
         for img in images:
             img_regular, img_fused = torch.split(img, [CHANNELS_PER_TOWER, CHANNELS_PER_TOWER], dim=1)
-            patches = self.featurizer(img_regular)
-            patches_fused = self.fused_featurizer(img_fused)
+            patches = self.primary_featurizer(img_regular)
+            patches_fused = self.secondary_featurizer(img_fused)
             all_patches.append(torch.cat([patches, patches_fused], dim=2))
 
         return torch.cat(all_patches, dim=1)
@@ -310,6 +313,12 @@ class VLM(nn.Module):
     ``state_dict()`` matches that file key for key.
     """
 
+    # Declared for the same reason as the vision towers: `.config` and friends
+    # are resolved dynamically by transformers.
+    language_model: Qwen2Model
+    llm_dim: int
+    num_layers: int
+
     def __init__(self, config: VLAAdapterConfig) -> None:
         """Assemble the towers, projector, language model and action queries.
 
@@ -349,7 +358,7 @@ class VLM(nn.Module):
         self.trainable_module_keys: list[str] = []
         self.apply_trainability()
 
-    def _build_language_model(self) -> nn.Module:
+    def _build_language_model(self) -> Qwen2Model:
         """Build the Qwen2 language model, taking its geometry from the reference.
 
         Geometry is never configured locally: it is read from
@@ -366,14 +375,12 @@ class VLM(nn.Module):
         """
         from transformers import Qwen2Config, Qwen2Model  # noqa: PLC0415
 
-        name = self.config.llm_model_name
-        llm_config = Qwen2Config.from_pretrained(name)
-        llm_config.use_cache = False
-
         if not self.config.load_pretrained_backbone:
+            llm_config = Qwen2Config.from_pretrained(self.config.llm_model_name)
+            llm_config.use_cache = False
             return Qwen2Model(llm_config)
 
-        model = Qwen2Model.from_pretrained(name, dtype=torch.float32)
+        model = Qwen2Model.from_pretrained(self.config.llm_model_name, dtype=torch.float32)
         model.config.use_cache = False
         return model
 

--- a/library/src/physicalai/policies/vla_adapter/config.py
+++ b/library/src/physicalai/policies/vla_adapter/config.py
@@ -6,16 +6,10 @@
 Upstream reference: https://github.com/OpenHelix-Team/VLA-Adapter (MIT),
 arXiv:2509.09372.
 
-Upstream keeps chunk length, action dimension and proprio dimension as
-*module-level globals* in ``prismatic/vla/constants.py``, selected from
-``sys.argv`` at import. That is incompatible with Studio's frozen dataclass
-configs, so they are typed fields here; defaults reproduce the LIBERO preset.
+Upstream's constants are typed fields in Studio's dataclass
+configs; defaults reproduce the LIBERO preset.
 
 CLI: ``physicalai fit --config configs/physicalai/vla_adapter.yaml``
-
-Example:
-    >>> from physicalai.policies.vla_adapter import VLAAdapterConfig
-    >>> config = VLAAdapterConfig(chunk_size=8, max_action_dim=7)
 """
 
 from __future__ import annotations
@@ -23,6 +17,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from physicalai.config import Config
+
+# Vision-backbone constants: VLA-Adapter always fuses two vision towers,
+# and each tower consumes its own normalised RGB copy of every camera view,
+# so an image reaches the backbone as six channels rather than three.
+NUM_VISION_TOWERS = 2
+CHANNELS_PER_TOWER = 3
+CHANNELS_PER_IMAGE = NUM_VISION_TOWERS * CHANNELS_PER_TOWER
 
 
 @dataclass(frozen=True)
@@ -97,19 +98,12 @@ class VLAAdapterConfig(Config):
     num_cameras: int = 0
     num_images_in_input: int = 2
 
-    # NOTE: fixed for export compatibility (avoids dynamic input shapes).
-    # Masking ignores unused tokens, so this should not affect accuracy.
-    tokenizer_max_length: int = 48
-
     num_task_tokens: int = 512
+    tokenizer_max_length: int = 48
     num_action_queries: int = 64
     head_num_heads: int = 8
 
-    # The Prismatic checkpoint defines the topology but ships no usable fast
-    # tokenizer, so both tokenizer and LLM weights come from Qwen directly.
     llm_model_name: str = "Qwen/Qwen2.5-0.5B"
-    load_pretrained_backbone: bool = True
-    # timm ids taken verbatim from the checkpoint's config.json (timm_model_ids).
     vision_backbone_ids: tuple[str, str] = (
         "vit_large_patch14_reg4_dinov2.lvd142m",
         "vit_so400m_patch14_siglip_224",
@@ -118,12 +112,10 @@ class VLAAdapterConfig(Config):
 
     use_proprio: bool = True
 
-    # Only the two large pretrained backbones are configurable. Everything else
-    # — visual projector, action queries, action head, proprio projector —
-    # always trains: each is randomly or zero-initialised, so freezing any of
-    # them would leave the policy unable to learn.
+    # default: loading the pretrained backbones and freezing them
     train_vision_backbone: bool = False
     train_llm: bool = False
+    load_pretrained_backbone: bool = True
 
     optimizer_lr: float = 5e-4
     optimizer_betas: tuple[float, float] = (0.9, 0.95)
@@ -139,13 +131,21 @@ class VLAAdapterConfig(Config):
         """Validate configuration parameters after initialization.
 
         Raises:
-            ValueError: If ``n_action_steps`` exceeds ``chunk_size``, or if any
-                count that must be positive is not.
+            ValueError: If ``n_action_steps`` exceeds ``chunk_size``, if the
+                wrong number of vision towers is given, or if any count that
+                must be positive is not.
         """
         if self.n_action_steps > self.chunk_size:
             msg = (
                 f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
                 f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
+            )
+            raise ValueError(msg)
+
+        if len(self.vision_backbone_ids) != NUM_VISION_TOWERS:
+            msg = (
+                f"VLA-Adapter always fuses exactly {NUM_VISION_TOWERS} vision towers "
+                f"(DINOv2 + SigLIP), got {len(self.vision_backbone_ids)}."
             )
             raise ValueError(msg)
 

--- a/library/src/physicalai/policies/vla_adapter/config.py
+++ b/library/src/physicalai/policies/vla_adapter/config.py
@@ -1,0 +1,158 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration for the VLA-Adapter model.
+
+Upstream reference: https://github.com/OpenHelix-Team/VLA-Adapter (MIT),
+arXiv:2509.09372.
+
+Upstream keeps chunk length, action dimension and proprio dimension as
+*module-level globals* in ``prismatic/vla/constants.py``, selected from
+``sys.argv`` at import. That is incompatible with Studio's frozen dataclass
+configs, so they are typed fields here; defaults reproduce the LIBERO preset.
+
+CLI: ``physicalai fit --config configs/physicalai/vla_adapter.yaml``
+
+Example:
+    >>> from physicalai.policies.vla_adapter import VLAAdapterConfig
+    >>> config = VLAAdapterConfig(chunk_size=8, max_action_dim=7)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from physicalai.config import Config
+
+
+@dataclass(frozen=True)
+class VLAAdapterConfig(Config):
+    """Configuration for the VLA-Adapter vision-language-action model.
+
+    Attributes:
+        n_obs_steps: Number of observation steps to use. Defaults to 1.
+        chunk_size: Size of action chunks for prediction. Upstream
+            ``NUM_ACTIONS_CHUNK``. Defaults to 8 (the LIBERO preset).
+        n_action_steps: Number of action steps executed per model invocation.
+            Must not exceed ``chunk_size``. Defaults to 8, matching upstream's
+            ``num_open_loop_steps``.
+        max_state_dim: Proprioceptive state dimension. Upstream ``PROPRIO_DIM``.
+            Defaults to 8 (LIBERO: xyz + axis-angle + gripper).
+        max_action_dim: Action vector dimension. Upstream ``ACTION_DIM``.
+            Defaults to 7.
+        image_size: Target (height, width). Checkpoints record
+            ``resize-naive`` — a plain stretch, no pad or crop. Default (224, 224).
+        image_key_reorder_map: Optional mapping from dataset camera keys to
+            policy camera slot indices, applied during preprocessing. Defaults to {}.
+        num_cameras: Camera slots expected; uncovered slots are filled with
+            masked empty cameras. Values <= 0 keep only batch cameras.
+        num_images_in_input: Number of camera views the backbone consumes.
+            Defaults to 2 (third-person + wrist).
+        tokenizer_max_length: Maximum language token length. Fixed rather than
+            dynamic so exported graphs keep static input shapes. Defaults to 48.
+        num_task_tokens: Leading positions treated as *task* features by the
+            head; the rest are action-query features. Derived from the backbone
+            at build time; this documents the LIBERO layout. Defaults to 512.
+        num_action_queries: Number of learned action-query tokens appended to
+            the LLM input sequence. Upstream ``NUM_TOKENS``. Defaults to 64.
+        head_num_heads: Number of attention heads inside each action-head block.
+            Defaults to 8.
+        llm_model_name: HuggingFace id supplying both the tokenizer and the
+            pretrained language-model weights. Its geometry must match the
+            ``llm_*`` fields below, or pretrained loading is skipped.
+        load_pretrained_backbone: Whether to initialise the vision towers and
+            language model from pretrained weights. Defaults to True: both are
+            frozen, so random initialisation would leave the head reading noise.
+            Set False for tests, or when a full VLA-Adapter checkpoint will
+            supply every weight anyway.
+        vision_backbone_ids: timm model ids for the fused DINOv2 and SigLIP
+            towers.
+        arch_specifier: Projector architecture, as recorded in the checkpoint's
+            ``config.json``. Defaults to "no-align+fused-gelu-mlp".
+        use_proprio: Whether to feed proprioceptive state to the action head.
+            Defaults to True.
+        train_vision_backbone: Whether the fused DINOv2 + SigLIP towers train.
+            Defaults to False, as upstream freezes them.
+        train_llm: Whether the language model trains. Defaults to False, as
+            upstream freezes it and adapts through LoRA instead.
+        optimizer_lr: Learning rate. Defaults to 5e-4, matching upstream.
+        optimizer_betas: Adam beta coefficients. Defaults to (0.9, 0.95).
+        optimizer_eps: Adam epsilon. Defaults to 1e-8.
+        optimizer_weight_decay: Weight decay coefficient. Defaults to 1e-10.
+        optimizer_grad_clip_norm: Maximum gradient norm. Defaults to 1.0.
+        scheduler_warmup_steps: LR warmup steps. Defaults to 1000.
+        scheduler_decay_steps: LR decay steps. Defaults to 30000.
+        scheduler_decay_lr: Final learning rate after decay. Defaults to 2.5e-6.
+    """
+
+    n_obs_steps: int = 1
+    chunk_size: int = 8
+    n_action_steps: int = 8
+
+    max_state_dim: int = 8
+    max_action_dim: int = 7
+
+    image_size: tuple[int, int] = (224, 224)
+    image_key_reorder_map: dict[str, int] = field(default_factory=dict)
+    num_cameras: int = 0
+    num_images_in_input: int = 2
+
+    # NOTE: fixed for export compatibility (avoids dynamic input shapes).
+    # Masking ignores unused tokens, so this should not affect accuracy.
+    tokenizer_max_length: int = 48
+
+    num_task_tokens: int = 512
+    num_action_queries: int = 64
+    head_num_heads: int = 8
+
+    # The Prismatic checkpoint defines the topology but ships no usable fast
+    # tokenizer, so both tokenizer and LLM weights come from Qwen directly.
+    llm_model_name: str = "Qwen/Qwen2.5-0.5B"
+    load_pretrained_backbone: bool = True
+    # timm ids taken verbatim from the checkpoint's config.json (timm_model_ids).
+    vision_backbone_ids: tuple[str, str] = (
+        "vit_large_patch14_reg4_dinov2.lvd142m",
+        "vit_so400m_patch14_siglip_224",
+    )
+    arch_specifier: str = "no-align+fused-gelu-mlp"
+
+    use_proprio: bool = True
+
+    # Only the two large pretrained backbones are configurable. Everything else
+    # — visual projector, action queries, action head, proprio projector —
+    # always trains: each is randomly or zero-initialised, so freezing any of
+    # them would leave the policy unable to learn.
+    train_vision_backbone: bool = False
+    train_llm: bool = False
+
+    optimizer_lr: float = 5e-4
+    optimizer_betas: tuple[float, float] = (0.9, 0.95)
+    optimizer_eps: float = 1e-8
+    optimizer_weight_decay: float = 1e-10
+    optimizer_grad_clip_norm: float = 1.0
+
+    scheduler_warmup_steps: int = 1_000
+    scheduler_decay_steps: int = 30_000
+    scheduler_decay_lr: float = 2.5e-6
+
+    def __post_init__(self) -> None:
+        """Validate configuration parameters after initialization.
+
+        Raises:
+            ValueError: If ``n_action_steps`` exceeds ``chunk_size``, or if any
+                count that must be positive is not.
+        """
+        if self.n_action_steps > self.chunk_size:
+            msg = (
+                f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
+                f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
+            )
+            raise ValueError(msg)
+
+        for name, value in (
+            ("num_images_in_input", self.num_images_in_input),
+            ("num_action_queries", self.num_action_queries),
+        ):
+            if value <= 0:
+                msg = f"`{name}` must be positive, got {value}."
+                raise ValueError(msg)

--- a/library/src/physicalai/policies/vla_adapter/model.py
+++ b/library/src/physicalai/policies/vla_adapter/model.py
@@ -1,18 +1,16 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-VLA-Adapter model
+"""VLA-Adapter model.
 
-Default trainability: the head, proprio projector, visual projector and 
+Default trainability: the head, proprio projector, visual projector and
 action queries train, while the visual backbone and LLM stay frozen.
-
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING
 
 import torch
 from torch import nn
@@ -21,7 +19,9 @@ from physicalai.data.constants import TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
 from physicalai.data.observation import ACTION, IMAGES, STATE
 from physicalai.policies.base.model import Model
 from physicalai.policies.vla_adapter.components import VLM, L1RegressionActionHead, ProprioProjector
-from physicalai.policies.vla_adapter.config import VLAAdapterConfig
+
+if TYPE_CHECKING:
+    from physicalai.policies.vla_adapter.config import VLAAdapterConfig
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class VLAAdapterModel(Model):
     def __init__(
         self,
         config: VLAAdapterConfig,
-        dataset_stats: dict[str, dict[str, Any]] | None = None,
+        dataset_stats: dict[str, dict[str, list[float] | str | tuple]] | None = None,
     ) -> None:
         """Build the VLM, proprio projector and action head.
 

--- a/library/src/physicalai/policies/vla_adapter/model.py
+++ b/library/src/physicalai/policies/vla_adapter/model.py
@@ -1,0 +1,298 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+VLA-Adapter model
+
+Default trainability: the head, proprio projector, visual projector and 
+action queries train, while the visual backbone and LLM stay frozen.
+
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+from torch import nn
+
+from physicalai.data.constants import TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
+from physicalai.data.observation import ACTION, IMAGES, STATE
+from physicalai.policies.base.model import Model
+from physicalai.policies.vla_adapter.components import VLM, L1RegressionActionHead, ProprioProjector
+from physicalai.policies.vla_adapter.config import VLAAdapterConfig
+
+logger = logging.getLogger(__name__)
+
+
+class VLAAdapterModel(Model):
+    """Prismatic VLM plus the VLA-Adapter Policy head.
+
+    Mostly frozen: the vision towers and language model do not train, while the
+    action head, proprio projector, visual projector and action queries do.
+
+    Args:
+        config: Resolved policy configuration.
+        dataset_stats: Dataset statistics, retained for downstream consumers
+            (normalization itself is applied by the preprocessor).
+    """
+
+    def __init__(
+        self,
+        config: VLAAdapterConfig,
+        dataset_stats: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        """Build the VLM, proprio projector and action head.
+
+        Args:
+            config: Resolved policy configuration.
+            dataset_stats: Retained for downstream consumers; normalization
+                itself is applied by the preprocessor.
+        """
+        super().__init__()
+        self._config = config
+        self._dataset_stats = dataset_stats
+
+        self.vlm = VLM(config)
+        llm_dim = self.vlm.llm_dim
+
+        self.proprio_projector: ProprioProjector | None = None
+        if config.use_proprio:
+            self.proprio_projector = ProprioProjector(
+                llm_dim=llm_dim,
+                proprio_dim=config.max_state_dim,
+            )
+
+        # The head's split point *is* the number of vision tokens, so derive it
+        # from the VLM rather than trusting the config to agree. The config
+        # value documents the upstream LIBERO layout (512 = 2 views x 256
+        # patches); a mismatch means a different resolution or camera count.
+        num_task_tokens = self.vlm.num_vision_tokens
+        if num_task_tokens != config.num_task_tokens:
+            logger.warning(
+                "num_task_tokens=%d from config does not match the backbone's %d vision tokens "
+                "(%d views x %d patches); using the backbone value.",
+                config.num_task_tokens,
+                num_task_tokens,
+                config.num_images_in_input,
+                self.vlm.vision_backbone.get_num_patches(),
+            )
+
+        self.action_head = L1RegressionActionHead(
+            input_dim=llm_dim,
+            hidden_dim=llm_dim,
+            action_dim=config.max_action_dim,
+            chunk_size=config.chunk_size,
+            num_task_tokens=num_task_tokens,
+            num_blocks=self.vlm.num_layers,
+            num_heads=config.head_num_heads,
+        )
+
+        self.log_trainable_parameters()
+
+    @property
+    def config(self) -> VLAAdapterConfig:
+        """The configuration this model was built from.
+
+        Returns:
+            The resolved policy configuration.
+        """
+        return self._config
+
+    def set_dataset_stats(self, dataset_stats: dict) -> None:
+        """Update dataset statistics.
+
+        Args:
+            dataset_stats: Dataset normalization statistics.
+        """
+        self._dataset_stats = dataset_stats
+
+    def trainable_parameter_summary(self) -> dict[str, tuple[int, int]]:
+        """Count trainable and total parameters per component.
+
+        VLM submodules are reported individually, since the freeze split runs
+        inside the VLM rather than at its boundary.
+
+        Returns:
+            Component name -> ``(trainable, total)``.
+        """
+        groups: dict[str, nn.Module] = {f"vlm.{key}": getattr(self.vlm, key) for key in self.vlm.all_module_keys}
+        groups["action_head"] = self.action_head
+        if self.proprio_projector is not None:
+            groups["proprio_projector"] = self.proprio_projector
+
+        return {
+            name: (
+                sum(p.numel() for p in module.parameters() if p.requires_grad),
+                sum(p.numel() for p in module.parameters()),
+            )
+            for name, module in groups.items()
+        }
+
+    def log_trainable_parameters(self) -> None:
+        """Log the per-component trainable/total split.
+
+        Makes the freeze decision visible at build time, rather than something
+        inferred later from a loss that will not move.
+        """
+        summary = self.trainable_parameter_summary()
+        total = sum(t for _, t in summary.values())
+        trainable = sum(t for t, _ in summary.values())
+        logger.info(
+            "VLA-Adapter parameters: %s trainable / %s total (%.2f%%)",
+            f"{trainable:,}",
+            f"{total:,}",
+            100.0 * trainable / total if total else 0.0,
+        )
+        for name, (tr, tot) in summary.items():
+            logger.info("  %-24s %14s / %14s  %s", name, f"{tr:,}", f"{tot:,}", "trains" if tr else "frozen")
+
+    def _predict(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
+        """Run the VLM plus head and return the raw action chunk.
+
+        Args:
+            batch: Preprocessed batch with channel-stacked images, a tokenized
+                prompt and (optionally) state.
+
+        Returns:
+            ``(B, chunk_size, action_dim)``.
+
+        Raises:
+            KeyError: If a required batch key is missing.
+        """
+        missing = [k for k in (IMAGES, TOKENIZED_PROMPT) if k not in batch]
+        if missing:
+            msg = f"Batch is missing required key(s) for VLA-Adapter: {missing}"
+            raise KeyError(msg)
+
+        hidden_states = self.vlm(
+            pixel_values=batch[IMAGES],
+            input_ids=batch[TOKENIZED_PROMPT],
+            attention_mask=batch.get(TOKENIZED_PROMPT_MASK),
+        )
+
+        proprio_features = None
+        if self.proprio_projector is not None:
+            state = batch[STATE]
+            state = state.reshape(state.shape[0], -1).to(hidden_states.dtype)
+            proprio_features = self.proprio_projector(state).unsqueeze(1)
+
+        return self.action_head(hidden_states, proprio_features=proprio_features)
+
+    def _target_actions(self, batch: dict[str, torch.Tensor], like: torch.Tensor) -> torch.Tensor:
+        """Slice ground-truth actions to the predicted chunk and dtype.
+
+        Args:
+            batch: Preprocessed batch containing ``action``.
+            like: Prediction tensor supplying the target dtype.
+
+        Returns:
+            ``(B, chunk_size, action_dim)``.
+
+        Raises:
+            KeyError: If ground-truth actions are absent.
+        """
+        if ACTION not in batch:
+            msg = "Ground-truth `action` is required to compute the VLA-Adapter loss."
+            raise KeyError(msg)
+        target = batch[ACTION][:, : self._config.chunk_size, : self._config.max_action_dim]
+        return target.to(like.dtype)
+
+    def forward(
+        self,
+        batch: dict[str, torch.Tensor],
+    ) -> torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor | float]]:
+        """Standard PyTorch forward.
+
+        Args:
+            batch: Preprocessed batch dict.
+
+        Returns:
+            ``(loss, loss_dict)`` in training mode, else the action chunk.
+        """
+        if self.training:
+            return self.compute_loss(batch)
+        return self._predict(batch)
+
+    def compute_loss(
+        self,
+        batch: dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor | float]]:
+        """Compute the L1 training loss against the ground-truth chunk.
+
+        Args:
+            batch: Preprocessed batch dict; must contain ``action``.
+
+        Returns:
+            ``(loss, loss_dict)``. Dict values stay tensors so ``torch.compile``
+            graphs are not broken by host syncs.
+        """
+        predicted = self._predict(batch)
+        target = self._target_actions(batch, like=predicted)
+
+        loss = nn.functional.l1_loss(predicted, target)
+        return loss, {"loss": loss.detach(), "l1_loss": loss.detach()}
+
+    @torch.no_grad()
+    def compute_val_loss(
+        self,
+        batch: dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor | float]]:
+        """Compute validation loss.
+
+        The training objective is already a direct action-prediction error, not
+        a stochastic surrogate, so validation reuses it. MSE is also reported
+        for comparability with the flow-matching families.
+
+        Args:
+            batch: Preprocessed batch dict with ground-truth actions.
+
+        Returns:
+            ``(loss, loss_dict)``.
+        """
+        predicted = self._predict(batch)
+        target = self._target_actions(batch, like=predicted)
+
+        loss = nn.functional.l1_loss(predicted, target)
+        mse = nn.functional.mse_loss(predicted, target)
+        return loss, {"loss": loss.detach(), "l1_loss": loss.detach(), "mse_loss": mse.detach()}
+
+    @torch.no_grad()
+    def predict_action_chunk(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
+        """Predict an action chunk without gradients.
+
+        Args:
+            batch: Preprocessed batch dict.
+
+        Returns:
+            ``(B, chunk_size, action_dim)``.
+        """
+        return self._predict(batch)
+
+    @property
+    def reward_delta_indices(self) -> None:
+        """Return reward indices; rewards are not implemented.
+
+        Returns:
+            None
+        """
+        return None
+
+    @property
+    def action_delta_indices(self) -> list[int]:
+        """Get action indices relative to the current timestep.
+
+        Returns:
+            Relative action indices.
+        """
+        return list(range(self._config.chunk_size))
+
+    @property
+    def observation_delta_indices(self) -> list[int]:
+        """Get observation indices relative to the current timestep.
+
+        Returns:
+            Relative observation indices.
+        """
+        return [0]

--- a/library/src/physicalai/policies/vla_adapter/policy.py
+++ b/library/src/physicalai/policies/vla_adapter/policy.py
@@ -30,12 +30,15 @@ from physicalai.export import ExportablePolicyMixin, ExportBackend
 from physicalai.policies.base import Policy
 from physicalai.policies.vla_adapter.config import VLAAdapterConfig
 from physicalai.policies.vla_adapter.model import VLAAdapterModel
-from physicalai.policies.vla_adapter.preprocessor import VLAAdapterPostprocessor, VLAAdapterPreprocessor
 from physicalai.train.schedulers import cosine_decay_with_warmup_scheduler
 from physicalai.train.utils import reformat_dataset_to_match_policy
 
 if TYPE_CHECKING:
     from physicalai.data import Observation
+    from physicalai.policies.vla_adapter.preprocessor import (
+        VLAAdapterPostprocessor,
+        VLAAdapterPreprocessor,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +91,7 @@ class VLAAdapter(ExportablePolicyMixin, Policy):
         scheduler_decay_steps: int = 30_000,
         scheduler_decay_lr: float = 2.5e-6,
         # Eager initialization (for checkpoint loading)
-        dataset_stats: dict[str, dict[str, Any]] | None = None,
+        dataset_stats: dict[str, dict[str, list[float] | str | tuple]] | None = None,
     ) -> None:
         """Initialize the policy.
 
@@ -149,7 +152,7 @@ class VLAAdapter(ExportablePolicyMixin, Policy):
             self.hparams[key] = value
         self.hparams["config"] = self.config.to_dict()
 
-    def _initialize_model(self, dataset_stats: dict[str, dict[str, Any]]) -> None:
+    def _initialize_model(self, dataset_stats: dict[str, dict[str, list[float] | str | tuple]]) -> None:
         """Build the model and its pre/postprocessors.
 
         Args:
@@ -158,7 +161,7 @@ class VLAAdapter(ExportablePolicyMixin, Policy):
         self.model = VLAAdapterModel(self.config, dataset_stats=dataset_stats)
         self._update_preprocessor_stats(dataset_stats)
 
-    def _update_preprocessor_stats(self, dataset_stats: dict[str, dict[str, Any]]) -> None:
+    def _update_preprocessor_stats(self, dataset_stats: dict[str, dict[str, list[float] | str | tuple]]) -> None:
         """Rebuild pre- and postprocessors from dataset statistics.
 
         Args:

--- a/library/src/physicalai/policies/vla_adapter/policy.py
+++ b/library/src/physicalai/policies/vla_adapter/policy.py
@@ -1,0 +1,347 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Architecture derived from https://github.com/OpenHelix-Team/VLA-Adapter (MIT).
+
+"""VLA-Adapter policy — Lightning wrapper for training and inference.
+
+A frozen 0.5B Prismatic VLM (fused DINOv2 + SigLIP towers feeding Qwen2.5-0.5B)
+paired with a lightweight Bridge-Attention head. Only the head, proprio
+projector, visual projector and action queries train by default, which is what
+makes it trainable on a single consumer GPU.
+
+Actions come from **continuous L1 regression in one forward pass** — no
+diffusion or flow-matching loop — so training and inference share a code path
+and the exported graph stays static.
+
+Export beyond the Torch backend is added later; ``get_supported_export_backends``
+currently advertises Torch only.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from physicalai.data.observation import ACTION
+from physicalai.export import ExportablePolicyMixin, ExportBackend
+from physicalai.policies.base import Policy
+from physicalai.policies.vla_adapter.config import VLAAdapterConfig
+from physicalai.policies.vla_adapter.model import VLAAdapterModel
+from physicalai.policies.vla_adapter.preprocessor import VLAAdapterPostprocessor, VLAAdapterPreprocessor
+from physicalai.train.schedulers import cosine_decay_with_warmup_scheduler
+from physicalai.train.utils import reformat_dataset_to_match_policy
+
+if TYPE_CHECKING:
+    from physicalai.data import Observation
+
+logger = logging.getLogger(__name__)
+
+
+class VLAAdapter(ExportablePolicyMixin, Policy):
+    """Lightning policy for the VLA-Adapter vision-language-action model.
+
+    Example:
+        >>> from physicalai.policies import get_policy
+        >>> policy = get_policy("vla_adapter")  # doctest: +SKIP
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        # Input / output structure
+        n_obs_steps: int = 1,
+        chunk_size: int = 8,
+        n_action_steps: int = 8,
+        max_state_dim: int = 8,
+        max_action_dim: int = 7,
+        # Image preprocessing
+        image_size: tuple[int, int] = (224, 224),
+        image_key_reorder_map: dict[str, int] | None = None,
+        num_cameras: int = 0,
+        num_images_in_input: int = 2,
+        *,
+        # Architecture
+        tokenizer_max_length: int = 48,
+        num_task_tokens: int = 512,
+        num_action_queries: int = 64,
+        head_num_heads: int = 8,
+        llm_model_name: str = "Qwen/Qwen2.5-0.5B",
+        load_pretrained_backbone: bool = True,
+        vision_backbone_ids: tuple[str, str] = (
+            "vit_large_patch14_reg4_dinov2.lvd142m",
+            "vit_so400m_patch14_siglip_224",
+        ),
+        arch_specifier: str = "no-align+fused-gelu-mlp",
+        use_proprio: bool = True,
+        # Trainability of the two pretrained backbones; everything else always trains
+        train_vision_backbone: bool = False,
+        train_llm: bool = False,
+        # Training presets
+        optimizer_lr: float = 5e-4,
+        optimizer_betas: tuple[float, float] = (0.9, 0.95),
+        optimizer_eps: float = 1e-8,
+        optimizer_weight_decay: float = 1e-10,
+        optimizer_grad_clip_norm: float = 1.0,
+        scheduler_warmup_steps: int = 1_000,
+        scheduler_decay_steps: int = 30_000,
+        scheduler_decay_lr: float = 2.5e-6,
+        # Eager initialization (for checkpoint loading)
+        dataset_stats: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        """Initialize the policy.
+
+        Builds a :class:`VLAAdapterConfig` from the explicit arguments and saves
+        it as Lightning hyperparameters. The model is created lazily in
+        :meth:`setup`, or immediately when ``dataset_stats`` is given.
+        """
+        super().__init__(n_action_steps=n_action_steps)
+
+        self.config = VLAAdapterConfig(
+            n_obs_steps=n_obs_steps,
+            chunk_size=chunk_size,
+            n_action_steps=n_action_steps,
+            max_state_dim=max_state_dim,
+            max_action_dim=max_action_dim,
+            image_size=image_size,
+            image_key_reorder_map=image_key_reorder_map or {},
+            num_cameras=num_cameras,
+            num_images_in_input=num_images_in_input,
+            tokenizer_max_length=tokenizer_max_length,
+            num_task_tokens=num_task_tokens,
+            num_action_queries=num_action_queries,
+            head_num_heads=head_num_heads,
+            llm_model_name=llm_model_name,
+            load_pretrained_backbone=load_pretrained_backbone,
+            vision_backbone_ids=vision_backbone_ids,
+            arch_specifier=arch_specifier,
+            use_proprio=use_proprio,
+            train_vision_backbone=train_vision_backbone,
+            train_llm=train_llm,
+            optimizer_lr=optimizer_lr,
+            optimizer_betas=optimizer_betas,
+            optimizer_eps=optimizer_eps,
+            optimizer_weight_decay=optimizer_weight_decay,
+            optimizer_grad_clip_norm=optimizer_grad_clip_norm,
+            scheduler_warmup_steps=scheduler_warmup_steps,
+            scheduler_decay_steps=scheduler_decay_steps,
+            scheduler_decay_lr=scheduler_decay_lr,
+        )
+
+        self.save_hyperparameters(ignore=["config"])
+        self._set_hparam_keys()
+
+        self.model: VLAAdapterModel | None = None
+        self._preprocessor: VLAAdapterPreprocessor | None = None
+        self._postprocessor: VLAAdapterPostprocessor | None = None
+
+        if dataset_stats is not None:
+            self._initialize_model(dataset_stats)
+
+        self._dataset_stats = dataset_stats
+
+    def _set_hparam_keys(self) -> None:
+        """Sync top-level checkpoint hparams from the resolved policy config."""
+        for key, value in self.config.__dict__.items():
+            if key not in self.hparams:
+                continue
+            self.hparams[key] = value
+        self.hparams["config"] = self.config.to_dict()
+
+    def _initialize_model(self, dataset_stats: dict[str, dict[str, Any]]) -> None:
+        """Build the model and its pre/postprocessors.
+
+        Args:
+            dataset_stats: Dataset normalization statistics.
+        """
+        self.model = VLAAdapterModel(self.config, dataset_stats=dataset_stats)
+        self._update_preprocessor_stats(dataset_stats)
+
+    def _update_preprocessor_stats(self, dataset_stats: dict[str, dict[str, Any]]) -> None:
+        """Rebuild pre- and postprocessors from dataset statistics.
+
+        Args:
+            dataset_stats: Dataset normalization statistics.
+        """
+        from physicalai.policies.vla_adapter.preprocessor import make_vla_adapter_preprocessors  # noqa: PLC0415
+
+        self._preprocessor, self._postprocessor = make_vla_adapter_preprocessors(
+            max_state_dim=self.config.max_state_dim,
+            max_action_dim=self.config.max_action_dim,
+            stats=dataset_stats,
+            image_resolution=self.config.image_size,
+            vision_backbone_ids=self.config.vision_backbone_ids,
+            image_key_reorder_map=self.config.image_key_reorder_map,
+            num_cameras=self.config.num_cameras,
+            max_token_len=self.config.tokenizer_max_length,
+            tokenizer_name=self.config.llm_model_name,
+        )
+        self._dataset_stats = dataset_stats
+        self.hparams["dataset_stats"] = dataset_stats
+        if self.model is not None:
+            self.model.set_dataset_stats(dataset_stats)
+
+    def setup(self, stage: str) -> None:
+        """Build the model from the datamodule (lazy initialization path).
+
+        Args:
+            stage: Lightning stage (unused).
+
+        Raises:
+            TypeError: If the train dataset is not a physicalai ``Dataset``.
+        """
+        del stage
+
+        from physicalai.data.dataset import Dataset  # noqa: PLC0415
+
+        datamodule = self.trainer.datamodule  # type: ignore[attr-defined]
+        train_dataset = datamodule.train_dataset
+
+        if not isinstance(train_dataset, Dataset):
+            msg = f"Expected physicalai Dataset, got {type(train_dataset)}"
+            raise TypeError(msg)
+
+        stats_dict = train_dataset.stats
+
+        if self.model is not None:
+            self._update_preprocessor_stats(stats_dict)
+            reformat_dataset_to_match_policy(self, datamodule)
+            return
+
+        self.hparams["dataset_stats"] = stats_dict
+        self._initialize_model(stats_dict)
+        reformat_dataset_to_match_policy(self, datamodule)
+
+    def forward(self, batch: Observation) -> torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor | float]]:
+        """Run a forward pass.
+
+        Args:
+            batch: Input observation batch.
+
+        Returns:
+            ``(loss, loss_dict)`` in training mode, else the action chunk.
+
+        Raises:
+            ValueError: If the model has not been initialized.
+        """
+        if self.training:
+            if self.model is None or self._preprocessor is None:
+                msg = "Model is not initialized"
+                raise ValueError(msg)
+            processed_batch = self._preprocessor(batch.to_dict())
+            return self.model(processed_batch)
+        return self.predict_action_chunk(batch)
+
+    @torch.no_grad()
+    def predict_action_chunk(self, batch: Observation) -> torch.Tensor:
+        """Predict a chunk of actions from an observation batch.
+
+        Args:
+            batch: Input observation batch.
+
+        Returns:
+            Denormalized ``(B, chunk_size, action_dim)``.
+
+        Raises:
+            ValueError: If the model has not been initialized.
+        """
+        if self.model is None or self._preprocessor is None or self._postprocessor is None:
+            msg = "Model is not initialized"
+            raise ValueError(msg)
+
+        processed_batch = self._preprocessor(batch.to(self.device).to_dict())
+        chunk = self.model.predict_action_chunk(processed_batch)
+        return self._postprocessor({ACTION: chunk})[ACTION]
+
+    def training_step(self, batch: Observation, batch_idx: int) -> torch.Tensor:
+        """Lightning training step.
+
+        Args:
+            batch: Input batch.
+            batch_idx: Batch index (unused).
+
+        Returns:
+            Loss tensor for backpropagation.
+        """
+        del batch_idx
+        loss, loss_dict = self(batch)
+        self.log("train/loss", loss_dict["loss"], prog_bar=True)
+        return loss
+
+    def compute_val_loss(self, batch: Observation) -> tuple[torch.Tensor, dict[str, torch.Tensor | float]]:
+        """Compute validation loss on a batch.
+
+        Args:
+            batch: Observation batch with ground-truth actions.
+
+        Returns:
+            ``(loss, loss_dict)``.
+
+        Raises:
+            ValueError: If the model has not been initialized.
+        """
+        if self.model is None or self._preprocessor is None:
+            msg = "Model is not initialized"
+            raise ValueError(msg)
+        processed_batch = self._preprocessor(batch.to_dict())
+        return self.model.compute_val_loss(processed_batch)
+
+    def configure_optimizers(self) -> dict[str, Any]:
+        """Configure the optimizer and learning-rate scheduler.
+
+        Returns:
+            Lightning optimizer configuration dict.
+        """
+        params = [p for p in self.parameters() if p.requires_grad]
+
+        optimizer = torch.optim.AdamW(
+            params,
+            lr=self.config.optimizer_lr,
+            weight_decay=self.config.optimizer_weight_decay,
+            betas=self.config.optimizer_betas,
+            eps=self.config.optimizer_eps,
+        )
+
+        scheduler = cosine_decay_with_warmup_scheduler(
+            optimizer,
+            peak_lr=self.config.optimizer_lr,
+            decay_lr=self.config.scheduler_decay_lr,
+            num_warmup_steps=self.config.scheduler_warmup_steps,
+            num_decay_steps=self.config.scheduler_decay_steps,
+        )
+
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {"scheduler": scheduler, "interval": "step"},
+        }
+
+    def configure_gradient_clipping(
+        self,
+        optimizer: torch.optim.Optimizer,
+        gradient_clip_val: float | None = None,
+        gradient_clip_algorithm: str | None = None,
+    ) -> None:
+        """Apply the configured gradient clipping.
+
+        Args:
+            optimizer: The optimizer being stepped.
+            gradient_clip_val: Clip value from the Trainer, if any.
+            gradient_clip_algorithm: Clipping algorithm from the Trainer.
+        """
+        clip_val = gradient_clip_val if gradient_clip_val is not None else self.config.optimizer_grad_clip_norm
+        if clip_val and clip_val > 0:
+            self.clip_gradients(
+                optimizer,
+                gradient_clip_val=clip_val,
+                gradient_clip_algorithm=gradient_clip_algorithm or "norm",
+            )
+
+    @staticmethod
+    def get_supported_export_backends() -> list[str | ExportBackend]:
+        """Get the export backends supported by this policy.
+
+        Returns:
+            Supported export backends.
+        """
+        return [ExportBackend.TORCH]

--- a/library/src/physicalai/policies/vla_adapter/policy.py
+++ b/library/src/physicalai/policies/vla_adapter/policy.py
@@ -21,13 +21,22 @@ currently advertises Torch only.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
+from physicalai.inference.data import InferenceFeature, InferenceFeatureDtype, InferenceFeatureType
+from physicalai.inference.manifest import ComponentSpec
 
-from physicalai.data.observation import ACTION
+from physicalai.data.observation import ACTION, IMAGES, STATE, TASK, FeatureType
 from physicalai.export import ExportablePolicyMixin, ExportBackend
+from physicalai.export.backends import (
+    ExportParameters,
+    ONNXExportParameters,
+    OpenVINOExportParameters,
+    TorchExportParameters,
+)
 from physicalai.policies.base import Policy
+from physicalai.policies.utils.normalization import NormalizationType
 from physicalai.policies.vla_adapter.config import VLAAdapterConfig
 from physicalai.policies.vla_adapter.model import VLAAdapterModel
 from physicalai.train.schedulers import cosine_decay_with_warmup_scheduler
@@ -347,4 +356,191 @@ class VLAAdapter(ExportablePolicyMixin, Policy):
         Returns:
             Supported export backends.
         """
-        return [ExportBackend.TORCH]
+        return [ExportBackend.TORCH, ExportBackend.OPENVINO]
+
+    @property
+    def inputs_schema(self) -> list[InferenceFeature] | None:
+        """Describe the inputs the exported policy expects.
+
+        Everything is read from the dataset statistics rather than the config,
+        so the schema follows whatever dataset the policy was trained on: the
+        camera count and names, the state width and the image resolution all
+        come from the data. Image shapes are the *dataset's* — resizing to
+        ``image_size`` happens inside the preprocessor, which travels with the
+        Torch artifact.
+
+        Returns:
+            One ``STATE`` feature, one ``VISUAL`` feature per camera and one
+            ``LANGUAGE`` feature, or None before ``setup`` has run.
+        """
+        if self.model is None or self._dataset_stats is None:
+            return None
+
+        dataset_stats = self._dataset_stats
+
+        num_image_features = sum(
+            1 for feature in dataset_stats.values() if str(FeatureType.VISUAL) in str(feature.get("type", ""))
+        )
+
+        schema: list[InferenceFeature] = []
+        for feature_id, feature in dataset_stats.items():
+            feature_type = str(feature.get("type", ""))
+            if STATE in feature_id:
+                schema.append(
+                    InferenceFeature(
+                        ftype=InferenceFeatureType.STATE,
+                        shape=cast("tuple", feature["shape"]),
+                        name=STATE,
+                        dtype=InferenceFeatureDtype.FLOAT32,
+                    ),
+                )
+            elif str(FeatureType.VISUAL) in feature_type:
+                feature_name = (
+                    str(feature.get("name", feature_id)).removeprefix("observation.").removeprefix(f"{IMAGES}.")
+                )
+                schema.append(
+                    InferenceFeature(
+                        ftype=InferenceFeatureType.VISUAL,
+                        shape=cast("tuple", feature["shape"]),
+                        name=IMAGES if num_image_features == 1 else f"{IMAGES}.{feature_name}",
+                        dtype=InferenceFeatureDtype.FLOAT32,
+                    ),
+                )
+
+        schema.append(
+            InferenceFeature(
+                ftype=InferenceFeatureType.LANGUAGE,
+                shape=(),
+                name=TASK,
+                dtype=InferenceFeatureDtype.STRING,
+            ),
+        )
+
+        return schema
+
+    @property
+    def outputs_schema(self) -> list[InferenceFeature] | None:
+        """Describe the exported policy's output.
+
+        Returns:
+            A single ``ACTION`` feature of ``(chunk_size, *action_dim)``, with
+            the action width taken from the dataset statistics. None before
+            ``setup`` has run.
+        """
+        if self.model is None or self._dataset_stats is None:
+            return None
+
+        action_shape = cast("tuple", self._dataset_stats[ACTION]["shape"])
+
+        return [
+            InferenceFeature(
+                ftype=InferenceFeatureType.ACTION,
+                shape=(self.config.chunk_size, *action_shape),
+                name=ACTION,
+                dtype=InferenceFeatureDtype.FLOAT32,
+            ),
+        ]
+
+    @property
+    def extra_export_args(self) -> dict[str, ExportParameters]:
+        """Provide backend-specific export parameters.
+
+        The Torch artifact is the whole Lightning policy, so the preprocessor
+        and postprocessor — and the normalization buffers they hold — are saved
+        inside it and run within the policy. Runtime therefore only has to
+        supply what ``Observation`` cannot: uint8 images cast to float32 in
+        [0, 1] and transposed to channels-first.
+
+        The deployment backends are the opposite case: only ``self.model`` is
+        traced, so the preprocessor and postprocessor are left outside the graph
+        and Runtime has to rebuild both from these specs — hence the image
+        component, the tokenizer and the ``denormalize`` that Torch does not need.
+
+        Returns:
+            Export parameters keyed by backend name.
+
+        Raises:
+            ValueError: If dataset stats are unavailable.
+        """
+        if self._dataset_stats is None:
+            msg = (
+                "Dataset stats are required for export. Initialize the policy with dataset_stats"
+                " or train for at least one epoch to populate them."
+            )
+            raise ValueError(msg)
+
+        trimmer_specs = []
+        if self.config.chunk_size != self.config.n_action_steps:
+            trimmer_specs.append(
+                ComponentSpec(
+                    type="action_chunk_trimmer",
+                    n_action_steps=self.config.n_action_steps,
+                ),
+            )
+
+        # Take the tower statistics from the preprocessor's own buffers rather
+        # than re-resolving them through timm, so the numpy component cannot
+        # drift from the torch reference — and so Runtime needs no timm.
+        preprocessor = cast("Any", self._preprocessor)
+        deployment_preproc_specs = [
+            ComponentSpec(
+                type="normalize",
+                stats={STATE: self._dataset_stats[f"observation.{STATE}"]},
+                mode=NormalizationType.QUANTILES.lower(),
+            ),
+            ComponentSpec(
+                type="vla_adapter",
+                image_resolution=self.config.image_size,
+                primary_mean=tuple(preprocessor.primary_mean.flatten().tolist()),
+                primary_std=tuple(preprocessor.primary_std.flatten().tolist()),
+                secondary_mean=tuple(preprocessor.secondary_mean.flatten().tolist()),
+                secondary_std=tuple(preprocessor.secondary_std.flatten().tolist()),
+                image_key_reorder_map=self.config.image_key_reorder_map,
+                num_cameras=self.config.num_cameras,
+            ),
+        ]
+        deployment_postproc_specs = [
+            ComponentSpec(
+                type="denormalize",
+                stats={ACTION: self._dataset_stats[ACTION]},
+                mode=NormalizationType.QUANTILES.lower(),
+            ),
+            *trimmer_specs,
+        ]
+
+        output_names = [feature.name for feature in (self.outputs_schema or [])]
+
+        return {
+            "torch": TorchExportParameters(
+                preprocessors_specs=[ComponentSpec(type="to_float_tensor")],
+                postprocessors_specs=trimmer_specs,
+            ),
+            # ONNX is not an advertised backend, but `to_openvino` reads its
+            # `exporter_kwargs` when `via_onnx` is set, so `output_names` would
+            # never reach `torch.onnx.export` without this entry.
+            "onnx": ONNXExportParameters(
+                exporter_kwargs={"output_names": output_names},
+                preprocessors_specs=[
+                    *deployment_preproc_specs,
+                    ComponentSpec(
+                        type="hf_tokenizer",
+                        tokenizer_name=self.config.llm_model_name,
+                        revision="main",
+                        max_token_len=self.config.tokenizer_max_length,
+                    ),
+                ],
+                postprocessors_specs=deployment_postproc_specs,
+            ),
+            "openvino": OpenVINOExportParameters(
+                outputs=output_names,
+                compress_to_fp16=True,
+                via_onnx=True,
+                export_tokenizer=True,
+                exporter_kwargs={},
+                preprocessors_specs=[
+                    *deployment_preproc_specs,
+                    ComponentSpec(type="ov_tokenizer", artifact="tokenizer.xml"),
+                ],
+                postprocessors_specs=deployment_postproc_specs,
+            ),
+        }

--- a/library/src/physicalai/policies/vla_adapter/preprocessor.py
+++ b/library/src/physicalai/policies/vla_adapter/preprocessor.py
@@ -36,46 +36,25 @@ from physicalai.policies.utils.normalization import FeatureNormalizeTransform, N
 logger = logging.getLogger(__name__)
 
 
+# An image tensor carries a leading time axis when the datamodule applies
+# observation delta timestamps: (B, T, C, H, W) rather than (B, C, H, W).
+IMAGE_DIMS_WITH_TIME = 5
+
 # VLA-Adapter inherits OpenVLA's BOUNDS_Q99 convention for both state and action.
 NORM_MAP = {
     FeatureType.STATE: NormalizationType.QUANTILES,
     FeatureType.ACTION: NormalizationType.QUANTILES,
 }
 
-# Fallback pixel statistics if a tower id carries no pretrained config.
-_FALLBACK_MEAN = (0.5, 0.5, 0.5)
-_FALLBACK_STD = (0.5, 0.5, 0.5)
-
-
-def resolve_tower_stats(model_id: str) -> tuple[tuple[float, ...], tuple[float, ...]]:
-    """Look up a timm model's pixel mean/std without instantiating it.
-
-    Args:
-        model_id: timm model identifier.
-
-    Returns:
-        ``(mean, std)``, each a 3-tuple.
-    """
-    try:
-        import timm  # noqa: PLC0415
-
-        cfg = timm.get_pretrained_cfg(model_id)
-        data = cfg.to_dict() if hasattr(cfg, "to_dict") else vars(cfg)
-        mean, std = data.get("mean"), data.get("std")
-    except Exception:  # noqa: BLE001 - any lookup failure falls back to symmetric stats
-        mean = std = None
-
-    if not mean or not std:
-        logger.warning(
-            "No pretrained pixel statistics found for %r; falling back to symmetric [-1, 1] normalization.",
-            model_id,
-        )
-        return _FALLBACK_MEAN, _FALLBACK_STD
-    return tuple(mean), tuple(std)
-
 
 class VLAAdapterPreprocessor(torch.nn.Module):
     """Transform raw observations into VLA-Adapter model inputs."""
+
+    # Registered buffers, declared so they type as tensors rather than modules.
+    primary_mean: torch.Tensor
+    primary_std: torch.Tensor
+    secondary_mean: torch.Tensor
+    secondary_std: torch.Tensor
 
     def __init__(
         self,
@@ -99,8 +78,8 @@ class VLAAdapterPreprocessor(torch.nn.Module):
             max_state_dim: Proprioceptive state dimension.
             max_action_dim: Action dimension.
             image_resolution: Target ``(height, width)``.
-            vision_backbone_ids: timm ids of the primary and fused towers, used
-                to resolve per-tower pixel statistics.
+            vision_backbone_ids: timm ids of the primary and secondary towers,
+                used to resolve per-tower pixel statistics.
             image_key_reorder_map: Image-key to camera-slot mapping.
             num_cameras: Camera slots; <= 0 keeps only batch cameras.
             features: Feature descriptors for normalization, or None.
@@ -122,36 +101,28 @@ class VLAAdapterPreprocessor(torch.nn.Module):
         self.max_token_len = max_token_len
         self.tokenizer_name = tokenizer_name
         self.padding = padding
-        self._tokenizer: Any = None
+
+        import timm  # noqa: PLC0415
+        from transformers import AutoTokenizer  # noqa: PLC0415
+
+        tokenizer: Any = AutoTokenizer.from_pretrained(tokenizer_name)
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        self.tokenizer = tokenizer
 
         # Per-tower pixel statistics, registered as buffers so they move with
         # the module and are captured by exported graphs.
-        for name, model_id in zip(("primary", "fused"), vision_backbone_ids, strict=False):
-            mean, std = resolve_tower_stats(model_id)
-            self.register_buffer(f"{name}_mean", torch.tensor(mean).view(1, 3, 1, 1), persistent=False)
-            self.register_buffer(f"{name}_std", torch.tensor(std).view(1, 3, 1, 1), persistent=False)
+        for name, model_id in zip(("primary", "secondary"), vision_backbone_ids, strict=False):
+            cfg: Any = timm.get_pretrained_cfg(model_id)
+            self.register_buffer(f"{name}_mean", torch.tensor(cfg.mean).view(1, 3, 1, 1), persistent=False)
+            self.register_buffer(f"{name}_std", torch.tensor(cfg.std).view(1, 3, 1, 1), persistent=False)
 
         if features is not None:
             self._state_action_normalizer: torch.nn.Module = FeatureNormalizeTransform(features, NORM_MAP)
         else:
             self._state_action_normalizer = torch.nn.Identity()
 
-    @property
-    def tokenizer(self) -> Any:  # noqa: ANN401 - HF tokenizer has no stable public type
-        """Lazily instantiated HuggingFace tokenizer.
-
-        Returns:
-            The tokenizer for ``tokenizer_name``.
-        """
-        if self._tokenizer is None:
-            from transformers import AutoTokenizer  # noqa: PLC0415
-
-            self._tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name)
-            if self._tokenizer.pad_token is None:
-                self._tokenizer.pad_token = self._tokenizer.eos_token
-        return self._tokenizer
-
-    def _tokenize(self, task: Any) -> tuple[torch.Tensor, torch.Tensor]:  # noqa: ANN401
+    def _tokenize(self, task: str | list[str]) -> tuple[torch.Tensor, torch.Tensor]:
         """Tokenize the task description(s) to a fixed length.
 
         Args:
@@ -197,11 +168,18 @@ class VLAAdapterPreprocessor(torch.nn.Module):
         """Resize one view and stack its two normalised copies.
 
         Args:
-            view: Images ``(B, 3, H, W)`` with values in [0, 1].
+            view: Images ``(B, 3, H, W)``, or ``(B, T, 3, H, W)`` when the
+                datamodule has applied observation delta timestamps.
 
         Returns:
             ``(B, 6, *image_resolution)``.
         """
+        # The datamodule sets observation delta timestamps from the model's
+        # `observation_delta_indices`, which adds a time axis even for a single
+        # step. Keep the most recent frame, as the other policies do.
+        if view.dim() == IMAGE_DIMS_WITH_TIME:
+            view = view[:, -1]
+
         resized = F.interpolate(
             view.float(),
             size=self.image_resolution,
@@ -209,8 +187,8 @@ class VLAAdapterPreprocessor(torch.nn.Module):
             align_corners=False,
         )
         primary = (resized - self.primary_mean) / self.primary_std
-        fused = (resized - self.fused_mean) / self.fused_std
-        return torch.cat([primary, fused], dim=1)
+        secondary = (resized - self.secondary_mean) / self.secondary_std
+        return torch.cat([primary, secondary], dim=1)
 
     def _preprocess_images(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Resize, normalise per tower, and channel-stack all camera views.
@@ -223,9 +201,6 @@ class VLAAdapterPreprocessor(torch.nn.Module):
         Returns:
             Batch dict with ``IMAGES`` as ``(B, 6 * num_views, H, W)``.
         """
-        # Observation.to_dict() flattens nested dicts, so cameras normally
-        # arrive as `images.image`, `images.image2`, ... rather than a nested
-        # dict under `images`.
         flat_keys = [key for key in Observation.get_flattened_keys(batch, IMAGES) if "is_pad" not in key]
 
         if flat_keys:
@@ -266,12 +241,13 @@ class VLAAdapterPreprocessor(torch.nn.Module):
             quantile-normalized state/action.
         """
         batch = dict(batch)
-
-        if TASK in batch:
-            tokens, masks = self._tokenize(batch[TASK])
-            device = batch[STATE].device if STATE in batch else tokens.device
-            batch[TOKENIZED_PROMPT] = tokens.to(device)
-            batch[TOKENIZED_PROMPT_MASK] = masks.to(device)
+        task = batch.get(TASK)
+        if not task:
+            task = [""] * _batch_size(batch)
+        tokens, masks = self._tokenize(task)
+        device = batch[STATE].device if STATE in batch else tokens.device
+        batch[TOKENIZED_PROMPT] = tokens.to(device)
+        batch[TOKENIZED_PROMPT_MASK] = masks.to(device)
 
         batch = self._preprocess_images(batch)
 
@@ -315,7 +291,26 @@ class VLAAdapterPostprocessor(torch.nn.Module):
         return batch
 
 
-def _quantile_params(stat: dict[str, Any]) -> NormalizationParameters:
+def _batch_size(batch: dict[str, Any]) -> int:
+    """Infer the batch size from whichever tensor the batch carries.
+
+    Args:
+        batch: Batch dict, before image stacking.
+
+    Returns:
+        Leading dimension of the first tensor found, or 1 if there is none.
+    """
+    for value in batch.values():
+        if isinstance(value, torch.Tensor) and value.dim() > 0:
+            return int(value.shape[0])
+        if isinstance(value, dict):
+            for inner in value.values():
+                if isinstance(inner, torch.Tensor) and inner.dim() > 0:
+                    return int(inner.shape[0])
+    return 1
+
+
+def _quantile_params(stat: dict[str, list[float] | str | tuple]) -> NormalizationParameters:
     """Build quantile normalization parameters from a dataset stat entry.
 
     LeRobot datasets do not always carry ``q01``/``q99``, so fall back to
@@ -357,7 +352,7 @@ def _quantile_params(stat: dict[str, Any]) -> NormalizationParameters:
 def make_vla_adapter_preprocessors(
     max_state_dim: int = 8,
     max_action_dim: int = 7,
-    stats: dict[str, dict[str, Any]] | None = None,
+    stats: dict[str, dict[str, list[float] | str | tuple]] | None = None,
     *,
     image_resolution: tuple[int, int] = (224, 224),
     vision_backbone_ids: tuple[str, str] = (

--- a/library/src/physicalai/policies/vla_adapter/preprocessor.py
+++ b/library/src/physicalai/policies/vla_adapter/preprocessor.py
@@ -1,0 +1,419 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preprocessor and postprocessor for the VLA-Adapter model.
+
+Two details are taken from upstream rather than chosen.
+
+``image_resize_strategy: "resize-naive"`` in the checkpoint means a straight
+**bicubic** stretch to 224x224 — no letterboxing, no centre crop.
+
+The fused backbone feeds each tower its *own* normalization, so every view
+becomes six channels: three for DINOv2 (ImageNet stats) then three for SigLIP
+(symmetric +/-1). Those constants are resolved from ``timm.get_pretrained_cfg``
+rather than hardcoded, so they track the tower ids. Views are concatenated on
+the channel axis, giving ``(B, 6 * num_images, H, W)`` — the layout
+``PrismaticVisionBackbone`` splits back apart.
+
+State and action use ``NormalizationType.QUANTILES``, the 1st/99th-percentile
+mapping to [-1, 1] that upstream calls ``BOUNDS_Q99``. Runtime's
+``StatsNormalizer`` implements the identical formula under ``mode="quantiles"``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+
+from physicalai.data import Feature, FeatureType, NormalizationParameters
+from physicalai.data.constants import TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
+from physicalai.data.observation import ACTION, IMAGES, STATE, TASK, Observation
+from physicalai.policies.utils.normalization import FeatureNormalizeTransform, NormalizationType
+
+logger = logging.getLogger(__name__)
+
+
+# VLA-Adapter inherits OpenVLA's BOUNDS_Q99 convention for both state and action.
+NORM_MAP = {
+    FeatureType.STATE: NormalizationType.QUANTILES,
+    FeatureType.ACTION: NormalizationType.QUANTILES,
+}
+
+# Fallback pixel statistics if a tower id carries no pretrained config.
+_FALLBACK_MEAN = (0.5, 0.5, 0.5)
+_FALLBACK_STD = (0.5, 0.5, 0.5)
+
+
+def resolve_tower_stats(model_id: str) -> tuple[tuple[float, ...], tuple[float, ...]]:
+    """Look up a timm model's pixel mean/std without instantiating it.
+
+    Args:
+        model_id: timm model identifier.
+
+    Returns:
+        ``(mean, std)``, each a 3-tuple.
+    """
+    try:
+        import timm  # noqa: PLC0415
+
+        cfg = timm.get_pretrained_cfg(model_id)
+        data = cfg.to_dict() if hasattr(cfg, "to_dict") else vars(cfg)
+        mean, std = data.get("mean"), data.get("std")
+    except Exception:  # noqa: BLE001 - any lookup failure falls back to symmetric stats
+        mean = std = None
+
+    if not mean or not std:
+        logger.warning(
+            "No pretrained pixel statistics found for %r; falling back to symmetric [-1, 1] normalization.",
+            model_id,
+        )
+        return _FALLBACK_MEAN, _FALLBACK_STD
+    return tuple(mean), tuple(std)
+
+
+class VLAAdapterPreprocessor(torch.nn.Module):
+    """Transform raw observations into VLA-Adapter model inputs."""
+
+    def __init__(
+        self,
+        max_state_dim: int = 8,
+        max_action_dim: int = 7,
+        image_resolution: tuple[int, int] = (224, 224),
+        vision_backbone_ids: tuple[str, str] = (
+            "vit_large_patch14_reg4_dinov2.lvd142m",
+            "vit_so400m_patch14_siglip_224",
+        ),
+        image_key_reorder_map: dict[str, int] | None = None,
+        num_cameras: int = 0,
+        features: dict[str, Feature] | None = None,
+        max_token_len: int = 48,
+        tokenizer_name: str = "Qwen/Qwen2.5-0.5B",
+        padding: str = "max_length",
+    ) -> None:
+        """Initialize the preprocessor.
+
+        Args:
+            max_state_dim: Proprioceptive state dimension.
+            max_action_dim: Action dimension.
+            image_resolution: Target ``(height, width)``.
+            vision_backbone_ids: timm ids of the primary and fused towers, used
+                to resolve per-tower pixel statistics.
+            image_key_reorder_map: Image-key to camera-slot mapping.
+            num_cameras: Camera slots; <= 0 keeps only batch cameras.
+            features: Feature descriptors for normalization, or None.
+            max_token_len: Fixed language token length.
+            tokenizer_name: HuggingFace tokenizer identifier.
+            padding: Tokenizer padding; ``"max_length"`` keeps export shapes
+                static.
+        """
+        super().__init__()
+
+        self.max_state_dim = max_state_dim
+        self.max_action_dim = max_action_dim
+        self.image_resolution = image_resolution
+        self.image_key_reorder_map = {
+            key if key.startswith(f"{IMAGES}.") else f"{IMAGES}.{key}": order
+            for key, order in (image_key_reorder_map or {}).items()
+        }
+        self.num_cameras = num_cameras
+        self.max_token_len = max_token_len
+        self.tokenizer_name = tokenizer_name
+        self.padding = padding
+        self._tokenizer: Any = None
+
+        # Per-tower pixel statistics, registered as buffers so they move with
+        # the module and are captured by exported graphs.
+        for name, model_id in zip(("primary", "fused"), vision_backbone_ids, strict=False):
+            mean, std = resolve_tower_stats(model_id)
+            self.register_buffer(f"{name}_mean", torch.tensor(mean).view(1, 3, 1, 1), persistent=False)
+            self.register_buffer(f"{name}_std", torch.tensor(std).view(1, 3, 1, 1), persistent=False)
+
+        if features is not None:
+            self._state_action_normalizer: torch.nn.Module = FeatureNormalizeTransform(features, NORM_MAP)
+        else:
+            self._state_action_normalizer = torch.nn.Identity()
+
+    @property
+    def tokenizer(self) -> Any:  # noqa: ANN401 - HF tokenizer has no stable public type
+        """Lazily instantiated HuggingFace tokenizer.
+
+        Returns:
+            The tokenizer for ``tokenizer_name``.
+        """
+        if self._tokenizer is None:
+            from transformers import AutoTokenizer  # noqa: PLC0415
+
+            self._tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name)
+            if self._tokenizer.pad_token is None:
+                self._tokenizer.pad_token = self._tokenizer.eos_token
+        return self._tokenizer
+
+    def _tokenize(self, task: Any) -> tuple[torch.Tensor, torch.Tensor]:  # noqa: ANN401
+        """Tokenize the task description(s) to a fixed length.
+
+        Args:
+            task: A string or list of task descriptions.
+
+        Returns:
+            ``(input_ids, attention_mask)``.
+        """
+        prompts = [task] if isinstance(task, str) else list(task)
+        encoded = self.tokenizer(
+            prompts,
+            padding=self.padding,
+            truncation=True,
+            max_length=self.max_token_len,
+            return_tensors="pt",
+        )
+        return encoded["input_ids"], encoded["attention_mask"]
+
+    def _ordered_image_keys(self, batch_img_keys: list[str]) -> list[str]:
+        """Resolve deterministic camera ordering.
+
+        Args:
+            batch_img_keys: Image keys present in the batch.
+
+        Returns:
+            Image keys in camera-slot order.
+
+        Raises:
+            ValueError: If ``image_key_reorder_map`` does not match the keys.
+        """
+        if not self.image_key_reorder_map:
+            return sorted(batch_img_keys)
+
+        if set(self.image_key_reorder_map) != set(batch_img_keys):
+            msg = (
+                "image_key_reorder_map keys must match the batch image keys exactly. "
+                f"Expected {sorted(self.image_key_reorder_map)}, got {sorted(batch_img_keys)}."
+            )
+            raise ValueError(msg)
+        return sorted(batch_img_keys, key=lambda key: self.image_key_reorder_map[key])
+
+    def _stack_view(self, view: torch.Tensor) -> torch.Tensor:
+        """Resize one view and stack its two normalised copies.
+
+        Args:
+            view: Images ``(B, 3, H, W)`` with values in [0, 1].
+
+        Returns:
+            ``(B, 6, *image_resolution)``.
+        """
+        resized = F.interpolate(
+            view.float(),
+            size=self.image_resolution,
+            mode="bicubic",
+            align_corners=False,
+        )
+        primary = (resized - self.primary_mean) / self.primary_std
+        fused = (resized - self.fused_mean) / self.fused_std
+        return torch.cat([primary, fused], dim=1)
+
+    def _preprocess_images(self, batch: dict[str, Any]) -> dict[str, Any]:
+        """Resize, normalise per tower, and channel-stack all camera views.
+
+        Args:
+            batch: Batch dict. ``Observation.to_dict()`` flattens cameras to
+                ``images.<name>`` keys; a nested dict or a single stacked
+                tensor under ``IMAGES`` are also accepted.
+
+        Returns:
+            Batch dict with ``IMAGES`` as ``(B, 6 * num_views, H, W)``.
+        """
+        # Observation.to_dict() flattens nested dicts, so cameras normally
+        # arrive as `images.image`, `images.image2`, ... rather than a nested
+        # dict under `images`.
+        flat_keys = [key for key in Observation.get_flattened_keys(batch, IMAGES) if "is_pad" not in key]
+
+        if flat_keys:
+            ordered = self._ordered_image_keys(flat_keys)
+            views = [batch[key] for key in ordered]
+            for key in flat_keys:
+                batch.pop(key, None)
+        else:
+            images = batch.get(IMAGES)
+            if images is None:
+                return batch
+            if isinstance(images, torch.Tensor):
+                views = [images] if images.dim() == 4 else list(images.unbind(dim=1))  # noqa: PLR2004
+            else:
+                lookup = {
+                    key if key.startswith(f"{IMAGES}.") else f"{IMAGES}.{key}": value for key, value in images.items()
+                }
+                views = [lookup[key] for key in self._ordered_image_keys(list(lookup))]
+
+        stacked = [self._stack_view(view) for view in views]
+
+        if self.num_cameras > 0:
+            while len(stacked) < self.num_cameras:
+                stacked.append(torch.zeros_like(stacked[0]))
+            stacked = stacked[: self.num_cameras]
+
+        batch[IMAGES] = torch.cat(stacked, dim=1)
+        return batch
+
+    def forward(self, batch: dict[str, Any]) -> dict[str, torch.Tensor]:
+        """Preprocess a raw batch.
+
+        Args:
+            batch: Raw batch dict, typically ``Observation.to_dict()``.
+
+        Returns:
+            Batch with channel-stacked images, tokenized prompt and
+            quantile-normalized state/action.
+        """
+        batch = dict(batch)
+
+        if TASK in batch:
+            tokens, masks = self._tokenize(batch[TASK])
+            device = batch[STATE].device if STATE in batch else tokens.device
+            batch[TOKENIZED_PROMPT] = tokens.to(device)
+            batch[TOKENIZED_PROMPT_MASK] = masks.to(device)
+
+        batch = self._preprocess_images(batch)
+
+        return self._state_action_normalizer(batch)
+
+
+class VLAAdapterPostprocessor(torch.nn.Module):
+    """Map model outputs back to the original action space."""
+
+    def __init__(self, features: dict[str, Feature] | None = None) -> None:
+        """Initialize the postprocessor.
+
+        Args:
+            features: Action features drive denormalization; None means
+                identity.
+        """
+        super().__init__()
+
+        if features is not None:
+            action_features = {k: v for k, v in features.items() if v.ftype == FeatureType.ACTION}
+            self._action_denormalizer: torch.nn.Module = FeatureNormalizeTransform(
+                action_features,
+                NORM_MAP,
+                inverse=True,
+            )
+        else:
+            self._action_denormalizer = torch.nn.Identity()
+
+    def forward(self, batch: dict[str, Any]) -> dict[str, torch.Tensor]:
+        """Denormalize actions if present.
+
+        Args:
+            batch: Batch dict, optionally containing ``ACTION``.
+
+        Returns:
+            Batch with denormalized actions.
+        """
+        batch = dict(batch)
+        if ACTION in batch:
+            batch[ACTION] = self._action_denormalizer({ACTION: batch[ACTION]})[ACTION]
+        return batch
+
+
+def _quantile_params(stat: dict[str, Any]) -> NormalizationParameters:
+    """Build quantile normalization parameters from a dataset stat entry.
+
+    LeRobot datasets do not always carry ``q01``/``q99``, so fall back to
+    ``min``/``max`` — the same affine mapping over the full range rather than
+    the trimmed one.
+
+    Args:
+        stat: A single feature's statistics dict.
+
+    Returns:
+        Populated normalization parameters.
+
+    Raises:
+        KeyError: If neither quantiles nor min/max are available.
+    """
+    if stat.get("q01") is not None and stat.get("q99") is not None:
+        return NormalizationParameters(
+            q01=cast("list[float]", stat["q01"]),
+            q99=cast("list[float]", stat["q99"]),
+        )
+
+    if stat.get("min") is None or stat.get("max") is None:
+        msg = (
+            f"Feature {stat.get('name')!r} has neither q01/q99 nor min/max statistics; "
+            "quantile normalization cannot be configured."
+        )
+        raise KeyError(msg)
+
+    logger.warning(
+        "Dataset stats for %r lack q01/q99; falling back to min/max for quantile normalization.",
+        stat.get("name"),
+    )
+    return NormalizationParameters(
+        q01=cast("list[float]", stat["min"]),
+        q99=cast("list[float]", stat["max"]),
+    )
+
+
+def make_vla_adapter_preprocessors(
+    max_state_dim: int = 8,
+    max_action_dim: int = 7,
+    stats: dict[str, dict[str, Any]] | None = None,
+    *,
+    image_resolution: tuple[int, int] = (224, 224),
+    vision_backbone_ids: tuple[str, str] = (
+        "vit_large_patch14_reg4_dinov2.lvd142m",
+        "vit_so400m_patch14_siglip_224",
+    ),
+    image_key_reorder_map: dict[str, int] | None = None,
+    num_cameras: int = 0,
+    max_token_len: int = 48,
+    token_pad_type: str = "max_length",  # noqa: S107
+    tokenizer_name: str = "Qwen/Qwen2.5-0.5B",
+) -> tuple[VLAAdapterPreprocessor, VLAAdapterPostprocessor]:
+    """Create a matched preprocessor / postprocessor pair.
+
+    Args:
+        max_state_dim: Proprioceptive state dimension.
+        max_action_dim: Action dimension.
+        stats: Dataset statistics as nested dicts.
+        image_resolution: Target image resolution.
+        vision_backbone_ids: timm ids of the two towers.
+        image_key_reorder_map: Image-key to camera-slot mapping.
+        num_cameras: Total camera slots.
+        max_token_len: Fixed language token length.
+        token_pad_type: Tokenizer padding strategy.
+        tokenizer_name: HuggingFace tokenizer identifier.
+
+    Returns:
+        ``(preprocessor, postprocessor)``.
+    """
+    features: dict[str, Feature] = {}
+    if stats is not None:
+        for key, stat in stats.items():
+            if ACTION in key:
+                feature_type = FeatureType.ACTION
+            elif STATE in key:
+                feature_type = FeatureType.STATE
+            else:
+                continue
+            features[str(stat["name"])] = Feature(
+                name=str(stat["name"]),
+                ftype=feature_type,
+                shape=cast("tuple[int, ...]", stat["shape"]),
+                normalization_data=_quantile_params(stat),
+            )
+
+    preprocessor = VLAAdapterPreprocessor(
+        max_state_dim=max_state_dim,
+        max_action_dim=max_action_dim,
+        image_resolution=image_resolution,
+        vision_backbone_ids=vision_backbone_ids,
+        image_key_reorder_map=image_key_reorder_map,
+        num_cameras=num_cameras,
+        features=features,
+        max_token_len=max_token_len,
+        tokenizer_name=tokenizer_name,
+        padding=token_pad_type,
+    )
+    postprocessor = VLAAdapterPostprocessor(features=features)
+    return preprocessor, postprocessor


### PR DESCRIPTION
## Description

Adds [VLA-Adapter](https://github.com/OpenHelix-Team/VLA-Adapter) (MIT) as a first-party policy: a Prismatic VLM (fused DINOv2 + SigLIP towers → Qwen2.5-0.5B) with a Bridge-Attention regression head. Actions come from continuous L1 regression in a single forward pass.

### Changes
- **The policy itself** — the vision-language backbone, the action head, and the input handling that turns camera frames, robot state and a language instruction into what the model expects
- **Registration** — the policy is selectable by name like any other, with its dependencies behind an optional install extra
- **Training config** — a ready-to-run setup on the public LIBERO dataset, with the large backbones frozen so roughly a tenth of the model trains
- **Export** — Torch and OpenVINO artifacts, described automatically from the dataset rather than hardcoded, so the same policy exports correctly whatever it was trained on

### Notable details
- **Checkpoint-compatible naming.** `VLM.state_dict()` matches the released `model.safetensors` **982/982 tensors verbatim**, so public LIBERO weights import without key rewriting. This drove keeping upstream's `featurizer` / `fused_featurizer` names and adding a thin `LanguageModel` container that reproduces the checkpoint's `language_model.model.*` nesting without carrying an unused `lm_head`.
- **Three silent divergences avoided by vendoring:** features from the second-to-last block via `get_intermediate_layers`, the LayerScale `gamma` → `scale_factor` rename (48 tensors), and 6-channel-per-image input.

