### PR TITLE
feat: verify user has accss to gated models

### DIFF
--- a/application/backend/src/api/policies.py
+++ b/application/backend/src/api/policies.py
@@ -1,5 +1,13 @@
-from fastapi import APIRouter
+import asyncio
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException
+from huggingface_hub import HfApi
+from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
 from physicalai.policies import ACT, Pi0, Pi05, SmolVLA
+from pydantic import BaseModel
+
+from settings import get_settings
 
 router = APIRouter(prefix="/api/policies", tags=["Policies"])
 
@@ -9,6 +17,34 @@ _POLICY_CLASSES = {
     "pi05": Pi05,
     "smolvla": SmolVLA,
 }
+
+_HUGGINGFACE_REQUIREMENTS = {
+    # Hub dependencies are lazy and can vary with a policy's configuration, so
+    # there is no library API that can discover them safely without starting a
+    # download. When adding/changing a policy, inspect its `from_pretrained`,
+    # `hf_hub_download`, and `Auto*from_pretrained` calls and list every default
+    # repository that Studio training needs here.
+    "pi05": (
+        ("lerobot/pi05_base", True),
+        ("google/paligemma-3b-pt-224", True),
+    ),
+    "smolvla": (("lerobot/smolvla_base", False),),
+}
+
+
+class HuggingFaceRequirementAccess(BaseModel):
+    """Access status for one Hub repository a policy needs."""
+
+    repository: str
+    status: Literal["granted", "missing_token", "denied", "unavailable", "not_required"]
+    access_url: str
+    required: bool
+
+
+class HuggingFaceAccessResponse(BaseModel):
+    """Hub access statuses for every repository a policy requires."""
+
+    requirements: list[HuggingFaceRequirementAccess]
 
 
 @router.get("/backends")
@@ -20,3 +56,50 @@ def get_supported_backends_per_policy() -> dict[str, list[str]]:
         else []
         for name, cls in _POLICY_CLASSES.items()
     }
+
+
+@router.get("/{policy}/huggingface-access")
+async def check_huggingface_access(policy: str) -> HuggingFaceAccessResponse:
+    """Check whether the configured token can read a policy's required Hub model."""
+    if policy not in _POLICY_CLASSES:
+        raise HTTPException(status_code=404, detail="Unknown policy")
+
+    requirements = _HUGGINGFACE_REQUIREMENTS.get(policy, ())
+    if not requirements:
+        return HuggingFaceAccessResponse(requirements=[])
+    token = get_settings().huggingface.hf_token
+    token_value = token.get_secret_value() if token is not None else ""
+    if not token_value:
+        return HuggingFaceAccessResponse(
+            requirements=[
+                HuggingFaceRequirementAccess(
+                    repository=repository,
+                    status="missing_token",
+                    access_url=f"https://huggingface.co/{repository}",
+                    required=required,
+                )
+                for repository, required in requirements
+            ]
+        )
+
+    async def check_requirement(repository: str, required: bool) -> HuggingFaceRequirementAccess:
+        access_url = f"https://huggingface.co/{repository}"
+        try:
+            await asyncio.to_thread(HfApi(token=token_value).auth_check, repository)
+        except (GatedRepoError, RepositoryNotFoundError):
+            status = "denied"
+        except Exception:
+            status = "unavailable"
+        else:
+            status = "granted"
+        return HuggingFaceRequirementAccess(
+            repository=repository,
+            status=status,
+            access_url=access_url,
+            required=required,
+        )
+
+    checked_requirements = await asyncio.gather(
+        *(check_requirement(repository, required) for repository, required in requirements)
+    )
+    return HuggingFaceAccessResponse(requirements=checked_requirements)

--- a/application/backend/src/api/policies.py
+++ b/application/backend/src/api/policies.py
@@ -11,6 +11,8 @@ from settings import get_settings
 
 router = APIRouter(prefix="/api/policies", tags=["Policies"])
 
+_AccessStatus = Literal["granted", "missing_token", "denied", "unavailable", "not_required"]
+
 _POLICY_CLASSES = {
     "act": ACT,
     "pi0": Pi0,
@@ -36,7 +38,7 @@ class HuggingFaceRequirementAccess(BaseModel):
     """Access status for one Hub repository a policy needs."""
 
     repository: str
-    status: Literal["granted", "missing_token", "denied", "unavailable", "not_required"]
+    status: _AccessStatus
     access_url: str
     required: bool
 
@@ -84,6 +86,7 @@ async def check_huggingface_access(policy: str) -> HuggingFaceAccessResponse:
 
     async def check_requirement(repository: str, required: bool) -> HuggingFaceRequirementAccess:
         access_url = f"https://huggingface.co/{repository}"
+        status: _AccessStatus
         try:
             await asyncio.to_thread(HfApi(token=token_value).auth_check, repository)
         except (GatedRepoError, RepositoryNotFoundError):

--- a/application/backend/tests/api/test_policy_huggingface_access.py
+++ b/application/backend/tests/api/test_policy_huggingface_access.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from main import app
+from settings import write_user_settings
+
+
+def test_huggingface_access_reports_missing_token(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+
+    with TestClient(app) as client:
+        response = client.get("/api/policies/pi05/huggingface-access")
+
+    assert response.json() == {
+        "requirements": [
+            {
+                "repository": "lerobot/pi05_base",
+                "status": "missing_token",
+                "access_url": "https://huggingface.co/lerobot/pi05_base",
+                "required": True,
+            },
+            {
+                "repository": "google/paligemma-3b-pt-224",
+                "status": "missing_token",
+                "access_url": "https://huggingface.co/google/paligemma-3b-pt-224",
+                "required": True,
+            },
+        ],
+    }
+
+
+def test_huggingface_access_reports_gated_access_denied(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+    write_user_settings({"huggingface": {"hf_token": "hf-secret"}})
+
+    class AccessDenied(Exception):
+        pass
+
+    def deny_access(*_args, **_kwargs) -> None:
+        raise AccessDenied
+
+    monkeypatch.setattr("api.policies.GatedRepoError", AccessDenied)
+    monkeypatch.setattr("api.policies.HfApi.auth_check", deny_access)
+    with TestClient(app) as client:
+        response = client.get("/api/policies/pi05/huggingface-access")
+
+    assert [requirement["status"] for requirement in response.json()["requirements"]] == ["denied", "denied"]

--- a/application/ui/src/features/models/train-model-dialog/policy-access-alert.tsx
+++ b/application/ui/src/features/models/train-model-dialog/policy-access-alert.tsx
@@ -22,11 +22,16 @@ export const PolicyAccessAlert = ({ policy }: PolicyAccessAlertProps) => {
                 <Flex direction='column' gap='size-100'>
                     <span>
                         {failedRequirements.some((requirement) => requirement.status === 'missing_token')
-                            ? 'This policy needs a Hugging Face token to download pretrained assets.'
-                            : 'Your Hugging Face token does not have access to every required pretrained asset.'}
+                            ? 'This policy downloads pretrained assets from Hugging Face, but no token is configured.'
+                            : 'Your Hugging Face token does not have access to this policy.'}
                     </span>
                     {failedRequirements.map((requirement) => (
-                        <SpectrumLink key={requirement.repository} href={requirement.access_url} target='_blank'>
+                        <SpectrumLink
+                            key={requirement.repository}
+                            href={requirement.access_url}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                        >
                             Request access to {requirement.repository}
                         </SpectrumLink>
                     ))}

--- a/application/ui/src/features/models/train-model-dialog/policy-access-alert.tsx
+++ b/application/ui/src/features/models/train-model-dialog/policy-access-alert.tsx
@@ -1,0 +1,49 @@
+import { Flex, Link as SpectrumLink } from '@geti-ui/ui';
+import { Link } from 'react-router';
+
+import { $api } from '../../../api/client';
+import { paths } from '../../../router';
+import { InlineAlert } from '../../robots/setup-wizard/shared/inline-alert';
+
+type PolicyAccessAlertProps = { policy: string };
+
+export const PolicyAccessAlert = ({ policy }: PolicyAccessAlertProps) => {
+    const { data: policyAccess } = $api.useQuery('get', '/api/policies/{policy}/huggingface-access', {
+        params: { path: { policy } },
+    });
+
+    const failedRequirements =
+        policyAccess?.requirements.filter(({ status }) => status === 'missing_token' || status === 'denied') ?? [];
+    const blocksTraining = failedRequirements.some(({ required }) => required);
+
+    if (failedRequirements.length > 0) {
+        return (
+            <InlineAlert variant={blocksTraining ? 'error' : 'warning'}>
+                <Flex direction='column' gap='size-100'>
+                    <span>
+                        {failedRequirements.some((requirement) => requirement.status === 'missing_token')
+                            ? 'This policy needs a Hugging Face token to download pretrained assets.'
+                            : 'Your Hugging Face token does not have access to every required pretrained asset.'}
+                    </span>
+                    {failedRequirements.map((requirement) => (
+                        <SpectrumLink key={requirement.repository} href={requirement.access_url} target='_blank'>
+                            Request access to {requirement.repository}
+                        </SpectrumLink>
+                    ))}
+                    <Link to={paths.settings.index.pattern}>Open Settings</Link>
+                </Flex>
+            </InlineAlert>
+        );
+    }
+
+    const unavailable = policyAccess?.requirements.some((requirement) => requirement.status === 'unavailable');
+    if (unavailable) {
+        return (
+            <InlineAlert variant='warning'>
+                We couldn&apos;t verify Hugging Face access. Check your network connection and try again.
+            </InlineAlert>
+        );
+    }
+
+    return null;
+};

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
@@ -66,7 +66,23 @@ const mockProjectWithRemoteTrainer = () => {
                 },
                 huggingface: { hf_token: null },
             })
-        )
+        ),
+        http.get('/api/policies/{policy}/huggingface-access', ({ params }) => {
+            const policy = params.policy;
+            return HttpResponse.json({
+                requirements:
+                    policy === 'act'
+                        ? []
+                        : [
+                              {
+                                  repository: 'google/paligemma-3b-pt-224',
+                                  status: 'missing_token',
+                                  required: policy === 'pi05',
+                                  access_url: 'https://huggingface.co/google/paligemma-3b-pt-224',
+                              },
+                          ],
+            });
+        })
     );
 };
 
@@ -143,8 +159,8 @@ describe('TrainModelDialog', () => {
 
         await user.click(await screen.findByLabelText('Select SmolVLA policy'));
 
-        expect(screen.getByText(/SmolVLA downloads pretrained assets from Hugging Face/i)).toBeInTheDocument();
-        expect(screen.queryByText(/Pi0.5 requires a Hugging Face token/i)).not.toBeInTheDocument();
+        expect(await screen.findByText(/This policy downloads pretrained assets from Hugging Face/i)).toBeInTheDocument();
+        expect(screen.queryByText(/gated base model/i)).not.toBeInTheDocument();
     });
 
     it('blocks Pi0.5 training without a Hugging Face token', async () => {
@@ -156,7 +172,34 @@ describe('TrainModelDialog', () => {
         await user.click(await screen.findByRole('option', { name: 'Test dataset' }));
         await user.click(screen.getByLabelText('Select Pi0.5 policy'));
 
-        expect(screen.getByText(/Pi0.5 requires a Hugging Face token/i)).toBeInTheDocument();
+        expect(await screen.findByText(/This policy downloads pretrained assets from Hugging Face/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Train' })).toBeDisabled();
+    });
+
+    it('blocks Pi0.5 training when the token lacks gated-model access', async () => {
+        const user = userEvent.setup();
+        mockProjectWithRemoteTrainer();
+        server.use(
+            http.get('/api/policies/{policy}/huggingface-access', () =>
+                HttpResponse.json({
+                    requirements: [
+                        {
+                            repository: 'google/paligemma-3b-pt-224',
+                            status: 'denied',
+                            required: true,
+                            access_url: 'https://huggingface.co/google/paligemma-3b-pt-224',
+                        },
+                    ],
+                })
+            )
+        );
+
+        renderDialog();
+        await user.click(await screen.findByRole('button', { name: /select…/i }));
+        await user.click(await screen.findByRole('option', { name: 'Test dataset' }));
+        await user.click(screen.getByLabelText('Select Pi0.5 policy'));
+
+        expect(await screen.findByText(/does not have access to this policy/i)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Train' })).toBeDisabled();
     });
 });

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
@@ -159,7 +159,9 @@ describe('TrainModelDialog', () => {
 
         await user.click(await screen.findByLabelText('Select SmolVLA policy'));
 
-        expect(await screen.findByText(/This policy downloads pretrained assets from Hugging Face/i)).toBeInTheDocument();
+        expect(
+            await screen.findByText(/This policy downloads pretrained assets from Hugging Face/i)
+        ).toBeInTheDocument();
         expect(screen.queryByText(/gated base model/i)).not.toBeInTheDocument();
     });
 
@@ -172,7 +174,9 @@ describe('TrainModelDialog', () => {
         await user.click(await screen.findByRole('option', { name: 'Test dataset' }));
         await user.click(screen.getByLabelText('Select Pi0.5 policy'));
 
-        expect(await screen.findByText(/This policy downloads pretrained assets from Hugging Face/i)).toBeInTheDocument();
+        expect(
+            await screen.findByText(/This policy downloads pretrained assets from Hugging Face/i)
+        ).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Train' })).toBeDisabled();
     });
 

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.tsx
@@ -16,15 +16,14 @@ import {
     Picker,
     Text,
 } from '@geti-ui/ui';
-import { Link } from 'react-router';
 
 import { $api } from '../../../api/client';
 import { SchemaTrainJob as SchemaJob, SchemaModel } from '../../../api/openapi-spec';
-import { paths } from '../../../router';
 import { useProject } from '../../projects/use-project';
 import { useRemoteTrainerHealth } from '../../remote-trainers/use-remote-trainer-health';
 import { InlineAlert } from '../../robots/setup-wizard/shared/inline-alert';
 import { MODELS } from './policies';
+import { PolicyAccessAlert } from './policy-access-alert';
 import { PolicySelection } from './policy-selection';
 import { TrainingDeviceInfo } from './training-device-info';
 import { TrainingParameters } from './training-parameters';
@@ -50,7 +49,6 @@ type TrainingTargetOption = {
 export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: TrainModelDialogProps) => {
     const bestDevice = useBestTrainingDevice();
     const { data: remoteTrainers = [] } = $api.useQuery('get', '/api/remote-trainers');
-    const { data: settings } = $api.useQuery('get', '/api/settings');
     // Continuing an existing model needs its checkpoint, which only this machine
     // has: the trainer protocol can receive a dataset but not a base checkpoint.
     // So a resumed run offers local training only.
@@ -86,9 +84,19 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
         checkHealth: checkRemoteTrainerHealth,
     } = useRemoteTrainerHealth(isRemoteTarget ? (remoteTrainerId?.toString() ?? null) : null);
     const remoteUnavailable = isRemoteTarget && remoteTrainerHealth?.status === 'unreachable';
-    const hasHuggingFaceToken = settings?.huggingface.hf_token != null;
-    const smolVlaMissingToken = selectedPolicy === 'smolvla' && !hasHuggingFaceToken;
-    const pi05MissingToken = selectedPolicy === 'pi05' && !hasHuggingFaceToken;
+    const { data: policyAccess, isLoading: isCheckingPolicyAccess } = $api.useQuery(
+        'get',
+        '/api/policies/{policy}/huggingface-access',
+        {
+            params: { path: { policy: selectedPolicy } },
+        }
+    );
+    const policyAccessBlocksTraining =
+        isCheckingPolicyAccess ||
+        policyAccess?.requirements.some(
+            (requirement) =>
+                requirement.required && (requirement.status === 'missing_token' || requirement.status === 'denied')
+        ) === true;
     const bestRemoteDevice = useMemo(() => pickBestDevice(remoteTrainerHealth?.devices ?? []), [remoteTrainerHealth]);
     // The device actually driving this job: the local GPU when training locally,
     // or the remote trainer's reported GPU once its health check resolves. Auto
@@ -202,28 +210,7 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
                         isDisabled={baseModel !== undefined}
                         trainingDevice={activeDevice}
                     />
-                    {smolVlaMissingToken && (
-                        <InlineAlert variant='warning'>
-                            <Flex direction='column' gap='size-100'>
-                                <span>
-                                    SmolVLA downloads pretrained assets from Hugging Face. Configure a token in Settings
-                                    to avoid download failures.
-                                </span>
-                                <Link to={paths.settings.index.pattern}>Open Settings</Link>
-                            </Flex>
-                        </InlineAlert>
-                    )}
-                    {pi05MissingToken && (
-                        <InlineAlert variant='error'>
-                            <Flex direction='column' gap='size-100'>
-                                <span>
-                                    Pi0.5 requires a Hugging Face token to download its gated base model. Configure one
-                                    in Settings before training.
-                                </span>
-                                <Link to={paths.settings.index.pattern}>Open Settings</Link>
-                            </Flex>
-                        </InlineAlert>
-                    )}
+                    <PolicyAccessAlert policy={selectedPolicy} />
 
                     <Disclosure
                         isQuiet
@@ -267,7 +254,7 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
                         !selectedPolicy ||
                         remoteTrainerId === null ||
                         remoteUnavailable ||
-                        pi05MissingToken
+                        policyAccessBlocksTraining
                     }
                 >
                     Train

--- a/application/ui/src/features/settings/general/huggingface-settings-form.tsx
+++ b/application/ui/src/features/settings/general/huggingface-settings-form.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { ActionButton, Flex, Icon, TextField } from '@geti-ui/ui';
 import { Close } from '@geti-ui/ui/icons';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { SchemaHuggingFaceSettings, SchemaSettingsUpdate } from '../../../api/openapi-spec';
 import { SettingsSection } from './settings-section';
@@ -10,10 +11,15 @@ import { useSettingsPatch } from './use-settings-patch';
 type HuggingFaceSettingsFormProps = { huggingface: SchemaHuggingFaceSettings };
 
 export const HuggingFaceSettingsForm = ({ huggingface }: HuggingFaceSettingsFormProps) => {
+    const queryClient = useQueryClient();
     const patchMutation = useSettingsPatch();
     const [token, setToken] = useState('');
     const [saved, setSaved] = useState(false);
     const isSet = huggingface.hf_token != null;
+
+    const clearPolicyAccess = () => {
+        queryClient.removeQueries({ queryKey: ['get', '/api/policies/{policy}/huggingface-access'] });
+    };
 
     const save = () => {
         const body: SchemaSettingsUpdate = {
@@ -25,13 +31,22 @@ export const HuggingFaceSettingsForm = ({ huggingface }: HuggingFaceSettingsForm
                 onSuccess: () => {
                     setToken('');
                     setSaved(true);
+                    clearPolicyAccess();
                 },
             }
         );
     };
 
     const clear = () => {
-        patchMutation.mutate({ body: { huggingface: { hf_token: null } } }, { onSuccess: () => setSaved(true) });
+        patchMutation.mutate(
+            { body: { huggingface: { hf_token: null } } },
+            {
+                onSuccess: () => {
+                    setSaved(true);
+                    clearPolicyAccess();
+                },
+            }
+        );
     };
 
     return (


### PR DESCRIPTION
Follow up of #1028 that improves our UX by checking if the user has access to the selected model

Add a new API endpoint that allows us to check if the user has access to all of a policy's models.
Don't allow users to train a model if they don't have access to all its models.
The UI will show a link to huggingface where the user can request access.

<img width="1920" height="1200" alt="screenshot-2026-08-21_18-38-04" src="https://github.com/user-attachments/assets/3da7ca07-9f33-4652-8ca5-ccca33e13f18" />
