### PR TITLE
fix(ui, logs): Auto scroll and receive logs in batches

### DIFF
--- a/application/ui/src/features/logs/jump-to-latest-button.tsx
+++ b/application/ui/src/features/logs/jump-to-latest-button.tsx
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { ActionButton, Icon, Text } from '@geti-ui/ui';
+import { ChevronDownLight } from '@geti-ui/ui/icons';
+
+import styles from './log-viewer.module.css';
+
+export const JumpToLatestButton = ({ isVisible, onPress }: { isVisible: boolean; onPress: () => void }) => {
+    return (
+        <ActionButton
+            onPress={onPress}
+            excludeFromTabOrder={!isVisible}
+            UNSAFE_className={`${styles.jumpToLatest} ${isVisible ? '' : styles.jumpToLatestHidden}`}
+        >
+            <Text>Jump to latest</Text>
+            <Icon>
+                <ChevronDownLight />
+            </Icon>
+        </ActionButton>
+    );
+};

--- a/application/ui/src/features/logs/jump-to-latest-button.tsx
+++ b/application/ui/src/features/logs/jump-to-latest-button.tsx
@@ -3,15 +3,18 @@
 
 import { ActionButton, Icon, Text } from '@geti-ui/ui';
 import { ChevronDownLight } from '@geti-ui/ui/icons';
+import { clsx } from 'clsx';
 
-import styles from './log-viewer.module.css';
+import classes from './log-viewer.module.css';
 
 export const JumpToLatestButton = ({ isVisible, onPress }: { isVisible: boolean; onPress: () => void }) => {
     return (
         <ActionButton
             onPress={onPress}
             excludeFromTabOrder={!isVisible}
-            UNSAFE_className={`${styles.jumpToLatest} ${isVisible ? '' : styles.jumpToLatestHidden}`}
+            UNSAFE_className={clsx(classes.jumpToLatest, {
+                [classes.jumpToLatestHidden]: !isVisible,
+            })}
         >
             <Text>Jump to latest</Text>
             <Icon>

--- a/application/ui/src/features/logs/log-content.tsx
+++ b/application/ui/src/features/logs/log-content.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { AriaListBox, AriaListBoxItem, Flex, ListLayout, Text, View, Virtualizer } from '@geti-ui/ui';
 
+import { JumpToLatestButton } from './jump-to-latest-button';
 import { LogEntry } from './log-entry';
 import { LogFilters } from './log-filters';
 import { DEFAULT_LOG_FILTERS, type LogEntry as LogEntryType, type LogFilters as LogFiltersType } from './log-types';
@@ -78,12 +79,14 @@ const virtualizedContainerWithDefinedHeight = (virtualizedList: HTMLDivElement |
     return virtualizedList.firstElementChild;
 };
 
-const useScrollToBottom = () => {
+const SCROLL_TRESHOLD = 10;
+
+const useScrollLogs = () => {
     // The list is rendered conditionally, so its DOM node does not exist on the first render.
     // Keeping the node in state makes its attachment observable to the effects below, a ref
     // mutation would not re-run them.
     const [logsList, setLogsList] = useState<HTMLDivElement | null>(null);
-    const [autoScrollEnabled, setAutoScrollEnabled] = useState<boolean>(true);
+    const [autoScroll, setAutoScroll] = useState<boolean>(true);
     const [isAtTheBottom, setIsAtTheBottom] = useState<boolean>(true);
     const lastScrollPositionRef = useRef(0);
     const isAutomaticScroll = useRef(false);
@@ -94,11 +97,16 @@ const useScrollToBottom = () => {
             setIsAtTheBottom(true);
         }
 
-        setAutoScrollEnabled(value);
+        setAutoScroll(value);
+    };
+
+    const jumpToLatest = () => {
+        logsList?.scrollTo({ top: logsList.scrollHeight });
+        setIsAtTheBottom(true);
     };
 
     useEffect(() => {
-        if (logsList === null || !autoScrollEnabled) {
+        if (logsList === null || !autoScroll) {
             return;
         }
 
@@ -126,7 +134,7 @@ const useScrollToBottom = () => {
         return () => {
             resizeObserver.disconnect();
         };
-    }, [autoScrollEnabled, logsList]);
+    }, [autoScroll, logsList]);
 
     useEffect(() => {
         if (logsList === null) {
@@ -147,12 +155,12 @@ const useScrollToBottom = () => {
                     !isAutomaticScroll.current &&
                     currentScrollPosition > lastScrollPositionRef.current
                 ) {
-                    setAutoScrollEnabled(false);
+                    setAutoScroll(false);
 
                     lastScrollPositionRef.current = currentScrollPosition;
                 }
 
-                setIsAtTheBottom(target.scrollHeight - target.clientHeight - currentScrollPosition < 10);
+                setIsAtTheBottom(target.scrollHeight - target.clientHeight - currentScrollPosition < SCROLL_TRESHOLD);
             },
             { passive: true, signal: abortController.signal }
         );
@@ -162,7 +170,13 @@ const useScrollToBottom = () => {
         };
     }, [logsList, isAtTheBottom]);
 
-    return [autoScrollEnabled, handleAutoScroll, setLogsList] as const;
+    return {
+        autoScroll,
+        setAutoScroll: handleAutoScroll,
+        setLogsList,
+        isAtTheBottom,
+        jumpToLatest,
+    };
 };
 
 const useFilteredLogs = (logs: Array<LogEntryType>, filters: LogFiltersType) => {
@@ -180,7 +194,7 @@ export const LogContent = ({ logs, isLoading = false }: { logs: LogEntryType[]; 
         await navigator.clipboard.writeText(formattedLogs);
     };
 
-    const [autoScroll, setAutoScroll, setLogsList] = useScrollToBottom(filteredLogs.length);
+    const { autoScroll, setAutoScroll, setLogsList, isAtTheBottom, jumpToLatest } = useScrollLogs();
 
     return (
         <View UNSAFE_className={styles.logViewer}>
@@ -213,6 +227,8 @@ export const LogContent = ({ logs, isLoading = false }: { logs: LogEntryType[]; 
                                 )}
                             </AriaListBox>
                         </Virtualizer>
+
+                        <JumpToLatestButton isVisible={!autoScroll && !isAtTheBottom} onPress={jumpToLatest} />
                     </View>
                 )}
             </div>

--- a/application/ui/src/features/logs/log-content.tsx
+++ b/application/ui/src/features/logs/log-content.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { AriaListBox, AriaListBoxItem, Flex, ListLayout, Text, View, Virtualizer } from '@geti-ui/ui';
 
@@ -71,17 +71,37 @@ const NoLogs = ({ isLoading, totalLogs }: { isLoading: boolean; totalLogs: numbe
 };
 
 const useScrollToBottom = (totalLogs: number) => {
-    const logsListRef = useRef<HTMLDivElement | null>(null);
+    // The list is rendered conditionally, so its DOM node does not exist on the first render.
+    // Keeping the node in state makes its attachment observable to the effects below, a ref
+    // mutation would not re-run them.
+    const [logsList, setLogsList] = useState<HTMLDivElement | null>(null);
     const [enabled, setEnabled] = useState(true);
 
     useEffect(() => {
-        if (!enabled || !logsListRef.current) {
+        if (logsList === null || !enabled) {
             return;
         }
-        logsListRef.current.scrollTop = logsListRef.current.scrollHeight;
-    }, [enabled, totalLogs]);
 
-    return [enabled, setEnabled, logsListRef] as const;
+        const mutationObserver = new MutationObserver(() => {
+            logsList.scrollTo({ top: logsList.scrollHeight });
+        });
+
+        mutationObserver.observe(logsList, { childList: true, subtree: true });
+
+        return () => {
+            mutationObserver.disconnect();
+        };
+    }, [enabled, logsList]);
+
+    useEffect(() => {
+        if (logsList === null || !enabled) {
+            return;
+        }
+
+        logsList.scrollTo({ top: logsList.scrollHeight });
+    }, [enabled, logsList, totalLogs]);
+
+    return [enabled, setEnabled, setLogsList] as const;
 };
 
 const useFilteredLogs = (logs: Array<LogEntryType>, filters: LogFiltersType) => {
@@ -99,7 +119,7 @@ export const LogContent = ({ logs, isLoading = false }: { logs: LogEntryType[]; 
         await navigator.clipboard.writeText(formattedLogs);
     };
 
-    const [autoScroll, setAutoScroll, logsListRef] = useScrollToBottom(filteredLogs.length);
+    const [autoScroll, setAutoScroll, setLogsList] = useScrollToBottom(filteredLogs.length);
 
     return (
         <View UNSAFE_className={styles.logViewer}>
@@ -121,7 +141,7 @@ export const LogContent = ({ logs, isLoading = false }: { logs: LogEntryType[]; 
                         <Virtualizer layout={ListLayout} layoutOptions={{ estimatedRowHeight: 36 }}>
                             <AriaListBox
                                 aria-label='Log entries'
-                                ref={logsListRef}
+                                ref={setLogsList}
                                 items={filteredLogs}
                                 className={styles.virtualizedList}
                             >

--- a/application/ui/src/features/logs/log-content.tsx
+++ b/application/ui/src/features/logs/log-content.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { AriaListBox, AriaListBoxItem, Flex, ListLayout, Text, View, Virtualizer } from '@geti-ui/ui';
 
@@ -70,38 +70,99 @@ const NoLogs = ({ isLoading, totalLogs }: { isLoading: boolean; totalLogs: numbe
     );
 };
 
-const useScrollToBottom = (totalLogs: number) => {
+const virtualizedContainerWithDefinedHeight = (virtualizedList: HTMLDivElement | null) => {
+    if (virtualizedList === null) {
+        return null;
+    }
+
+    return virtualizedList.firstElementChild;
+};
+
+const useScrollToBottom = () => {
     // The list is rendered conditionally, so its DOM node does not exist on the first render.
     // Keeping the node in state makes its attachment observable to the effects below, a ref
     // mutation would not re-run them.
     const [logsList, setLogsList] = useState<HTMLDivElement | null>(null);
-    const [enabled, setEnabled] = useState(true);
+    const [autoScrollEnabled, setAutoScrollEnabled] = useState<boolean>(true);
+    const [isAtTheBottom, setIsAtTheBottom] = useState<boolean>(true);
+    const lastScrollPositionRef = useRef(0);
+    const isAutomaticScroll = useRef(false);
+
+    const handleAutoScroll = (value: boolean) => {
+        if (value) {
+            logsList?.scrollTo({ top: logsList.scrollHeight });
+            setIsAtTheBottom(true);
+        }
+
+        setAutoScrollEnabled(value);
+    };
 
     useEffect(() => {
-        if (logsList === null || !enabled) {
+        if (logsList === null || !autoScrollEnabled) {
             return;
         }
 
-        const mutationObserver = new MutationObserver(() => {
-            logsList.scrollTo({ top: logsList.scrollHeight });
+        const resizeObserver = new ResizeObserver(() => {
+            isAutomaticScroll.current = true;
+            logsList?.scrollTo({ top: logsList.scrollHeight });
+
+            logsList.addEventListener(
+                'scrollend',
+                () => {
+                    isAutomaticScroll.current = false;
+                },
+                { once: true }
+            );
+
+            setIsAtTheBottom(true);
         });
 
-        mutationObserver.observe(logsList, { childList: true, subtree: true });
+        const container = virtualizedContainerWithDefinedHeight(logsList);
+
+        if (container !== null) {
+            resizeObserver.observe(container);
+        }
 
         return () => {
-            mutationObserver.disconnect();
+            resizeObserver.disconnect();
         };
-    }, [enabled, logsList]);
+    }, [autoScrollEnabled, logsList]);
 
     useEffect(() => {
-        if (logsList === null || !enabled) {
+        if (logsList === null) {
             return;
         }
 
-        logsList.scrollTo({ top: logsList.scrollHeight });
-    }, [enabled, logsList, totalLogs]);
+        const abortController = new AbortController();
 
-    return [enabled, setEnabled, setLogsList] as const;
+        logsList.addEventListener(
+            'scroll',
+            (event) => {
+                const target = event.currentTarget as HTMLDivElement;
+
+                const currentScrollPosition = target.scrollTop;
+
+                if (
+                    isAtTheBottom &&
+                    !isAutomaticScroll.current &&
+                    currentScrollPosition > lastScrollPositionRef.current
+                ) {
+                    setAutoScrollEnabled(false);
+
+                    lastScrollPositionRef.current = currentScrollPosition;
+                }
+
+                setIsAtTheBottom(target.scrollHeight - target.clientHeight - currentScrollPosition < 10);
+            },
+            { passive: true, signal: abortController.signal }
+        );
+
+        return () => {
+            abortController.abort();
+        };
+    }, [logsList, isAtTheBottom]);
+
+    return [autoScrollEnabled, handleAutoScroll, setLogsList] as const;
 };
 
 const useFilteredLogs = (logs: Array<LogEntryType>, filters: LogFiltersType) => {

--- a/application/ui/src/features/logs/log-viewer.module.css
+++ b/application/ui/src/features/logs/log-viewer.module.css
@@ -140,6 +140,28 @@
     box-sizing: border-box;
 }
 
+.jumpToLatest {
+    position: absolute;
+    bottom: var(--spectrum-global-dimension-size-200);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1;
+    opacity: 1;
+    visibility: visible;
+    transition:
+        opacity 130ms ease-in-out,
+        visibility 0s;
+}
+
+.jumpToLatestHidden {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+        opacity 130ms ease-in-out,
+        visibility 0s linear 130ms;
+}
+
 .virtualizedList {
     scrollbar-gutter: stable;
     display: block;

--- a/application/ui/src/features/logs/logs-dialog.tsx
+++ b/application/ui/src/features/logs/logs-dialog.tsx
@@ -6,11 +6,18 @@ import { Suspense, useMemo, useState } from 'react';
 import { Button, ButtonGroup, Content, Dialog, Divider, Flex, Heading, Loading, Text } from '@geti-ui/ui';
 import { experimental_streamedQuery as streamedQuery, useQuery } from '@tanstack/react-query';
 
+import { batchAsyncIterable } from '../../api/batch-async-iterable';
 import { fetchClient } from '../../api/client';
 import { fetchSSE } from '../../api/fetch-sse';
 import { LogContent } from './log-content';
 import type { LogEntry } from './log-types';
 import { SourcesPicker } from './sources-picker';
+
+const LOGS_BATCH_INTERVAL_MS = 200;
+
+const selectLogs = (logs: LogEntry[][]): LogEntry[] => {
+    return logs.flat();
+};
 
 const LogStreamContent = ({ sourceId }: { sourceId: string }) => {
     const query = useQuery({
@@ -21,9 +28,10 @@ const LogStreamContent = ({ sourceId }: { sourceId: string }) => {
                     params: { path: { source_id: sourceId } },
                 });
 
-                return fetchSSE<LogEntry>(url, { signal: context.signal });
+                return batchAsyncIterable(fetchSSE<LogEntry>(url, { signal: context.signal }), LOGS_BATCH_INTERVAL_MS);
             },
         }),
+        select: selectLogs,
         staleTime: Infinity,
     });
 


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->

1. The auto scroll was not working on first mount (because of not known scroll height of the virutalized list). The changes includes:
- when auto scroll enabled and new entry comes, we scroll to the bottom to make the last entry visible;
- when auto scroll enabled and user scrolls up, we disable the auto scroll and we show "Jump to latest" button.
2. Reused code for receiving logs in batches that we have in the models metrics.

## Related Issues

<!-- Fixes #123 -->
