### PR TITLE
fix(backend): map available robots through schema adapter

### DIFF
--- a/application/backend/src/repositories/mappers/project_robot_mapper.py
+++ b/application/backend/src/repositories/mappers/project_robot_mapper.py
@@ -1,7 +1,7 @@
 from db.schema import ProjectRobotDB
 from repositories.mappers.base_mapper_interface import IBaseMapper
 from robots.catalog.registry import RobotCatalogRegistry
-from schemas.robot import Robot, UnavailableRobot
+from schemas.robot import Robot, RobotAdapter, UnavailableRobot
 
 
 class ProjectRobotMapper(IBaseMapper[ProjectRobotDB, Robot | UnavailableRobot]):
@@ -34,4 +34,4 @@ class ProjectRobotMapper(IBaseMapper[ProjectRobotDB, Robot | UnavailableRobot]):
         }
         if catalog_registry.get_definition(model.type) is None:
             return UnavailableRobot.model_validate(robot)
-        return catalog_registry.get_robot_adapter().validate_python(robot)
+        return RobotAdapter.validate_python(robot)

--- a/application/backend/tests/repositories/mappers/test_project_robot_mapper_bimanual.py
+++ b/application/backend/tests/repositories/mappers/test_project_robot_mapper_bimanual.py
@@ -8,12 +8,11 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
-from physicalai_studio_plugin import RobotCatalogDefinition
-from pydantic import BaseModel
 
 from repositories.mappers.project_robot_mapper import ProjectRobotMapper
 from robots.catalog.registry import RobotCatalogRegistry
 from robots.catalog.widowxai import TrossenBimanualPayload, TrossenBimanualRobot
+from schemas.environment import RobotWithTeleoperator, TeleoperatorNoneWithRobot
 from schemas.robot import UnavailableRobot
 
 
@@ -92,23 +91,11 @@ class TestProjectRobotMapperBimanual:
         assert result.unavailable is True
         assert result.payload == db_model.payload
 
-    def test_from_schema_uses_the_injected_registry_adapter(self):
-        class PluginPayload(BaseModel):
-            connection_string: str
-
+    def test_from_schema_uses_schema_adapter_for_available_robot(self):
         registry = RobotCatalogRegistry()
-        registry.register_robot(
-            RobotCatalogDefinition(
-                type="Test_Plugin_Robot",
-                display_name="Test Plugin Robot",
-                role="follower",
-                robot_payload=PluginPayload,
-            )
-        )
-        db_model = _make_bimanual_db_model("Test_Plugin_Robot")
-        db_model.payload = {"connection_string": "test://robot"}
+        db_model = _make_bimanual_db_model("Trossen_Bimanual_WidowXAI_Follower")
 
         result = ProjectRobotMapper.from_schema(db_model, registry)
+        relation = RobotWithTeleoperator(robot=result, tele_operator=TeleoperatorNoneWithRobot())
 
-        assert result.type == "Test_Plugin_Robot"
-        assert result.payload.connection_string == "test://robot"
+        assert relation.robot is result


### PR DESCRIPTION
PR #1023 added the UnavailableRobot fallback for persisted robot types whose plugin is not installed. It also changed available robot reads to validate with an injected RobotCatalogRegistry adapter.
This introduced a bug due to the `_registry` in [`schemas/robot.py`](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/backend/src/schemas/robot.py#L28) being different than the one from say [`robot_catalog_service.py`](https://github.com/open-edge-platform/physical-ai-studio/blob/main/application/backend/src/services/robot_catalog_service.py#L9), which therefore triggered validation isseus when loading a `EnvironmentWithRelations`.

This pr fixes the validation issue, though it doesn't fix the actual design flaw yet. I plan on fixing this after merging more of the robot plugin implementations.