### PR TITLE
fix(snapflow): compile-friendly FM/CD loss split + --weights_from warm start

### DIFF
--- a/library/configs/physicalai/pi05_snapflow_distillation.yaml
+++ b/library/configs/physicalai/pi05_snapflow_distillation.yaml
@@ -94,7 +94,7 @@ data:
 trainer:
   # Weights-only warm start via --weights_from starts step/epoch counting at 0,
   # so this is the phase-2 budget alone (not phase-1 + phase-2).
-  max_steps: 30000
+  max_epochs: 2
   accelerator: gpu
   devices: 1
   precision: 32

--- a/library/configs/physicalai/pi05_snapflow_distillation.yaml
+++ b/library/configs/physicalai/pi05_snapflow_distillation.yaml
@@ -9,18 +9,24 @@
 #   # Phase 1 — standard flow-matching training
 #   physicalai fit --config configs/physicalai/pi05.yaml
 #
-#   # Phase 2 — SnapFlow distillation, VLM frozen
+#   # Phase 2 — SnapFlow distillation, VLM frozen, weights-only warm start
 #   physicalai fit \
 #       --config configs/physicalai/pi05_snapflow_distillation.yaml \
-#       --fit.ckpt_path ./experiments/lightning_logs/version_0/checkpoints/last.ckpt \
-#       --trainer.max_steps 30000
+#       --weights_from ./experiments/lightning_logs/version_0/checkpoints/last.ckpt
 #
-# Note that `--fit.ckpt_path` is a full Lightning *resume*: it restores the
-# global step, optimizer state, and LR schedule from phase 1. Set
-# `--trainer.max_steps` to the combined phase-1 + phase-2 budget accordingly.
-# This does NOT give phase 2 its own optimizer state or LR horizon — if you
-# need that, warm-start from phase-1 weights only via the Python API instead
-# (see `Policy.load_from_checkpoint` in docs/how-to/training/snapflow_distillation.md).
+# `--weights_from` loads only the phase-1 state_dict and then re-applies this
+# config's model init_args (train_expert_only, snapflow_enabled, ...) on top of
+# it. It does NOT resume the optimizer, LR schedule, or global step — training
+# starts fresh at step 0 with this file's own trainer.max_steps budget.
+#
+# Do not use `--fit.ckpt_path` for the phase-2 handoff: that performs a full
+# Lightning resume, which restores the phase-1 optimizer state (one param group
+# per trainable phase-1 tensor) into an optimizer built over the frozen-VLM
+# phase-2 model (many fewer trainable tensors) and fails with
+# "loaded state dict contains a parameter group that doesn't match the size of
+# optimizer's group". `--fit.ckpt_path` is only correct for resuming a run
+# that was itself already using this same config (i.e. resuming phase 2 from
+# its own earlier checkpoint).
 #
 # Single-run alternative (recommended):
 #   configs/physicalai/pi05_finetune_and_snapflow_distillation.yaml uses
@@ -60,6 +66,14 @@ model:
     train_expert_only: true
     freeze_vision_encoder: false # train_expert_only already covers the VLM
 
+    # Memory / throughput. Phase 2 only trains ~10% of params, so the
+    # compile-friendly SnapFlow loss split (static FM/CD branch sizes) keeps
+    # torch.compile stable across steps instead of recompiling on every batch.
+    # compile_model: true
+    # compile_mode: max-autotune
+    gradient_checkpointing: true
+    compile_model: true # disable compile_model if you hit OOM
+
     # Optimizer
     optimizer_lr: 2.5e-5
     optimizer_weight_decay: 0.01
@@ -78,6 +92,8 @@ data:
     data_format: "physicalai"
 
 trainer:
+  # Weights-only warm start via --weights_from starts step/epoch counting at 0,
+  # so this is the phase-2 budget alone (not phase-1 + phase-2).
   max_steps: 30000
   accelerator: gpu
   devices: 1

--- a/library/configs/physicalai/smolvla_snapflow_distillation.yaml
+++ b/library/configs/physicalai/smolvla_snapflow_distillation.yaml
@@ -9,18 +9,24 @@
 #   # Phase 1 — standard flow-matching training
 #   physicalai fit --config configs/physicalai/smolvla.yaml
 #
-#   # Phase 2 — SnapFlow distillation, VLM frozen
+#   # Phase 2 — SnapFlow distillation, VLM frozen, weights-only warm start
 #   physicalai fit \
 #       --config configs/physicalai/smolvla_snapflow_distillation.yaml \
-#       --fit.ckpt_path ./experiments/lightning_logs/version_0/checkpoints/last.ckpt \
-#       --trainer.max_steps 30000
+#       --weights_from ./experiments/lightning_logs/version_0/checkpoints/last.ckpt
 #
-# Note that `--fit.ckpt_path` is a full Lightning *resume*: it restores the
-# global step, optimizer state, and LR schedule from phase 1. Set
-# `--trainer.max_steps` to the combined phase-1 + phase-2 budget accordingly.
-# This does NOT give phase 2 its own optimizer state or LR horizon — if you
-# need that, warm-start from phase-1 weights only via the Python API instead
-# (see `Policy.load_from_checkpoint` in docs/how-to/training/snapflow_distillation.md).
+# `--weights_from` loads only the phase-1 state_dict and then re-applies this
+# config's model init_args (train_expert_only, snapflow_enabled, ...) on top of
+# it. It does NOT resume the optimizer, LR schedule, or global step — training
+# starts fresh at step 0 with this file's own trainer.max_steps budget.
+#
+# Do not use `--fit.ckpt_path` for the phase-2 handoff: that performs a full
+# Lightning resume, which restores the phase-1 optimizer state (one param group
+# per trainable phase-1 tensor) into an optimizer built over the frozen-VLM
+# phase-2 model (many fewer trainable tensors) and fails with
+# "loaded state dict contains a parameter group that doesn't match the size of
+# optimizer's group". `--fit.ckpt_path` is only correct for resuming a run
+# that was itself already using this same config (i.e. resuming phase 2 from
+# its own earlier checkpoint).
 #
 # Single-run alternative (recommended):
 #   Add SnapFlowPhaseCallback to smolvla.yaml trainer.callbacks with a

--- a/library/configs/physicalai/smolvla_snapflow_distillation.yaml
+++ b/library/configs/physicalai/smolvla_snapflow_distillation.yaml
@@ -71,7 +71,7 @@ data:
                 - 1.3
 
 trainer:
-  max_steps: 30000
+  max_epochs: 2
   accelerator: gpu
   devices: 1
   precision: 32

--- a/library/docs/how-to/training/snapflow_distillation.md
+++ b/library/docs/how-to/training/snapflow_distillation.md
@@ -342,7 +342,7 @@ This is exactly what `--weights_from` does under the hood (see Option 2).
 | `best_teacher_monitor`   | `None`                   | Disambiguates which monitored `ModelCheckpoint` to restore from when more than one is configured.                               |
 | `scope_best_to_phase`    | `true`                   | Reset best-checkpoint tracking at the boundary, since `val/loss` is not comparable across `num_inference_steps`.                |
 | Phase-1 budget           | 5-10 epochs              | Fewer for a warm-started VLA than for from-scratch training.                                                                    |
-| Phase-2 budget           | ~2-3 epochs (~30k steps) | Short because the target-time embedding is zero-initialised.                                                                    |
+| Phase-2 budget           | ~2-3 epochs | Short because the target-time embedding is zero-initialised.                                                                    |
 | `scheduler_warmup_steps` | ~5% of total steps       | No fractional option exists; compute it from your dataset (below).                                                              |
 
 Converting an epoch budget into steps, for warmup sizing:

--- a/library/docs/how-to/training/snapflow_distillation.md
+++ b/library/docs/how-to/training/snapflow_distillation.md
@@ -249,11 +249,10 @@ job). Note that `--fit.ckpt_path` is a full Lightning resume, so this does
 # Phase 1 — standard flow-matching training
 physicalai fit --config configs/physicalai/pi05.yaml
 
-# Phase 2 — SnapFlow distillation, VLM frozen, resumed from phase 1
+# Phase 2 — SnapFlow distillation, VLM frozen, weights-only warm start from phase 1
 physicalai fit \
     --config configs/physicalai/pi05_snapflow_distillation.yaml \
-    --fit.ckpt_path ./experiments/lightning_logs/version_0/checkpoints/last.ckpt \
-    --trainer.max_steps 60000
+    --weights_from ./experiments/lightning_logs/version_0/checkpoints/last.ckpt
 ```
 
 Substitute `pi05` with `smolvla` for the SmolVLA policy. Phase-2 templates:
@@ -267,18 +266,24 @@ defaults (`snapflow_alpha: 0.5`, `snapflow_lambda: 0.1`,
 
 Two things to be aware of:
 
-- The flag is **`--fit.ckpt_path`**, not `--ckpt_path`. Method-level arguments
-  are namespaced under the subcommand (`--validate.ckpt_path`,
-  `--test.ckpt_path`, `--predict.ckpt_path`).
-- `--fit.ckpt_path` is a full Lightning **resume**: it restores the global step,
-  optimizer state, and LR schedule from phase 1. Set `--trainer.max_steps` to
-  the _combined_ phase-1 + phase-2 budget, not the phase-2 budget alone. This
-  means Option 2 does **not** give phase 2 an independent LR horizon either —
-  the LR schedule still spans both phases, exactly like Option 1's
-  single-run caveat above. There is currently no supported way to warm-start
-  phase 2 from a checkpoint's weights only (a fresh optimizer/LR schedule);
-  doing so would require loading just the `state_dict` manually instead of
-  passing `--fit.ckpt_path` (see Option 3 below).
+- **Use `--weights_from`, not `--fit.ckpt_path`, for the phase-1 -> phase-2
+  handoff.** `--weights_from` loads only the phase-1 `state_dict` and then
+  re-applies this config's `model` init*args on top of it (`train_expert_only`,
+  `snapflow_enabled`, ...), so training starts fresh at step 0 with the
+  optimizer built over the now-frozen-VLM model.
+  `--fit.ckpt_path` performs a full Lightning **resume** instead: it restores
+  the phase-1 optimizer state verbatim, which was built over the \_full* model
+  (every parameter trainable). Phase 2's optimizer only covers the ~10% of
+  parameters left trainable after `train_expert_only: true` freezes the VLM, so
+  the shapes never match and `Trainer.fit` fails with `ValueError: loaded state
+dict contains a parameter group that doesn't match the size of optimizer's
+group`. `--fit.ckpt_path` is only correct for resuming a run that was itself
+  already using this same phase-2 config (i.e. continuing an interrupted phase
+  2 from its own checkpoint), never for the phase-1 -> phase-2 transition.
+- Set `trainer.max_steps`/`trainer.max_epochs` (or `--trainer.max_steps`/
+  `--trainer.max_epochs`) to the phase-2 budget alone, not phase-1 + phase-2 —
+  `--weights_from` does not restore the global step, so epoch/step counting
+  starts at 0.
 
 ---
 
@@ -321,6 +326,8 @@ Or flip an already-constructed policy after `setup()` has run:
 policy.enable_snapflow(alpha=0.5, lambda_=0.1, num_inference_steps=1)
 ```
 
+This is exactly what `--weights_from` does under the hood (see Option 2).
+
 ---
 
 ## Hyperparameter guidance
@@ -335,7 +342,7 @@ policy.enable_snapflow(alpha=0.5, lambda_=0.1, num_inference_steps=1)
 | `best_teacher_monitor`   | `None`                   | Disambiguates which monitored `ModelCheckpoint` to restore from when more than one is configured.                               |
 | `scope_best_to_phase`    | `true`                   | Reset best-checkpoint tracking at the boundary, since `val/loss` is not comparable across `num_inference_steps`.                |
 | Phase-1 budget           | 5-10 epochs              | Fewer for a warm-started VLA than for from-scratch training.                                                                    |
-| Phase-2 budget           | ~3-5 epochs (~30k steps) | Short because the target-time embedding is zero-initialised.                                                                    |
+| Phase-2 budget           | ~2-3 epochs (~30k steps) | Short because the target-time embedding is zero-initialised.                                                                    |
 | `scheduler_warmup_steps` | ~5% of total steps       | No fractional option exists; compute it from your dataset (below).                                                              |
 
 Converting an epoch budget into steps, for warmup sizing:

--- a/library/docs/how-to/training/snapflow_distillation.md
+++ b/library/docs/how-to/training/snapflow_distillation.md
@@ -332,18 +332,18 @@ This is exactly what `--weights_from` does under the hood (see Option 2).
 
 ## Hyperparameter guidance
 
-| Parameter                | Paper default            | Notes                                                                                                                           |
-| ------------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `alpha`                  | `0.5`                    | FM-loss weight. Keep at or above `0.5` to preserve multi-step ability.                                                          |
-| `lambda_`                | `0.1`                    | Shortcut-loss scale, balances the two gradient magnitudes.                                                                      |
-| `num_inference_steps`    | `1`                      | `1` gives the full SnapFlow speedup; raise it for intermediate modes.                                                           |
-| `checkpoint_prefix`      | `"snapflow-"`            | Marks phase-2 checkpoints on disk. `null` disables the rewrite.                                                                 |
-| `restore_best_teacher`   | `true`                   | Restore the monitored `ModelCheckpoint`'s best-val-loss weights before enabling SnapFlow, instead of distilling the live model. |
-| `best_teacher_monitor`   | `None`                   | Disambiguates which monitored `ModelCheckpoint` to restore from when more than one is configured.                               |
-| `scope_best_to_phase`    | `true`                   | Reset best-checkpoint tracking at the boundary, since `val/loss` is not comparable across `num_inference_steps`.                |
-| Phase-1 budget           | 5-10 epochs              | Fewer for a warm-started VLA than for from-scratch training.                                                                    |
-| Phase-2 budget           | ~2-3 epochs | Short because the target-time embedding is zero-initialised.                                                                    |
-| `scheduler_warmup_steps` | ~5% of total steps       | No fractional option exists; compute it from your dataset (below).                                                              |
+| Parameter                | Paper default      | Notes                                                                                                                           |
+| ------------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `alpha`                  | `0.5`              | FM-loss weight. Keep at or above `0.5` to preserve multi-step ability.                                                          |
+| `lambda_`                | `0.1`              | Shortcut-loss scale, balances the two gradient magnitudes.                                                                      |
+| `num_inference_steps`    | `1`                | `1` gives the full SnapFlow speedup; raise it for intermediate modes.                                                           |
+| `checkpoint_prefix`      | `"snapflow-"`      | Marks phase-2 checkpoints on disk. `null` disables the rewrite.                                                                 |
+| `restore_best_teacher`   | `true`             | Restore the monitored `ModelCheckpoint`'s best-val-loss weights before enabling SnapFlow, instead of distilling the live model. |
+| `best_teacher_monitor`   | `None`             | Disambiguates which monitored `ModelCheckpoint` to restore from when more than one is configured.                               |
+| `scope_best_to_phase`    | `true`             | Reset best-checkpoint tracking at the boundary, since `val/loss` is not comparable across `num_inference_steps`.                |
+| Phase-1 budget           | 5-10 epochs        | Fewer for a warm-started VLA than for from-scratch training.                                                                    |
+| Phase-2 budget           | ~2-3 epochs        | Short because the target-time embedding is zero-initialised.                                                                    |
+| `scheduler_warmup_steps` | ~5% of total steps | No fractional option exists; compute it from your dataset (below).                                                              |
 
 Converting an epoch budget into steps, for warmup sizing:
 

--- a/library/src/physicalai/cli/_dispatch.py
+++ b/library/src/physicalai/cli/_dispatch.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from jsonargparse import ActionConfigFile, ArgumentParser, Namespace
 
@@ -38,6 +38,19 @@ def _build_lightning_parser(method_name: str) -> ArgumentParser:
 
     parser = ArgumentParser(prog=f"physicalai {method_name}", description=f"Run `Trainer.{method_name}()`.")
     parser.add_argument("--config", action=ActionConfigFile, help="YAML/JSON config file.")
+    parser.add_argument(
+        "--weights_from",
+        type=str,
+        default=None,
+        help=(
+            "Warm-start the model's weights from a Lightning checkpoint (.ckpt) without resuming "
+            "training state. Unlike --fit.ckpt_path (a full resume that also restores the optimizer, "
+            "LR schedule, and global step), --weights_from loads only the checkpoint's state_dict and "
+            "then re-applies this command's --model class_path/init_args on top of the checkpoint's "
+            "saved hyperparameters -- so overrides such as train_expert_only or snapflow_enabled take "
+            "effect and training starts fresh from step 0."
+        ),
+    )
     parser.add_subclass_arguments(Policy, "model", required=True)
     parser.add_subclass_arguments(DataModule, "data", required=True)
     parser.add_class_arguments(Trainer, "trainer")
@@ -67,7 +80,19 @@ def _dispatch(method_name: str) -> Callable[[ArgumentParser, Namespace], int]:
 
     def _run(parser: ArgumentParser, cfg: Namespace) -> int:
         configure_console_logging()
+
+        # Capture the raw (pre-instantiation) model init_args so they can be
+        # replayed as overrides on top of the checkpoint's saved hyperparameters
+        # when warm-starting. instantiate_classes() below consumes cfg in place
+        # for some jsonargparse versions, so this must run first.
+        weights_from = getattr(cfg, "weights_from", None)
+        model_init_args = _model_init_args(cfg) if weights_from else {}
+
         cfg_init = cast("Namespace", parser.instantiate_classes(cfg))
+        model = cfg_init.model
+        if weights_from:
+            model = type(model).load_from_checkpoint(weights_from, map_location="cpu", **model_init_args)
+
         trainer = cfg_init.trainer
         method_ns = getattr(cfg_init, method_name, None)
         # Drop unset options so Trainer's own defaults win over jsonargparse Nones.
@@ -76,7 +101,42 @@ def _dispatch(method_name: str) -> Callable[[ArgumentParser, Namespace], int]:
             if isinstance(method_ns, Namespace)
             else {}
         )
-        getattr(trainer, method_name)(model=cfg_init.model, datamodule=cfg_init.data, **method_args)
+        getattr(trainer, method_name)(model=model, datamodule=cfg_init.data, **method_args)
         return 0
 
     return _run
+
+
+def _model_init_args(cfg: Namespace) -> dict[str, Any]:
+    """Return the ``--model`` init_args as overrides for ``Policy.load_from_checkpoint``.
+
+    Args:
+        cfg: Parsed (not yet instantiated) configuration namespace.
+
+    Returns:
+        The model's ``init_args`` as a plain dict, with ``pretrained_name_or_path``
+        and an unset (``None``) ``dataset_stats`` stripped so they don't shadow the
+        checkpoint's own pretrained weights / saved dataset stats. Empty when the
+        model namespace is absent.
+    """
+    model_ns = cfg.get("model")
+    if not isinstance(model_ns, Namespace):
+        return {}
+    init_args = model_ns.get("init_args")
+    if not isinstance(init_args, Namespace):
+        return {}
+    args = cast("dict[str, Any]", init_args.as_dict())
+
+    # --weights_from supersedes any pretrained warm start: keeping it would trigger a
+    # redundant HF fetch whose weights are immediately overwritten by the checkpoint.
+    args.pop("pretrained_name_or_path", None)
+
+    # dataset_stats is data-derived state, not config, and jsonargparse fills it with
+    # None when the config omits it. Passing that None through would clobber the
+    # checkpoint's saved stats, leaving the policy lazily un-built (model/preprocessor
+    # stay None) so the strict state_dict load below has no modules to load into.
+    # Only override when the config sets it explicitly.
+    if args.get("dataset_stats") is None:
+        args.pop("dataset_stats", None)
+
+    return args

--- a/library/src/physicalai/policies/mixins/snapflow.py
+++ b/library/src/physicalai/policies/mixins/snapflow.py
@@ -335,6 +335,21 @@ class SnapFlowModelMixin:
         velocity predictions (with gradients detached) and trains a single-step
         shortcut to match it, scaled by ``snapflow_lambda``.
 
+        The split uses a random permutation cut at a fixed size
+        (``round(alpha * bsize)``) rather than an independent per-sample
+        Bernoulli draw. Both give every sample the same marginal probability
+        ``alpha`` of landing in the FM branch, but the permutation keeps the
+        branch sizes a static Python int instead of a data-dependent
+        ``Binomial(bsize, alpha)`` count. That makes this method safe to run
+        under ``torch.compile``: with a data-dependent split, ``nonzero()`` and
+        the two branches' varying shapes force a graph break and a recompile
+        for nearly every step, which trips ``torch._dynamo.config.recompile_limit``
+        and silently falls back to eager. With a static split size, Dynamo
+        guards once on ``(alpha, bsize)`` and compiles a stable graph for the
+        rest of phase 2. See
+        ``docs/explanation/policy/snapflow-two-phase-distillation.md`` ("Proposed
+        design: compile-friendly SnapFlow loss") for the full rationale.
+
         Args:
             u_t: Target velocity ``noise - actions``, shape ``(B, T, D)``.
             x_t: Noisy interpolated actions ``time * noise + (1 - time) * actions``.
@@ -354,13 +369,28 @@ class SnapFlowModelMixin:
         """
         bsize = actions.shape[0]
         device = actions.device
-        fm_mask = torch.rand(bsize, device=device) < self._snapflow_alpha
-        fm_idx = fm_mask.nonzero(as_tuple=True)[0]
-        cd_idx = (~fm_mask).nonzero(as_tuple=True)[0]
+
+        # n_fm is a Python int: self._snapflow_alpha only changes in
+        # enable_snapflow (which already forces a recompile via the
+        # _snapflow_enabled flag flip), and bsize is the batch's static shape.
+        # Everything indexed by fm_idx/cd_idx below therefore has a shape fixed
+        # at trace time, unlike a Bernoulli-mask-and-nonzero split.
+        n_fm = round(self._snapflow_alpha * bsize)
+
+        # A random permutation preserves the original per-sample marginal
+        # (every sample still lands in the FM branch with probability alpha)
+        # while making the two branch *sizes* static. Advanced indexing with a
+        # fixed-length index tensor compiles cleanly even though its contents
+        # are randomized.
+        perm = torch.randperm(bsize, device=device)
+        fm_idx, cd_idx = perm[:n_fm], perm[n_fm:]
 
         losses = torch.zeros_like(actions)
 
-        if fm_idx.numel() > 0:
+        # Guards on n_fm (a Python int), not on fm_idx.numel() (a tensor
+        # property) -- so these branches are only "data-dependent" in the
+        # sense that alpha is, and alpha is already a recompile boundary.
+        if n_fm > 0:
             v_fm = predict_velocity(
                 x_t[fm_idx],
                 time[fm_idx],
@@ -371,8 +401,8 @@ class SnapFlowModelMixin:
             )
             losses[fm_idx] = F.mse_loss(u_t[fm_idx], v_fm, reduction="none")
 
-        if cd_idx.numel() > 0:
-            cd_bsize = cd_idx.numel()
+        if n_fm < bsize:
+            cd_bsize = bsize - n_fm
             cd_actions_shape = (cd_bsize, *actions.shape[1:])
             x_1 = sample_noise(cd_actions_shape, device)
             cd_prefix_embs = prefix_embs[cd_idx]

--- a/library/tests/unit/cli/test_cli.py
+++ b/library/tests/unit/cli/test_cli.py
@@ -49,6 +49,10 @@ def _libero_config_path() -> Path:
     return _library_root() / "configs" / "benchmark" / "libero.yaml"
 
 
+def _pi05_snapflow_config_path() -> Path:
+    return _library_root() / "configs" / "physicalai" / "pi05_snapflow_distillation.yaml"
+
+
 class TestRegister:
     """ST-1 register() returns expected names and specs."""
 
@@ -157,6 +161,109 @@ class TestDispatch:
 
         assert exit_code == 0
         assert trainer.validate.call_args.kwargs["ckpt_path"] == "/tmp/best.ckpt"
+
+    def test_fit_dispatch_weights_from_warm_starts_without_resuming(self) -> None:
+        """``--weights_from`` must load weights only, replaying --model init_args as overrides."""
+        parser = fit_module.register().parser
+        cfg = parser.parse_args(
+            [
+                f"--config={_act_config_path()}",
+                "--weights_from=/tmp/phase1.ckpt",
+            ],
+        )
+        trainer = MagicMock()
+        datamodule = object()
+
+        class _FakePolicy:
+            last_call: tuple[str, dict[str, object]] | None = None
+
+            @classmethod
+            def load_from_checkpoint(cls, checkpoint_path: str, **kwargs: object) -> _FakePolicy:
+                cls.last_call = (checkpoint_path, kwargs)
+                return cls()
+
+        discarded_model = _FakePolicy()
+
+        with patch.object(
+            parser,
+            "instantiate_classes",
+            return_value=Namespace(trainer=trainer, model=discarded_model, data=datamodule),
+        ):
+            exit_code = fit_module.run(cast(ArgumentParser, parser), cast(Namespace, cfg))
+
+        assert exit_code == 0
+        assert _FakePolicy.last_call is not None
+        ckpt_path, init_args = _FakePolicy.last_call
+        assert ckpt_path == "/tmp/phase1.ckpt"
+        assert init_args["map_location"] == "cpu"
+        # The model's own class_path/init_args from --config are replayed as overrides.
+        assert "chunk_size" in init_args
+        warm_started_model = trainer.fit.call_args.kwargs["model"]
+        assert isinstance(warm_started_model, _FakePolicy)
+        assert warm_started_model is not discarded_model
+
+    def test_fit_dispatch_weights_from_strips_pretrained_path_and_unset_dataset_stats(self) -> None:
+        """``--weights_from`` must not shadow the checkpoint's own weights/dataset stats.
+
+        Both ``pretrained_name_or_path`` and ``dataset_stats`` are filled in by
+        jsonargparse with their class defaults (``None``) when a config omits them.
+        Passing that ``None`` through to ``load_from_checkpoint`` would overwrite the
+        checkpoint's saved pretrained path / dataset stats and, for ``dataset_stats``,
+        prevent the policy from being built eagerly (regression: see
+        ``docs/how-to/training/snapflow_distillation.md``).
+        """
+        parser = fit_module.register().parser
+        cfg = parser.parse_args(
+            [
+                f"--config={_pi05_snapflow_config_path()}",
+                "--weights_from=/tmp/phase1.ckpt",
+            ],
+        )
+        trainer = MagicMock()
+        datamodule = object()
+
+        class _FakePolicy:
+            last_call: tuple[str, dict[str, object]] | None = None
+
+            @classmethod
+            def load_from_checkpoint(cls, checkpoint_path: str, **kwargs: object) -> _FakePolicy:
+                cls.last_call = (checkpoint_path, kwargs)
+                return cls()
+
+        with patch.object(
+            parser,
+            "instantiate_classes",
+            return_value=Namespace(trainer=trainer, model=_FakePolicy(), data=datamodule),
+        ):
+            exit_code = fit_module.run(cast(ArgumentParser, parser), cast(Namespace, cfg))
+
+        assert exit_code == 0
+        assert _FakePolicy.last_call is not None
+        _, init_args = _FakePolicy.last_call
+        assert "pretrained_name_or_path" not in init_args
+        assert "dataset_stats" not in init_args
+        # Real config overrides for the phase-2 handoff must still come through.
+        assert init_args["train_expert_only"] is True
+        assert init_args["snapflow_enabled"] is True
+        assert init_args["compile_model"] is True
+
+    def test_fit_dispatch_without_weights_from_uses_instantiated_model(self) -> None:
+        """Without ``--weights_from``, the normally instantiated model must be used untouched."""
+        parser = fit_module.register().parser
+        cfg = parser.parse_args([f"--config={_act_config_path()}"])
+        trainer = MagicMock()
+        model = object()
+        datamodule = object()
+
+        with patch.object(
+            parser,
+            "instantiate_classes",
+            return_value=Namespace(trainer=trainer, model=model, data=datamodule),
+        ):
+            exit_code = fit_module.run(cast(ArgumentParser, parser), cast(Namespace, cfg))
+
+        assert exit_code == 0
+        trainer.fit.assert_called_once_with(model=model, datamodule=datamodule)
 
     def test_benchmark_dispatch_calls_benchmark_evaluate(self, tmp_path: Path) -> None:
         parser = benchmark_module.register().parser

--- a/library/tests/unit/policies/test_snapflow.py
+++ b/library/tests/unit/policies/test_snapflow.py
@@ -18,7 +18,7 @@ import pytest
 import torch
 from physicalai.config import Config
 from physicalai.policies import Pi05, SmolVLA
-from physicalai.policies.mixins import SnapFlowConfigMixin, SnapFlowPolicyMixin
+from physicalai.policies.mixins import SnapFlowConfigMixin, SnapFlowModelMixin, SnapFlowPolicyMixin
 from physicalai.policies.pi05 import Pi05Config
 from physicalai.policies.smolvla import SmolVLAConfig
 
@@ -223,3 +223,180 @@ class TestPoliciesShareTheMixin:
             policy.enable_snapflow()
         with pytest.raises(RuntimeError, match="before the model was initialized"):
             _ = policy.inner_model
+
+
+
+
+# ============================================================================ #
+# Mixed FM/consistency loss                                                    #
+# ============================================================================ #
+
+
+class _StubFlowModel(SnapFlowModelMixin):
+    """Minimal host for ``snapflow_mixed_loss``: records which indices each
+    velocity-prediction call touches, so tests can assert on the FM/CD split
+    without a real flow-matching model."""
+
+    def __init__(self, *, alpha: float, lambda_: float = 0.1) -> None:
+        self.init_snapflow_state(enabled=True, alpha=alpha, lambda_=lambda_, num_inference_steps=1)
+        self.predict_velocity_call_shapes: list[int] = []
+        self.predict_velocity_call_markers: list[torch.Tensor] = []
+
+    def sample_noise(self, shape: tuple[int, ...], device: torch.device) -> torch.Tensor:
+        return torch.randn(shape, device=device)
+
+    def predict_velocity(
+        self,
+        x_t: torch.Tensor,
+        _timestep: torch.Tensor,
+        _target_time: torch.Tensor,
+        prefix_embs: torch.Tensor,
+        _prefix_pad_masks: torch.Tensor,
+        _prefix_att_masks: torch.Tensor,
+    ) -> torch.Tensor:
+        self.predict_velocity_call_shapes.append(x_t.shape[0])
+        # prefix_embs[:, 0, 0] carries a per-row identity marker in these
+        # tests (see _mixed_loss_inputs), which lets tests recover exactly
+        # which original rows landed in this call's branch.
+        self.predict_velocity_call_markers.append(prefix_embs[:, 0, 0].clone())
+        # A predictable function of the conditioning, so FM and CD losses are
+        # both well-defined and distinguishable in tests.
+        return x_t + prefix_embs.mean(dim=(1, 2), keepdim=True).expand_as(x_t)
+
+
+def _mixed_loss_inputs(bsize: int, chunk: int = 4, dim: int = 3) -> dict[str, torch.Tensor]:
+    """Build minimal-but-real tensors for ``snapflow_mixed_loss``.
+
+    ``prefix_embs[:, 0, 0]`` is set to ``arange(bsize)`` so tests can recover
+    exactly which original rows a given ``predict_velocity`` call touched.
+    """
+    prefix_embs = torch.randn(bsize, 2, dim)
+    prefix_embs[:, 0, 0] = torch.arange(bsize, dtype=prefix_embs.dtype)
+    return {
+        "u_t": torch.randn(bsize, chunk, dim),
+        "x_t": torch.randn(bsize, chunk, dim),
+        "time": torch.rand(bsize),
+        "actions": torch.randn(bsize, chunk, dim),
+        "prefix_embs": prefix_embs,
+        "prefix_pad_masks": torch.ones(bsize, 2, dtype=torch.bool),
+        "prefix_att_masks": torch.ones(bsize, 2, dtype=torch.bool),
+    }
+
+
+class TestSnapFlowMixedLoss:
+    """The FM/CD split must be a static-size, compile-friendly partition.
+
+    See docs/explanation/policy/snapflow-two-phase-distillation.md ("Proposed
+    design: compile-friendly SnapFlow loss") for the rationale: a fixed-size
+    ``torch.randperm`` split instead of a per-sample Bernoulli mask, so
+    ``torch.compile`` sees a static shape per branch instead of a
+    data-dependent one.
+    """
+
+    @pytest.mark.parametrize(
+        ("alpha", "bsize", "expected_n_fm"),
+        [
+            (0.5, 8, 4),
+            (0.5, 7, 4),  # round(3.5) == 4 (banker's rounding lands here for .5)
+            (0.25, 8, 2),
+            (0.3, 7, 2),
+            (0.0, 8, 0),
+            (1.0, 8, 8),
+        ],
+    )
+    def test_split_size_is_deterministic_given_alpha_and_bsize(
+        self, alpha: float, bsize: int, expected_n_fm: int
+    ) -> None:
+        """The split size must be an exact function of (alpha, bsize), not a
+        random count, so torch.compile only ever sees one shape per config."""
+        model = _StubFlowModel(alpha=alpha)
+        inputs = _mixed_loss_inputs(bsize)
+
+        for _ in range(5):
+            model.predict_velocity_call_shapes.clear()
+            model.snapflow_mixed_loss(
+                sample_noise=model.sample_noise,
+                predict_velocity=model.predict_velocity,
+                **inputs,
+            )
+            shapes = model.predict_velocity_call_shapes
+            # Every call must be one of exactly two sizes: the (constant) FM
+            # branch size or the (constant) CD branch size. No other shape
+            # should ever appear, across repeated calls with fresh randomness.
+            assert all(s in (expected_n_fm, bsize - expected_n_fm) for s in shapes)
+            # Exactly one FM call (if the branch runs) and exactly three CD
+            # calls (v_1, v_half, v_pred, if that branch runs). Counted by
+            # call count rather than by size, because alpha=0.5 on an even
+            # batch makes the two branch sizes coincide.
+            expected_n_calls = (1 if expected_n_fm > 0 else 0) + (3 if expected_n_fm < bsize else 0)
+            assert len(shapes) == expected_n_calls
+
+    def test_pure_fm_skips_the_cd_branch_entirely(self) -> None:
+        """alpha=1.0: no CD velocity calls, and every sample gets a real FM loss."""
+        model = _StubFlowModel(alpha=1.0)
+        inputs = _mixed_loss_inputs(bsize=6)
+
+        losses = model.snapflow_mixed_loss(
+            sample_noise=model.sample_noise, predict_velocity=model.predict_velocity, **inputs
+        )
+
+        assert model.predict_velocity_call_shapes == [6]  # only the FM branch call
+        assert not torch.any(losses == 0)
+
+    def test_pure_cd_skips_the_fm_branch_entirely(self) -> None:
+        """alpha=0.0: no FM velocity calls, every sample goes through CD."""
+        model = _StubFlowModel(alpha=0.0)
+        inputs = _mixed_loss_inputs(bsize=6)
+
+        losses = model.snapflow_mixed_loss(
+            sample_noise=model.sample_noise, predict_velocity=model.predict_velocity, **inputs
+        )
+
+        assert model.predict_velocity_call_shapes == [6, 6, 6]  # v_1, v_half, v_pred
+        assert not torch.any(losses == 0)
+
+    def test_fm_and_cd_index_sets_partition_the_batch(self) -> None:
+        """The FM and CD branches must not overlap and must cover every row,
+        and every row of `losses` must be written by exactly one branch."""
+        bsize = 10
+        model = _StubFlowModel(alpha=0.5)
+        inputs = _mixed_loss_inputs(bsize)
+
+        losses = model.snapflow_mixed_loss(
+            sample_noise=model.sample_noise, predict_velocity=model.predict_velocity, **inputs
+        )
+
+        fm_markers = model.predict_velocity_call_markers[0]
+        cd_markers = model.predict_velocity_call_markers[1]  # v_1's call; identical across v_1/v_half/v_pred
+        all_indices = torch.cat([fm_markers, cd_markers]).sort().values
+        assert torch.equal(all_indices, torch.arange(bsize, dtype=all_indices.dtype))
+        assert losses.shape == inputs["actions"].shape
+        assert not torch.any(losses == 0)
+
+    def test_split_membership_matches_alpha_marginal_across_many_trials(self) -> None:
+        """A single batch has a static split *size*, but the point of using
+        ``torch.randperm`` (over a fixed-order slice) is that which physical
+        row lands in which branch still varies uniformly, so every sample
+        keeps the same marginal probability ``alpha`` of landing in FM that
+        the Bernoulli mask it replaces gave it."""
+        alpha = 0.3
+        bsize = 20
+        model = _StubFlowModel(alpha=alpha)
+        fm_hit_counts = torch.zeros(bsize)
+        n_trials = 300
+
+        for _ in range(n_trials):
+            inputs = _mixed_loss_inputs(bsize)
+            model.predict_velocity_call_markers.clear()
+            model.snapflow_mixed_loss(
+                sample_noise=model.sample_noise, predict_velocity=model.predict_velocity, **inputs
+            )
+            fm_markers = model.predict_velocity_call_markers[0]
+            fm_hit_counts[fm_markers.long()] += 1
+
+        empirical_rate = fm_hit_counts / n_trials
+        assert abs(empirical_rate.mean().item() - alpha) < 0.02
+        # No row should be systematically favored or excluded by the
+        # permutation -- every row's individual empirical rate should also
+        # sit close to alpha, not just the batch-wide average.
+        assert (empirical_rate - alpha).abs().max().item() < 0.15


### PR DESCRIPTION
## Summary
- Makes the SnapFlow FM/CD batch split compile-friendly: replaces the data-dependent Bernoulli-mask-and-`nonzero()` split with a static-size random permutation split (`n_fm = round(alpha * bsize)`, `torch.randperm`), avoiding `torch.compile` graph breaks/recompiles on every step.
- Adds a `--weights_from` CLI option to `physicalai fit`/etc. for warm-starting a model's weights from a checkpoint without resuming full training state (optimizer/LR schedule/global step), which is needed for the SnapFlow phase-1 -> phase-2 handoff when `train_expert_only` changes the optimizer's trainable parameter set.
- Updates SnapFlow distillation configs/docs to use `--weights_from` instead of `--fit.ckpt_path` for the phase-2 handoff, and documents the compile-friendly split rationale.

## Testing
- `uv run pytest tests/unit/policies/test_snapflow.py tests/unit/train/test_callbacks.py tests/unit/cli/test_cli.py -q` → 102 passed

## Notes
- This branch merges the SnapFlow mixin refactor already landed on `main` (`physicalai.policies.mixins`) — the compile-friendly split logic was ported into that new location.