### PR TITLE
feat: add restart server button to footer

### DIFF
--- a/application/ui/src/components/app-footer/app-footer.tsx
+++ b/application/ui/src/components/app-footer/app-footer.tsx
@@ -3,6 +3,7 @@ import { Manifest } from '@geti-ui/ui/icons';
 
 import { JobStatus } from '../../features/jobs/footer/job-status';
 import { LogsDialog } from '../../features/logs/logs-dialog';
+import { RestartRequiredBanner } from '../../features/system/restart-required-banner';
 
 export const AppFooter = ({ gridArea = 'footer' }: { gridArea?: string }) => {
     return (
@@ -16,25 +17,28 @@ export const AppFooter = ({ gridArea = 'footer' }: { gridArea?: string }) => {
             paddingX='size-100'
             paddingY='size-0'
         >
-            <Flex alignItems={'center'} height='100%' gap='size-100' minWidth={0}>
-                <View overflow={'hidden'}>
-                    <DialogTrigger type='fullscreen'>
-                        <ActionButton
-                            isQuiet
-                            UNSAFE_style={{
-                                paddingRight: 'var(--spectrum-global-dimension-size-100)',
-                            }}
-                        >
-                            <Icon>
-                                <Manifest />
-                            </Icon>
-                            Logs
-                        </ActionButton>
-                        {(close) => <LogsDialog close={close} />}
-                    </DialogTrigger>
-                </View>
-                <Divider orientation='vertical' size='S' />
-                <JobStatus />
+            <Flex alignItems='center' justifyContent='space-between' gap='size-100' height='100%'>
+                <Flex alignItems={'center'} height='100%' gap='size-100' flex={1} minWidth={0}>
+                    <View overflow={'hidden'}>
+                        <DialogTrigger type='fullscreen'>
+                            <ActionButton
+                                isQuiet
+                                UNSAFE_style={{
+                                    paddingRight: 'var(--spectrum-global-dimension-size-100)',
+                                }}
+                            >
+                                <Icon>
+                                    <Manifest />
+                                </Icon>
+                                Logs
+                            </ActionButton>
+                            {(close) => <LogsDialog close={close} />}
+                        </DialogTrigger>
+                    </View>
+                    <Divider orientation='vertical' size='S' />
+                    <JobStatus />
+                </Flex>
+                <RestartRequiredBanner />
             </Flex>
         </View>
     );

--- a/application/ui/src/features/system/restart-required-banner.tsx
+++ b/application/ui/src/features/system/restart-required-banner.tsx
@@ -1,0 +1,54 @@
+import { Button, Flex, Text, View } from '@geti-ui/ui';
+
+import { useRestartServerMutation, useRestartState } from './restart-state';
+
+const statusText: Record<string, string> = {
+    idle: 'Restart the server to activate the plugin changes.',
+    requesting: 'Requesting server restart…',
+    waiting_for_down: 'Waiting for server to go down…',
+    waiting_for_up: 'Waiting for server startup…',
+    failed: 'Could not confirm restart from health checks. You can retry.',
+};
+
+export const RestartRequiredBanner = () => {
+    const restartMutation = useRestartServerMutation();
+    const isRestarting = restartMutation.isPending;
+    const { restartRequired, openRestartPrompt } = useRestartState();
+
+    const restart = async () => {
+        openRestartPrompt();
+    };
+
+    if (restartRequired === false) {
+        return null;
+    }
+
+    return (
+        <View backgroundColor={'yellow-400'} paddingX='size-400'>
+            <Flex
+                alignItems='center'
+                justifyContent='space-between'
+                gap='size-100'
+                UNSAFE_style={{
+                    color: 'black',
+                }}
+            >
+                <Text>{statusText[restartMutation.restartStatus]}</Text>
+                <Button
+                    variant='primary'
+                    style='fill'
+
+                    isDisabled={isRestarting}
+                    onPress={restart}
+                    UNSAFE_style={{
+                        minHeight: '24px',
+                        paddingInline: 'var(--spectrum-global-dimension-size-200)',
+                        borderRadius: 0,
+                    }}
+                >
+                    {isRestarting ? 'Restarting…' : 'Restart server'}
+                </Button>
+            </Flex>
+        </View>
+    );
+};

--- a/application/ui/src/features/system/restart-required-banner.tsx
+++ b/application/ui/src/features/system/restart-required-banner.tsx
@@ -1,25 +1,11 @@
 import { Button, Flex, Text, View } from '@geti-ui/ui';
 
-import { useRestartServerMutation, useRestartState } from './restart-state';
-
-const statusText: Record<string, string> = {
-    idle: 'Restart the server to activate the plugin changes.',
-    requesting: 'Requesting server restart…',
-    waiting_for_down: 'Waiting for server to go down…',
-    waiting_for_up: 'Waiting for server startup…',
-    failed: 'Could not confirm restart from health checks. You can retry.',
-};
+import { useRestartState } from './restart-state';
 
 export const RestartRequiredBanner = () => {
-    const restartMutation = useRestartServerMutation();
-    const isRestarting = restartMutation.isPending;
-    const { restartRequired, openRestartPrompt } = useRestartState();
+    const { restartRequired, isRestarting, openRestartPrompt } = useRestartState();
 
-    const restart = async () => {
-        openRestartPrompt();
-    };
-
-    if (restartRequired === false) {
+    if (!restartRequired) {
         return null;
     }
 
@@ -33,13 +19,14 @@ export const RestartRequiredBanner = () => {
                     color: 'black',
                 }}
             >
-                <Text>{statusText[restartMutation.restartStatus]}</Text>
+                <Text>
+                    {isRestarting ? 'Restarting the server…' : 'Restart the server to activate the plugin changes.'}
+                </Text>
                 <Button
                     variant='primary'
                     style='fill'
-
                     isDisabled={isRestarting}
-                    onPress={restart}
+                    onPress={openRestartPrompt}
                     UNSAFE_style={{
                         minHeight: '24px',
                         paddingInline: 'var(--spectrum-global-dimension-size-200)',

--- a/application/ui/src/features/system/restart-state.tsx
+++ b/application/ui/src/features/system/restart-state.tsx
@@ -1,0 +1,207 @@
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import {
+    Button,
+    ButtonGroup,
+    Content,
+    Dialog,
+    DialogContainer,
+    Divider,
+    Flex,
+    Heading,
+    ProgressCircle,
+    Text,
+} from '@geti-ui/ui';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { $api } from '../../api/client';
+import { SchemaTrainJob } from '../../api/openapi-spec';
+
+type HealthResponse = {
+    status?: string;
+    instance_id?: string;
+    restart_required?: boolean;
+};
+
+type RestartStateValue = {
+    restartRequired: boolean;
+    restartStatus: 'idle' | 'restarting' | 'failed';
+    restartPromptOpen: boolean;
+    activeTrainingJobCount: number;
+    hasActiveTrainingJobs: boolean;
+    triggerRestartRequired: () => void;
+    openRestartPrompt: () => void;
+    closeRestartPrompt: () => void;
+    restartServer: () => Promise<void>;
+};
+
+const HEALTH_POLL_INTERVAL_MS = 1500;
+const MIN_RESTART_DIALOG_MS = 2000;
+
+const RestartStateContext = createContext<RestartStateValue | null>(null);
+
+export const RestartStateProvider = ({ children }: { children: ReactNode }) => {
+    const queryClient = useQueryClient();
+    const [restartRequested, setRestartRequested] = useState(false);
+    const [restartPromptOpen, setRestartPromptOpen] = useState(false);
+    const [previousInstanceId, setPreviousInstanceId] = useState<string>();
+
+    const restartMutation = $api.useMutation('post', '/api/system/restart', {
+        meta: { skipInvalidation: true },
+    });
+    const { data: jobs = [] } = $api.useQuery('get', '/api/jobs');
+    const healthQuery = $api.useQuery('get', '/api/health', {
+        retry: false,
+        staleTime: 0,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: 'always',
+    });
+    const health = healthQuery.data as HealthResponse | undefined;
+    const isRestarting = previousInstanceId !== undefined;
+    const restartRequired = restartRequested || health?.restart_required === true;
+
+    const activeTrainingJobCount = jobs.filter(
+        (job): job is SchemaTrainJob =>
+            job.type === 'training' && (job.status === 'running' || job.status === 'pending')
+    ).length;
+
+    const triggerRestartRequired = () => {
+        setRestartRequested(true);
+    };
+
+    const openRestartPrompt = () => {
+        setRestartPromptOpen(true);
+    };
+
+    const closeRestartPrompt = useCallback(() => {
+        if (!isRestarting) {
+            setRestartPromptOpen(false);
+        }
+    }, [isRestarting]);
+
+    const restartServer = useCallback(async () => {
+        if (isRestarting) {
+            return;
+        }
+
+        const { data } = await healthQuery.refetch();
+        const instanceId = (data as HealthResponse | undefined)?.instance_id;
+        if (instanceId === undefined) {
+            return;
+        }
+
+        setRestartPromptOpen(true);
+        setPreviousInstanceId(instanceId);
+
+        try {
+            await restartMutation.mutateAsync({});
+        } catch {
+            // The backend may replace itself before the response is returned.
+        }
+    }, [healthQuery, isRestarting, restartMutation]);
+
+    useEffect(() => {
+        if (!isRestarting || health?.instance_id === previousInstanceId || health?.restart_required !== false) {
+            return;
+        }
+
+        const remainingMs = Math.max(0, restartMutation.submittedAt + MIN_RESTART_DIALOG_MS - Date.now());
+        const timeout = window.setTimeout(() => {
+            queryClient.clear();
+            setPreviousInstanceId(undefined);
+            setRestartRequested(false);
+            setRestartPromptOpen(false);
+        }, remainingMs);
+
+        return () => window.clearTimeout(timeout);
+    }, [
+        health?.instance_id,
+        health?.restart_required,
+        isRestarting,
+        previousInstanceId,
+        queryClient,
+        restartMutation.submittedAt,
+    ]);
+
+    useEffect(() => {
+        if (!isRestarting || healthQuery.isFetching) {
+            return;
+        }
+
+        const timeout = window.setTimeout(() => {
+            void healthQuery.refetch();
+        }, HEALTH_POLL_INTERVAL_MS);
+
+        return () => window.clearTimeout(timeout);
+    }, [healthQuery, isRestarting]);
+
+    const value = useMemo(
+        (): RestartStateValue => ({
+            restartRequired,
+            restartStatus: isRestarting ? 'restarting' : 'idle',
+            restartPromptOpen,
+            activeTrainingJobCount,
+            hasActiveTrainingJobs: activeTrainingJobCount > 0,
+            triggerRestartRequired,
+            openRestartPrompt,
+            closeRestartPrompt,
+            restartServer,
+        }),
+        [activeTrainingJobCount, closeRestartPrompt, isRestarting, restartPromptOpen, restartRequired, restartServer]
+    );
+
+    return (
+        <RestartStateContext.Provider value={value}>
+            {children}
+            {restartRequired && restartPromptOpen ? (
+                <DialogContainer onDismiss={closeRestartPrompt}>
+                    <Dialog>
+                        <Heading>Restart server now?</Heading>
+                        <Divider />
+                        <Content>
+                            <Flex direction='column' gap='size-150'>
+                                <Text>Plugin changes require a server restart to become active.</Text>
+                                {activeTrainingJobCount > 0 ? (
+                                    <Text>
+                                        Restarting now will interrupt {activeTrainingJobCount} active training job
+                                        {activeTrainingJobCount === 1 ? '' : 's'}.
+                                    </Text>
+                                ) : null}
+                                {isRestarting ? (
+                                    <Flex alignItems='center' gap='size-100'>
+                                        <ProgressCircle aria-label='Restarting server' isIndeterminate size='S' />
+                                        <Text>Waiting for server restart…</Text>
+                                    </Flex>
+                                ) : null}
+                            </Flex>
+                        </Content>
+                        <ButtonGroup>
+                            <Button variant='accent' isDisabled={isRestarting} onPress={() => void restartServer()}>
+                                {isRestarting ? 'Restarting…' : 'Restart now'}
+                            </Button>
+                            {!isRestarting ? (
+                                <Button variant='secondary' onPress={closeRestartPrompt}>
+                                    Later
+                                </Button>
+                            ) : null}
+                        </ButtonGroup>
+                    </Dialog>
+                </DialogContainer>
+            ) : null}
+        </RestartStateContext.Provider>
+    );
+};
+
+export const useRestartState = () => {
+    const context = useContext(RestartStateContext);
+    if (context === null) {
+        throw new Error('useRestartState must be used within RestartStateProvider');
+    }
+    return context;
+};
+
+export const useRestartServerMutation = () => {
+    const { restartServer, restartStatus } = useRestartState();
+    const isPending = restartStatus !== 'idle' && restartStatus !== 'failed';
+    return { restartServer, restartStatus, isPending };
+};

--- a/application/ui/src/features/system/restart-state.tsx
+++ b/application/ui/src/features/system/restart-state.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
     Button,
@@ -25,7 +25,7 @@ type HealthResponse = {
 
 type RestartStateValue = {
     restartRequired: boolean;
-    restartStatus: 'idle' | 'restarting' | 'failed';
+    isRestarting: boolean;
     restartPromptOpen: boolean;
     activeTrainingJobCount: number;
     hasActiveTrainingJobs: boolean;
@@ -36,15 +36,63 @@ type RestartStateValue = {
 };
 
 const HEALTH_POLL_INTERVAL_MS = 1500;
-const MIN_RESTART_DIALOG_MS = 2000;
 
 const RestartStateContext = createContext<RestartStateValue | null>(null);
+
+type RestartPromptDialogProps = {
+    isRestarting: boolean;
+    activeTrainingJobCount: number;
+    onDismiss: () => void;
+    onRestart: () => Promise<void>;
+};
+
+const RestartPromptDialog = ({
+    isRestarting,
+    activeTrainingJobCount,
+    onDismiss,
+    onRestart,
+}: RestartPromptDialogProps) => (
+    <DialogContainer onDismiss={onDismiss}>
+        <Dialog>
+            <Heading>Restart server now?</Heading>
+            <Divider />
+            <Content>
+                <Flex direction='column' gap='size-150'>
+                    <Text>Plugin changes require a server restart to become active.</Text>
+                    {activeTrainingJobCount > 0 ? (
+                        <Text>
+                            Restarting now will interrupt {activeTrainingJobCount} active training job
+                            {activeTrainingJobCount === 1 ? '' : 's'}.
+                        </Text>
+                    ) : null}
+                    {isRestarting ? (
+                        <Flex alignItems='center' gap='size-100'>
+                            <ProgressCircle aria-label='Restarting server' isIndeterminate size='S' />
+                            <Text>Waiting for server restart…</Text>
+                        </Flex>
+                    ) : null}
+                </Flex>
+            </Content>
+            <ButtonGroup>
+                <Button variant='accent' isDisabled={isRestarting} onPress={() => void onRestart()}>
+                    {isRestarting ? 'Restarting…' : 'Restart now'}
+                </Button>
+                {!isRestarting ? (
+                    <Button variant='secondary' onPress={onDismiss}>
+                        Later
+                    </Button>
+                ) : null}
+            </ButtonGroup>
+        </Dialog>
+    </DialogContainer>
+);
 
 export const RestartStateProvider = ({ children }: { children: ReactNode }) => {
     const queryClient = useQueryClient();
     const [restartRequested, setRestartRequested] = useState(false);
     const [restartPromptOpen, setRestartPromptOpen] = useState(false);
-    const [previousInstanceId, setPreviousInstanceId] = useState<string>();
+    const [isRestarting, setIsRestarting] = useState(false);
+    const lastInstanceId = useRef<string | undefined>(undefined);
 
     const restartMutation = $api.useMutation('post', '/api/system/restart', {
         meta: { skipInvalidation: true },
@@ -57,7 +105,6 @@ export const RestartStateProvider = ({ children }: { children: ReactNode }) => {
         refetchOnReconnect: 'always',
     });
     const health = healthQuery.data as HealthResponse | undefined;
-    const isRestarting = previousInstanceId !== undefined;
     const restartRequired = restartRequested || health?.restart_required === true;
 
     const activeTrainingJobCount = jobs.filter(
@@ -86,12 +133,12 @@ export const RestartStateProvider = ({ children }: { children: ReactNode }) => {
 
         const { data } = await healthQuery.refetch();
         const instanceId = (data as HealthResponse | undefined)?.instance_id;
-        if (instanceId === undefined) {
-            return;
+        if (instanceId !== undefined) {
+            lastInstanceId.current = instanceId;
         }
 
         setRestartPromptOpen(true);
-        setPreviousInstanceId(instanceId);
+        setIsRestarting(true);
 
         try {
             await restartMutation.mutateAsync({});
@@ -101,27 +148,19 @@ export const RestartStateProvider = ({ children }: { children: ReactNode }) => {
     }, [healthQuery, isRestarting, restartMutation]);
 
     useEffect(() => {
-        if (!isRestarting || health?.instance_id === previousInstanceId || health?.restart_required !== false) {
+        const instanceId = health?.instance_id;
+        if (instanceId === undefined) {
             return;
         }
 
-        const remainingMs = Math.max(0, restartMutation.submittedAt + MIN_RESTART_DIALOG_MS - Date.now());
-        const timeout = window.setTimeout(() => {
+        if (lastInstanceId.current !== undefined && instanceId !== lastInstanceId.current) {
             queryClient.clear();
-            setPreviousInstanceId(undefined);
+            setIsRestarting(false);
             setRestartRequested(false);
             setRestartPromptOpen(false);
-        }, remainingMs);
-
-        return () => window.clearTimeout(timeout);
-    }, [
-        health?.instance_id,
-        health?.restart_required,
-        isRestarting,
-        previousInstanceId,
-        queryClient,
-        restartMutation.submittedAt,
-    ]);
+        }
+        lastInstanceId.current = instanceId;
+    }, [health?.instance_id, queryClient]);
 
     useEffect(() => {
         if (!isRestarting || healthQuery.isFetching) {
@@ -138,7 +177,7 @@ export const RestartStateProvider = ({ children }: { children: ReactNode }) => {
     const value = useMemo(
         (): RestartStateValue => ({
             restartRequired,
-            restartStatus: isRestarting ? 'restarting' : 'idle',
+            isRestarting,
             restartPromptOpen,
             activeTrainingJobCount,
             hasActiveTrainingJobs: activeTrainingJobCount > 0,
@@ -154,39 +193,12 @@ export const RestartStateProvider = ({ children }: { children: ReactNode }) => {
         <RestartStateContext.Provider value={value}>
             {children}
             {restartRequired && restartPromptOpen ? (
-                <DialogContainer onDismiss={closeRestartPrompt}>
-                    <Dialog>
-                        <Heading>Restart server now?</Heading>
-                        <Divider />
-                        <Content>
-                            <Flex direction='column' gap='size-150'>
-                                <Text>Plugin changes require a server restart to become active.</Text>
-                                {activeTrainingJobCount > 0 ? (
-                                    <Text>
-                                        Restarting now will interrupt {activeTrainingJobCount} active training job
-                                        {activeTrainingJobCount === 1 ? '' : 's'}.
-                                    </Text>
-                                ) : null}
-                                {isRestarting ? (
-                                    <Flex alignItems='center' gap='size-100'>
-                                        <ProgressCircle aria-label='Restarting server' isIndeterminate size='S' />
-                                        <Text>Waiting for server restart…</Text>
-                                    </Flex>
-                                ) : null}
-                            </Flex>
-                        </Content>
-                        <ButtonGroup>
-                            <Button variant='accent' isDisabled={isRestarting} onPress={() => void restartServer()}>
-                                {isRestarting ? 'Restarting…' : 'Restart now'}
-                            </Button>
-                            {!isRestarting ? (
-                                <Button variant='secondary' onPress={closeRestartPrompt}>
-                                    Later
-                                </Button>
-                            ) : null}
-                        </ButtonGroup>
-                    </Dialog>
-                </DialogContainer>
+                <RestartPromptDialog
+                    isRestarting={isRestarting}
+                    activeTrainingJobCount={activeTrainingJobCount}
+                    onDismiss={closeRestartPrompt}
+                    onRestart={restartServer}
+                />
             ) : null}
         </RestartStateContext.Provider>
     );
@@ -198,10 +210,4 @@ export const useRestartState = () => {
         throw new Error('useRestartState must be used within RestartStateProvider');
     }
     return context;
-};
-
-export const useRestartServerMutation = () => {
-    const { restartServer, restartStatus } = useRestartState();
-    const isPending = restartStatus !== 'idle' && restartStatus !== 'failed';
-    return { restartServer, restartStatus, isPending };
 };

--- a/application/ui/src/providers.tsx
+++ b/application/ui/src/providers.tsx
@@ -6,6 +6,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouterProps, MemoryRouter as Router, RouterProvider } from 'react-router';
 
 import { ZoomProvider } from './components/zoom/zoom';
+import { RestartStateProvider } from './features/system/restart-state';
 import { queryClient } from './query-client/query-client';
 import { router } from './router';
 
@@ -44,7 +45,9 @@ export const Providers = () => {
             <ThemeProvider router={router}>
                 <CustomThemeProvider>
                     <ZoomProvider>
-                        <RouterProvider router={router} />
+                        <RestartStateProvider>
+                            <RouterProvider router={router} />
+                        </RestartStateProvider>
                         <ToastContainer />
                     </ZoomProvider>
                 </CustomThemeProvider>

--- a/application/ui/src/routes/app/app.layout.test.tsx
+++ b/application/ui/src/routes/app/app.layout.test.tsx
@@ -4,6 +4,7 @@ import { render as rtlRender, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { vi } from 'vitest';
 
+import { RestartStateProvider } from '../../features/system/restart-state';
 import { createQueryClient } from '../../query-client/query-client';
 import { render } from '../../test-utils/render';
 import { AppLayout } from './app.layout';
@@ -31,7 +32,9 @@ describe('AppLayout', () => {
                     element: (
                         <QueryClientProvider client={queryClient}>
                             <ThemeProvider>
-                                <AppLayout />
+                                <RestartStateProvider>
+                                    <AppLayout />
+                                </RestartStateProvider>
                             </ThemeProvider>
                         </QueryClientProvider>
                     ),

--- a/application/ui/src/test-utils/render.tsx
+++ b/application/ui/src/test-utils/render.tsx
@@ -9,6 +9,7 @@ import {
 } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 
+import { RestartStateProvider } from '../features/system/restart-state';
 import { createQueryClient } from '../query-client/query-client';
 
 type RenderOptions = RTLRenderOptions & {
@@ -23,7 +24,9 @@ type RenderOptions = RTLRenderOptions & {
 const TestProviders = ({ children, queryClient }: { children: ReactNode; queryClient: QueryClient }) => (
     <QueryClientProvider client={queryClient}>
         <ThemeProvider>
-            <Suspense>{children}</Suspense>
+            <RestartStateProvider>
+                <Suspense>{children}</Suspense>
+            </RestartStateProvider>
         </ThemeProvider>
     </QueryClientProvider>
 );


### PR DESCRIPTION
This PR adds a new UI component that gets shown when the UI detects that the server requires a restart.
When the user clicks the 'Restart server" button we show a dialog which, when confirmed, remains open until the server has finished restarting.
To check that the server successfully restarted we compare the `instance_id` added to the health endpoint in #1030

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/eb7d3f8a-ee64-418f-936c-796625762d34" />
