### PR TITLE
fix: improve error handling when removing a robot

### DIFF
--- a/application/ui/src/features/robots/robot-detail-error.test.tsx
+++ b/application/ui/src/features/robots/robot-detail-error.test.tsx
@@ -1,0 +1,85 @@
+import { Suspense } from 'react';
+
+import { ThemeProvider } from '@geti-ui/ui';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { http } from '../../api/utils';
+import { server } from '../../msw-node-setup';
+import { createQueryClient } from '../../query-client/query-client';
+import { Robot } from '../../routes/robots/robot';
+import { RestartStateProvider } from '../system/restart-state';
+import { RobotDetailError } from './robot-detail-error';
+
+const PROJECT_ID = 'project-id';
+const ROBOT_ID = 'robot-id';
+
+const renderAtShowRoute = () => {
+    const queryClient = createQueryClient();
+    const router = createMemoryRouter(
+        [
+            {
+                path: '/projects/:project_id/robots/:robot_id',
+                element: <Robot />,
+                errorElement: <RobotDetailError />,
+            },
+            {
+                path: '/projects/:project_id/robots',
+                element: <div>Robots index</div>,
+            },
+        ],
+        { initialEntries: [`/projects/${PROJECT_ID}/robots/${ROBOT_ID}`], initialIndex: 0 }
+    );
+
+    return rtlRender(
+        <QueryClientProvider client={queryClient}>
+            <ThemeProvider>
+                <RestartStateProvider>
+                    <Suspense>
+                        <RouterProvider router={router} />
+                    </Suspense>
+                </RestartStateProvider>
+            </ThemeProvider>
+        </QueryClientProvider>
+    );
+};
+
+describe('RobotDetailError', () => {
+    it('shows a friendly message when the robot is not found', async () => {
+        server.use(
+            http.get('/api/projects/{project_id}/robots/{robot_id}', () =>
+                HttpResponse.json(
+                    { error_code: 'robot_not_found', message: 'Robot not found', http_status: 404 } as never,
+                    { status: 404 }
+                )
+            )
+        );
+
+        renderAtShowRoute();
+
+        expect(await screen.findByText('This robot no longer exists.')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Back to robots' })).toBeInTheDocument();
+    });
+
+    it('navigates back to the robots index', async () => {
+        server.use(
+            http.get('/api/projects/{project_id}/robots/{robot_id}', () =>
+                HttpResponse.json(
+                    { error_code: 'robot_not_found', message: 'Robot not found', http_status: 404 } as never,
+                    { status: 404 }
+                )
+            )
+        );
+        const user = userEvent.setup();
+
+        renderAtShowRoute();
+
+        await user.click(await screen.findByRole('button', { name: 'Back to robots' }));
+
+        expect(await screen.findByText('Robots index')).toBeInTheDocument();
+    });
+});

--- a/application/ui/src/features/robots/robot-detail-error.test.tsx
+++ b/application/ui/src/features/robots/robot-detail-error.test.tsx
@@ -12,7 +12,6 @@ import { http } from '../../api/utils';
 import { server } from '../../msw-node-setup';
 import { createQueryClient } from '../../query-client/query-client';
 import { Robot } from '../../routes/robots/robot';
-import { RestartStateProvider } from '../system/restart-state';
 import { RobotDetailError } from './robot-detail-error';
 
 const PROJECT_ID = 'project-id';
@@ -38,11 +37,9 @@ const renderAtShowRoute = () => {
     return rtlRender(
         <QueryClientProvider client={queryClient}>
             <ThemeProvider>
-                <RestartStateProvider>
-                    <Suspense>
-                        <RouterProvider router={router} />
-                    </Suspense>
-                </RestartStateProvider>
+                <Suspense>
+                    <RouterProvider router={router} />
+                </Suspense>
             </ThemeProvider>
         </QueryClientProvider>
     );

--- a/application/ui/src/features/robots/robot-detail-error.tsx
+++ b/application/ui/src/features/robots/robot-detail-error.tsx
@@ -1,0 +1,41 @@
+import { Button, Heading, IllustratedMessage, View } from '@geti-ui/ui';
+import { AlertCircle as NotFound } from '@geti-ui/ui/icons';
+import { isRouteErrorResponse, useNavigate, useRouteError } from 'react-router';
+
+import { getApiErrorMessage } from '../../api/errors';
+import { paths } from '../../router';
+import { useProjectId } from '../projects/use-project';
+
+const isNotFound = (error: unknown): boolean =>
+    isRouteErrorResponse(error)
+        ? error.status === 404
+        : typeof error === 'object' &&
+          error !== null &&
+          'http_status' in error &&
+          (error as Record<string, unknown>).http_status === 404;
+
+export const RobotDetailError = () => {
+    const error = useRouteError();
+    const navigate = useNavigate();
+    const { project_id } = useProjectId();
+
+    const heading = isNotFound(error)
+        ? 'This robot no longer exists.'
+        : (getApiErrorMessage(error) ?? 'Something went wrong while loading this robot.');
+
+    return (
+        <View height='100%' flex='1'>
+            <IllustratedMessage>
+                <NotFound />
+                <Heading>{heading}</Heading>
+                <Button
+                    variant='accent'
+                    marginTop='size-200'
+                    onPress={() => navigate(paths.project.robots.index({ project_id }))}
+                >
+                    Back to robots
+                </Button>
+            </IllustratedMessage>
+        </View>
+    );
+};

--- a/application/ui/src/features/robots/robots-list.test.tsx
+++ b/application/ui/src/features/robots/robots-list.test.tsx
@@ -1,11 +1,18 @@
-import { screen, waitFor } from '@testing-library/react';
+import { ReactNode, Suspense } from 'react';
+
+import { ThemeProvider } from '@geti-ui/ui';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { http } from '../../api/utils';
 import { server } from '../../msw-node-setup';
+import { createQueryClient } from '../../query-client/query-client';
 import { render } from '../../test-utils/render';
+import { RestartStateProvider } from '../system/restart-state';
 import { RobotsList } from './robots-list';
 
 const PROJECT_ID = 'test-project-id';
@@ -35,6 +42,34 @@ const renderRobotsList = () =>
 const openRobotMenu = async (user: ReturnType<typeof userEvent.setup>) => {
     await screen.findByText(so101Robot.name);
     await user.click(screen.getByRole('button', { name: `Actions for ${so101Robot.name}` }));
+};
+
+const renderRobotsListAtShowRoute = () => {
+    const queryClient = createQueryClient();
+    const providers = (children: ReactNode) => (
+        <QueryClientProvider client={queryClient}>
+            <ThemeProvider>
+                <RestartStateProvider>
+                    <Suspense>{children}</Suspense>
+                </RestartStateProvider>
+            </ThemeProvider>
+        </QueryClientProvider>
+    );
+    const router = createMemoryRouter(
+        [
+            {
+                path: '/projects/:project_id/robots/:robot_id',
+                element: providers(<RobotsList />),
+            },
+            {
+                path: '/projects/:project_id/robots',
+                element: providers(<div>Robots index</div>),
+            },
+        ],
+        { initialEntries: [`/projects/${PROJECT_ID}/robots/${ROBOT_ID}`], initialIndex: 0 }
+    );
+
+    return rtlRender(<RouterProvider router={router} />);
 };
 
 describe('RobotsList', () => {
@@ -124,6 +159,21 @@ describe('RobotsList', () => {
         });
         expect(click).toHaveBeenCalledOnce();
         expect(revokeObjectUrl).toHaveBeenCalledWith('blob:calibration');
+    });
+
+    it('navigates to the robots index when the viewed robot is deleted', async () => {
+        server.use(
+            http.get(ROBOTS_PATH, () => HttpResponse.json([so101Robot])),
+            http.get(ONLINE_ROBOTS_PATH, () => HttpResponse.json([])),
+            http.delete('/api/projects/{project_id}/robots/{robot_id}', () => HttpResponse.json(null, { status: 204 }))
+        );
+        const user = userEvent.setup();
+
+        renderRobotsListAtShowRoute();
+        await openRobotMenu(user);
+        await user.click(await screen.findByText('Delete', { selector: '[role]' }));
+
+        expect(await screen.findByText('Robots index')).toBeInTheDocument();
     });
 
     it('shows unavailable robots without treating their status as loading', async () => {

--- a/application/ui/src/features/robots/robots-list.test.tsx
+++ b/application/ui/src/features/robots/robots-list.test.tsx
@@ -12,7 +12,6 @@ import { http } from '../../api/utils';
 import { server } from '../../msw-node-setup';
 import { createQueryClient } from '../../query-client/query-client';
 import { render } from '../../test-utils/render';
-import { RestartStateProvider } from '../system/restart-state';
 import { RobotsList } from './robots-list';
 
 const PROJECT_ID = 'test-project-id';
@@ -49,9 +48,7 @@ const renderRobotsListAtShowRoute = () => {
     const providers = (children: ReactNode) => (
         <QueryClientProvider client={queryClient}>
             <ThemeProvider>
-                <RestartStateProvider>
-                    <Suspense>{children}</Suspense>
-                </RestartStateProvider>
+                <Suspense>{children}</Suspense>
             </ThemeProvider>
         </QueryClientProvider>
     );

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -2,7 +2,7 @@ import { Grid, StatusLight } from '@adobe/react-spectrum';
 import { ActionButton, Button, Flex, Heading, Icon, Item, Menu, MenuTrigger, toast, View } from '@geti-ui/ui';
 import { Add, MoreMenu } from '@geti-ui/ui/icons';
 import { clsx } from 'clsx';
-import { NavLink } from 'react-router';
+import { NavLink, useNavigate, useParams } from 'react-router';
 
 import { $api } from '../../api/client';
 import { getApiErrorMessage, isResourceInUseError, isRuntimeSessionBusyError } from '../../api/errors';
@@ -29,11 +29,18 @@ const exportCalibration = async (_project_id: string, robot: SchemaRobot) => {
 
 const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
     const { project_id } = useProjectId();
+    const { robot_id: activeRobotId } = useParams<{ robot_id?: string }>();
+    const navigate = useNavigate();
     const deleteRobotMutation = $api.useMutation('delete', '/api/projects/{project_id}/robots/{robot_id}', {
         meta: {
             invalidates: [
                 ['get', '/api/projects/{project_id}/robots', { params: { path: { project_id } } }],
                 ['get', '/api/projects/{project_id}/robots/online', { params: { path: { project_id } } }],
+                [
+                    'get',
+                    '/api/projects/{project_id}/robots/{robot_id}',
+                    { params: { path: { project_id, robot_id: robot.id } } },
+                ],
             ],
         },
     });
@@ -57,6 +64,11 @@ const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
                         await deleteRobotMutation.mutateAsync(
                             { params: { path: { project_id, robot_id: robot.id } } },
                             {
+                                onSuccess: () => {
+                                    if (robot.id === activeRobotId) {
+                                        navigate(paths.project.robots.index({ project_id }));
+                                    }
+                                },
                                 onError: (error) => {
                                     if (isResourceInUseError(error) || isRuntimeSessionBusyError(error)) {
                                         toast.info(

--- a/application/ui/src/router.tsx
+++ b/application/ui/src/router.tsx
@@ -7,6 +7,7 @@ import { path } from 'static-path';
 import { fetchClient } from './api/client';
 import { ReactComponent as RobotIllustration } from './assets/illustrations/INTEL_08_NO-TESTS.svg';
 import { ErrorPage } from './components/error-page/error-page';
+import { RobotDetailError } from './features/robots/robot-detail-error';
 import { AppLayout } from './routes/app/app.layout';
 import { Camera } from './routes/cameras/camera';
 import { Edit as CameraEdit } from './routes/cameras/edit';
@@ -271,6 +272,7 @@ export const router = createBrowserRouter([
                                     {
                                         path: paths.project.robots.show.pattern,
                                         element: <Robot />,
+                                        errorElement: <RobotDetailError />,
                                     },
                                 ],
                             },


### PR DESCRIPTION
Before when the user would remove a robot that they've selected the route would remain the same, refreshing the page would result in a global "Something was wrong" error without option to select a different robot etc.

Note: as a follow up we can/should do the same to our cameras and environments pages. Let's create a PR for those after the review of this PR is finished