### PR TITLE
fix: "Catch" SIGSEGV crash when getting openvino devices

### DIFF
--- a/application/backend/src/services/system_service.py
+++ b/application/backend/src/services/system_service.py
@@ -4,6 +4,7 @@
 """Service for querying system hardware information."""
 
 import os
+from functools import lru_cache
 from importlib import import_module
 from typing import Any
 
@@ -73,16 +74,31 @@ class SystemService:
 
         return devices
 
-    @classmethod
-    def _get_openvino_inference_devices(cls) -> list[InferenceDeviceInfo]:
-        """Get compute devices available to the OpenVINO backend for inference."""
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _get_openvino_core() -> Any | None:
+        """Return a process-wide OpenVINO ``Core``, or None when OpenVINO is unavailable.
+
+        The Core is cached deliberately: enumerating devices instantiates every registered
+        OpenVINO plugin, and the NPU plugin calls Level Zero's ``zeInitDrivers()``. On hosts
+        with no Level Zero driver installed, ``zeInitDrivers()`` returns UNINITIALIZED on the
+        first call and segfaults on any later one, so a second Core enumeration would take the
+        whole process down. Building the Core once keeps that call to a single invocation.
+        """
         try:
             openvino = import_module("openvino")
         except ImportError:
             logger.debug("OpenVINO is not installed; skipping OpenVINO inference devices.")
+            return None
+        return openvino.Core()
+
+    @classmethod
+    def _get_openvino_inference_devices(cls) -> list[InferenceDeviceInfo]:
+        """Get compute devices available to the OpenVINO backend for inference."""
+        core = cls._get_openvino_core()
+        if core is None:
             return []
 
-        core = openvino.Core()
         system_memory = cls._get_system_memory()
         devices: list[InferenceDeviceInfo] = [
             InferenceDeviceInfo(

--- a/application/backend/tests/services/test_system_service.py
+++ b/application/backend/tests/services/test_system_service.py
@@ -1,8 +1,18 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from schemas.hardware import DeviceType, InferenceBackend
 from services.system_service import SystemService
+
+
+@pytest.fixture(autouse=True)
+def _reset_openvino_core_cache():
+    """Reset the process-wide OpenVINO Core cache so each test sees its own mock."""
+    SystemService._get_openvino_core.cache_clear()
+    yield
+    SystemService._get_openvino_core.cache_clear()
 
 
 def _device_props(name: str, total_memory: int) -> SimpleNamespace:


### PR DESCRIPTION
Multiple cores in one process can cause a SIGSEGV when a host doesnt have the correct drivers.
Since the SIGSEGV cannot be caught we cache the openvino core to prevent it.