### PR TITLE
fix(runtime): close recording lifecycle races from the #992 review

### DIFF
--- a/application/backend/src/runtime/callbacks/recording.py
+++ b/application/backend/src/runtime/callbacks/recording.py
@@ -93,6 +93,17 @@ class RecordingState:
             self._is_recording = False
             return self._mutation
 
+    def current_mutation(self) -> RecordingMutation | None:
+        """Return the attached mutation without requiring an open episode.
+
+        Discard doubles as the recovery path after a failed save, which has
+        already cleared the recording flag. Requiring an open episode there
+        would leave the buffer with no way to clear it.
+        """
+        with self._lock:
+            self._is_recording = False
+            return self._mutation
+
     def take_mutation(self) -> RecordingMutation | None:
         """Detach the mutation so teardown can finalize it once.
 

--- a/application/backend/src/runtime/command_thread.py
+++ b/application/backend/src/runtime/command_thread.py
@@ -39,14 +39,21 @@ class CommandWorker:
         self._thread: threading.Thread | None = None
 
     def submit(self, name: str, fn: Callable[[], None], *, request_id: str | None = None) -> None:
-        """Enqueue ``fn`` for FIFO execution. Optional ``request_id`` can be waited on."""
+        """Enqueue ``fn`` for FIFO execution. Optional ``request_id`` can be waited on.
+
+        The queue insertion happens under ``_lock``, the same lock that guards
+        ``_closed``. Enqueueing after the release would let a concurrent
+        ``shutdown`` slip ``_SHUTDOWN`` in front of a job that passed the closed
+        check, and the worker would exit without running it. The queue is
+        unbounded, so holding the lock across ``put`` cannot block.
+        """
         with self._lock:
             if self._closed:
                 raise RuntimeError(f"Cannot submit {name} after the command worker has shut down")
             if request_id is not None:
                 self._events[request_id] = threading.Event()
             self._ensure_thread_locked()
-        self._jobs.put(_Job(name=name, fn=fn, request_id=request_id))
+            self._jobs.put(_Job(name=name, fn=fn, request_id=request_id))
 
     def wait(self, request_id: str, timeout: float) -> AckData:
         """Block until the job with ``request_id`` finishes, or the timeout elapses."""
@@ -60,22 +67,30 @@ class CommandWorker:
             self._events.pop(request_id, None)
             return self._results.pop(request_id)
 
-    def shutdown(self, timeout: float) -> None:
-        """Drain queued work, then stop. A stop cannot strand an in-flight save."""
+    def shutdown(self, timeout: float) -> bool:
+        """Drain queued work, then stop. Return whether the worker actually drained.
+
+        A caller that owns the same objects as the queued jobs -- the recording
+        mutation, above all -- must not touch them while a job is still running.
+        Returning False says the join timed out and the worker thread is still
+        inside its job.
+        """
         with self._lock:
-            if self._closed:
-                return
+            already_closed = self._closed
             self._closed = True
             thread = self._thread
+            if thread is not None and not already_closed:
+                self._jobs.put(_SHUTDOWN)
         if thread is None:
-            return
-        self._jobs.put(_SHUTDOWN)
+            return True
         thread.join(timeout=timeout)
         if thread.is_alive():
             logger.error(
                 "Command worker did not finish within {}s; in-flight recording work may be lost",
                 timeout,
             )
+            return False
+        return True
 
     def _run(self) -> None:
         while True:

--- a/application/backend/src/runtime/session.py
+++ b/application/backend/src/runtime/session.py
@@ -200,8 +200,13 @@ class RuntimeSession:
     async def teardown(self) -> None:
         # Finalize first: a dataset that will not copy back must not prevent
         # the arm from being released, but skipping it loses the recording.
-        self._command_worker.shutdown(timeout=RECORDING_TEARDOWN_TIMEOUT_S)
-        self._finalize_recording()
+        # Only once the worker has drained, though -- a job that is still
+        # running holds this same mutation, and finalizing underneath it stops
+        # the image writer mid-encode or copies a half-written dataset.
+        if self._command_worker.shutdown(timeout=RECORDING_TEARDOWN_TIMEOUT_S):
+            self._finalize_recording()
+        else:
+            logger.error("Command worker did not drain; leaving the recording to its in-flight job")
         if self._recording_callback is not None:
             self._recording_callback.close()
         # Device lifetime belongs to the session, not to a disposable runtime view.
@@ -249,6 +254,7 @@ class RuntimeSession:
         not close ``RecordingState`` -- a client reattaching within the idle
         window records into a fresh mutation over the updated dataset.
         """
+        self._discard_open_episode()
         mutation = self._recording.take_mutation()
         if mutation is None:
             return
@@ -258,6 +264,28 @@ class RuntimeSession:
             logger.exception("Recording mutation teardown failed; the cache may not have been copied back")
         # The cached state is what a returning client recovers, so it must not
         # keep advertising a dataset this session no longer holds.
+        self._emit_state()
+
+    def _discard_open_episode(self) -> None:
+        """Drop an episode that was still open when the session was abandoned.
+
+        The frames cannot be recovered -- the cache is deleted moments later --
+        so drop them deliberately and say so, rather than letting the buffer
+        disappear inside ``teardown()``, which copies back only what
+        ``save_episode`` marked. Safe to check then stop: on abandonment this
+        runs on the command worker, the same thread as save and discard, and on
+        teardown the worker has already drained. Ticks cannot interleave either
+        -- ``add_frame`` and ``stop_episode`` share the recording lock.
+        """
+        if not self._recording.is_recording:
+            return
+        mutation = self._recording.stop_episode()
+        logger.warning("Discarding the episode that was still open when the session was abandoned")
+        try:
+            mutation.discard_buffer()
+        except Exception:
+            logger.exception("Failed to discard the open episode buffer")
+        self._recording.mark_discarded()
         self._emit_state()
 
     def _load_dataset(self, command: LoadDatasetCommand) -> None:
@@ -292,12 +320,26 @@ class RuntimeSession:
 
     def _save_episode(self) -> None:
         mutation = self._recording.stop_episode()
-        mutation.save_episode()
+        try:
+            mutation.save_episode()
+        except Exception:
+            # The episode did not land. ``stop_episode`` already cleared the
+            # recording flag, so publish that state anyway or the browser keeps
+            # offering Save and Discard for an episode the session has stopped.
+            # The buffer stays attached: discard is what clears it. Do not
+            # reopen recording -- that would append frames to a buffer whose
+            # write just failed.
+            self._emit_state()
+            raise
         self._recording.mark_saved()
         self._emit_state()
 
     def _discard_episode(self) -> None:
-        mutation = self._recording.stop_episode()
+        # Not ``stop_episode``: discard is also how a client recovers from a
+        # failed save, which has already cleared the recording flag.
+        mutation = self._recording.current_mutation()
+        if mutation is None:
+            raise RuntimeError("No dataset is loaded.")
         mutation.discard_buffer()
         self._recording.mark_discarded()
         self._emit_state()

--- a/application/backend/tests/runtime/test_recording_lifecycle.py
+++ b/application/backend/tests/runtime/test_recording_lifecycle.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import queue
 import threading
 import time
 
 import pytest
 
 from runtime.callbacks.recording import RecordingState
-from runtime.command_thread import CommandWorker
-from runtime.contract import AckData, DiscardEpisodeCommand, QueueEventSink, SaveEpisodeCommand
+from runtime.command_thread import CommandWorker, _Job
+from runtime.contract import AckData, DiscardEpisodeCommand, QueueEventSink, SaveEpisodeCommand, StateEvent
 from runtime.hosts.session_worker import _watch_subscribers
 from runtime.session import RuntimeSession
 from tests.runtime.test_session import _document, _document_with_cameras
@@ -31,6 +32,7 @@ class _FakeMutation:
 
     def discard_buffer(self) -> None:
         self.discarded += 1
+        self.order.append("discard")
 
     def teardown(self) -> None:
         self.torn_down += 1
@@ -325,3 +327,120 @@ def test_save_episode_stops_recording_before_the_mutation_writes() -> None:
     assert mutation.saved == 1
     assert recording.is_recording is False
     assert recording.episodes_recorded == 1
+
+
+class _FailingSaveMutation(_FakeMutation):
+    def save_episode(self) -> None:
+        raise RuntimeError("video encoding failed")
+
+
+def _last_state(sink: QueueEventSink) -> StateEvent | None:
+    latest: StateEvent | None = None
+    while True:
+        try:
+            event = sink.get_nowait()
+        except queue.Empty:
+            return latest
+        if isinstance(event, StateEvent):
+            latest = event
+
+
+def test_a_job_accepted_before_shutdown_is_never_dropped() -> None:
+    """submit and shutdown race for the queue, and the job must not land behind the sentinel.
+
+    Enqueueing outside the lock let shutdown insert _SHUTDOWN between the
+    closed check and the put, so the worker returned without running a job it
+    had already accepted. Slowing the job's own enqueue widens that window to
+    something a test can observe; under the lock, shutdown simply waits.
+    """
+    worker = CommandWorker()
+    ran = threading.Event()
+    enqueueing = threading.Event()
+    real_put = worker._jobs.put
+
+    def slow_put(item, *args, **kwargs):
+        if isinstance(item, _Job):
+            enqueueing.set()
+            time.sleep(0.2)
+        return real_put(item, *args, **kwargs)
+
+    worker._jobs.put = slow_put
+
+    def stop_once_submitting() -> None:
+        enqueueing.wait(2.0)
+        worker.shutdown(timeout=2.0)
+
+    stopper = threading.Thread(target=stop_once_submitting)
+    stopper.start()
+    worker.submit("save_episode", ran.set)
+    stopper.join(timeout=5.0)
+
+    assert ran.wait(2.0), "a job accepted before shutdown was dropped behind the sentinel"
+
+
+def test_teardown_leaves_the_mutation_to_a_worker_that_did_not_drain(monkeypatch) -> None:
+    """Finalizing on top of a running save stops the image writer mid-encode."""
+    monkeypatch.setattr("runtime.session.RECORDING_TEARDOWN_TIMEOUT_S", 0.05)
+    session = RuntimeSession(_document(), event_sink=QueueEventSink())
+    mutation = _FakeMutation(save_delay=0.5)
+    session._recording.attach_mutation(mutation)
+    session._recording.start("pick")
+    session._command_worker.submit("save_episode", session._save_episode)
+
+    asyncio.run(session.teardown())
+
+    assert mutation.torn_down == 0
+    _wait_until(lambda: mutation.saved == 1)
+    assert mutation.order == ["save"]
+
+
+def test_a_failed_save_publishes_the_stopped_state() -> None:
+    """The ack carries the error, but the browser only moves on a state event."""
+    sink = QueueEventSink()
+    session = RuntimeSession(_document(), event_sink=sink)
+    asyncio.run(session.setup())
+    mutation = _FailingSaveMutation()
+    session._recording.attach_mutation(mutation)
+    session._recording.start("pick")
+
+    with pytest.raises(RuntimeError, match="video encoding failed"):
+        session._save_episode()
+
+    state = _last_state(sink)
+    assert state is not None
+    assert state.data.is_recording is False
+    assert session._recording.episodes_recorded == 0
+
+
+def test_discard_clears_the_buffer_after_a_failed_save() -> None:
+    """Discard is the recovery path, so it cannot require an open episode."""
+    session = RuntimeSession(_document(), event_sink=QueueEventSink())
+    mutation = _FailingSaveMutation()
+    session._recording.attach_mutation(mutation)
+    session._recording.start("pick")
+    with pytest.raises(RuntimeError):
+        session._save_episode()
+
+    session._discard_episode()
+
+    assert mutation.discarded == 1
+    assert session._recording.is_recording is False
+
+
+def test_abandonment_discards_an_open_episode_before_finalizing() -> None:
+    """An open buffer is never copied back, so drop it deliberately and say so."""
+    sink = QueueEventSink()
+    session = RuntimeSession(_document(), event_sink=sink)
+    asyncio.run(session.setup())
+    mutation = _FakeMutation()
+    session._recording.attach_mutation(mutation)
+    session._recording.start("pick")
+
+    session.finalize_recording()
+    _wait_until(lambda: mutation.torn_down == 1)
+    session._command_worker.shutdown(timeout=5.0)
+
+    assert mutation.order == ["discard", "teardown"]
+    state = _last_state(sink)
+    assert state is not None
+    assert state.data.is_recording is False


### PR DESCRIPTION
Addresses the Copilot review comments left unresolved when #992 merged. 

 - A queued command could be dropped on shutdown. submit() accepted the job but queued it after releasing the lock, so a shutdown running at the same time could slip its stop signal in front. It now queues under the lock.

- Teardown could corrupt a save that was still running. shutdown() now reports whether the worker finished, and teardown only finalizes if it did.

- A failed save left the UI stuck. The backend stopped recording without telling the browser, which kept showing Discard/Accept, and Discard then failed too. The stopped state is now published, and Discard clears the leftover buffer.

- An episode still open when the tab closed vanished with no trace. Those frames still cannot be saved, but they are now discarded deliberately, with a warning in the log and a state event.