### PR TITLE
fix(ui, dataset views): Fix dataset view layout and wrong displayed episodes

### DIFF
--- a/application/ui/src/features/datasets/episodes/episode-dock-view.tsx
+++ b/application/ui/src/features/datasets/episodes/episode-dock-view.tsx
@@ -9,12 +9,7 @@ import {
     IDockviewReactProps,
 } from 'dockview-react';
 
-import {
-    SchemaDatasetOutput,
-    SchemaEnvironmentWithRelations,
-    SchemaEpisode,
-    SchemaEpisodeVideo,
-} from '../../../api/openapi-spec';
+import { SchemaDatasetOutput, SchemaEnvironmentWithRelations, SchemaEpisode } from '../../../api/openapi-spec';
 import { physicalAiTheme } from '../../dockview';
 import { EpisodeVideoCell } from './episode-video-cell.component';
 import { RobotCell } from './robot-cell.component';
@@ -31,8 +26,8 @@ const components = {
     robot: (props: IDockviewPanelProps<{ robot_id: string }>) => {
         return <RobotCell robotId={props.params.robot_id} />;
     },
-    camera: (props: IDockviewPanelProps<{ video: SchemaEpisodeVideo; datasetId: string }>) => {
-        return <EpisodeVideoCell episodeVideo={props.params.video} datasetId={props.params.datasetId} />;
+    camera: (props: IDockviewPanelProps<{ videoId: string; datasetId: string | undefined }>) => {
+        return <EpisodeVideoCell videoId={props.params.videoId} datasetId={props.params.datasetId} />;
     },
     default: (props: IDockviewPanelProps<{ title: string }>) => {
         return <div style={{ padding: '20px', color: 'white' }}>{props.params.title}</div>;
@@ -60,7 +55,7 @@ const buildDockviewPanels = (
                 title: cameraName,
                 component: 'camera',
                 params: {
-                    video: episode.videos[videoId],
+                    videoId,
                     datasetId: dataset.id,
                 },
                 position: {

--- a/application/ui/src/features/datasets/episodes/episode-video-cell.component.tsx
+++ b/application/ui/src/features/datasets/episodes/episode-video-cell.component.tsx
@@ -4,24 +4,15 @@ import { fetchClient } from '../../../api/client';
 import { SchemaEpisodeVideo } from '../../../api/openapi-spec';
 import { useFittedMediaSize } from '../../cameras/use-fitted-media-size';
 import { useEpisodeViewer } from './episode-viewer-provider.component';
+import { Player } from './use-player';
 
-export const EpisodeVideoCell = ({ videoId, datasetId }: { videoId: string; datasetId: string | undefined }) => {
-    const { player, episode } = useEpisodeViewer();
+type EpisodeVideoProps = {
+    url: string | undefined;
+    player: Player;
+    episodeVideo: SchemaEpisodeVideo | undefined;
+};
 
-    const episodeVideo: SchemaEpisodeVideo | undefined = episode.videos[videoId];
-
-    const url =
-        episodeVideo === undefined || datasetId === undefined
-            ? undefined
-            : fetchClient.PATH('/api/dataset/{dataset_id}/video/{video_path}', {
-                  params: {
-                      path: {
-                          dataset_id: datasetId,
-                          video_path: episodeVideo.path,
-                      },
-                  },
-              });
-
+const EpisodeVideo = ({ url, player, episodeVideo }: EpisodeVideoProps) => {
     const videoRef = useRef<HTMLVideoElement>(null);
 
     useEffect(() => {
@@ -60,4 +51,24 @@ export const EpisodeVideoCell = ({ videoId, datasetId }: { videoId: string; data
             {url !== undefined && <video ref={videoRef} src={url} width={width} height={height} />}
         </div>
     );
+};
+
+export const EpisodeVideoCell = ({ videoId, datasetId }: { videoId: string; datasetId: string | undefined }) => {
+    const { player, episode } = useEpisodeViewer();
+
+    const episodeVideo: SchemaEpisodeVideo | undefined = episode.videos[videoId];
+
+    const url =
+        episodeVideo === undefined || datasetId === undefined
+            ? undefined
+            : fetchClient.PATH('/api/dataset/{dataset_id}/video/{video_path}', {
+                  params: {
+                      path: {
+                          dataset_id: datasetId,
+                          video_path: episodeVideo.path,
+                      },
+                  },
+              });
+
+    return <EpisodeVideo key={episode.episode_index} url={url} player={player} episodeVideo={episodeVideo} />;
 };

--- a/application/ui/src/features/datasets/episodes/episode-video-cell.component.tsx
+++ b/application/ui/src/features/datasets/episodes/episode-video-cell.component.tsx
@@ -5,29 +5,29 @@ import { SchemaEpisodeVideo } from '../../../api/openapi-spec';
 import { useFittedMediaSize } from '../../cameras/use-fitted-media-size';
 import { useEpisodeViewer } from './episode-viewer-provider.component';
 
-export const EpisodeVideoCell = ({
-    episodeVideo,
-    datasetId,
-}: {
-    episodeVideo: SchemaEpisodeVideo;
-    datasetId: string;
-}) => {
-    const { player } = useEpisodeViewer();
-    const url = fetchClient.PATH('/api/dataset/{dataset_id}/video/{video_path}', {
-        params: {
-            path: {
-                dataset_id: datasetId,
-                video_path: episodeVideo.path,
-            },
-        },
-    });
+export const EpisodeVideoCell = ({ videoId, datasetId }: { videoId: string; datasetId: string | undefined }) => {
+    const { player, episode } = useEpisodeViewer();
+
+    const episodeVideo: SchemaEpisodeVideo | undefined = episode.videos[videoId];
+
+    const url =
+        episodeVideo === undefined || datasetId === undefined
+            ? undefined
+            : fetchClient.PATH('/api/dataset/{dataset_id}/video/{video_path}', {
+                  params: {
+                      path: {
+                          dataset_id: datasetId,
+                          video_path: episodeVideo.path,
+                      },
+                  },
+              });
 
     const videoRef = useRef<HTMLVideoElement>(null);
 
     useEffect(() => {
         const video = videoRef.current;
-        const start = episodeVideo.start;
-        if (!video || !Number.isFinite(start)) return;
+        const start = episodeVideo?.start;
+        if (!video || start === undefined || !Number.isFinite(start)) return;
 
         video.currentTime = player.timeRef.current + start;
         if (player.isPlaying) {
@@ -35,19 +35,19 @@ export const EpisodeVideoCell = ({
         } else {
             video.pause();
         }
-    }, [player, episodeVideo.start, videoRef]);
+    }, [player, episodeVideo?.start, videoRef]);
 
     useEffect(() => {
         const video = videoRef.current;
-        const start = episodeVideo.start;
+        const start = episodeVideo?.start;
 
-        if (video && player.isSeeking && Number.isFinite(start)) {
+        if (video && player.isSeeking && start !== undefined && Number.isFinite(start)) {
             const interval = setInterval(() => {
                 video.currentTime = player.timeRef.current + start;
             }, 1000 / 60);
             return () => clearInterval(interval);
         }
-    }, [player, episodeVideo.start]);
+    }, [player, episodeVideo?.start]);
 
     const { containerRef, width, height } = useFittedMediaSize(
         videoRef.current?.videoWidth,
@@ -57,7 +57,7 @@ export const EpisodeVideoCell = ({
     /* eslint-disable jsx-a11y/media-has-caption */
     return (
         <div ref={containerRef} style={{ height: '100%', width: '100%' }}>
-            <video ref={videoRef} src={url} width={width} height={height} />
+            {url !== undefined && <video ref={videoRef} src={url} width={width} height={height} />}
         </div>
     );
 };

--- a/application/ui/src/features/projects/use-project.ts
+++ b/application/ui/src/features/projects/use-project.ts
@@ -7,7 +7,7 @@ export function useProjectId() {
     const { project_id } = useParams<{ project_id: string }>();
 
     if (project_id === undefined) {
-        throw new Error('Unkown project_id parameter');
+        throw new Error('Unknown project_id parameter');
     }
 
     return { project_id };

--- a/application/ui/src/index.css
+++ b/application/ui/src/index.css
@@ -117,7 +117,3 @@ svg {
 button:not(:disabled):not([aria-disabled='true']) {
     cursor: pointer !important;
 }
-
-div[class*='spectrum-Modal'] {
-    --spectrum-dialog-background-color: hsl(from var(--spectrum-global-color-gray-75) h s calc(l - 10));
-}

--- a/application/ui/src/routes/datasets/dataset-viewer.tsx
+++ b/application/ui/src/routes/datasets/dataset-viewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
     ActionButton,
@@ -15,10 +15,11 @@ import {
     View,
 } from '@geti-ui/ui';
 import { Add, Delete } from '@geti-ui/ui/icons';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData } from '@tanstack/react-query';
 
-import { SchemaEpisode } from '../../api/openapi-spec';
+import { $api } from '../../api/client';
 import { useDeleteEpisodeQuery } from '../../features/datasets/episodes/use-episodes';
+import { useProjectId } from '../../features/projects/use-project';
 import { paths } from '../../router';
 import { pluralize } from '../../utils';
 import { ReactComponent as EmptyIllustration } from './../../assets/illustration.svg';
@@ -28,15 +29,14 @@ import { EpisodeViewer } from './episode-viewer';
 
 export const DatasetViewer = () => {
     const { dataset, episodes, selectedEpisodes, setSelectedEpisodes } = useDataset();
+    const { project_id } = useProjectId();
 
     const { deleteEpisodes, isPending } = useDeleteEpisodeQuery(dataset.id!);
     const [currentEpisode, setCurrentEpisode] = useState<number | null>(null);
 
-    useEffect(() => {
-        if (episodes.length > 0 && currentEpisode === null) {
-            setCurrentEpisode(episodes[0].episode_index);
-        }
-    }, [episodes, currentEpisode]);
+    if (episodes.length > 0 && currentEpisode === null) {
+        setCurrentEpisode(episodes[0].episode_index);
+    }
 
     const currentEpisodeIndex = useMemo(() => {
         if (currentEpisode !== null && episodes.some((episode) => episode.episode_index === currentEpisode)) {
@@ -46,21 +46,29 @@ export const DatasetViewer = () => {
         return episodes[0]?.episode_index ?? null;
     }, [currentEpisode, episodes]);
 
-    const { data: selectedEpisode, isLoading: isEpisodeLoading } = useQuery({
-        queryKey: ['dataset-episode', dataset.id, currentEpisodeIndex],
-        enabled: currentEpisodeIndex !== null,
-        queryFn: async (): Promise<SchemaEpisode> => {
-            const response = await fetch(
-                `/api/dataset/${encodeURIComponent(dataset.id!)}/episodes/${encodeURIComponent(currentEpisodeIndex!)}`
-            );
+    const { data: environment } = $api.useSuspenseQuery(
+        'get',
+        '/api/projects/{project_id}/environments/{environment_id}',
+        {
+            params: { path: { project_id, environment_id: dataset.environment_id } },
+        }
+    );
 
-            if (!response.ok) {
-                throw new Error(`Failed to load episode ${currentEpisodeIndex}`);
-            }
-
-            return (await response.json()) as SchemaEpisode;
+    const { data: selectedEpisode, isLoading: isEpisodeLoading } = $api.useQuery(
+        'get',
+        '/api/dataset/{dataset_id}/episodes/{episode_index}',
+        {
+            params: {
+                path: {
+                    dataset_id: String(dataset.id),
+                    episode_index: currentEpisodeIndex,
+                },
+            },
         },
-    });
+        {
+            placeholderData: keepPreviousData,
+        }
+    );
 
     const recordPath = paths.project.datasets.record({ project_id: dataset.project_id, dataset_id: dataset.id! });
 
@@ -88,7 +96,7 @@ export const DatasetViewer = () => {
                 {isEpisodeLoading || !selectedEpisode ? (
                     <Loading />
                 ) : (
-                    <EpisodeViewer episode={selectedEpisode} dataset={dataset} />
+                    <EpisodeViewer episode={selectedEpisode} dataset={dataset} environment={environment} />
                 )}
             </View>
             <Divider orientation='vertical' size='S' />

--- a/application/ui/src/routes/datasets/episode-viewer.tsx
+++ b/application/ui/src/routes/datasets/episode-viewer.tsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { Disclosure, DisclosurePanel, DisclosureTitle, Divider, Flex, Text } from '@geti-ui/ui';
 
-import { $api } from '../../api/client';
-import { SchemaDatasetOutput, SchemaEpisode } from '../../api/openapi-spec';
+import { SchemaDatasetOutput, SchemaEnvironmentWithRelations, SchemaEpisode } from '../../api/openapi-spec';
 import EpisodeChart from '../../components/episode-chart/episode-chart';
 import { EpisodeDockView } from '../../features/datasets/episodes/episode-dock-view';
 import { EpisodeTag } from '../../features/datasets/episodes/episode-tag';
@@ -12,7 +11,6 @@ import {
     useEpisodeViewer,
 } from '../../features/datasets/episodes/episode-viewer-provider.component';
 import { Player } from '../../features/datasets/episodes/use-player';
-import { useProjectId } from '../../features/projects/use-project';
 import { RobotModelsProvider } from '../../features/robots/robot-models-context';
 import { TimelineControls } from './timeline-controls';
 
@@ -21,6 +19,7 @@ import classes from './episode-viewer.module.css';
 interface EpisodeViewerProps {
     episode: SchemaEpisode;
     dataset: SchemaDatasetOutput;
+    environment: SchemaEnvironmentWithRelations;
 }
 
 interface LiveEpisodeChartProps {
@@ -75,17 +74,7 @@ const EpisodeTimelineComponent = () => {
     );
 };
 
-export const EpisodeViewer = ({ episode, dataset }: EpisodeViewerProps) => {
-    const { project_id } = useProjectId();
-
-    const { data: environment } = $api.useSuspenseQuery(
-        'get',
-        '/api/projects/{project_id}/environments/{environment_id}',
-        {
-            params: { path: { project_id, environment_id: dataset.environment_id } },
-        }
-    );
-
+export const EpisodeViewer = ({ episode, dataset, environment }: EpisodeViewerProps) => {
     return (
         <EpisodeViewerProvider episode={episode} environment={environment}>
             <RobotModelsProvider>

--- a/application/ui/src/routes/datasets/episode-viewer.tsx
+++ b/application/ui/src/routes/datasets/episode-viewer.tsx
@@ -69,7 +69,8 @@ const EpisodeTimelineComponent = () => {
                     <LiveEpisodeChart episode={episode} player={player} />
                 </DisclosurePanel>
             </Disclosure>
-            <TimelineControls player={player} />
+            {/* We reset the time controls state for the new episode */}
+            <TimelineControls key={episode.episode_index} player={player} />
         </div>
     );
 };


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->
This PR fixes a few issues:
1. When loading episodes and selected episode, for a moment episodes list is displayed, then hidden because of the loading spinner and the displayed together with the selected episode.
2. When episodes are selected in order 1 -> 2 -> 3 -> 1, then 1 episode is selected but its content is not visible.
3. When episode is played and paused at 00:10 and new episode is selected but not played, there are two issues:
- timeline still shows 00:10;
- player still shows frames from the previous episode.
4. When new episode is selected, we show loading spinner in place where video players are displayed. In this PR we show the previous episode until new episode is fetched (we don't need to unmount and mount dock views again).


## Related Issues

<!-- Fixes #123 -->
