### PR TITLE
fix(pi05,rldx1,smolvla): ignore unknown keys in pretrained config.json

### DIFF
--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -30,6 +30,7 @@ from physicalai.export.backends import (
 from physicalai.policies.base import Policy
 from physicalai.policies.mixins import SnapFlowPolicyMixin
 from physicalai.policies.mixins.peft import PeftPolicyMixin
+from physicalai.policies.utils.pretrained import known_config_fields_only
 from physicalai.train.schedulers import cosine_decay_with_warmup_scheduler
 from physicalai.train.utils import reformat_dataset_to_match_policy
 
@@ -544,8 +545,11 @@ class Pi05(PeftPolicyMixin, SnapFlowPolicyMixin, ExportablePolicyMixin, Policy):
             if detected is not None:
                 hf_config["normalization_mode"] = detected
 
-        # strict=False: ignore legacy config.json keys not present in Pi05Config
-        config = Pi05Config.from_dict(hf_config, strict=False)
+        # Drop keys not present on Pi05Config before parsing. Pretrained lerobot
+        # config.json files carry extra fields (e.g. input_features, output_features,
+        # architectures, model_type) that from_dict() cannot silently ignore; see
+        # known_config_fields_only() for details.
+        config = Pi05Config.from_dict(known_config_fields_only(Pi05Config, hf_config))
 
         # --- build dataset_stats from HF artefacts ---
         dataset_stats = _extract_dataset_stats(hf_config, preprocessor_file, preprocessor_dir)

--- a/library/src/physicalai/policies/rldx1/policy.py
+++ b/library/src/physicalai/policies/rldx1/policy.py
@@ -57,6 +57,7 @@ from physicalai.policies.base import Policy
 from physicalai.policies.rldx1.config import Rldx1Config
 from physicalai.policies.rldx1.model import Rldx1Model
 from physicalai.policies.rldx1.pretrained_utils import extract_dataset_stats, retrieve_safetensors_shards
+from physicalai.policies.utils.pretrained import known_config_fields_only
 from physicalai.train.schedulers import cosine_decay_with_warmup_scheduler
 from physicalai.train.utils import reformat_dataset_to_match_policy
 
@@ -367,10 +368,11 @@ class Rldx1(Policy):
         hf_config["action_horizon"] = action_horizon
         hf_config["embodiment_tag"] = embodiment_tag
 
-        # strict=False: ignore upstream config.json keys with no Rldx1Config field
-        # (e.g. architectures, model_type, rtc_inference_*) instead of denylisting
-        # them one by one.
-        config = Rldx1Config.from_dict(hf_config, strict=False)
+        # Drop keys not present on Rldx1Config before parsing. Upstream config.json
+        # files carry extra fields (e.g. architectures, model_type, rtc_inference_*)
+        # that from_dict() cannot silently ignore; see known_config_fields_only()
+        # for details.
+        config = Rldx1Config.from_dict(known_config_fields_only(Rldx1Config, hf_config))
 
         # --- build dataset_stats from HF artefacts ---
         dataset_stats = extract_dataset_stats(

--- a/library/src/physicalai/policies/smolvla/policy.py
+++ b/library/src/physicalai/policies/smolvla/policy.py
@@ -29,6 +29,7 @@ from physicalai.export.backends import (
 )
 from physicalai.policies.base import Policy
 from physicalai.policies.mixins import SnapFlowPolicyMixin
+from physicalai.policies.utils.pretrained import known_config_fields_only
 from physicalai.train.schedulers import cosine_decay_with_warmup_scheduler
 from physicalai.train.utils import reformat_dataset_to_match_policy
 
@@ -439,8 +440,10 @@ class SmolVLA(SnapFlowPolicyMixin, ExportablePolicyMixin, Policy):
 
         dataset_stats = extract_dataset_stats(hf_config, preprocessor_file, preprocessor_dir)
 
-        # strict=False: ignore legacy config.json keys not present in SmolVLAConfig
-        config = SmolVLAConfig.from_dict(hf_config, strict=False)
+        # Drop keys not present on SmolVLAConfig before parsing. Legacy config.json
+        # files carry extra fields that from_dict() cannot silently ignore; see
+        # known_config_fields_only() for details.
+        config = SmolVLAConfig.from_dict(known_config_fields_only(SmolVLAConfig, hf_config))
 
         return config, dataset_stats, weights_file
 

--- a/library/src/physicalai/policies/utils/__init__.py
+++ b/library/src/physicalai/policies/utils/__init__.py
@@ -4,7 +4,9 @@
 """Utils for policies."""
 
 from .normalization import FeatureNormalizeTransform
+from .pretrained import known_config_fields_only
 
 __all__ = [
     "FeatureNormalizeTransform",
+    "known_config_fields_only",
 ]

--- a/library/src/physicalai/policies/utils/pretrained.py
+++ b/library/src/physicalai/policies/utils/pretrained.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for loading pretrained ``config.json`` files across policies."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["known_config_fields_only"]
+
+
+def known_config_fields_only[ConfigT](config_cls: type[ConfigT], data: Mapping[str, object]) -> dict[str, object]:
+    """Drop keys from *data* that have no matching field on *config_cls*.
+
+    This is a workaround for an upstream regression in runtime-owned
+    ``physicalai.config.Config.from_dict``: passing ``strict=False`` no longer
+    silently ignores unknown keys. The current implementation builds a
+    jsonargparse parser from only the dataclass's known fields and always
+    rejects any key without a matching constructor argument, regardless of
+    ``strict``. Pretrained ``lerobot`` ``config.json`` files always carry extra
+    bookkeeping keys (e.g. ``input_features``, ``output_features``, ``repo_id``,
+    ``license``, ``push_to_hub``) that trip this up (see physical-ai-studio#1069).
+
+    Filtering the keys ourselves before calling ``from_dict`` sidesteps the
+    issue without depending on ``strict`` doing anything. Tracked upstream at
+    openvinotoolkit/physicalai#251; this helper should be revisited (and
+    likely removed) once the runtime's ``Config.from_dict`` honours
+    ``strict=False`` again.
+
+    Args:
+        config_cls: The dataclass ``Config`` subclass being constructed.
+        data: Raw mapping (typically parsed from a pretrained ``config.json``).
+
+    Returns:
+        A copy of *data* containing only keys that are fields on *config_cls*.
+
+    Raises:
+        TypeError: If *config_cls* is not a dataclass.
+    """
+    if not dataclasses.is_dataclass(config_cls):
+        msg = f"{config_cls.__name__} must be a dataclass"
+        raise TypeError(msg)
+
+    known_fields = {field.name for field in dataclasses.fields(config_cls)}
+    dropped = sorted(set(data) - known_fields)
+    if dropped:
+        logger.debug(
+            "Ignoring %d pretrained config key(s) with no matching %s field: %s",
+            len(dropped),
+            config_cls.__name__,
+            dropped,
+        )
+
+    return {key: value for key, value in data.items() if key in known_fields}

--- a/library/tests/unit/policies/test_pi05.py
+++ b/library/tests/unit/policies/test_pi05.py
@@ -8,6 +8,9 @@ Fast, self-contained tests with no external dependencies (no HuggingFace model d
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 import torch
 from physicalai.config import Config
@@ -18,6 +21,7 @@ from physicalai.policies.pi05.pretrained_utils import (
     parse_config_features,
     resolve_feature_shape,
 )
+from safetensors.torch import save_file
 
 
 # ============================================================================ #
@@ -1594,3 +1598,87 @@ class TestPi05LoRAConfig:
         total = sum(p.numel() for p in policy.parameters())
         assert 0 < trainable < total
 
+
+# ============================================================================ #
+# Pretrained Config Loading Regression Tests (issue #1069)                    #
+# ============================================================================ #
+
+
+class TestPi05FromHfConfigFiltering:
+    """Regression tests for loading pretrained config.json files with extra keys.
+
+    Real lerobot config.json files (e.g. ``lerobot/pi05_base``) include keys such
+    as ``input_features``/``output_features``/``repo_id``/``license`` that are
+    not fields on ``Pi05Config``. The underlying jsonargparse-based parser used
+    by ``Config.from_dict`` rejects any key without a matching constructor
+    argument regardless of ``strict``, so ``_from_hf`` must filter unknown keys
+    out via ``known_config_fields_only`` before calling ``from_dict`` (see
+    physicalai.policies.utils.pretrained). These tests exercise ``_from_hf``
+    end-to-end and assert that *known* file values survive filtering (not just
+    that no exception is raised), to catch an over-aggressive filter.
+    """
+
+    def _make_pretrained_dir(self, tmp_path: Path) -> Path:
+        config = {
+            # Real-world junk keys observed on lerobot/pi05_base's config.json;
+            # none of these are Pi05Config fields.
+            "type": "pi05",
+            "device": "cuda",
+            "use_amp": False,
+            "push_to_hub": True,
+            "repo_id": "lerobot/pi05_base",
+            "private": None,
+            "tags": None,
+            "license": "apache-2.0",
+            "input_features": {
+                "observation.images.base_0_rgb": {
+                    "type": "VISUAL",
+                    "shape": [3, 224, 224],
+                },
+                "observation.state": {
+                    "type": "STATE",
+                    "shape": [8],
+                },
+            },
+            "output_features": {
+                "action": {
+                    "type": "ACTION",
+                    "shape": [7],
+                },
+            },
+            # Known Pi05Config fields, deliberately set to non-default values and
+            # NOT among _from_hf's explicit override parameters, so a filter that
+            # drops too much (or a caller override masking the bug) can't hide it.
+            "paligemma_variant": "gemma_300m",
+            "tokenizer_max_length": 48,
+            "empty_cameras": 2,
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        save_file({"model.some_layer.weight": torch.randn(2, 2)}, str(tmp_path / "model.safetensors"))
+        preprocessor: dict[str, list[object]] = {"steps": []}
+        (tmp_path / "policy_preprocessor.json").write_text(json.dumps(preprocessor), encoding="utf-8")
+        return tmp_path
+
+    def test_from_hf_ignores_unknown_config_keys(self, tmp_path: Path) -> None:
+        """_from_hf should not raise on config.json keys absent from Pi05Config."""
+        pretrained_dir = self._make_pretrained_dir(tmp_path)
+
+        loader = object.__new__(Pi05)
+        config, dataset_stats, weight_file = loader._from_hf(pretrained_dir)  # noqa: SLF001
+
+        assert isinstance(config, Pi05Config)
+        # Default values, to make sure the assertions below actually pin file
+        # values rather than defaults that happen to match.
+        default_config = Pi05Config()
+        assert config.paligemma_variant != default_config.paligemma_variant
+        assert config.tokenizer_max_length != default_config.tokenizer_max_length
+        assert config.empty_cameras != default_config.empty_cameras
+
+        # File-sourced values must survive the unknown-key filtering.
+        assert config.paligemma_variant == "gemma_300m"
+        assert config.tokenizer_max_length == 48
+        assert config.empty_cameras == 2
+
+        assert "observation.state" in dataset_stats
+        assert "action" in dataset_stats
+        assert weight_file == pretrained_dir / "model.safetensors"

--- a/library/tests/unit/policies/utils/test_pretrained.py
+++ b/library/tests/unit/policies/utils/test_pretrained.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit Tests - Pretrained Config Loading Helpers
+
+Regression coverage for issue physical-ai-studio#1069: pretrained lerobot
+``config.json`` files carry extra keys (e.g. ``input_features``,
+``output_features``, ``repo_id``, ``license``) that
+``physicalai.config.Config.from_dict(..., strict=False)`` no longer silently
+ignores (upstream regression, see known_config_fields_only() docstring).
+``known_config_fields_only`` is the Studio-side workaround; these tests pin
+its contract across all first-party policies that load pretrained weights.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from physicalai.policies.pi05.config import Pi05Config
+from physicalai.policies.rldx1.config import Rldx1Config
+from physicalai.policies.smolvla.config import SmolVLAConfig
+from physicalai.policies.utils.pretrained import known_config_fields_only
+
+# Junk keys observed on real lerobot pretrained config.json files (e.g.
+# lerobot/pi05_base), none of which are fields on any first-party policy
+# config dataclass.
+_REAL_WORLD_JUNK_KEYS: dict[str, object] = {
+    "type": "pi05",
+    "device": "cuda",
+    "use_amp": False,
+    "push_to_hub": True,
+    "repo_id": "lerobot/pi05_base",
+    "private": None,
+    "tags": None,
+    "license": "apache-2.0",
+    "input_features": {
+        "observation.images.base_0_rgb": {"type": "VISUAL", "shape": [3, 224, 224]},
+        "observation.state": {"type": "STATE", "shape": [8]},
+    },
+    "output_features": {"action": {"type": "ACTION", "shape": [7]}},
+}
+
+
+@pytest.mark.parametrize("config_cls", [Pi05Config, Rldx1Config, SmolVLAConfig])
+class TestKnownConfigFieldsOnly:
+    """Contract tests for known_config_fields_only, parametrized per policy config."""
+
+    def test_drops_unknown_keys(self, config_cls: type) -> None:
+        """Keys with no matching dataclass field are dropped."""
+        data = {**_REAL_WORLD_JUNK_KEYS, "not_a_real_field_either": 123}
+        filtered = known_config_fields_only(config_cls, data)
+        known_fields = {field.name for field in dataclasses.fields(config_cls)}
+        assert set(filtered) <= known_fields
+        assert "input_features" not in filtered
+        assert "output_features" not in filtered
+        assert "not_a_real_field_either" not in filtered
+
+    def test_preserves_known_keys(self, config_cls: type) -> None:
+        """Keys that do match a dataclass field survive filtering, values intact."""
+        known_fields = list(dataclasses.fields(config_cls))
+        assert known_fields, f"{config_cls.__name__} unexpectedly has no fields"
+
+        sentinel_field = known_fields[0].name
+        data = {**_REAL_WORLD_JUNK_KEYS, sentinel_field: "sentinel-value"}
+        filtered = known_config_fields_only(config_cls, data)
+
+        assert filtered[sentinel_field] == "sentinel-value"
+
+    def test_does_not_mutate_input(self, config_cls: type) -> None:
+        """The input mapping is not mutated in place."""
+        data = dict(_REAL_WORLD_JUNK_KEYS)
+        original = dict(data)
+        known_config_fields_only(config_cls, data)
+        assert data == original
+
+    def test_empty_input_returns_empty(self, config_cls: type) -> None:
+        """Filtering an empty mapping returns an empty mapping."""
+        assert known_config_fields_only(config_cls, {}) == {}
+
+    def test_logs_dropped_keys(
+        self,
+        config_cls: type,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Dropped keys are logged at debug level for observability."""
+        with caplog.at_level("DEBUG", logger="physicalai.policies.utils.pretrained"):
+            known_config_fields_only(config_cls, _REAL_WORLD_JUNK_KEYS)
+        assert any("input_features" in record.message for record in caplog.records)
+
+
+def test_raises_for_non_dataclass() -> None:
+    """A non-dataclass target raises TypeError instead of failing obscurely."""
+
+    class NotADataclass:
+        pass
+
+    with pytest.raises(TypeError, match="must be a dataclass"):
+        known_config_fields_only(NotADataclass, {"a": 1})

--- a/skills/library/physicalai-train-adding-a-policy/SKILL.md
+++ b/skills/library/physicalai-train-adding-a-policy/SKILL.md
@@ -38,10 +38,22 @@ Policies live in `library/src/physicalai/policies/<name>/`. Each family is a Lig
 
 6. **Add a training config** in `library/configs/physicalai/<name>.yaml` when the policy is user-facing from the CLI. Wire `model.class_path`, a `data.class_path` (usually `physicalai.data.lerobot.LeRobotDataModule`), and `trainer.*`. Mirror `configs/physicalai/pi05.yaml`.
    - Done when: `physicalai fit --config configs/physicalai/<name>.yaml --trainer.fast_dev_run=true` completes one step.
-7. **Wire export only when ready.** Add `ExportablePolicyMixin` and a valid sample input, then follow the `physicalai-train-exporting-and-validating` skill. If export is intentionally unsupported, say so explicitly in the policy docstring.
-8. **Add tests** under `library/tests/unit/policies/` next to existing policy tests: at least one construction/config path and one shape-validation test.
+7. **If loading pretrained weights (`_from_hf(...)`), filter the raw `config.json` before calling `<Name>Config.from_dict(...)`.** Pretrained `lerobot`-format `config.json` files always carry keys with no matching `Config` field (e.g. `input_features`, `output_features`, `repo_id`, `license`, `push_to_hub`). `Config.from_dict(data, strict=False)` does **not** silently ignore these — the jsonargparse-based parser rejects any unknown key regardless of `strict` (tracked upstream at `openvinotoolkit/physicalai#251`). Use the shared helper instead of hand-rolling a filter or relying on `strict=False` alone:
+
+   ```python
+   from physicalai.policies.utils.pretrained import known_config_fields_only
+
+   config = <Name>Config.from_dict(known_config_fields_only(<Name>Config, hf_config))
+   ```
+
+   See `pi05/policy.py`, `smolvla/policy.py`, or `rldx1/policy.py` for the full `_from_hf` pattern. This only filters top-level keys; keep `<Name>Config` flat (no nested `Config`/dataclass fields) so this remains sufficient — a nested field with its own extra keys would still be rejected.
+
+   - Done when: loading a real pretrained checkpoint's `config.json` (not just a synthetic one) does not raise, and a test exercises `_from_hf` with a config containing at least one unknown top-level key.
+
+8. **Wire export only when ready.** Add `ExportablePolicyMixin` and a valid sample input, then follow the `physicalai-train-exporting-and-validating` skill. If export is intentionally unsupported, say so explicitly in the policy docstring.
+9. **Add tests** under `library/tests/unit/policies/` next to existing policy tests: at least one construction/config path and one shape-validation test.
    - Done when: `uv run --no-sync pytest tests/unit/policies -k <name>` passes.
-9. **Update docs** if the policy is user-visible: `library/docs/explanation/policy/` and any config/API examples.
+10. **Update docs** if the policy is user-visible: `library/docs/explanation/policy/` and any config/API examples.
 
 ## Required checks
 
@@ -51,6 +63,7 @@ Account for every item below (not just "looks fine"):
 - **Observation features** — feature names align with dataset/config conventions (`data/observation.py`: `Feature`, `FeatureType`).
 - **API construction path** — imports, `get_policy(...)`, direct constructor use, and synthetic shape checks pass without CLI involvement.
 - **Config path** — construction works through the jsonargparse CLI path used by `physicalai fit` (`class_path`/`init_args`) when the policy is CLI-visible.
+- **Pretrained config loading** — if the policy loads a pretrained `config.json` (`_from_hf`/similar), unknown keys are filtered via `known_config_fields_only` before `Config.from_dict(...)`, not via `strict=False` alone.
 - **Heavy dependencies** — gate large families behind an optional extra in `library/pyproject.toml` and import lazily, matching `pi05`/`pi0`/`groot`/`smolvla`.
 - **No silent contract changes** — do not alter action dims, feature names, or preprocessing without coordinating export/Runtime.
 


### PR DESCRIPTION
### What

Loading any pretrained Pi05/Rldx1/SmolVLA checkpoint (e.g. `lerobot/pi05_base`) fails with:

```
jsonargparse._namespace.NSKeyError: Group 'object' does not accept option 'input_features.observation.images.base_0_rgb.type'
```

### Why

`_from_hf()` in all three policies calls `<Name>Config.from_dict(hf_config, strict=False)`. Pretrained `lerobot`-format `config.json` files always carry keys with no matching `Config` field (`input_features`, `output_features`, `repo_id`, `license`, `push_to_hub`, ...). `strict=False` is supposed to tolerate that, but doesn't: the runtime's jsonargparse-based `Config.from_dict` rejects unknown keys regardless of `strict`. This is a regression in runtime-owned `physicalai.config` introduced by #1024's dictionary-based-payload rewrite — reported and fixed upstream at [openvinotoolkit/physicalai#251](https://github.com/openvinotoolkit/physicalai/issues/251) / [openvinotoolkit/physicalai#253](https://github.com/openvinotoolkit/physicalai/pull/253).

### Fix

Added `physicalai.policies.utils.pretrained.known_config_fields_only(config_cls, data)`, which filters a raw config dict down to the dataclass's known fields (with debug logging of what's dropped), and used it in `Pi05._from_hf`, `Rldx1._from_hf`, and `SmolVLA._from_hf` instead of relying on `strict=False` alone. This workaround can be removed once Studio's `physicalai` pin picks up the upstream fix (docstring links both).

Also documented the pattern in the `physicalai-train-adding-a-policy` skill so a future policy that loads pretrained weights doesn't hit the same issue.

### Testing

- Verified against the real cached `lerobot/pi05_base` checkpoint: reproduced the exact reported error on `main`, confirmed it loads cleanly with this fix.
- `library/tests/unit/policies/utils/test_pretrained.py` (new): 16 tests parametrized across `Pi05Config`/`Rldx1Config`/`SmolVLAConfig` — drops junk keys, preserves known fields, doesn't mutate input, logs drops, rejects non-dataclasses.
- `library/tests/unit/policies/test_pi05.py`: strengthened the `_from_hf` regression test with the real-world junk-key set and assertions on file-sourced values that differ from defaults (so it can't pass under an over-aggressive filter).
- Full pi05 / checkpoint-loading / smolvla / rldx1 suites: 245 passed.
- `uvx prek run` clean (ruff, ruff format, mypy, Pyrefly, bandit) on all changed files.

Fixes #1069
