### PR TITLE
feat: Implements hotkey editor in settings page

### DIFF
--- a/application/backend/src/api/settings.py
+++ b/application/backend/src/api/settings.py
@@ -6,7 +6,14 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from settings import HuggingFaceSettings, Settings, TrainerClientSettings, get_settings, merge_user_settings
+from settings import (
+    HotkeySettings,
+    HuggingFaceSettings,
+    Settings,
+    TrainerClientSettings,
+    get_settings,
+    merge_user_settings,
+)
 
 router = APIRouter(prefix="/api/settings", tags=["Settings"])
 
@@ -16,12 +23,14 @@ class UserSettingsResponse(BaseModel):
 
     trainer: TrainerClientSettings
     huggingface: HuggingFaceSettings
+    hotkeys: HotkeySettings
 
     @classmethod
     def from_settings(cls, settings: Settings) -> "UserSettingsResponse":
         return cls(
             trainer=settings.trainer,
             huggingface=settings.huggingface,
+            hotkeys=settings.hotkeys,
         )
 
 
@@ -30,6 +39,7 @@ class SettingsUpdate(BaseModel):
 
     trainer: TrainerClientSettings | None = None
     huggingface: HuggingFaceSettings | None = None
+    hotkeys: HotkeySettings | None = None
 
 
 @router.get("")

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -65,7 +65,19 @@ class HuggingFaceSettings(BaseModel):
         return value
 
 
-_USER_CONFIG_GROUPS: tuple[str, ...] = ("trainer", "huggingface")
+class HotkeySettings(BaseModel):
+    """User-configurable keyboard shortcut bindings.
+
+    Opaque action_id -> serialized key combo map (e.g. {"recording.discard_episode":
+    "Shift+ArrowLeft"}). The frontend hotkey registry owns action ids and default
+    combos; only overrides are stored here, so a stale id from a renamed/removed
+    frontend action is simply ignored rather than validated.
+    """
+
+    bindings: dict[str, str] = Field(default_factory=dict)
+
+
+_USER_CONFIG_GROUPS: tuple[str, ...] = ("trainer", "huggingface", "hotkeys")
 
 
 class UserConfigSettingsSource(JsonConfigSettingsSource):
@@ -158,6 +170,8 @@ class Settings(BaseSettings):
     trainer: TrainerClientSettings = TrainerClientSettings()
     # User-configurable Hugging Face credentials.
     huggingface: HuggingFaceSettings = HuggingFaceSettings()
+    # User-configurable keyboard shortcut bindings.
+    hotkeys: HotkeySettings = HotkeySettings()
 
     # SSH-provisioned remote training
     # Master switch. Off by default: the feature has no authentication model,

--- a/application/backend/tests/api/test_user_settings_api.py
+++ b/application/backend/tests/api/test_user_settings_api.py
@@ -57,3 +57,27 @@ def test_patch_empty_huggingface_token_clears_setting(monkeypatch, tmp_path: Pat
 
     assert response.status_code == 200
     assert get_settings().huggingface.hf_token is None
+
+
+def test_get_settings_returns_default_hotkey_bindings(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+
+    with TestClient(app) as client:
+        response = client.get("/api/settings")
+
+    assert response.status_code == 200
+    assert response.json()["hotkeys"]["bindings"] == {}
+
+
+def test_patch_hotkey_bindings_round_trips(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+
+    with TestClient(app) as client:
+        response = client.patch(
+            "/api/settings",
+            json={"hotkeys": {"bindings": {"recording.discard_episode": "Shift+ArrowLeft"}}},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["hotkeys"]["bindings"] == {"recording.discard_episode": "Shift+ArrowLeft"}
+    assert get_settings().hotkeys.bindings == {"recording.discard_episode": "Shift+ArrowLeft"}

--- a/application/backend/tests/test_settings.py
+++ b/application/backend/tests/test_settings.py
@@ -75,3 +75,25 @@ def test_huggingface_token_is_loaded_from_json(monkeypatch, tmp_path: Path) -> N
     assert settings.huggingface.hf_token is not None
     assert settings.huggingface.hf_token.get_secret_value() == "hf_example"
     assert load_user_settings_file() == {"huggingface": {"hf_token": "hf_example"}}
+
+
+def test_hotkey_bindings_are_loaded_from_json(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+
+    merge_user_settings({"hotkeys": {"bindings": {"recording.discard_episode": "Shift+ArrowLeft"}}})
+
+    settings = Settings()
+    assert settings.hotkeys.bindings == {"recording.discard_episode": "Shift+ArrowLeft"}
+
+
+def test_hotkey_bindings_patch_replaces_whole_map(monkeypatch, tmp_path: Path) -> None:
+    """The `bindings` dict is a single top-level key of the `hotkeys` group, so
+    merge_user_settings's shallow merge replaces it wholesale rather than deep-merging
+    individual action ids. Callers must always PATCH the complete bindings map."""
+    monkeypatch.setenv("SETTINGS_FILE", str(tmp_path / "settings.json"))
+
+    merge_user_settings({"hotkeys": {"bindings": {"a": "X", "b": "Y"}}})
+    merge_user_settings({"hotkeys": {"bindings": {"a": "Z"}}})
+
+    settings = Settings()
+    assert settings.hotkeys.bindings == {"a": "Z"}

--- a/application/ui/src/features/hotkeys/hotkey-actions.ts
+++ b/application/ui/src/features/hotkeys/hotkey-actions.ts
@@ -1,0 +1,27 @@
+export type HotkeyActionId = 'recording.start_episode' | 'recording.accept_episode' | 'recording.discard_episode';
+
+type HotkeyActionDefinition = {
+    label: string;
+    scope: string;
+    defaultCombo: string;
+};
+
+export const HOTKEY_ACTIONS: Record<HotkeyActionId, HotkeyActionDefinition> = {
+    'recording.start_episode': {
+        label: 'Start episode',
+        scope: 'Recording',
+        defaultCombo: 'ArrowRight',
+    },
+    'recording.accept_episode': {
+        label: 'Accept episode',
+        scope: 'Recording',
+        defaultCombo: 'ArrowRight',
+    },
+    'recording.discard_episode': {
+        label: 'Discard episode',
+        scope: 'Recording',
+        defaultCombo: 'ArrowLeft',
+    },
+};
+
+export const HOTKEY_ACTION_IDS = Object.keys(HOTKEY_ACTIONS) as HotkeyActionId[];

--- a/application/ui/src/features/hotkeys/key-combo.ts
+++ b/application/ui/src/features/hotkeys/key-combo.ts
@@ -1,0 +1,52 @@
+import { HOTKEY_ACTION_IDS, HOTKEY_ACTIONS, HotkeyActionId } from './hotkey-actions';
+
+const MODIFIER_KEYS = new Set(['Control', 'Alt', 'Shift', 'Meta']);
+
+const DISPLAY_KEY_LABELS: Record<string, string> = {
+    ArrowRight: '→',
+    ArrowLeft: '←',
+    ArrowUp: '↑',
+    ArrowDown: '↓',
+    ' ': 'Space',
+};
+
+const modifierPrefix = (e: Pick<KeyboardEvent, 'ctrlKey' | 'altKey' | 'shiftKey' | 'metaKey'>): string[] => {
+    const modifiers: string[] = [];
+    if (e.ctrlKey) modifiers.push('Ctrl');
+    if (e.altKey) modifiers.push('Alt');
+    if (e.shiftKey) modifiers.push('Shift');
+    if (e.metaKey) modifiers.push('Meta');
+    return modifiers;
+};
+
+// Modifiers come from the boolean event flags, never from `e.key`'s casing -
+// Caps Lock alone also produces an uppercase `e.key` with `shiftKey: false`, so
+// trusting casing would make that indistinguishable from an actual Shift press.
+const normalizeBaseKey = (key: string): string => (key.length === 1 ? key.toUpperCase() : key);
+
+/** Canonical combo string for a keydown event, or null for a bare modifier press. */
+export const keyboardEventToCombo = (e: KeyboardEvent): string | null => {
+    if (MODIFIER_KEYS.has(e.key)) {
+        return null;
+    }
+
+    return [...modifierPrefix(e), normalizeBaseKey(e.key)].join('+');
+};
+
+/** Human-readable form of a combo string, e.g. "Shift+ArrowLeft" -> "Shift+←". */
+export const formatKeyCombo = (combo: string): string =>
+    combo
+        .split('+')
+        .map((part) => DISPLAY_KEY_LABELS[part] ?? part)
+        .join('+');
+
+/** Merges registry defaults with any stored per-action overrides. */
+export const getEffectiveBindings = (bindings: Record<string, string> = {}): Record<HotkeyActionId, string> => {
+    const effective = {} as Record<HotkeyActionId, string>;
+
+    for (const actionId of HOTKEY_ACTION_IDS) {
+        effective[actionId] = bindings[actionId] ?? HOTKEY_ACTIONS[actionId].defaultCombo;
+    }
+
+    return effective;
+};

--- a/application/ui/src/features/hotkeys/use-hotkey.ts
+++ b/application/ui/src/features/hotkeys/use-hotkey.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+
+import { keyboardEventToCombo } from './key-combo';
+
+const isTypingTarget = (target: EventTarget | null): boolean => {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+
+    return (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        target.isContentEditable
+    );
+};
+
+/**
+ * Fires `handler` when `combo` (a canonical string from `keyboardEventToCombo`) is
+ * pressed anywhere in the document, while `enabled`. Ignores keystrokes into text
+ * inputs/content-editable elements and key-repeat events.
+ */
+export const useHotkey = (combo: string, handler: () => void, enabled = true): void => {
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.repeat || isTypingTarget(e.target)) {
+                return;
+            }
+
+            if (keyboardEventToCombo(e) === combo) {
+                e.preventDefault();
+                handler();
+            }
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [combo, enabled, handler]);
+};

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
@@ -65,6 +65,7 @@ const mockProjectWithRemoteTrainer = () => {
                     stream_reconnect_backoff_max_s: 30,
                 },
                 huggingface: { hf_token: null },
+                hotkeys: { bindings: {} },
             })
         ),
         http.get('/api/policies/{policy}/huggingface-access', ({ params }) => {

--- a/application/ui/src/features/settings/hotkeys/hotkey-capture-button.tsx
+++ b/application/ui/src/features/settings/hotkeys/hotkey-capture-button.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+import { ActionButton, Keyboard, Text } from '@geti-ui/ui';
+
+import { formatKeyCombo, keyboardEventToCombo } from '../../hotkeys/key-combo';
+
+type HotkeyCaptureButtonProps = {
+    combo: string;
+    onChange: (combo: string) => void;
+};
+
+export const HotkeyCaptureButton = ({ combo, onChange }: HotkeyCaptureButtonProps) => {
+    const [isListening, setIsListening] = useState(false);
+
+    useEffect(() => {
+        if (!isListening) {
+            return;
+        }
+
+        const onKeyDown = (e: KeyboardEvent) => {
+            e.preventDefault();
+
+            if (e.key === 'Escape') {
+                setIsListening(false);
+                return;
+            }
+
+            const nextCombo = keyboardEventToCombo(e);
+            if (nextCombo !== null) {
+                onChange(nextCombo);
+                setIsListening(false);
+            }
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [isListening, onChange]);
+
+    return (
+        <ActionButton onPress={() => setIsListening(true)} width='size-1600'>
+            {isListening ? <Text>Press a key…</Text> : <Keyboard>{formatKeyCombo(combo)}</Keyboard>}
+        </ActionButton>
+    );
+};

--- a/application/ui/src/features/settings/hotkeys/hotkeys-settings.tsx
+++ b/application/ui/src/features/settings/hotkeys/hotkeys-settings.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+
+import { ActionButton, Flex, Heading, Text, View } from '@geti-ui/ui';
+
+import { $api } from '../../../api/client';
+import { SchemaSettingsUpdate } from '../../../api/openapi-spec';
+import { HOTKEY_ACTION_IDS, HOTKEY_ACTIONS, HotkeyActionId } from '../../hotkeys/hotkey-actions';
+import { getEffectiveBindings } from '../../hotkeys/key-combo';
+import { SettingsSection } from '../general/settings-section';
+import { useSettingsPatch } from '../general/use-settings-patch';
+import { HotkeyCaptureButton } from './hotkey-capture-button';
+
+const SCOPES = [...new Set(HOTKEY_ACTION_IDS.map((actionId) => HOTKEY_ACTIONS[actionId].scope))];
+
+export const HotkeysSettings = () => {
+    const { data: settings } = $api.useSuspenseQuery('get', '/api/settings');
+    const patchMutation = useSettingsPatch();
+    const [bindings, setBindings] = useState(() => getEffectiveBindings(settings.hotkeys.bindings));
+    const [dirty, setDirty] = useState(false);
+    const [saved, setSaved] = useState(false);
+
+    const updateBinding = (actionId: HotkeyActionId, combo: string) => {
+        setBindings((prev) => ({ ...prev, [actionId]: combo }));
+        setDirty(true);
+        setSaved(false);
+    };
+
+    const resetBinding = (actionId: HotkeyActionId) => {
+        updateBinding(actionId, HOTKEY_ACTIONS[actionId].defaultCombo);
+    };
+
+    const save = () => {
+        const body: SchemaSettingsUpdate = { hotkeys: { bindings } };
+        patchMutation.mutate(
+            { body },
+            {
+                onSuccess: () => {
+                    setDirty(false);
+                    setSaved(true);
+                },
+            }
+        );
+    };
+
+    return (
+        <View padding='size-400' height='100%' maxWidth='240ch' marginX='auto'>
+            <Heading level={1}>Hotkeys</Heading>
+            <Text>Configure keyboard shortcuts for app actions.</Text>
+            {SCOPES.map((scope) => (
+                <SettingsSection
+                    key={scope}
+                    title={scope}
+                    description={`Keyboard shortcuts for ${scope.toLowerCase()}.`}
+                    isDirty={dirty}
+                    isPending={patchMutation.isPending}
+                    saved={saved}
+                    error={patchMutation.error}
+                    onSave={save}
+                >
+                    {HOTKEY_ACTION_IDS.filter((actionId) => HOTKEY_ACTIONS[actionId].scope === scope).map(
+                        (actionId) => (
+                            <Flex key={actionId} alignItems='center' justifyContent='space-between' gap='size-200'>
+                                <Text>{HOTKEY_ACTIONS[actionId].label}</Text>
+                                <Flex alignItems='center' gap='size-100'>
+                                    <HotkeyCaptureButton
+                                        combo={bindings[actionId]}
+                                        onChange={(combo) => updateBinding(actionId, combo)}
+                                    />
+                                    <ActionButton
+                                        isQuiet
+                                        aria-label={`Reset ${HOTKEY_ACTIONS[actionId].label} to default`}
+                                        onPress={() => resetBinding(actionId)}
+                                        isDisabled={bindings[actionId] === HOTKEY_ACTIONS[actionId].defaultCombo}
+                                    >
+                                        <Text>Reset</Text>
+                                    </ActionButton>
+                                </Flex>
+                            </Flex>
+                        )
+                    )}
+                </SettingsSection>
+            ))}
+        </View>
+    );
+};

--- a/application/ui/src/features/settings/settings.tsx
+++ b/application/ui/src/features/settings/settings.tsx
@@ -6,6 +6,7 @@ import { useMatch } from 'react-router';
 import { paths } from '../../router';
 import { Compute } from './compute';
 import { GeneralSettings } from './general/general-settings';
+import { HotkeysSettings } from './hotkeys/hotkeys-settings';
 
 type TabItem = {
     key: string;
@@ -39,6 +40,16 @@ export const SettingsView = () => {
             name: 'Compute',
             href: paths.settings.compute.pattern,
             content: <Compute />,
+        },
+        {
+            key: 'hotkeys',
+            name: 'Hotkeys',
+            href: paths.settings.hotkeys.pattern,
+            content: (
+                <Suspense fallback={<Loading />}>
+                    <HotkeysSettings />
+                </Suspense>
+            ),
         },
         /*{
             key: 'storage',

--- a/application/ui/src/router.tsx
+++ b/application/ui/src/router.tsx
@@ -51,6 +51,7 @@ export const paths = {
     settings: {
         index: settings,
         compute: settings.path('/compute'),
+        hotkeys: settings.path('/hotkeys'),
         storage: settings.path('/storage'),
         about: settings.path('/about'),
     },
@@ -139,6 +140,10 @@ export const router = createBrowserRouter([
                             },
                             {
                                 path: paths.settings.compute.pattern,
+                                element: <Settings />,
+                            },
+                            {
+                                path: paths.settings.hotkeys.pattern,
                                 element: <Settings />,
                             },
                         ],

--- a/application/ui/src/routes/datasets/record/recording-viewer.tsx
+++ b/application/ui/src/routes/datasets/record/recording-viewer.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useState } from 'react';
 
 import {
     Button,
@@ -14,6 +14,9 @@ import {
     Text,
 } from '@geti-ui/ui';
 
+import { $api } from '../../../api/client';
+import { formatKeyCombo, getEffectiveBindings } from '../../../features/hotkeys/key-combo';
+import { useHotkey } from '../../../features/hotkeys/use-hotkey';
 import { RobotControlView } from '../../../features/robots/robot-control/robot-control-view';
 import { RobotModelsProvider } from '../../../features/robots/robot-models-context';
 import { useRuntimeSession } from '../../../features/robots/runtime-session-provider';
@@ -39,24 +42,20 @@ export const RecordingViewer = () => {
     }
     const [task, setTask] = useState<string>(dataset.default_task);
 
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'ArrowRight') {
-                if (state.is_recording && !saveEpisode.isPending) {
-                    saveEpisode.mutate();
-                } else if (!state.is_recording && task !== '') {
-                    startEpisode.mutate(task);
-                }
-            } else if (e.key === 'ArrowLeft') {
-                if (state.is_recording && !saveEpisode.isPending) {
-                    discardEpisode.mutate();
-                }
-            }
-        };
+    const { data: settings } = $api.useSuspenseQuery('get', '/api/settings');
+    const bindings = getEffectiveBindings(settings.hotkeys.bindings);
 
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [state.is_recording, saveEpisode, startEpisode, discardEpisode, task]);
+    useHotkey(bindings['recording.start_episode'], () => startEpisode.mutate(task), !state.is_recording && task !== '');
+    useHotkey(
+        bindings['recording.accept_episode'],
+        () => saveEpisode.mutate(),
+        state.is_recording && !saveEpisode.isPending
+    );
+    useHotkey(
+        bindings['recording.discard_episode'],
+        () => discardEpisode.mutate(),
+        state.is_recording && !saveEpisode.isPending
+    );
 
     const onStart = (e: FormEvent) => {
         e.preventDefault();
@@ -114,17 +113,23 @@ export const RecordingViewer = () => {
                                     onPress={() => discardEpisode.mutate()}
                                 >
                                     <Text>Discard</Text>
-                                    <Keyboard UNSAFE_className={classes.hotkey}>←</Keyboard>
+                                    <Keyboard UNSAFE_className={classes.hotkey}>
+                                        {formatKeyCombo(bindings['recording.discard_episode'])}
+                                    </Keyboard>
                                 </Button>
                                 <Button isPending={saveEpisode.isPending} onPress={() => saveEpisode.mutate()}>
                                     <Text>Accept</Text>
-                                    <Keyboard UNSAFE_className={classes.hotkey}>→</Keyboard>
+                                    <Keyboard UNSAFE_className={classes.hotkey}>
+                                        {formatKeyCombo(bindings['recording.accept_episode'])}
+                                    </Keyboard>
                                 </Button>
                             </ButtonGroup>
                         ) : (
                             <Button type={'submit'}>
                                 <Text>Start episode</Text>
-                                <Keyboard UNSAFE_className={classes.hotkey}>→</Keyboard>
+                                <Keyboard UNSAFE_className={classes.hotkey}>
+                                    {formatKeyCombo(bindings['recording.start_episode'])}
+                                </Keyboard>
                             </Button>
                         )}
                     </Flex>


### PR DESCRIPTION
Allow for custom hotkeys for the user.
Hotkeys are stored in settings.json.
UI can then useHotkey for a specific key (e.g. recording.start)

Bindings page:
<img width="2056" height="819" alt="image" src="https://github.com/user-attachments/assets/aeba5531-64d2-4229-864f-2d6e58d03b6b" />

Recording page:
<img width="2056" height="819" alt="image" src="https://github.com/user-attachments/assets/76adfc43-1f20-4f7d-a8b2-728f9c69ac08" />
