### PR TITLE
fix: Bump physical ai framework dep to fix jsonargparse issue

### DIFF
--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -123,7 +123,7 @@ explicit = false
 
 [tool.uv.sources]
 physicalai-train = { path = "../../library", editable = true }
-physicalai = { git = "https://github.com/openvinotoolkit/physicalai.git", rev = "a7ee74d0a65bd8f27dc31d831210c7a905e92309" }
+physicalai = { git = "https://github.com/openvinotoolkit/physicalai.git", rev = "8e4021703ef43387a835c6647b993cecc069ca85" }
 physicalai-studio-plugin = { path = "../plugin", editable = true }
 # Keep torchao on PyPI for all extras.
 # The XPU index publishes `torchao` local-version wheels (e.g. `+xpu`) that can

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -2790,8 +2790,8 @@ wheels = [
 
 [[package]]
 name = "physicalai"
-version = "0.1.2.dev67+ga7ee74d0a"
-source = { git = "https://github.com/openvinotoolkit/physicalai.git?rev=a7ee74d0a65bd8f27dc31d831210c7a905e92309#a7ee74d0a65bd8f27dc31d831210c7a905e92309" }
+version = "0.1.2.dev70+g8e4021703"
+source = { git = "https://github.com/openvinotoolkit/physicalai.git?rev=8e4021703ef43387a835c6647b993cecc069ca85#8e4021703ef43387a835c6647b993cecc069ca85" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "jsonargparse", extra = ["shtab", "signatures"] },
@@ -2936,7 +2936,7 @@ requires-dist = [
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "opencv-python" },
     { name = "packaging", specifier = ">=24.0" },
-    { name = "physicalai", extras = ["robots", "capture", "transport"], git = "https://github.com/openvinotoolkit/physicalai.git?rev=a7ee74d0a65bd8f27dc31d831210c7a905e92309" },
+    { name = "physicalai", extras = ["robots", "capture", "transport"], git = "https://github.com/openvinotoolkit/physicalai.git?rev=8e4021703ef43387a835c6647b993cecc069ca85" },
     { name = "physicalai-studio-plugin", editable = "../plugin" },
     { name = "physicalai-train", extras = ["executorch"], marker = "extra == 'cpu'", editable = "../../library" },
     { name = "physicalai-train", extras = ["executorch"], marker = "extra == 'cuda'", editable = "../../library" },
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "physicalai", git = "https://github.com/openvinotoolkit/physicalai.git?rev=a7ee74d0a65bd8f27dc31d831210c7a905e92309" },
+    { name = "physicalai", git = "https://github.com/openvinotoolkit/physicalai.git?rev=8e4021703ef43387a835c6647b993cecc069ca85" },
     { name = "pydantic", specifier = ">=2.12" },
 ]
 
@@ -3091,7 +3091,7 @@ requires-dist = [
     { name = "openvino-tokenizers", specifier = ">=2026.3" },
     { name = "peft", specifier = ">=0.20.0,<1.0.0" },
     { name = "peft", marker = "extra == 'rldx1'", specifier = ">=0.13.0,<1.0.0" },
-    { name = "physicalai", git = "https://github.com/openvinotoolkit/physicalai.git?rev=a7ee74d0a65bd8f27dc31d831210c7a905e92309" },
+    { name = "physicalai", git = "https://github.com/openvinotoolkit/physicalai.git?rev=8e4021703ef43387a835c6647b993cecc069ca85" },
     { name = "physicalai-train", extras = ["groot"], marker = "extra == 'all'" },
     { name = "physicalai-train", extras = ["libero"], marker = "extra == 'all'" },
     { name = "physicalai-train", extras = ["nncf"], marker = "extra == 'executorch-openvino'" },

--- a/application/plugin/pyproject.toml
+++ b/application/plugin/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "hatchling.build"
 packages = ["src/physicalai_studio_plugin"]
 
 [tool.uv.sources]
-physicalai = { git = "https://github.com/openvinotoolkit/physicalai.git", rev = "a7ee74d0a65bd8f27dc31d831210c7a905e92309" }
+physicalai = { git = "https://github.com/openvinotoolkit/physicalai.git", rev = "8e4021703ef43387a835c6647b993cecc069ca85" }
 
 [dependency-groups]
 dev = [

--- a/application/plugin/uv.lock
+++ b/application/plugin/uv.lock
@@ -7,12 +7,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-25T08:44:21.857899155Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 markupsafe = false
-pyrealsense2 = { timestamp = "2026-08-31T08:44:21.857907448Z", span = "P1D" }
+pyrealsense2 = { timestamp = "0001-01-01T00:00:00Z", span = "P1D" }
 
 [[package]]
 name = "annotated-doc"
@@ -578,8 +578,8 @@ wheels = [
 
 [[package]]
 name = "physicalai"
-version = "0.1.2.dev67+ga7ee74d0a"
-source = { git = "https://github.com/openvinotoolkit/physicalai.git?rev=a7ee74d0a65bd8f27dc31d831210c7a905e92309#a7ee74d0a65bd8f27dc31d831210c7a905e92309" }
+version = "0.1.2.dev70+g8e4021703"
+source = { git = "https://github.com/openvinotoolkit/physicalai.git?rev=8e4021703ef43387a835c6647b993cecc069ca85#8e4021703ef43387a835c6647b993cecc069ca85" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "jsonargparse", extra = ["shtab", "signatures"] },
@@ -629,7 +629,7 @@ lint = [
 
 [package.metadata]
 requires-dist = [
-    { name = "physicalai", git = "https://github.com/openvinotoolkit/physicalai.git?rev=a7ee74d0a65bd8f27dc31d831210c7a905e92309" },
+    { name = "physicalai", git = "https://github.com/openvinotoolkit/physicalai.git?rev=8e4021703ef43387a835c6647b993cecc069ca85" },
     { name = "pydantic", specifier = ">=2.12" },
 ]
 

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -208,7 +208,7 @@ explicit = false
 
 # PyTorch sources configuration
 [tool.uv.sources]
-physicalai = { git = "https://github.com/openvinotoolkit/physicalai.git", rev = "a7ee74d0a65bd8f27dc31d831210c7a905e92309" }
+physicalai = { git = "https://github.com/openvinotoolkit/physicalai.git", rev = "8e4021703ef43387a835c6647b993cecc069ca85" }
 torch = [
     { index = "pytorch-cpu", extra = "cpu" },
     { index = "pytorch-cu128", extra = "cu128" },

--- a/library/uv.lock
+++ b/library/uv.lock
@@ -3887,8 +3887,8 @@ wheels = [
 
 [[package]]
 name = "physicalai"
-version = "0.1.2.dev67+ga7ee74d0a"
-source = { git = "https://github.com/openvinotoolkit/physicalai.git?rev=a7ee74d0a65bd8f27dc31d831210c7a905e92309#a7ee74d0a65bd8f27dc31d831210c7a905e92309" }
+version = "0.1.2.dev70+g8e4021703"
+source = { git = "https://github.com/openvinotoolkit/physicalai.git?rev=8e4021703ef43387a835c6647b993cecc069ca85#8e4021703ef43387a835c6647b993cecc069ca85" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "jsonargparse", extra = ["shtab", "signatures"] },
@@ -4067,7 +4067,7 @@ requires-dist = [
     { name = "openvino-tokenizers", specifier = ">=2026.3" },
     { name = "peft", specifier = ">=0.20.0,<1.0.0" },
     { name = "peft", marker = "extra == 'rldx1'", specifier = ">=0.13.0,<1.0.0" },
-    { name = "physicalai", git = "https://github.com/openvinotoolkit/physicalai.git?rev=a7ee74d0a65bd8f27dc31d831210c7a905e92309" },
+    { name = "physicalai", git = "https://github.com/openvinotoolkit/physicalai.git?rev=8e4021703ef43387a835c6647b993cecc069ca85" },
     { name = "physicalai-train", extras = ["groot"], marker = "extra == 'all'" },
     { name = "physicalai-train", extras = ["libero"], marker = "extra == 'all'" },
     { name = "physicalai-train", extras = ["nncf"], marker = "extra == 'executorch-openvino'" },


### PR DESCRIPTION
### What

Loading any pretrained Pi05/Rldx1/SmolVLA checkpoint (e.g. `lerobot/pi05_base`) fails with:

```
jsonargparse._namespace.NSKeyError: Group 'object' does not accept option 'input_features.observation.images.base_0_rgb.type'
```

### Fix
This issue has been fixed in physical ai framework:
https://github.com/openvinotoolkit/physicalai/pull/253
### Testing
 - Manually tested both physical ai framework, as well as studio

Fixes #1069
