### PR TITLE
feat(data): enable pinned memory and persistent workers for train/val dataloaders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Physical AI Studio is the training-side repo for the Physical AI workflow: colle
 
 ## Contribution Notes
 
+- **Before pushing any commit, run `prek run --all-files` (scoped to the changed area, e.g. `prek run --all-files library/`) and make sure it exits clean.** This is what CI's `code-quality` job actually runs; ad hoc `ruff check`/`ruff format --check`/`mypy` calls are not equivalent and can miss real failures (e.g. hook args like ruff's `--fix`, or rules like `unused-noqa` that only show up when a directive stops being necessary). If `prek` modifies files, re-run it until clean and include those changes in the commit.
 - Use Conventional Commits for PR titles and commits.
 - Sign commits when committing changes.
 - Follow `docs/development/coding-standards.md` for repo-wide coding standards.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,6 @@ Physical AI Studio is the training-side repo for the Physical AI workflow: colle
 
 ## Contribution Notes
 
-- **Before pushing any commit, run `prek run --all-files` (scoped to the changed area, e.g. `prek run --all-files library/`) and make sure it exits clean.** This is what CI's `code-quality` job actually runs; ad hoc `ruff check`/`ruff format --check`/`mypy` calls are not equivalent and can miss real failures (e.g. hook args like ruff's `--fix`, or rules like `unused-noqa` that only show up when a directive stops being necessary). If `prek` modifies files, re-run it until clean and include those changes in the commit.
 - Use Conventional Commits for PR titles and commits.
 - Sign commits when committing changes.
 - Follow `docs/development/coding-standards.md` for repo-wide coding standards.

--- a/library/src/physicalai/data/datamodules.py
+++ b/library/src/physicalai/data/datamodules.py
@@ -134,6 +134,7 @@ class DataModule(LightningDataModule):
     def __init__(
         self,
         train_dataset: Dataset,
+        *,
         train_batch_size: int = 16,
         num_workers: int | Literal["auto"] = "auto",
         val_gym: Gym | None = None,
@@ -143,6 +144,7 @@ class DataModule(LightningDataModule):
         test_gym: Gym | None = None,
         num_rollouts_test: int = 10,
         max_episode_steps: int | None = 300,
+        pin_memory: bool = True,
     ) -> None:
         """Initialize the ActionDataModule.
 
@@ -161,6 +163,9 @@ class DataModule(LightningDataModule):
             test_gym (Gym | None): Test environment.
             num_rollouts_test (int): Number of rollouts to run for test environments.
             max_episode_steps (int, None): Maximum steps allowed per episode. If None, no time limit.
+            pin_memory (bool): Whether to use pinned (page-locked) memory for the training and
+                eval-loss validation DataLoaders, which speeds up host-to-GPU transfers.
+                Defaults to `True`.
         """
         super().__init__()
 
@@ -168,6 +173,7 @@ class DataModule(LightningDataModule):
         self.train_dataset: Dataset = train_dataset
         self.train_batch_size: int = train_batch_size
         self.num_workers: int = resolve_auto_num_workers() if num_workers == "auto" else num_workers
+        self.pin_memory: bool = pin_memory
         logger.info("DataLoader workers: %d%s", self.num_workers, " (auto)" if num_workers == "auto" else "")
 
         # eval-loss validation dataset
@@ -244,6 +250,7 @@ class DataModule(LightningDataModule):
             batch_size=self.train_batch_size,
             shuffle=True,
             drop_last=True,
+            pin_memory=self.pin_memory,
             collate_fn=_collate_observations,
         )
 
@@ -265,6 +272,7 @@ class DataModule(LightningDataModule):
                 batch_size=self.val_batch_size,
                 shuffle=False,
                 drop_last=False,
+                pin_memory=self.pin_memory,
                 collate_fn=_collate_observations,
             )
 

--- a/library/src/physicalai/data/datamodules.py
+++ b/library/src/physicalai/data/datamodules.py
@@ -131,10 +131,9 @@ class DataModule(LightningDataModule):
     When both are provided, ``val_eval_dataset`` takes precedence (eval-loss mode).
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         train_dataset: Dataset,
-        *,
         train_batch_size: int = 16,
         num_workers: int | Literal["auto"] = "auto",
         val_gym: Gym | None = None,
@@ -144,8 +143,8 @@ class DataModule(LightningDataModule):
         test_gym: Gym | None = None,
         num_rollouts_test: int = 10,
         max_episode_steps: int | None = 300,
-        pin_memory: bool = True,
-        persistent_workers: bool = True,
+        pin_memory: bool = True,  # noqa: FBT001, FBT002
+        persistent_workers: bool = True,  # noqa: FBT001, FBT002
     ) -> None:
         """Initialize the ActionDataModule.
 

--- a/library/src/physicalai/data/datamodules.py
+++ b/library/src/physicalai/data/datamodules.py
@@ -143,8 +143,9 @@ class DataModule(LightningDataModule):
         test_gym: Gym | None = None,
         num_rollouts_test: int = 10,
         max_episode_steps: int | None = 300,
-        pin_memory: bool = True,  # noqa: FBT001, FBT002
+        pin_memory: bool | Literal["auto"] = "auto",  # noqa: FBT001
         persistent_workers: bool = True,  # noqa: FBT001, FBT002
+        val_persistent_workers: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
         """Initialize the ActionDataModule.
 
@@ -163,13 +164,17 @@ class DataModule(LightningDataModule):
             test_gym (Gym | None): Test environment.
             num_rollouts_test (int): Number of rollouts to run for test environments.
             max_episode_steps (int, None): Maximum steps allowed per episode. If None, no time limit.
-            pin_memory (bool): Whether to use pinned (page-locked) memory for the training and
-                eval-loss validation DataLoaders, which speeds up host-to-GPU transfers.
-                Defaults to `True`.
-            persistent_workers (bool): Whether to keep DataLoader worker processes alive between
-                epochs for the training and eval-loss validation DataLoaders, avoiding the cost of
-                re-spawning them every epoch. Has no effect when ``num_workers`` resolves to ``0``.
-                Defaults to `True`.
+            pin_memory (bool | Literal["auto"]): Whether to use pinned (page-locked) memory for the
+                training and eval-loss validation DataLoaders, which speeds up host-to-GPU transfers.
+                ``"auto"`` (default) enables it only when an accelerator (CUDA/XPU/etc.) is available,
+                avoiding PyTorch's ``pin_memory=True`` warning on CPU-only setups.
+            persistent_workers (bool): Whether to keep training DataLoader worker processes alive
+                between epochs, avoiding the cost of re-spawning them every epoch. Has no effect
+                when ``num_workers`` resolves to ``0``. Defaults to `True`.
+            val_persistent_workers (bool): Same as ``persistent_workers`` but for the eval-loss
+                validation DataLoader. Defaults to `False`, since validation runs far less often
+                than training and keeping its workers alive for the whole run has limited benefit
+                relative to the extra worker processes it holds open.
         """
         super().__init__()
 
@@ -177,8 +182,9 @@ class DataModule(LightningDataModule):
         self.train_dataset: Dataset = train_dataset
         self.train_batch_size: int = train_batch_size
         self.num_workers: int = resolve_auto_num_workers() if num_workers == "auto" else num_workers
-        self.pin_memory: bool = pin_memory
+        self._pin_memory: bool | Literal["auto"] = pin_memory
         self.persistent_workers: bool = persistent_workers and self.num_workers > 0
+        self.val_persistent_workers: bool = val_persistent_workers and self.num_workers > 0
         logger.info("DataLoader workers: %d%s", self.num_workers, " (auto)" if num_workers == "auto" else "")
 
         # eval-loss validation dataset
@@ -224,6 +230,22 @@ class DataModule(LightningDataModule):
     @val_batch_size.setter
     def val_batch_size(self, value: int | None) -> None:
         self._val_batch_size = value
+
+    @property
+    def pin_memory(self) -> bool:
+        """Effective ``pin_memory`` setting for train/val DataLoaders.
+
+        Resolves ``"auto"`` lazily (each access) to whether an accelerator (CUDA/XPU/etc.)
+        is currently available, so the check happens per-process (relevant for spawned
+        DataLoader workers) rather than once at construction time.
+        """
+        if self._pin_memory == "auto":
+            return torch.accelerator.is_available()
+        return self._pin_memory
+
+    @pin_memory.setter
+    def pin_memory(self, value: bool | Literal["auto"]) -> None:
+        self._pin_memory = value
 
     def setup(self, stage: str) -> None:
         """Set up datasets depending on the stage (fit or test).
@@ -279,7 +301,7 @@ class DataModule(LightningDataModule):
                 shuffle=False,
                 drop_last=False,
                 pin_memory=self.pin_memory,
-                persistent_workers=self.persistent_workers,
+                persistent_workers=self.val_persistent_workers,
                 collate_fn=_collate_observations,
             )
 

--- a/library/src/physicalai/data/datamodules.py
+++ b/library/src/physicalai/data/datamodules.py
@@ -131,7 +131,7 @@ class DataModule(LightningDataModule):
     When both are provided, ``val_eval_dataset`` takes precedence (eval-loss mode).
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         train_dataset: Dataset,
         train_batch_size: int = 16,

--- a/library/src/physicalai/data/datamodules.py
+++ b/library/src/physicalai/data/datamodules.py
@@ -145,6 +145,7 @@ class DataModule(LightningDataModule):
         num_rollouts_test: int = 10,
         max_episode_steps: int | None = 300,
         pin_memory: bool = True,
+        persistent_workers: bool = True,
     ) -> None:
         """Initialize the ActionDataModule.
 
@@ -166,6 +167,10 @@ class DataModule(LightningDataModule):
             pin_memory (bool): Whether to use pinned (page-locked) memory for the training and
                 eval-loss validation DataLoaders, which speeds up host-to-GPU transfers.
                 Defaults to `True`.
+            persistent_workers (bool): Whether to keep DataLoader worker processes alive between
+                epochs for the training and eval-loss validation DataLoaders, avoiding the cost of
+                re-spawning them every epoch. Has no effect when ``num_workers`` resolves to ``0``.
+                Defaults to `True`.
         """
         super().__init__()
 
@@ -174,6 +179,7 @@ class DataModule(LightningDataModule):
         self.train_batch_size: int = train_batch_size
         self.num_workers: int = resolve_auto_num_workers() if num_workers == "auto" else num_workers
         self.pin_memory: bool = pin_memory
+        self.persistent_workers: bool = persistent_workers and self.num_workers > 0
         logger.info("DataLoader workers: %d%s", self.num_workers, " (auto)" if num_workers == "auto" else "")
 
         # eval-loss validation dataset
@@ -251,6 +257,7 @@ class DataModule(LightningDataModule):
             shuffle=True,
             drop_last=True,
             pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
             collate_fn=_collate_observations,
         )
 
@@ -273,6 +280,7 @@ class DataModule(LightningDataModule):
                 shuffle=False,
                 drop_last=False,
                 pin_memory=self.pin_memory,
+                persistent_workers=self.persistent_workers,
                 collate_fn=_collate_observations,
             )
 

--- a/library/src/physicalai/data/lerobot/datamodule.py
+++ b/library/src/physicalai/data/lerobot/datamodule.py
@@ -149,8 +149,9 @@ class LeRobotDataModule(DataModule):
         test_gym: Gym | None = None,
         num_rollouts_test: int = 10,
         max_episode_steps: int | None = 300,
-        pin_memory: bool = True,
+        pin_memory: bool | Literal["auto"] = "auto",
         persistent_workers: bool = True,
+        val_persistent_workers: bool = False,
     ) -> None:
         """Initialize a LeRobot-specific Action DataModule.
 
@@ -210,12 +211,16 @@ class LeRobotDataModule(DataModule):
                 Defaults to `10`.
             max_episode_steps (int | None, optional): Maximum steps per episode.
                 Defaults to `300`.
-            pin_memory (bool, optional): Whether to use pinned (page-locked) memory for the
-                training and eval-loss validation DataLoaders, which speeds up host-to-GPU
-                transfers. Defaults to `True`.
-            persistent_workers (bool, optional): Whether to keep DataLoader worker processes
-                alive between epochs for the training and eval-loss validation DataLoaders.
-                Has no effect when ``num_workers`` resolves to ``0``. Defaults to `True`.
+            pin_memory (bool | Literal["auto"], optional): Whether to use pinned (page-locked)
+                memory for the training and eval-loss validation DataLoaders, which speeds up
+                host-to-GPU transfers. ``"auto"`` (default) enables it only when an accelerator
+                (CUDA/XPU/etc.) is available, avoiding PyTorch's ``pin_memory=True`` warning on
+                CPU-only setups.
+            persistent_workers (bool, optional): Whether to keep training DataLoader worker
+                processes alive between epochs, avoiding the cost of re-spawning them every
+                epoch. Has no effect when ``num_workers`` resolves to ``0``. Defaults to `True`.
+            val_persistent_workers (bool, optional): Same as ``persistent_workers`` but for the
+                eval-loss validation DataLoader. Defaults to `False`.
 
         Raises:
             ValueError: If neither `repo_id` nor `dataset` is provided, or if invalid `data_format`.
@@ -371,6 +376,7 @@ class LeRobotDataModule(DataModule):
             max_episode_steps=max_episode_steps,
             pin_memory=pin_memory,
             persistent_workers=persistent_workers,
+            val_persistent_workers=val_persistent_workers,
         )
 
     def train_dataloader(self) -> DataLoader:

--- a/library/src/physicalai/data/lerobot/datamodule.py
+++ b/library/src/physicalai/data/lerobot/datamodule.py
@@ -149,6 +149,7 @@ class LeRobotDataModule(DataModule):
         test_gym: Gym | None = None,
         num_rollouts_test: int = 10,
         max_episode_steps: int | None = 300,
+        pin_memory: bool = True,
     ) -> None:
         """Initialize a LeRobot-specific Action DataModule.
 
@@ -208,6 +209,9 @@ class LeRobotDataModule(DataModule):
                 Defaults to `10`.
             max_episode_steps (int | None, optional): Maximum steps per episode.
                 Defaults to `300`.
+            pin_memory (bool, optional): Whether to use pinned (page-locked) memory for the
+                training and eval-loss validation DataLoaders, which speeds up host-to-GPU
+                transfers. Defaults to `True`.
 
         Raises:
             ValueError: If neither `repo_id` nor `dataset` is provided, or if invalid `data_format`.
@@ -361,6 +365,7 @@ class LeRobotDataModule(DataModule):
             test_gym=test_gym,
             num_rollouts_test=num_rollouts_test,
             max_episode_steps=max_episode_steps,
+            pin_memory=pin_memory,
         )
 
     def train_dataloader(self) -> DataLoader:
@@ -384,6 +389,7 @@ class LeRobotDataModule(DataModule):
             batch_size=self.train_batch_size,
             shuffle=True,
             drop_last=True,
+            pin_memory=self.pin_memory,
         )
 
     @staticmethod

--- a/library/src/physicalai/data/lerobot/datamodule.py
+++ b/library/src/physicalai/data/lerobot/datamodule.py
@@ -150,6 +150,7 @@ class LeRobotDataModule(DataModule):
         num_rollouts_test: int = 10,
         max_episode_steps: int | None = 300,
         pin_memory: bool = True,
+        persistent_workers: bool = True,
     ) -> None:
         """Initialize a LeRobot-specific Action DataModule.
 
@@ -212,6 +213,9 @@ class LeRobotDataModule(DataModule):
             pin_memory (bool, optional): Whether to use pinned (page-locked) memory for the
                 training and eval-loss validation DataLoaders, which speeds up host-to-GPU
                 transfers. Defaults to `True`.
+            persistent_workers (bool, optional): Whether to keep DataLoader worker processes
+                alive between epochs for the training and eval-loss validation DataLoaders.
+                Has no effect when ``num_workers`` resolves to ``0``. Defaults to `True`.
 
         Raises:
             ValueError: If neither `repo_id` nor `dataset` is provided, or if invalid `data_format`.
@@ -366,6 +370,7 @@ class LeRobotDataModule(DataModule):
             num_rollouts_test=num_rollouts_test,
             max_episode_steps=max_episode_steps,
             pin_memory=pin_memory,
+            persistent_workers=persistent_workers,
         )
 
     def train_dataloader(self) -> DataLoader:
@@ -390,6 +395,7 @@ class LeRobotDataModule(DataModule):
             shuffle=True,
             drop_last=True,
             pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
         )
 
     @staticmethod

--- a/library/tests/unit/data/test_datamodules.py
+++ b/library/tests/unit/data/test_datamodules.py
@@ -160,17 +160,36 @@ class TestDataModuleTrainDataloader:
 class TestDataModulePinMemory:
     """Tests for the DataModule pin_memory parameter."""
 
-    def test_defaults_to_true(self, dummy_dataset):
+    def test_auto_resolves_to_accelerator_availability(self, dummy_dataset):
         from physicalai.data import DataModule
 
         dm = DataModule(train_dataset=dummy_dataset())
-        assert dm.pin_memory is True
+        with patch("physicalai.data.datamodules.torch.accelerator.is_available", return_value=True):
+            assert dm.pin_memory is True
+        with patch("physicalai.data.datamodules.torch.accelerator.is_available", return_value=False):
+            assert dm.pin_memory is False
+
+    def test_auto_is_resolved_lazily(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        # No accelerator probing should happen at construction time.
+        with patch("physicalai.data.datamodules.torch.accelerator.is_available") as mock:
+            DataModule(train_dataset=dummy_dataset())
+            mock.assert_not_called()
+
+    def test_explicit_true(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), pin_memory=True)
+        with patch("physicalai.data.datamodules.torch.accelerator.is_available", return_value=False):
+            assert dm.pin_memory is True
 
     def test_explicit_false(self, dummy_dataset):
         from physicalai.data import DataModule
 
         dm = DataModule(train_dataset=dummy_dataset(), pin_memory=False)
-        assert dm.pin_memory is False
+        with patch("physicalai.data.datamodules.torch.accelerator.is_available", return_value=True):
+            assert dm.pin_memory is False
 
     def test_train_dataloader_uses_pin_memory(self, dummy_dataset):
         from physicalai.data import DataModule
@@ -187,35 +206,40 @@ class TestDataModulePinMemory:
         dl = dm.val_dataloader()
         assert dl.pin_memory is False
 
-    def test_val_dataloader_pin_memory_defaults_true(self, dummy_dataset):
-        from physicalai.data import DataModule
-
-        dm = DataModule(train_dataset=dummy_dataset(), val_eval_dataset=dummy_dataset())
-        dm.setup(stage="fit")
-        dl = dm.val_dataloader()
-        assert dl.pin_memory is True
-
 
 class TestDataModulePersistentWorkers:
-    """Tests for the DataModule persistent_workers parameter."""
+    """Tests for the DataModule persistent_workers / val_persistent_workers parameters."""
 
-    def test_defaults_to_true_when_workers_positive(self, dummy_dataset):
+    def test_train_defaults_to_true_when_workers_positive(self, dummy_dataset):
         from physicalai.data import DataModule
 
         dm = DataModule(train_dataset=dummy_dataset(), num_workers=2)
         assert dm.persistent_workers is True
 
+    def test_val_defaults_to_false(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), num_workers=2)
+        assert dm.val_persistent_workers is False
+
     def test_forced_false_when_no_workers(self, dummy_dataset):
         from physicalai.data import DataModule
 
-        dm = DataModule(train_dataset=dummy_dataset(), num_workers=0)
+        dm = DataModule(train_dataset=dummy_dataset(), num_workers=0, val_persistent_workers=True)
         assert dm.persistent_workers is False
+        assert dm.val_persistent_workers is False
 
-    def test_explicit_false(self, dummy_dataset):
+    def test_train_explicit_false(self, dummy_dataset):
         from physicalai.data import DataModule
 
         dm = DataModule(train_dataset=dummy_dataset(), num_workers=2, persistent_workers=False)
         assert dm.persistent_workers is False
+
+    def test_val_explicit_true(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), num_workers=2, val_persistent_workers=True)
+        assert dm.val_persistent_workers is True
 
     def test_train_dataloader_uses_persistent_workers(self, dummy_dataset):
         from physicalai.data import DataModule
@@ -224,10 +248,23 @@ class TestDataModulePersistentWorkers:
         dl = dm.train_dataloader()
         assert dl.persistent_workers is True
 
-    def test_val_dataloader_uses_persistent_workers(self, dummy_dataset):
+    def test_val_dataloader_uses_val_persistent_workers(self, dummy_dataset):
         from physicalai.data import DataModule
 
         dm = DataModule(train_dataset=dummy_dataset(), val_eval_dataset=dummy_dataset(), num_workers=2)
+        dm.setup(stage="fit")
+        dl = dm.val_dataloader()
+        assert dl.persistent_workers is False
+
+    def test_val_dataloader_honors_explicit_val_persistent_workers(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(
+            train_dataset=dummy_dataset(),
+            val_eval_dataset=dummy_dataset(),
+            num_workers=2,
+            val_persistent_workers=True,
+        )
         dm.setup(stage="fit")
         dl = dm.val_dataloader()
         assert dl.persistent_workers is True

--- a/library/tests/unit/data/test_datamodules.py
+++ b/library/tests/unit/data/test_datamodules.py
@@ -185,6 +185,43 @@ class TestDataModulePinMemory:
         assert dl.pin_memory is True
 
 
+class TestDataModulePersistentWorkers:
+    """Tests for the DataModule persistent_workers parameter."""
+
+    def test_defaults_to_true_when_workers_positive(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), num_workers=2)
+        assert dm.persistent_workers is True
+
+    def test_forced_false_when_no_workers(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), num_workers=0)
+        assert dm.persistent_workers is False
+
+    def test_explicit_false(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), num_workers=2, persistent_workers=False)
+        assert dm.persistent_workers is False
+
+    def test_train_dataloader_uses_persistent_workers(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), num_workers=2)
+        dl = dm.train_dataloader()
+        assert dl.persistent_workers is True
+
+    def test_val_dataloader_uses_persistent_workers(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), val_eval_dataset=dummy_dataset(), num_workers=2)
+        dm.setup(stage="fit")
+        dl = dm.val_dataloader()
+        assert dl.persistent_workers is True
+
+
 class TestDataModuleLogging:
     """Tests for DataModule num_workers logging."""
 

--- a/library/tests/unit/data/test_datamodules.py
+++ b/library/tests/unit/data/test_datamodules.py
@@ -32,6 +32,17 @@ class TestResolveAutoNumWorkers:
             assert resolve_auto_num_workers() == 0
 
 
+class TestDataModuleBackwardCompatibility:
+    """Tests that DataModule remains constructible with positional arguments."""
+
+    def test_positional_construction(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(dummy_dataset(), 32, 4)
+        assert dm.train_batch_size == 32
+        assert dm.num_workers == 4
+
+
 class TestDataModuleNumWorkers:
     """Tests for the DataModule num_workers parameter."""
 

--- a/library/tests/unit/data/test_datamodules.py
+++ b/library/tests/unit/data/test_datamodules.py
@@ -146,6 +146,45 @@ class TestDataModuleTrainDataloader:
         assert dl.num_workers == 3
 
 
+class TestDataModulePinMemory:
+    """Tests for the DataModule pin_memory parameter."""
+
+    def test_defaults_to_true(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset())
+        assert dm.pin_memory is True
+
+    def test_explicit_false(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), pin_memory=False)
+        assert dm.pin_memory is False
+
+    def test_train_dataloader_uses_pin_memory(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), pin_memory=False)
+        dl = dm.train_dataloader()
+        assert dl.pin_memory is False
+
+    def test_val_dataloader_uses_pin_memory(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), val_eval_dataset=dummy_dataset(), pin_memory=False)
+        dm.setup(stage="fit")
+        dl = dm.val_dataloader()
+        assert dl.pin_memory is False
+
+    def test_val_dataloader_pin_memory_defaults_true(self, dummy_dataset):
+        from physicalai.data import DataModule
+
+        dm = DataModule(train_dataset=dummy_dataset(), val_eval_dataset=dummy_dataset())
+        dm.setup(stage="fit")
+        dl = dm.val_dataloader()
+        assert dl.pin_memory is True
+
+
 class TestDataModuleLogging:
     """Tests for DataModule num_workers logging."""
 


### PR DESCRIPTION
Training and eval-loss validation DataLoaders now pin memory and keep worker processes alive between epochs, instead of doing neither like before. Both settings resolve sensibly instead of being hardcoded.

## Changes
- Added a `pin_memory` parameter to `DataModule` and `LeRobotDataModule`, applied to both the training DataLoader and the eval-loss validation DataLoader. It defaults to `"auto"`, resolved lazily to `torch.accelerator.is_available()`, so memory gets pinned automatically when a CUDA/XPU/etc. accelerator is present, and PyTorch's "pin_memory=True but no accelerator found" warning stays quiet on CPU-only setups (this repo ships a `cpu` extra). You can still override it with an explicit bool.
- Added `persistent_workers` (train, default `True`) and `val_persistent_workers` (validation, default `False`). Both get disabled automatically when `num_workers` resolves to `0`, since `torch.utils.data.DataLoader` requires `num_workers > 0` for persistent workers. Validation defaults to off because it runs far less often than training, so keeping its worker processes alive for the whole run buys little and adds extra long-lived processes. It also sidesteps the documented instability from combining `pin_memory=True`, `persistent_workers=True`, and `reload_dataloaders_every_n_epochs > 0` (pytorch/pytorch#91252).
- `LeRobotDataModule`'s lerobot-format `train_dataloader` override honors all three settings.
- `DataModule.__init__` still accepts positional arguments. A `*` keyword-only marker went in and came back out after review feedback flagged it as a breaking change.

## Why
Validation batches weren't pinning memory, so host-to-GPU transfers during eval-loss validation were slower than they needed to be. Separately, Lightning warns that `persistent_workers=True` should be set on `train_dataloader`/`val_dataloader` to avoid re-spawning workers every epoch; this turns it on for training by default and leaves validation opt-in.

## Testing
Earlier test runs in this PR were done against an XPU-flavored `torch` build that a bare `uv run` had silently installed on this CUDA machine, so the `cv2` import failures reported at the time got mislabeled as pre-existing. Both problems are sorted now, and this run uses a correctly provisioned `cu128` environment (`torch.cuda.is_available()` confirmed `True`):
- `uv sync --frozen --extra tests --extra cu128 && uv run --no-sync pytest tests/unit/data/test_datamodules.py tests/unit/datamodules/test_lerobot.py tests/unit/datamodules/test_val_split.py -q` → 51 passed.
- `tests/unit/eval/test_rollout_metric.py::TestRolloutIntegration::test_lightning_training_integration` fails both with and without this PR's changes (checked against the pre-PR base commit), so it's a pre-existing issue unrelated to this change.
- `uv run --no-sync ruff check` / `ruff format --check` on all changed files: no new lint issues.
