### PR TITLE
feat(ui, models/jobs): Show more training parameters in the jobs and models

### DIFF
--- a/application/ui/AGENTS.md
+++ b/application/ui/AGENTS.md
@@ -17,7 +17,7 @@ src/
 ├── features/       Domain feature modules (cameras/, datasets/, jobs/, models/, projects/, robots/, …)
 ├── query-client/   TanStack QueryClient factory and mutation-meta type definitions
 ├── routes/         Route-level page components (thin shells — logic lives in features/)
-├── test-utils/     Custom RTL render utility for unit tests
+├── test-utils/     Custom RTL render utility + `getMocked*` factories for tests
 ├── index.tsx       App entry point
 ├── providers.tsx   Global providers (QueryClientProvider, ThemeProvider, RouterProvider)
 ├── router.tsx      createBrowserRouter config + exported `paths` map
@@ -228,13 +228,36 @@ npx vitest run src/features/robots/environment-form/submit-new-environment-butto
 
 ## Key test infrastructure files
 
-| File                        | Purpose                                                                    |
-| --------------------------- | -------------------------------------------------------------------------- |
-| `src/setup-tests.ts`        | Global setup: env vars, MSW server lifecycle                               |
-| `src/msw-node-setup.ts`     | Exports the MSW `server` instance                                          |
-| `src/test-utils/render.tsx` | Custom `render` / `renderHook` wrapping Router, QueryClient, ThemeProvider |
-| `src/api/utils.ts`          | Exports `http` — the type-safe MSW handler builder                         |
-| `src/api/client.ts`         | Exports `$api` — the openapi-react-query client used by components         |
+| File                        | Purpose                                                                                             |
+| --------------------------- | --------------------------------------------------------------------------------------------------- |
+| `src/setup-tests.ts`        | Global setup: env vars, MSW server lifecycle                                                        |
+| `src/msw-node-setup.ts`     | Exports the MSW `server` instance                                                                   |
+| `src/test-utils/render.tsx` | Custom `render` / `renderHook` wrapping Router, QueryClient, ThemeProvider                          |
+| `src/api/utils.ts`          | Exports `http` — the type-safe MSW handler builder                                                  |
+| `src/api/client.ts`         | Exports `$api` — the openapi-react-query client used by components                                  |
+| `src/test-utils/mocks/`     | `getMocked*` factories (e.g. `mock-dataset.ts` → `getMockedDataset`) returning spec-typed mock data |
+
+Prefer a `getMocked*` factory from `src/test-utils/mocks/` over a hand-built object literal when
+mocking an MSW response or a component prop. Each factory takes a `Partial<T>` of the OpenAPI
+schema type and spreads it over sensible defaults, e.g.:
+
+```ts
+// src/test-utils/mocks/mock-dataset.ts
+
+import { SchemaDatasetOutput } from '../../api/openapi-spec';
+
+export const getMockedDataset = (overrides: Partial<SchemaDatasetOutput> = {}): SchemaDatasetOutput => ({
+    id: 'dataset-1',
+    name: 'pick-dataset',
+    default_task: 'manipulation',
+    project_id: 'project-1',
+    environment_id: 'environment-1',
+    ...overrides,
+});
+```
+
+If no factory exists yet for the schema type you need, add one under `src/test-utils/mocks/` named
+`mock-<name>.ts` rather than inlining the object in the test file.
 
 ## Writing a component test
 

--- a/application/ui/src/features/models/api/queries.ts
+++ b/application/ui/src/features/models/api/queries.ts
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+import { Key } from '@geti-ui/ui';
+import { capitalize } from 'lodash-es';
+
+import { $api } from '../../../api/client';
+
+export const useDatasetQuery = (datasetId: string | undefined | null) => {
+    return $api.useQuery(
+        'get',
+        '/api/dataset/{dataset_id}',
+        {
+            params: { path: { dataset_id: String(datasetId) } },
+        },
+        {
+            enabled: datasetId != null,
+        }
+    );
+};
+
+export const useEnvironmentQuery = (projectId: string, environmentId: string | undefined) => {
+    return $api.useQuery(
+        'get',
+        '/api/projects/{project_id}/environments/{environment_id}',
+        {
+            params: {
+                path: {
+                    environment_id: String(environmentId),
+                    project_id: projectId,
+                },
+            },
+        },
+        {
+            enabled: environmentId !== undefined,
+        }
+    );
+};

--- a/application/ui/src/features/models/api/queries.ts
+++ b/application/ui/src/features/models/api/queries.ts
@@ -1,8 +1,3 @@
-import { useState } from 'react';
-
-import { Key } from '@geti-ui/ui';
-import { capitalize } from 'lodash-es';
-
 import { $api } from '../../../api/client';
 
 export const useDatasetQuery = (datasetId: string | undefined | null) => {

--- a/application/ui/src/features/models/job-table/job-list.tsx
+++ b/application/ui/src/features/models/job-table/job-list.tsx
@@ -9,8 +9,10 @@ const JOB_COLUMNS: TableColumn[] = [
     { width: 'max-content' },
     { width: '2fr', header: 'Model name' },
     { width: '1fr', header: 'Loss' },
-    { width: '1fr' },
     { width: '1fr', header: 'Architecture' },
+    { width: '1fr', header: 'Dataset' },
+    { width: '1fr', header: 'Environment' },
+    { width: '1fr', header: 'Trainer' },
     { width: '1fr' },
     { width: 'auto', align: 'end' },
 ];

--- a/application/ui/src/features/models/job-table/job-table.test.tsx
+++ b/application/ui/src/features/models/job-table/job-table.test.tsx
@@ -125,10 +125,29 @@ describe('TrainingRow', () => {
 
     it('shows the remote_trainer_name in the Trainer column when present', async () => {
         renderTrainingRow({
-            payload: { ...localJob.payload, training_target: 'remote', remote_trainer_name: remoteTrainer.name },
+            payload: {
+                ...localJob.payload,
+                training_target: 'remote',
+                remote_trainer_id: 'remote-trainer-1',
+                remote_trainer_name: remoteTrainer.name,
+            },
         });
 
         await waitFor(() => expect(screen.getByTestId('trainer-cell')).toHaveTextContent(remoteTrainer.name));
+    });
+
+    it('shows Local for a local job in the Trainer column', async () => {
+        renderTrainingRow();
+
+        await waitFor(() => expect(screen.getByTestId('trainer-cell')).toHaveTextContent('Local'));
+    });
+
+    it('shows SSH for an ssh job in the Trainer column', async () => {
+        renderTrainingRow({
+            payload: { ...localJob.payload, training_target: 'ssh', remote_server_id: 'server-1' },
+        });
+
+        await waitFor(() => expect(screen.getByTestId('trainer-cell')).toHaveTextContent('SSH'));
     });
 
     it('shows "-" in the Dataset and Environment cells when those requests fail', async () => {

--- a/application/ui/src/features/models/job-table/job-table.test.tsx
+++ b/application/ui/src/features/models/job-table/job-table.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
 import { vi } from 'vitest';
@@ -6,6 +6,9 @@ import { vi } from 'vitest';
 import { SchemaTrainJob } from '../../../api/openapi-spec';
 import { http } from '../../../api/utils';
 import { server } from '../../../msw-node-setup';
+import { getMockedDataset } from '../../../test-utils/mocks/mock-dataset';
+import { getMockedEnvironment } from '../../../test-utils/mocks/mock-environment';
+import { getMockedRemoteTrainer } from '../../../test-utils/mocks/mock-remote-trainer';
 import { render } from '../../../test-utils/render';
 import { TrainingRow } from './job-table';
 
@@ -55,12 +58,11 @@ const localJob: SchemaTrainJob = {
     },
 };
 
-const remoteTrainer = {
-    id: 'trainer-1',
-    name: 'managed-trainer',
-    url: 'https://trainer.example.test/api',
-    created_at: '2026-07-14T12:00:00Z',
-};
+const remoteTrainer = getMockedRemoteTrainer();
+
+const dataset = getMockedDataset();
+
+const environment = getMockedEnvironment();
 
 const renderTrainingRow = (
     trainJobOverride: Partial<SchemaTrainJob> = {},
@@ -80,7 +82,11 @@ describe('TrainingRow', () => {
     });
 
     beforeEach(() => {
-        server.use(http.get('/api/remote-trainers', () => HttpResponse.json([remoteTrainer])));
+        server.use(
+            http.get('/api/remote-trainers', () => HttpResponse.json([remoteTrainer])),
+            http.get('/api/dataset/{dataset_id}', () => HttpResponse.json(dataset)),
+            http.get('/api/projects/{project_id}/environments/{environment_id}', () => HttpResponse.json(environment))
+        );
     });
 
     it('renders the model name, loss to two decimal places, and the uppercased architecture', () => {
@@ -110,18 +116,43 @@ describe('TrainingRow', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     });
 
-    it('renders a Remote · {name} badge for a remote job', async () => {
-        renderTrainingRow({
-            payload: { ...localJob.payload, training_target: 'remote', remote_trainer_id: remoteTrainer.id },
-        });
-
-        expect(await screen.findByText(`Remote · ${remoteTrainer.name}`)).toBeInTheDocument();
-    });
-
-    it('renders no location badge for a local job', () => {
+    it('renders the Dataset name and the Environment name resolved via dataset.environment_id', async () => {
         renderTrainingRow();
 
-        expect(screen.queryByText(/^Remote ·/)).not.toBeInTheDocument();
+        await waitFor(() => expect(screen.getByTestId('dataset-cell')).toHaveTextContent(dataset.name));
+        await waitFor(() => expect(screen.getByTestId('environment-cell')).toHaveTextContent(environment.name));
+    });
+
+    it('shows the remote_trainer_name in the Trainer column when present', async () => {
+        renderTrainingRow({
+            payload: { ...localJob.payload, training_target: 'remote', remote_trainer_name: remoteTrainer.name },
+        });
+
+        await waitFor(() => expect(screen.getByTestId('trainer-cell')).toHaveTextContent(remoteTrainer.name));
+    });
+
+    it('shows "-" in the Dataset and Environment cells when those requests fail', async () => {
+        server.use(
+            http.get('/api/dataset/{dataset_id}', () => HttpResponse.error()),
+            http.get('/api/projects/{project_id}/environments/{environment_id}', () => HttpResponse.error())
+        );
+
+        renderTrainingRow();
+
+        await waitFor(() => expect(screen.getByTestId('dataset-cell')).toHaveTextContent('-'));
+        expect(screen.getByTestId('environment-cell')).toHaveTextContent('-');
+    });
+
+    it('does not display the job detail panel for a failed job', async () => {
+        const user = userEvent.setup();
+        renderTrainingRow({ status: 'failed' });
+
+        expect(screen.queryByRole('button', { name: 'Show details for pick-and-place' })).not.toBeInTheDocument();
+
+        await user.click(screen.getByText('pick-and-place'));
+
+        expect(screen.queryByRole('tab', { name: 'Model Metrics' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('tab', { name: 'Training Datasets' })).not.toBeInTheDocument();
     });
 
     it('reveals the panel tabs when the row is clicked', async () => {

--- a/application/ui/src/features/models/job-table/job-table.tsx
+++ b/application/ui/src/features/models/job-table/job-table.tsx
@@ -124,6 +124,24 @@ export const TrainingRow = ({
     const { data: environment } = useEnvironmentQuery(trainJob.payload.project_id, dataset?.environment_id);
     const trainer = trainJob.payload.remote_trainer_name ?? capitalize(trainJob.payload.training_target);
 
+    if (trainJob.status === 'failed') {
+        return (
+            <Table.Row id={trainJob.id}>
+                <div />
+                <TrainJobStatus job={trainJob} />
+                <Text>{loss ? loss.toFixed(2) : '...'}</Text>
+                <Text>{trainJob.payload.policy.toUpperCase()}</Text>
+                <Text>{dataset?.name ?? '-'}</Text>
+                <Text>{environment?.name ?? '-'}</Text>
+                <Text>{trainer || '-'}</Text>
+                <div />
+                <View>
+                    <JobMenu trainJob={trainJob} onViewLogs={onViewLogs} />
+                </View>
+            </Table.Row>
+        );
+    }
+
     return (
         <Table.ExpandableRow
             id={trainJob.id}

--- a/application/ui/src/features/models/job-table/job-table.tsx
+++ b/application/ui/src/features/models/job-table/job-table.tsx
@@ -14,7 +14,6 @@ import {
 } from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
 import { useQueryClient } from '@tanstack/react-query';
-import { capitalize } from 'lodash-es';
 
 import { $api } from '../../../api/client';
 import { ElapsedDuration } from '../../../components/elapsed-duration.component';
@@ -23,6 +22,7 @@ import { Table } from '../../../components/table/table';
 import { useDatasetQuery, useEnvironmentQuery } from '../api/queries';
 import { durationBetween } from '../shared/duration';
 import { SingleBadge, SplitBadge } from '../shared/split-badge';
+import { getTrainerLabel } from '../shared/trainer';
 import { SchemaTrainJob } from '../train-model-dialog/train-model-dialog';
 import { JobRowContent } from './job-row-content';
 
@@ -122,7 +122,7 @@ export const TrainingRow = ({
 
     const { data: dataset } = useDatasetQuery(trainJob.payload.dataset_id);
     const { data: environment } = useEnvironmentQuery(trainJob.payload.project_id, dataset?.environment_id);
-    const trainer = trainJob.payload.remote_trainer_name ?? capitalize(trainJob.payload.training_target);
+    const trainer = getTrainerLabel(trainJob.payload);
 
     if (trainJob.status === 'failed') {
         return (
@@ -163,7 +163,7 @@ export const TrainingRow = ({
             <Text>{trainJob.payload.policy.toUpperCase()}</Text>
             <Text data-testid='dataset-cell'>{dataset?.name ?? '-'}</Text>
             <Text data-testid='environment-cell'>{environment?.name ?? '-'}</Text>
-            <Text data-testid='trainer-cell'>{trainer ?? '-'}</Text>
+            <Text data-testid='trainer-cell'>{trainer || '-'}</Text>
             <div onClick={(e) => e.stopPropagation()}>
                 {trainJob.status === 'running' && (
                     <DialogTrigger>

--- a/application/ui/src/features/models/job-table/job-table.tsx
+++ b/application/ui/src/features/models/job-table/job-table.tsx
@@ -131,9 +131,9 @@ export const TrainingRow = ({
                 <TrainJobStatus job={trainJob} />
                 <Text>{loss ? loss.toFixed(2) : '...'}</Text>
                 <Text>{trainJob.payload.policy.toUpperCase()}</Text>
-                <Text>{dataset?.name ?? '-'}</Text>
-                <Text>{environment?.name ?? '-'}</Text>
-                <Text>{trainer || '-'}</Text>
+                <Text data-testid='dataset-cell'>{dataset?.name ?? '-'}</Text>
+                <Text data-testid='environment-cell'>{environment?.name ?? '-'}</Text>
+                <Text data-testid='trainer-cell'>{trainer || '-'}</Text>
                 <div />
                 <View>
                     <JobMenu trainJob={trainJob} onViewLogs={onViewLogs} />
@@ -161,9 +161,9 @@ export const TrainingRow = ({
             <TrainJobStatus job={trainJob} />
             <Text>{loss ? loss.toFixed(2) : '...'}</Text>
             <Text>{trainJob.payload.policy.toUpperCase()}</Text>
-            <Text>{dataset?.name ?? '-'}</Text>
-            <Text>{environment?.name ?? '-'}</Text>
-            <Text>{trainer ?? '-'}</Text>
+            <Text data-testid='dataset-cell'>{dataset?.name ?? '-'}</Text>
+            <Text data-testid='environment-cell'>{environment?.name ?? '-'}</Text>
+            <Text data-testid='trainer-cell'>{trainer ?? '-'}</Text>
             <div onClick={(e) => e.stopPropagation()}>
                 {trainJob.status === 'running' && (
                     <DialogTrigger>

--- a/application/ui/src/features/models/job-table/job-table.tsx
+++ b/application/ui/src/features/models/job-table/job-table.tsx
@@ -14,11 +14,13 @@ import {
 } from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
 import { useQueryClient } from '@tanstack/react-query';
+import { capitalize } from 'lodash-es';
 
 import { $api } from '../../../api/client';
 import { ElapsedDuration } from '../../../components/elapsed-duration.component';
 import { notify } from '../../../components/notification/notification.component';
 import { Table } from '../../../components/table/table';
+import { useDatasetQuery, useEnvironmentQuery } from '../api/queries';
 import { durationBetween } from '../shared/duration';
 import { SingleBadge, SplitBadge } from '../shared/split-badge';
 import { SchemaTrainJob } from '../train-model-dialog/train-model-dialog';
@@ -26,20 +28,6 @@ import { JobRowContent } from './job-row-content';
 
 import classes from './job-table.module.css';
 
-/** Small pill naming the remote trainer a job runs on. Hidden entirely for local jobs. */
-const TrainingLocationBadge = ({ payload }: { payload: SchemaTrainJob['payload'] }) => {
-    const { data: remoteTrainers = [] } = $api.useQuery('get', '/api/remote-trainers');
-
-    if (payload.training_target !== 'remote') {
-        return null;
-    }
-
-    const remoteTrainer = remoteTrainers.find((trainer) => trainer.id === payload.remote_trainer_id);
-    const label = remoteTrainer?.name ?? payload.remote_trainer_url ?? 'unknown';
-    const text = `Remote · ${label}`;
-
-    return <SingleBadge color='var(--spectrum-global-color-purple-600)' text={text} title={text} preserveCase />;
-};
 const TrainJobStatus = ({ job }: { job: SchemaTrainJob }) => {
     if (job.status === 'running') {
         return (
@@ -47,7 +35,6 @@ const TrainJobStatus = ({ job }: { job: SchemaTrainJob }) => {
                 <Flex gap={'size-100'} alignItems={'center'} wrap>
                     <Text UNSAFE_style={{ fontWeight: 500 }}>{job.payload.model_name}</Text>
                     <SplitBadge first={job.status} second={job.message} />
-                    <TrainingLocationBadge payload={job.payload} />
                 </Flex>
                 {job.start_time ? (
                     <Text UNSAFE_className={classes.rowInfo}>
@@ -66,7 +53,6 @@ const TrainJobStatus = ({ job }: { job: SchemaTrainJob }) => {
                 <Flex gap={'size-100'} alignItems={'center'} wrap>
                     <Text UNSAFE_style={{ fontWeight: 500 }}>{job.payload.model_name}</Text>
                     <SingleBadge color={color} text={job.status} />
-                    <TrainingLocationBadge payload={job.payload} />
                 </Flex>
                 {job.start_time && job.end_time && (
                     <Text UNSAFE_className={classes.rowInfo}>
@@ -134,6 +120,10 @@ export const TrainingRow = ({
 }) => {
     const loss = trainJob.extra_info && (trainJob.extra_info['train/loss_step'] as number | undefined);
 
+    const { data: dataset } = useDatasetQuery(trainJob.payload.dataset_id);
+    const { data: environment } = useEnvironmentQuery(trainJob.payload.project_id, dataset?.environment_id);
+    const trainer = trainJob.payload.remote_trainer_name ?? capitalize(trainJob.payload.training_target);
+
     return (
         <Table.ExpandableRow
             id={trainJob.id}
@@ -152,8 +142,10 @@ export const TrainingRow = ({
         >
             <TrainJobStatus job={trainJob} />
             <Text>{loss ? loss.toFixed(2) : '...'}</Text>
-            <div />
             <Text>{trainJob.payload.policy.toUpperCase()}</Text>
+            <Text>{dataset?.name ?? '-'}</Text>
+            <Text>{environment?.name ?? '-'}</Text>
+            <Text>{trainer ?? '-'}</Text>
             <div onClick={(e) => e.stopPropagation()}>
                 {trainJob.status === 'running' && (
                     <DialogTrigger>

--- a/application/ui/src/features/models/models-table/model-row.test.tsx
+++ b/application/ui/src/features/models/models-table/model-row.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
 import { vi } from 'vitest';
@@ -6,6 +6,8 @@ import { vi } from 'vitest';
 import { SchemaModel, SchemaTrainJob } from '../../../api/openapi-spec';
 import { http } from '../../../api/utils';
 import { server } from '../../../msw-node-setup';
+import { getMockedDataset } from '../../../test-utils/mocks/mock-dataset';
+import { getMockedEnvironment } from '../../../test-utils/mocks/mock-environment';
 import { render } from '../../../test-utils/render';
 import { durationBetween } from '../shared/duration';
 import { ModelRow } from './model-row';
@@ -77,6 +79,10 @@ const modelDetailResponse = {
     hparams: null,
 };
 
+const dataset = getMockedDataset();
+
+const environment = getMockedEnvironment();
+
 const renderModelRow = ({
     modelOverride,
     trainingJobOverride,
@@ -113,7 +119,9 @@ describe('ModelRow', () => {
     beforeEach(() => {
         server.use(
             http.get('/api/models/{model_id}', () => HttpResponse.json(modelDetailResponse)),
-            http.get('/api/policies/backends', () => HttpResponse.json({}))
+            http.get('/api/policies/backends', () => HttpResponse.json({})),
+            http.get('/api/dataset/{dataset_id}', () => HttpResponse.json(dataset)),
+            http.get('/api/projects/{project_id}/environments/{environment_id}', () => HttpResponse.json(environment))
         );
     });
 
@@ -141,21 +149,54 @@ describe('ModelRow', () => {
     });
 
     it('renders the v{n} suffix only when version > 1', () => {
-        const { rerender } = renderModelRow({ modelOverride: { version: 1 } });
+        renderModelRow({ modelOverride: { version: 1 } });
 
         expect(screen.queryByText(/^v\d+$/)).not.toBeInTheDocument();
 
-        rerender(
-            <ModelRow
-                model={{ ...model, version: 2 }}
-                trainingJob={undefined}
-                onDelete={vi.fn()}
-                onRetrain={vi.fn()}
-                onViewLogs={vi.fn()}
-            />
-        );
+        renderModelRow({ modelOverride: { version: 2 } });
 
         expect(screen.getByText('v2')).toBeInTheDocument();
+    });
+
+    it('renders the Dataset and Environment names', async () => {
+        renderModelRow({ modelOverride: { dataset_id: 'dataset-1' } });
+
+        await waitFor(() => expect(screen.getByTestId('dataset-cell')).toHaveTextContent(dataset.name));
+        await waitFor(() => expect(screen.getByTestId('environment-cell')).toHaveTextContent(environment.name));
+    });
+
+    it('shows "-" in the Dataset and Environment cells and makes no dataset request when dataset_id is null', async () => {
+        const datasetHandler = vi.fn(() => HttpResponse.error());
+        server.use(http.get('/api/dataset/{dataset_id}', datasetHandler));
+
+        renderModelRow({ modelOverride: { dataset_id: null }, trainingJobOverride: trainingJob });
+
+        expect(await screen.findByTestId('dataset-cell')).toHaveTextContent('-');
+        expect(screen.getByTestId('environment-cell')).toHaveTextContent('-');
+        expect(datasetHandler).not.toHaveBeenCalled();
+    });
+
+    it('shows the remote_trainer_name in the Trainer column when set', () => {
+        renderModelRow({
+            trainingJobOverride: {
+                ...trainingJob,
+                payload: { ...trainingJob.payload, training_target: 'remote', remote_trainer_name: 'managed-trainer' },
+            },
+        });
+
+        expect(screen.getByTestId('trainer-cell')).toHaveTextContent('managed-trainer');
+    });
+
+    it('shows the capitalized training_target in the Trainer column when there is no remote_trainer_name', () => {
+        renderModelRow({ trainingJobOverride: trainingJob });
+
+        expect(screen.getByTestId('trainer-cell')).toHaveTextContent('Local');
+    });
+
+    it('shows "-" in the Trainer column when there is no trainingJob at all', () => {
+        renderModelRow();
+
+        expect(screen.getByTestId('trainer-cell')).toHaveTextContent('-');
     });
 
     it('does not render the detail panel initially', () => {

--- a/application/ui/src/features/models/models-table/model-row.test.tsx
+++ b/application/ui/src/features/models/models-table/model-row.test.tsx
@@ -180,17 +180,33 @@ describe('ModelRow', () => {
         renderModelRow({
             trainingJobOverride: {
                 ...trainingJob,
-                payload: { ...trainingJob.payload, training_target: 'remote', remote_trainer_name: 'managed-trainer' },
+                payload: {
+                    ...trainingJob.payload,
+                    training_target: 'remote',
+                    remote_trainer_id: 'remote-trainer-1',
+                    remote_trainer_name: 'managed-trainer',
+                },
             },
         });
 
         expect(screen.getByTestId('trainer-cell')).toHaveTextContent('managed-trainer');
     });
 
-    it('shows the capitalized training_target in the Trainer column when there is no remote_trainer_name', () => {
+    it('shows Local in the Trainer column for a local job', () => {
         renderModelRow({ trainingJobOverride: trainingJob });
 
         expect(screen.getByTestId('trainer-cell')).toHaveTextContent('Local');
+    });
+
+    it('shows SSH in the Trainer column for an ssh job', () => {
+        renderModelRow({
+            trainingJobOverride: {
+                ...trainingJob,
+                payload: { ...trainingJob.payload, training_target: 'ssh', remote_server_id: 'server-1' },
+            },
+        });
+
+        expect(screen.getByTestId('trainer-cell')).toHaveTextContent('SSH');
     });
 
     it('shows "-" in the Trainer column when there is no trainingJob at all', () => {

--- a/application/ui/src/features/models/models-table/model-row.tsx
+++ b/application/ui/src/features/models/models-table/model-row.tsx
@@ -66,9 +66,9 @@ export const ModelRow = ({
                 {version > 1 && <Text UNSAFE_className={classes.versionBadge}>v{version}</Text>}
             </Flex>
             <Text>{model.policy.toUpperCase()}</Text>
-            <Text>{dataset?.name ?? '-'}</Text>
-            <Text>{environment?.name ?? '-'}</Text>
-            <Text>{trainer || '-'}</Text>
+            <Text data-testid='dataset-cell'>{dataset?.name ?? '-'}</Text>
+            <Text data-testid='environment-cell'>{environment?.name ?? '-'}</Text>
+            <Text data-testid='trainer-cell'>{trainer || '-'}</Text>
             <Text>{new Date(model.created_at!).toLocaleString()}</Text>
             <Text UNSAFE_className={duration ? undefined : classes.rowInfo}>{duration ?? '—'}</Text>
             <div onClick={(e) => e.stopPropagation()}>

--- a/application/ui/src/features/models/models-table/model-row.tsx
+++ b/application/ui/src/features/models/models-table/model-row.tsx
@@ -2,12 +2,12 @@ import { useState } from 'react';
 
 import { ActionButton, Button, DialogTrigger, Flex, Item, Key, Menu, MenuTrigger, Text, View } from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
-import { capitalize } from 'lodash-es';
 
 import { SchemaModel, SchemaTrainJob } from '../../../api/openapi-spec';
 import { Table } from '../../../components/table/table';
 import { useDatasetQuery, useEnvironmentQuery } from '../api/queries';
 import { durationBetween } from '../shared/duration';
+import { getTrainerLabel } from '../shared/trainer';
 import { ModelDownloadDialog } from './model-download-dialog';
 import { ModelRowContent } from './model-row-content';
 import { StartInferenceDialog } from './start-inference-dialog';
@@ -31,7 +31,7 @@ export const ModelRow = ({
     const { data: dataset } = useDatasetQuery(model.dataset_id);
     const { data: environment } = useEnvironmentQuery(model.project_id, dataset?.environment_id);
 
-    const trainer = trainingJob?.payload.remote_trainer_name ?? capitalize(trainingJob?.payload.training_target);
+    const trainer = getTrainerLabel(trainingJob?.payload);
 
     const onAction = (key: Key) => {
         const action = key.toString();

--- a/application/ui/src/features/models/models-table/model-row.tsx
+++ b/application/ui/src/features/models/models-table/model-row.tsx
@@ -68,7 +68,7 @@ export const ModelRow = ({
             <Text>{model.policy.toUpperCase()}</Text>
             <Text>{dataset?.name ?? '-'}</Text>
             <Text>{environment?.name ?? '-'}</Text>
-            <Text>{trainer ?? '-'}</Text>
+            <Text>{trainer || '-'}</Text>
             <Text>{new Date(model.created_at!).toLocaleString()}</Text>
             <Text UNSAFE_className={duration ? undefined : classes.rowInfo}>{duration ?? '—'}</Text>
             <div onClick={(e) => e.stopPropagation()}>

--- a/application/ui/src/features/models/models-table/model-row.tsx
+++ b/application/ui/src/features/models/models-table/model-row.tsx
@@ -2,47 +2,17 @@ import { useState } from 'react';
 
 import { ActionButton, Button, DialogTrigger, Flex, Item, Key, Menu, MenuTrigger, Text, View } from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
+import { capitalize } from 'lodash-es';
 
-import { $api } from '../../../api/client';
 import { SchemaModel, SchemaTrainJob } from '../../../api/openapi-spec';
 import { Table } from '../../../components/table/table';
+import { useDatasetQuery, useEnvironmentQuery } from '../api/queries';
 import { durationBetween } from '../shared/duration';
 import { ModelDownloadDialog } from './model-download-dialog';
 import { ModelRowContent } from './model-row-content';
 import { StartInferenceDialog } from './start-inference-dialog';
 
 import classes from './model-table.module.css';
-
-const useDatasetQuery = (datasetId: string | undefined | null) => {
-    return $api.useQuery(
-        'get',
-        '/api/dataset/{dataset_id}',
-        {
-            params: { path: { dataset_id: String(datasetId) } },
-        },
-        {
-            enabled: datasetId != null,
-        }
-    );
-};
-
-const useEnvironmentQuery = (projectId: string, environmentId: string | undefined) => {
-    return $api.useQuery(
-        'get',
-        '/api/projects/{project_id}/environments/{environment_id}',
-        {
-            params: {
-                path: {
-                    environment_id: String(environmentId),
-                    project_id: projectId,
-                },
-            },
-        },
-        {
-            enabled: environmentId !== undefined,
-        }
-    );
-};
 
 export const ModelRow = ({
     model,
@@ -61,7 +31,7 @@ export const ModelRow = ({
     const { data: dataset } = useDatasetQuery(model.dataset_id);
     const { data: environment } = useEnvironmentQuery(model.project_id, dataset?.environment_id);
 
-    const trainer = trainingJob?.payload.remote_trainer_name ?? trainingJob?.payload.training_target;
+    const trainer = trainingJob?.payload.remote_trainer_name ?? capitalize(trainingJob?.payload.training_target);
 
     const onAction = (key: Key) => {
         const action = key.toString();

--- a/application/ui/src/features/models/models-table/model-row.tsx
+++ b/application/ui/src/features/models/models-table/model-row.tsx
@@ -61,6 +61,8 @@ export const ModelRow = ({
     const { data: dataset } = useDatasetQuery(model.dataset_id);
     const { data: environment } = useEnvironmentQuery(model.project_id, dataset?.environment_id);
 
+    const trainer = trainingJob?.payload.remote_trainer_name ?? trainingJob?.payload.training_target;
+
     const onAction = (key: Key) => {
         const action = key.toString();
         if (action === 'delete') {
@@ -96,6 +98,7 @@ export const ModelRow = ({
             <Text>{model.policy.toUpperCase()}</Text>
             <Text>{dataset?.name ?? '-'}</Text>
             <Text>{environment?.name ?? '-'}</Text>
+            <Text>{trainer ?? '-'}</Text>
             <Text>{new Date(model.created_at!).toLocaleString()}</Text>
             <Text UNSAFE_className={duration ? undefined : classes.rowInfo}>{duration ?? '—'}</Text>
             <div onClick={(e) => e.stopPropagation()}>

--- a/application/ui/src/features/models/models-table/model-row.tsx
+++ b/application/ui/src/features/models/models-table/model-row.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { ActionButton, Button, DialogTrigger, Flex, Item, Key, Menu, MenuTrigger, Text, View } from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
 
+import { $api } from '../../../api/client';
 import { SchemaModel, SchemaTrainJob } from '../../../api/openapi-spec';
 import { Table } from '../../../components/table/table';
 import { durationBetween } from '../shared/duration';
@@ -11,6 +12,37 @@ import { ModelRowContent } from './model-row-content';
 import { StartInferenceDialog } from './start-inference-dialog';
 
 import classes from './model-table.module.css';
+
+const useDatasetQuery = (datasetId: string | undefined | null) => {
+    return $api.useQuery(
+        'get',
+        '/api/dataset/{dataset_id}',
+        {
+            params: { path: { dataset_id: String(datasetId) } },
+        },
+        {
+            enabled: datasetId != null,
+        }
+    );
+};
+
+const useEnvironmentQuery = (projectId: string, environmentId: string | undefined) => {
+    return $api.useQuery(
+        'get',
+        '/api/projects/{project_id}/environments/{environment_id}',
+        {
+            params: {
+                path: {
+                    environment_id: String(environmentId),
+                    project_id: projectId,
+                },
+            },
+        },
+        {
+            enabled: environmentId !== undefined,
+        }
+    );
+};
 
 export const ModelRow = ({
     model,
@@ -26,6 +58,8 @@ export const ModelRow = ({
     onViewLogs?: () => void;
 }) => {
     const [isDownloadDialogOpen, setDownloadDialogOpen] = useState(false);
+    const { data: dataset } = useDatasetQuery(model.dataset_id);
+    const { data: environment } = useEnvironmentQuery(model.project_id, dataset?.environment_id);
 
     const onAction = (key: Key) => {
         const action = key.toString();
@@ -59,9 +93,11 @@ export const ModelRow = ({
                 <Text>{model.name}</Text>
                 {version > 1 && <Text UNSAFE_className={classes.versionBadge}>v{version}</Text>}
             </Flex>
+            <Text>{model.policy.toUpperCase()}</Text>
+            <Text>{dataset?.name ?? '-'}</Text>
+            <Text>{environment?.name ?? '-'}</Text>
             <Text>{new Date(model.created_at!).toLocaleString()}</Text>
             <Text UNSAFE_className={duration ? undefined : classes.rowInfo}>{duration ?? '—'}</Text>
-            <Text>{model.policy.toUpperCase()}</Text>
             <div onClick={(e) => e.stopPropagation()}>
                 <DialogTrigger>
                     <Button variant='secondary'>Run model</Button>

--- a/application/ui/src/features/models/models-table/models-list.tsx
+++ b/application/ui/src/features/models/models-table/models-list.tsx
@@ -6,10 +6,12 @@ import { ModelRow } from './model-row';
 
 const MODEL_COLUMNS: TableColumn[] = [
     { width: 'max-content' },
-    { width: '2fr', header: 'Model name' },
+    { width: '1fr', header: 'Model name' },
+    { width: '1fr', header: 'Architecture' },
+    { width: '1fr', header: 'Dataset' },
+    { width: '1fr', header: 'Environment' },
     { width: '1fr', header: 'Trained' },
     { width: '1fr', header: 'Duration' },
-    { width: '1fr', header: 'Architecture' },
     { width: '1fr' },
     { width: 'auto', align: 'end' },
 ];

--- a/application/ui/src/features/models/models-table/models-list.tsx
+++ b/application/ui/src/features/models/models-table/models-list.tsx
@@ -10,6 +10,7 @@ const MODEL_COLUMNS: TableColumn[] = [
     { width: '1fr', header: 'Architecture' },
     { width: '1fr', header: 'Dataset' },
     { width: '1fr', header: 'Environment' },
+    { width: '1fr', header: 'Trainer' },
     { width: '1fr', header: 'Trained' },
     { width: '1fr', header: 'Duration' },
     { width: '1fr' },

--- a/application/ui/src/features/models/shared/trainer.test.ts
+++ b/application/ui/src/features/models/shared/trainer.test.ts
@@ -1,0 +1,30 @@
+import { getMockedTrainJobPayload } from '../../../test-utils/mocks/mock-train-job-payload';
+import { getTrainerLabel } from './trainer';
+
+describe('getTrainerLabel', () => {
+    it('returns undefined when there is no payload', () => {
+        expect(getTrainerLabel(undefined)).toBeUndefined();
+    });
+
+    it("returns 'Local' for a local training target", () => {
+        expect(getTrainerLabel(getMockedTrainJobPayload({ training_target: 'local' }))).toBe('Local');
+    });
+
+    it("returns 'SSH' for an ssh training target", () => {
+        expect(
+            getTrainerLabel(getMockedTrainJobPayload({ training_target: 'ssh', remote_server_id: 'server-1' }))
+        ).toBe('SSH');
+    });
+
+    it('returns the remote_trainer_name for a remote training target', () => {
+        expect(
+            getTrainerLabel(
+                getMockedTrainJobPayload({
+                    training_target: 'remote',
+                    remote_trainer_id: 'trainer-1',
+                    remote_trainer_name: 'managed-trainer',
+                })
+            )
+        ).toBe('managed-trainer');
+    });
+});

--- a/application/ui/src/features/models/shared/trainer.ts
+++ b/application/ui/src/features/models/shared/trainer.ts
@@ -1,0 +1,23 @@
+import { SchemaTrainJob } from '../../../api/openapi-spec';
+
+type TrainJobPayload = SchemaTrainJob['payload'];
+
+export const getTrainerLabel = (payload: TrainJobPayload | undefined): string | undefined => {
+    if (payload === undefined) {
+        return undefined;
+    }
+
+    if (payload.training_target === 'remote') {
+        return payload.remote_trainer_name ?? 'Remote';
+    }
+
+    if (payload.training_target === 'local') {
+        return 'Local';
+    }
+
+    if (payload.training_target === 'ssh') {
+        return 'SSH';
+    }
+
+    console.error('Unhandled training_target', payload satisfies never);
+};

--- a/application/ui/src/test-utils/mocks/mock-dataset.ts
+++ b/application/ui/src/test-utils/mocks/mock-dataset.ts
@@ -1,0 +1,13 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { SchemaDatasetOutput } from '../../api/openapi-spec';
+
+export const getMockedDataset = (overrides: Partial<SchemaDatasetOutput> = {}): SchemaDatasetOutput => ({
+    id: 'dataset-1',
+    name: 'pick-dataset',
+    default_task: 'manipulation',
+    project_id: 'project-1',
+    environment_id: 'environment-1',
+    ...overrides,
+});

--- a/application/ui/src/test-utils/mocks/mock-environment.ts
+++ b/application/ui/src/test-utils/mocks/mock-environment.ts
@@ -1,0 +1,12 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { SchemaEnvironmentWithRelations } from '../../api/openapi-spec';
+
+export const getMockedEnvironment = (
+    overrides: Partial<SchemaEnvironmentWithRelations> = {}
+): SchemaEnvironmentWithRelations => ({
+    id: 'environment-1',
+    name: 'lab-environment',
+    ...overrides,
+});

--- a/application/ui/src/test-utils/mocks/mock-remote-trainer.ts
+++ b/application/ui/src/test-utils/mocks/mock-remote-trainer.ts
@@ -1,0 +1,12 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { SchemaRemoteTrainer } from '../../api/openapi-spec';
+
+export const getMockedRemoteTrainer = (overrides: Partial<SchemaRemoteTrainer> = {}): SchemaRemoteTrainer => ({
+    id: 'trainer-1',
+    name: 'managed-trainer',
+    url: 'https://trainer.example.test/api',
+    created_at: '2026-07-14T12:00:00Z',
+    ...overrides,
+});

--- a/application/ui/src/test-utils/mocks/mock-train-job-payload.ts
+++ b/application/ui/src/test-utils/mocks/mock-train-job-payload.ts
@@ -1,0 +1,52 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    SchemaLocalTrainJobPayloadOutput,
+    SchemaRemoteTrainJobPayloadOutput,
+    SchemaSshTrainJobPayloadOutput,
+    SchemaTrainJob,
+} from '../../api/openapi-spec';
+
+type TrainJobPayload = SchemaTrainJob['payload'];
+
+const basePayload = {
+    project_id: 'project-1',
+    dataset_id: 'dataset-1',
+    policy: 'act',
+    model_name: 'pick-and-place',
+    batch_size: 8,
+    num_workers: 'auto' as const,
+    auto_scale_batch_size: false,
+    val_split: 0.1,
+    precision: 'bf16-mixed' as const,
+    compile_model: false,
+};
+
+type BaseKeys = keyof typeof basePayload;
+
+/**
+ * Overrides for one payload variant: fields already covered by `basePayload` stay
+ * optional, everything else (including the variant's own required fields, e.g.
+ * `remote_trainer_id`) keeps the required/optional-ness declared by the schema.
+ * This means a newly-added required field on a variant becomes a compile error
+ * here automatically, with no manual overload edits needed.
+ */
+type VariantOverrides<T> = Partial<Pick<T, Extract<keyof T, BaseKeys>>> & Omit<T, BaseKeys>;
+
+export function getMockedTrainJobPayload(
+    overrides?: Partial<VariantOverrides<SchemaLocalTrainJobPayloadOutput>>
+): SchemaLocalTrainJobPayloadOutput;
+export function getMockedTrainJobPayload(
+    overrides: VariantOverrides<SchemaRemoteTrainJobPayloadOutput>
+): SchemaRemoteTrainJobPayloadOutput;
+export function getMockedTrainJobPayload(
+    overrides: VariantOverrides<SchemaSshTrainJobPayloadOutput>
+): SchemaSshTrainJobPayloadOutput;
+export function getMockedTrainJobPayload(overrides: Partial<TrainJobPayload> = {}): TrainJobPayload {
+    return {
+        ...basePayload,
+        training_target: 'local',
+        ...overrides,
+    } as TrainJobPayload;
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->

<img width="1639" height="1289" alt="image" src="https://github.com/user-attachments/assets/666fd598-5bc7-4ccb-aafd-efd33cab5ebb" />

As a bonus: when job is failed, we don't have any info to display in the details, hence we don't show not expandable row.

## Related Issues

<!-- Fixes #123 -->
