### PR TITLE
fix(ui): Improve navigation and robot loading after robot deletion

### DIFF
--- a/application/ui/src/features/robots/robots-list.test.tsx
+++ b/application/ui/src/features/robots/robots-list.test.tsx
@@ -1,10 +1,16 @@
-import { screen, waitFor } from '@testing-library/react';
+import { ReactNode, Suspense } from 'react';
+
+import { ThemeProvider } from '@geti-ui/ui';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { http } from '../../api/utils';
 import { server } from '../../msw-node-setup';
+import { createQueryClient } from '../../query-client/query-client';
 import { render } from '../../test-utils/render';
 import { RobotsList } from './robots-list';
 
@@ -31,6 +37,32 @@ const renderRobotsList = () =>
         route: `/projects/${PROJECT_ID}/robots`,
         path: '/projects/:project_id/robots',
     });
+
+const renderRobotsListAtShowRoute = () => {
+    const queryClient = createQueryClient();
+    const providers = (children: ReactNode) => (
+        <QueryClientProvider client={queryClient}>
+            <ThemeProvider>
+                <Suspense>{children}</Suspense>
+            </ThemeProvider>
+        </QueryClientProvider>
+    );
+    const router = createMemoryRouter(
+        [
+            {
+                path: '/projects/:project_id/robots/:robot_id',
+                element: providers(<RobotsList />),
+            },
+            {
+                path: '/projects/:project_id/robots',
+                element: providers(<div>Robots index</div>),
+            },
+        ],
+        { initialEntries: [`/projects/${PROJECT_ID}/robots/${ROBOT_ID}`], initialIndex: 0 }
+    );
+
+    return rtlRender(<RouterProvider router={router} />);
+};
 
 const openRobotMenu = async (user: ReturnType<typeof userEvent.setup>) => {
     await screen.findByText(so101Robot.name);
@@ -146,6 +178,22 @@ describe('RobotsList', () => {
         expect(await screen.findByText('Unavailable')).toBeInTheDocument();
         expect(screen.getByText(/plugin unavailable/)).toBeInTheDocument();
         expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+
+    it('navigates to the robots index when the viewed robot is deleted', async () => {
+        server.use(
+            http.get(ROBOTS_PATH, () => HttpResponse.json([so101Robot])),
+            http.get(ONLINE_ROBOTS_PATH, () => HttpResponse.json([])),
+            http.delete('/api/projects/{project_id}/robots/{robot_id}', () => HttpResponse.json(null, { status: 204 }))
+        );
+
+        const user = userEvent.setup();
+
+        renderRobotsListAtShowRoute();
+        await openRobotMenu(user);
+        await user.click(screen.getByRole('menuitemradio', { name: 'Delete' }));
+
+        expect(await screen.findByText('Robots index')).toBeInTheDocument();
     });
 });
 

--- a/application/ui/src/features/robots/robots-list.tsx
+++ b/application/ui/src/features/robots/robots-list.tsx
@@ -2,7 +2,7 @@ import { Grid, StatusLight } from '@adobe/react-spectrum';
 import { ActionButton, Flex, Heading, Item, Menu, MenuTrigger, toast, View } from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
 import { clsx } from 'clsx';
-import { NavLink } from 'react-router';
+import { NavLink, useNavigate, useParams } from 'react-router';
 
 import { $api } from '../../api/client';
 import { getApiErrorMessage, isResourceInUseError, isRuntimeSessionBusyError } from '../../api/errors';
@@ -35,16 +35,56 @@ const exportCalibration = async (_project_id: string, robot: SchemaRobot) => {
     URL.revokeObjectURL(downloadUrl);
 };
 
-const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
+const useActiveRobotId = () => {
+    const { robot_id } = useParams<{ robot_id: string }>();
+
+    return robot_id;
+};
+
+const useDeleteRobot = (robot: SchemaRobot) => {
     const { project_id } = useProjectId();
+    const activeRobotId = useActiveRobotId();
+    const navigate = useNavigate();
     const deleteRobotMutation = $api.useMutation('delete', '/api/projects/{project_id}/robots/{robot_id}', {
         meta: {
             invalidates: [
                 ['get', '/api/projects/{project_id}/robots', { params: { path: { project_id } } }],
                 ['get', '/api/projects/{project_id}/robots/online', { params: { path: { project_id } } }],
+                [
+                    'get',
+                    '/api/projects/{project_id}/robots/{robot_id}',
+                    { params: { path: { project_id, robot_id: robot.id } } },
+                ],
             ],
         },
     });
+
+    const deleteRobot = () => {
+        deleteRobotMutation.mutate(
+            { params: { path: { project_id, robot_id: robot.id } } },
+            {
+                onSuccess: () => {
+                    if (robot.id === activeRobotId) {
+                        navigate(paths.project.robots.index({ project_id }));
+                    }
+                },
+                onError: (error) => {
+                    if (isResourceInUseError(error) || isRuntimeSessionBusyError(error)) {
+                        toast.info(getApiErrorMessage(error) ?? 'This robot is in use and cannot be deleted.');
+                        return;
+                    }
+                    toast.negative(getApiErrorMessage(error) ?? 'Failed to delete robot.');
+                },
+            }
+        );
+    };
+
+    return deleteRobot;
+};
+
+const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
+    const { project_id } = useProjectId();
+    const deleteRobot = useDeleteRobot(robot);
 
     const editPath = paths.project.robots.edit({ project_id, robot_id: robot.id });
     const isSO101 = robot.type === 'SO101_Follower' || robot.type === 'SO101_Leader';
@@ -62,20 +102,7 @@ const MenuActions = ({ robot }: { robot: SchemaRobot }) => {
                 }
                 onAction={async (action) => {
                     if (action === 'delete') {
-                        await deleteRobotMutation.mutateAsync(
-                            { params: { path: { project_id, robot_id: robot.id } } },
-                            {
-                                onError: (error) => {
-                                    if (isResourceInUseError(error) || isRuntimeSessionBusyError(error)) {
-                                        toast.info(
-                                            getApiErrorMessage(error) ?? 'This robot is in use and cannot be deleted.'
-                                        );
-                                        return;
-                                    }
-                                    toast.negative(getApiErrorMessage(error) ?? 'Failed to delete robot.');
-                                },
-                            }
-                        );
+                        deleteRobot();
                     }
                     if (action === 'export-calibration') {
                         try {

--- a/application/ui/src/router.tsx
+++ b/application/ui/src/router.tsx
@@ -279,6 +279,33 @@ export const router = createBrowserRouter([
                                     },
                                     {
                                         path: paths.project.robots.show.pattern,
+                                        loader: async ({ params }) => {
+                                            const { robot_id, project_id } = params;
+
+                                            if (project_id === undefined || robot_id === undefined) {
+                                                return redirect(paths.projects.index({}));
+                                            }
+
+                                            const { error } = await fetchClient.GET(
+                                                '/api/projects/{project_id}/robots/{robot_id}',
+                                                {
+                                                    params: {
+                                                        path: {
+                                                            robot_id,
+                                                            project_id,
+                                                        },
+                                                    },
+                                                }
+                                            );
+
+                                            if (
+                                                error !== undefined &&
+                                                'http_status' in error &&
+                                                error.http_status === 404
+                                            ) {
+                                                return redirect(paths.project.robots.index({ project_id }));
+                                            }
+                                        },
                                         element: <Robot />,
                                     },
                                 ],

--- a/application/ui/src/router.tsx
+++ b/application/ui/src/router.tsx
@@ -1,10 +1,12 @@
 import { Suspense } from 'react';
 
 import { Content, Grid, Heading, IllustratedMessage, Loading, minmax, View } from '@geti-ui/ui';
+import { isObject } from 'lodash-es';
 import { createBrowserRouter, Outlet, redirect } from 'react-router';
 import { path } from 'static-path';
 
-import { fetchClient } from './api/client';
+import { queryClient } from '../src/query-client/query-client';
+import { $api, fetchClient } from './api/client';
 import { ReactComponent as RobotIllustration } from './assets/illustrations/INTEL_08_NO-TESTS.svg';
 import { ErrorPage } from './components/error-page/error-page';
 import { AppLayout } from './routes/app/app.layout';
@@ -286,24 +288,16 @@ export const router = createBrowserRouter([
                                                 return redirect(paths.projects.index({}));
                                             }
 
-                                            const { error } = await fetchClient.GET(
-                                                '/api/projects/{project_id}/robots/{robot_id}',
-                                                {
-                                                    params: {
-                                                        path: {
-                                                            robot_id,
-                                                            project_id,
-                                                        },
-                                                    },
+                                            try {
+                                                await queryRobot(project_id, robot_id);
+                                            } catch (error: unknown) {
+                                                if (
+                                                    isObject(error) &&
+                                                    'http_status' in error &&
+                                                    error.http_status === 404
+                                                ) {
+                                                    return redirect(paths.project.robots.index({ project_id }));
                                                 }
-                                            );
-
-                                            if (
-                                                error !== undefined &&
-                                                'http_status' in error &&
-                                                error.http_status === 404
-                                            ) {
-                                                return redirect(paths.project.robots.index({ project_id }));
                                             }
                                         },
                                         element: <Robot />,
@@ -391,3 +385,16 @@ export const router = createBrowserRouter([
         ],
     },
 ]);
+
+function queryRobot(projectId: string, robotId: string) {
+    return queryClient.ensureQueryData(
+        $api.queryOptions('get', '/api/projects/{project_id}/robots/{robot_id}', {
+            params: {
+                path: {
+                    project_id: projectId,
+                    robot_id: robotId,
+                },
+            },
+        })
+    );
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->

Before when the user would remove a robot that they've selected the route would remain the same, refreshing the page would result in a global "Something was wrong" error without option to select a different robot etc.
Now we don't allow user to open route that has a robot that no longer exists.

After this PR is merged we can close https://github.com/open-edge-platform/physical-ai-studio/pull/1053.

## Related Issues

<!-- Fixes #123 -->
