### PR TITLE
fix: Reset selected episode when dataset is changed

### DIFF
--- a/application/ui/src/routes/datasets/dataset-viewer.tsx
+++ b/application/ui/src/routes/datasets/dataset-viewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import {
     ActionButton,
@@ -33,6 +33,12 @@ export const DatasetViewer = () => {
 
     const { deleteEpisodes, isPending } = useDeleteEpisodeQuery(dataset.id!);
     const [currentEpisode, setCurrentEpisode] = useState<number | null>(null);
+    const prevDatasetId = useRef(dataset.id);
+
+    if (prevDatasetId.current !== dataset.id) {
+        prevDatasetId.current = dataset.id;
+        setCurrentEpisode(null);
+    }
 
     if (episodes.length > 0 && currentEpisode === null) {
         setCurrentEpisode(episodes[0].episode_index);


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->

When for dataset A episode 10th is selected, we change dataset to B, episode 10th is still selected. This PR fixes that issue. The other issues mentioned in the ticket were fixed in https://github.com/open-edge-platform/physical-ai-studio/pull/1075.

Fix #1091 


## Related Issues

<!-- Fixes #123 -->
