### PR TITLE
feat: add contextual help to form fields

### DIFF
--- a/application/backend/src/robots/catalog/so101.py
+++ b/application/backend/src/robots/catalog/so101.py
@@ -42,11 +42,23 @@ class SO101RobotPayload(BaseModel):
     calibration: dict[str, SO101JointCalibration] | None = Field(  # pyrefly: ignore[no-matching-overload]
         default=None,
         description=(
-            "Optional per-joint calibration values (id, drive_mode, homing_offset, range_min, range_max). "
-            "When provided, Studio uses these values as-is: it does not overwrite calibration on the control board "
-            "and it skips the guided manual calibration flow."
+            "Provide SO101 calibration values. Studio uses these values as-is: it does not overwrite "
+            "calibration on the control board and it skips the guided manual calibration flow."
         ),
-        json_schema_extra=robot_field_ui({"advanced_configuration": True}),
+        json_schema_extra=robot_field_ui(
+            {
+                "advanced_configuration": True,
+                "info": {
+                    "title": "Calibration values",
+                    "description": (
+                        "Upload a calibration JSON exported for this SO101. If provided, Studio uses these "
+                        "values as-is, "
+                        "does not overwrite control-board calibration, and skips guided manual calibration."
+                    ),
+                    "variant": "help",
+                },
+            }
+        ),
     )
 
     model_config = ConfigDict(

--- a/application/plugin/src/physicalai_studio_plugin/ui_schema.py
+++ b/application/plugin/src/physicalai_studio_plugin/ui_schema.py
@@ -17,11 +17,21 @@ class RobotUiInfoItem(TypedDict, total=False):
     variant: NotRequired[Literal["info", "warning"]]
 
 
+class RobotUiContextualHelpInfo(TypedDict, total=False):
+    """Contextual help content rendered next to a field control."""
+
+    title: NotRequired[str]
+    description: Required[str]
+    link_url: NotRequired[str]
+    variant: NotRequired[Literal["info", "help"]]
+
+
 class RobotFieldUiOptions(TypedDict, total=False):
     """Per-field UI overrides understood by the Studio robot form."""
 
     required: bool
     advanced_configuration: bool
+    info: RobotUiContextualHelpInfo
 
 
 class RobotUiConnectionBinding(TypedDict, total=False):
@@ -37,6 +47,7 @@ class RobotUiConnectionItem(TypedDict, total=False):
     kind: Required[Literal["connection"]]
     label: NotRequired[str]
     description: NotRequired[str]
+    info: NotRequired[RobotUiContextualHelpInfo]
     device_discovery: NotRequired[bool]
     identify: NotRequired[bool]
     manual_entry: NotRequired[bool]
@@ -50,6 +61,7 @@ class RobotUiIpAddressItem(TypedDict, total=False):
     name: Required[str]
     label: NotRequired[str]
     description: NotRequired[str]
+    info: NotRequired[RobotUiContextualHelpInfo]
     identify: NotRequired[bool]
     identify_robot_type: NotRequired[str]
 
@@ -61,6 +73,7 @@ class RobotUiCalibrationItem(TypedDict, total=False):
     name: Required[str]
     label: NotRequired[str]
     description: NotRequired[str]
+    info: NotRequired[RobotUiContextualHelpInfo]
 
 
 class RobotUiFieldItem(TypedDict):
@@ -68,6 +81,7 @@ class RobotUiFieldItem(TypedDict):
 
     kind: Required[Literal["field"]]
     name: Required[str]
+    info: NotRequired[RobotUiContextualHelpInfo]
 
 
 class RobotUiSectionOptions(TypedDict, total=False):
@@ -136,6 +150,27 @@ def validate_robot_payload_ui(payload_model: type[BaseModel]) -> None:  # noqa: 
             return False
         return any(isinstance(variant, dict) and resolve(variant).get("type") == "object" for variant in variants)
 
+    def validate_info(info: object, path: str) -> None:
+        if not isinstance(info, dict):
+            error(path, "info must be an object")
+            return
+
+        description = info.get("description")
+        if not isinstance(description, str) or description == "":
+            error(path, "info.description must be a non-empty string")
+
+        title = info.get("title")
+        if title is not None and not isinstance(title, str):
+            error(path, "info.title must be a string")
+
+        link_url = info.get("link_url")
+        if link_url is not None and not isinstance(link_url, str):
+            error(path, "info.link_url must be a string")
+
+        variant = info.get("variant")
+        if variant is not None and variant not in {"info", "help"}:
+            error(path, "info.variant must be one of: info, help")
+
     def validate_items(  # noqa: C901, PLR0912, PLR0915
         items: list[object],
         properties: dict[str, Any],
@@ -170,6 +205,9 @@ def validate_robot_payload_ui(payload_model: type[BaseModel]) -> None:  # noqa: 
                 if not isinstance(name, str) or name not in properties:
                     error(item_path, "field items must reference an existing payload field")
                     continue
+                info = item.get("info")
+                if info is not None:
+                    validate_info(info, f"{item_path}.info")
                 if name in owned_fields:
                     error(item_path, f"field '{name}' is owned more than once")
                 owned_fields.add(name)
@@ -180,6 +218,9 @@ def validate_robot_payload_ui(payload_model: type[BaseModel]) -> None:  # noqa: 
                 if not isinstance(bindings, dict) or not isinstance(bindings.get("connection"), str):
                     error(item_path, "connection items require bind.connection")
                     continue
+                info = item.get("info")
+                if info is not None:
+                    validate_info(info, f"{item_path}.info")
                 for binding_name in ("connection", "serial_number"):
                     field_name = bindings.get(binding_name)
                     if field_name is None:
@@ -198,6 +239,9 @@ def validate_robot_payload_ui(payload_model: type[BaseModel]) -> None:  # noqa: 
                 if not isinstance(name, str) or name not in properties:
                     error(item_path, "ip_address items must reference an existing payload field")
                     continue
+                info = item.get("info")
+                if info is not None:
+                    validate_info(info, f"{item_path}.info")
                 if resolve(properties[name]).get("type") != "string":
                     error(item_path, "ip_address items must reference a string payload field")
                 if name in owned_fields:
@@ -210,6 +254,9 @@ def validate_robot_payload_ui(payload_model: type[BaseModel]) -> None:  # noqa: 
                 if not isinstance(name, str) or name not in properties:
                     error(item_path, "calibration items must reference an existing payload field")
                     continue
+                info = item.get("info")
+                if info is not None:
+                    validate_info(info, f"{item_path}.info")
                 if not is_object_field(properties[name]):
                     error(item_path, "calibration items must reference an object payload field")
                 if name in owned_fields:
@@ -234,6 +281,12 @@ def validate_robot_payload_ui(payload_model: type[BaseModel]) -> None:  # noqa: 
                 validate_items(ui, properties if isinstance(properties, dict) else {}, f"{path}.x-physicalai-ui")
         if isinstance(properties, dict):
             for field_name, field_schema in properties.items():
+                if isinstance(field_schema, dict):
+                    field_ui = field_schema.get("x-physicalai-ui")
+                    if isinstance(field_ui, dict):
+                        field_info = field_ui.get("info")
+                        if field_info is not None:
+                            validate_info(field_info, f"{path}.properties.{field_name}.x-physicalai-ui.info")
                 resolved = resolve(field_schema) if isinstance(field_schema, dict) else field_schema
                 if isinstance(resolved, dict) and isinstance(resolved.get("properties"), dict):
                     validate_model_schema(resolved, f"{path}.properties.{field_name}")

--- a/application/plugin/tests/test_contracts.py
+++ b/application/plugin/tests/test_contracts.py
@@ -201,6 +201,28 @@ def test_robot_field_ui_supports_advanced_configuration_option() -> None:
     }
 
 
+def test_robot_field_ui_supports_contextual_info() -> None:
+    assert robot_field_ui(
+        {
+            "info": {
+                "title": "Calibration file",
+                "description": "Provide a calibration JSON exported from the robot.",
+                "link_url": "https://example.com/calibration",
+                "variant": "help",
+            }
+        }
+    ) == {
+        "x-physicalai-ui": {
+            "info": {
+                "title": "Calibration file",
+                "description": "Provide a calibration JSON exported from the robot.",
+                "link_url": "https://example.com/calibration",
+                "variant": "help",
+            }
+        }
+    }
+
+
 def test_robot_payload_ui_supports_recursive_items() -> None:
     assert robot_payload_ui(
         [
@@ -279,6 +301,42 @@ def test_robot_payload_ui_supports_calibration_items() -> None:
     }
 
 
+def test_robot_payload_ui_supports_info_attribute_on_items() -> None:
+    assert robot_payload_ui(
+        [
+            {
+                "kind": "field",
+                "name": "connection_string",
+                "info": {
+                    "description": "Set the robot endpoint address.",
+                    "link_url": "https://example.com/network-setup",
+                },
+            },
+        ],
+    ) == {
+        "x-physicalai-ui": [
+            {
+                "kind": "field",
+                "name": "connection_string",
+                "info": {
+                    "description": "Set the robot endpoint address.",
+                    "link_url": "https://example.com/network-setup",
+                },
+            },
+        ],
+    }
+
+
+def test_validate_robot_payload_ui_accepts_field_level_info() -> None:
+    class Payload(BaseModel):
+        connection_string: str = Field(
+            default="",
+            json_schema_extra=robot_field_ui({"info": {"description": "Connection string for the robot."}}),
+        )
+
+    validate_robot_payload_ui(Payload)
+
+
 def test_validate_robot_payload_ui_accepts_nested_item_lists() -> None:
     class ConnectionPayload(BaseModel):
         connection_string: str
@@ -320,6 +378,21 @@ def test_validate_robot_payload_ui_ignores_field_options() -> None:
         ([{"kind": "ip_address", "name": "port"}], "must reference a string payload field"),
         ([{"kind": "calibration", "name": "missing"}], "must reference an existing payload field"),
         ([{"kind": "calibration", "name": "connection_string"}], "must reference an object payload field"),
+        ([{"kind": "field", "name": "connection_string", "info": "bad"}], "info must be an object"),
+        (
+            [{"kind": "field", "name": "connection_string", "info": {"title": "Info"}}],
+            "info.description must be a non-empty string",
+        ),
+        (
+            [
+                {
+                    "kind": "field",
+                    "name": "connection_string",
+                    "info": {"description": "text", "variant": "warning"},
+                }
+            ],
+            "info.variant must be one of: info, help",
+        ),
         (
             [
                 {"kind": "field", "name": "connection_string"},
@@ -352,4 +425,12 @@ def test_validate_robot_payload_ui_rejects_invalid_metadata(items: object, messa
         model_config = ConfigDict(json_schema_extra={"x-physicalai-ui": items})
 
     with pytest.raises(ValueError, match=message):
+        validate_robot_payload_ui(InvalidPayload)
+
+
+def test_validate_robot_payload_ui_rejects_invalid_field_info() -> None:
+    class InvalidPayload(BaseModel):
+        connection_string: str = Field(default="", json_schema_extra=robot_field_ui({"info": {"title": "Broken"}}))
+
+    with pytest.raises(ValueError, match="info.description must be a non-empty string"):
         validate_robot_payload_ui(InvalidPayload)

--- a/application/ui/src/features/robots/robot-form/robot-schema/components/calibration-field.test.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/components/calibration-field.test.tsx
@@ -149,4 +149,34 @@ describe('CalibrationField', () => {
 
         expect(onChange).toHaveBeenCalledWith({});
     });
+
+    it('renders contextual help and learn more link when info is provided', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <CalibrationField
+                label='Calibration'
+                description='Upload robot calibration values'
+                isRequired={false}
+                value={null}
+                valueSchema={jointCalibrationSchema}
+                info={{
+                    title: 'Calibration JSON',
+                    description: 'Use calibration exported from the control board tools.',
+                    link_url: 'https://example.com/calibration-docs',
+                    variant: 'help',
+                }}
+                onChange={() => undefined}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: /Help$/ }));
+
+        expect(await screen.findByRole('heading', { name: 'Calibration JSON' })).toBeVisible();
+        expect(screen.getByText('Use calibration exported from the control board tools.')).toBeVisible();
+        expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+            'href',
+            'https://example.com/calibration-docs'
+        );
+    });
 });

--- a/application/ui/src/features/robots/robot-form/robot-schema/components/calibration-field.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/components/calibration-field.tsx
@@ -5,11 +5,13 @@ import { Button, FileTrigger, Flex, Text, View } from '@geti-ui/ui';
 import { CalibrationTable } from '../../../calibration-table';
 import { InlineAlert } from '../../../setup-wizard/shared/inline-alert';
 import { asRecord, resolveReference } from '../schema-utils';
-import { FieldSchema } from '../types';
+import { ContextualInfo, FieldSchema } from '../types';
+import { FieldContextualHelp } from './field-contextual-help';
 
 type CalibrationFieldProps = {
     label: string;
     description?: string;
+    info?: ContextualInfo;
     value: unknown;
     isRequired: boolean;
     onChange: (value: unknown) => void;
@@ -98,6 +100,7 @@ export const validateCalibrationPayload = (
 export const CalibrationField = ({
     label,
     description,
+    info,
     value,
     isRequired,
     onChange,
@@ -135,15 +138,22 @@ export const CalibrationField = ({
 
     return (
         <Flex direction='column' gap='size-100'>
-            <Text
-                UNSAFE_style={{
-                    fontSize: 'var(--spectrum-global-dimension-font-size-100)',
-                    color: 'var(--spectrum-global-color-gray-800)',
-                }}
-            >
-                {label}
-                {isRequired ? ' *' : ' (optional)'}
-            </Text>
+            <Flex gap='size-100'>
+                <Text
+                    UNSAFE_style={{
+                        fontSize: 'var(--spectrum-global-dimension-font-size-100)',
+                        color: 'var(--spectrum-global-color-gray-700)',
+                    }}
+                >
+                    {label}
+                    {isRequired ? ' *' : ' (optional)'}
+                </Text>
+                {info !== undefined && (
+                    <View>
+                        <FieldContextualHelp info={info} />
+                    </View>
+                )}
+            </Flex>
             {description !== undefined && description !== '' && (
                 <Text
                     UNSAFE_style={{

--- a/application/ui/src/features/robots/robot-form/robot-schema/components/connection-field.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/components/connection-field.tsx
@@ -96,7 +96,9 @@ export const ConnectionField = ({ robotType, payload, options, isRequired, onCha
                 <ComboBoxField
                     label={options.label ?? 'Connection'}
                     description={options.description}
-                    contextualHelp={<FieldContextualHelp info={options.info} />}
+                    contextualHelp={
+                        options.info === undefined ? undefined : <FieldContextualHelp info={options.info} />
+                    }
                     value={value}
                     devices={discover.data ?? []}
                     allowsCustomValue={options.manual_entry !== false}

--- a/application/ui/src/features/robots/robot-form/robot-schema/components/connection-field.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/components/connection-field.tsx
@@ -1,9 +1,12 @@
+import { ReactNode } from 'react';
+
 import { ActionButton, ComboBox, Flex, Icon, Item, Text, View } from '@geti-ui/ui';
 import { Refresh } from '@geti-ui/ui/icons';
 
 import { useCatalogIdentifyMutation, useDiscoverRobotsQuery } from '../../../robot-catalog.hooks';
 import { SchemaRobotType } from '../../../robot-types';
 import { ConnectionItem } from '../types';
+import { FieldContextualHelp } from './field-contextual-help';
 import { IdentifyError } from './identify-error';
 
 type Device = { serial_number: string | null; connection_string: string | null };
@@ -15,6 +18,7 @@ type ComboBoxFieldProps = {
     allowsCustomValue: boolean;
     isRequired: boolean;
     description?: string;
+    contextualHelp?: ReactNode;
     onInputChange: (value: string) => void;
     onSelectionChange: (key: string | number | null) => void;
 };
@@ -37,12 +41,14 @@ const ComboBoxField = ({
     allowsCustomValue,
     isRequired,
     description,
+    contextualHelp,
     onInputChange,
     onSelectionChange,
 }: ComboBoxFieldProps) => (
     <ComboBox
         label={label}
         description={description}
+        contextualHelp={contextualHelp}
         isRequired={isRequired}
         width='100%'
         allowsCustomValue={allowsCustomValue}
@@ -90,6 +96,7 @@ export const ConnectionField = ({ robotType, payload, options, isRequired, onCha
                 <ComboBoxField
                     label={options.label ?? 'Connection'}
                     description={options.description}
+                    contextualHelp={<FieldContextualHelp info={options.info} />}
                     value={value}
                     devices={discover.data ?? []}
                     allowsCustomValue={options.manual_entry !== false}

--- a/application/ui/src/features/robots/robot-form/robot-schema/components/field-contextual-help.test.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/components/field-contextual-help.test.tsx
@@ -1,0 +1,58 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { render } from '../../../../../test-utils/render';
+import { FieldContextualHelp } from './field-contextual-help';
+
+describe('FieldContextualHelp', () => {
+    it('renders nothing when info is not provided', () => {
+        render(<FieldContextualHelp />);
+
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders help content with title and description', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <FieldContextualHelp
+                info={{
+                    title: 'Calibration guidance',
+                    description: 'Upload the calibration values exported from your control board.',
+                    variant: 'help',
+                }}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: /Help$/ }));
+
+        expect(await screen.findByRole('heading', { name: 'Calibration guidance' })).toBeVisible();
+        expect(screen.getByText('Upload the calibration values exported from your control board.')).toBeVisible();
+    });
+
+    it('renders a Learn more link when link_url is set', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <FieldContextualHelp
+                info={{
+                    title: 'Robot plugin docs',
+                    description: 'Read the plugin documentation for payload and calibration details.',
+                    link_url: 'https://github.com/open-edge-platform/physical-ai-studio/tree/main/application/docs',
+                    variant: 'info',
+                }}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: /Information$/ }));
+
+        const learnMore = await screen.findByRole('link', { name: 'Learn more' });
+        expect(learnMore).toHaveAttribute(
+            'href',
+            'https://github.com/open-edge-platform/physical-ai-studio/tree/main/application/docs'
+        );
+        expect(learnMore).toHaveAttribute('target', '_blank');
+        expect(learnMore).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+});

--- a/application/ui/src/features/robots/robot-form/robot-schema/components/field-contextual-help.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/components/field-contextual-help.tsx
@@ -8,7 +8,7 @@ type FieldContextualHelpProps = {
 
 export const FieldContextualHelp = ({ info }: FieldContextualHelpProps) => {
     if (info === undefined) {
-        return undefined;
+        return null;
     }
 
     return (

--- a/application/ui/src/features/robots/robot-form/robot-schema/components/field-contextual-help.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/components/field-contextual-help.tsx
@@ -1,0 +1,29 @@
+import { Content, ContextualHelp, Footer, Heading, Link, Text } from '@geti-ui/ui';
+
+import { ContextualInfo } from '../types';
+
+type FieldContextualHelpProps = {
+    info?: ContextualInfo;
+};
+
+export const FieldContextualHelp = ({ info }: FieldContextualHelpProps) => {
+    if (info === undefined) {
+        return undefined;
+    }
+
+    return (
+        <ContextualHelp variant={info.variant ?? 'info'}>
+            {info.title !== undefined && info.title !== '' && <Heading>{info.title}</Heading>}
+            <Content>
+                <Text>{info.description}</Text>
+            </Content>
+            {info.link_url !== undefined && info.link_url !== '' && (
+                <Footer>
+                    <Link href={info.link_url} target='_blank' rel='noopener noreferrer'>
+                        Learn more
+                    </Link>
+                </Footer>
+            )}
+        </ContextualHelp>
+    );
+};

--- a/application/ui/src/features/robots/robot-form/robot-schema/components/ip-address-field.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/components/ip-address-field.tsx
@@ -3,6 +3,7 @@ import { ActionButton, Flex, TextField, View } from '@geti-ui/ui';
 import { useCatalogIdentifyMutation } from '../../../robot-catalog.hooks';
 import { SchemaRobotType } from '../../../robot-types';
 import { IpAddressItem } from '../types';
+import { FieldContextualHelp } from './field-contextual-help';
 import { IdentifyError } from './identify-error';
 
 type IpAddressFieldProps = {
@@ -30,6 +31,7 @@ export const IpAddressField = ({ robotType, payload, options, isRequired, onChan
                     isRequired={isRequired}
                     label={options.label ?? 'IP address'}
                     description={options.description}
+                    contextualHelp={<FieldContextualHelp info={options.info} />}
                     width='100%'
                     value={value}
                     onChange={(next) => onChange(options.name, next)}

--- a/application/ui/src/features/robots/robot-form/robot-schema/components/ip-address-field.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/components/ip-address-field.tsx
@@ -31,7 +31,9 @@ export const IpAddressField = ({ robotType, payload, options, isRequired, onChan
                     isRequired={isRequired}
                     label={options.label ?? 'IP address'}
                     description={options.description}
-                    contextualHelp={<FieldContextualHelp info={options.info} />}
+                    contextualHelp={
+                        options.info === undefined ? undefined : <FieldContextualHelp info={options.info} />
+                    }
                     width='100%'
                     value={value}
                     onChange={(next) => onChange(options.name, next)}

--- a/application/ui/src/features/robots/robot-form/robot-schema/schema-field.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/schema-field.tsx
@@ -1,26 +1,38 @@
 import { Flex, Item, Picker, Switch, Text, TextField } from '@geti-ui/ui';
 
+import { FieldContextualHelp } from './components/field-contextual-help';
 import { fieldLabel } from './schema-utils';
-import { FieldSchema } from './types';
+import { ContextualInfo, FieldSchema } from './types';
 
 type FieldProps = {
     name: string;
     schema: FieldSchema;
     value: unknown;
     isRequired: boolean;
+    info?: ContextualInfo;
     onChange: (value: unknown) => void;
 };
 
-const commonProps = ({ name, schema, isRequired }: Pick<FieldProps, 'name' | 'schema' | 'isRequired'>) => ({
+const commonProps = ({
+    name,
+    schema,
+    isRequired,
+    info,
+}: Pick<FieldProps, 'name' | 'schema' | 'isRequired' | 'info'>) => ({
     label: fieldLabel(name, schema),
     description: schema.description,
+    contextualHelp: (
+        <FieldContextualHelp
+            info={info ?? (!Array.isArray(schema['x-physicalai-ui']) ? schema['x-physicalai-ui']?.info : undefined)}
+        />
+    ),
     isRequired,
     width: '100%' as const,
 });
 
-const EnumPickerField = ({ name, schema, value, isRequired, onChange }: FieldProps) => (
+const EnumPickerField = ({ name, schema, value, isRequired, onChange, info }: FieldProps) => (
     <Picker
-        {...commonProps({ name, schema, isRequired })}
+        {...commonProps({ name, schema, isRequired, info })}
         selectedKey={String(value ?? '')}
         onSelectionChange={onChange}
     >
@@ -30,16 +42,21 @@ const EnumPickerField = ({ name, schema, value, isRequired, onChange }: FieldPro
     </Picker>
 );
 
-const BooleanField = ({ name, schema, value, isRequired, onChange }: FieldProps) => (
+const BooleanField = ({ name, schema, value, isRequired, onChange, info }: FieldProps) => (
     <Flex direction='column' gap='size-50'>
-        <Switch isRequired={isRequired} isSelected={Boolean(value)} onChange={onChange}>
-            {fieldLabel(name, schema)}
-        </Switch>
+        <Flex alignItems='center' gap='size-75'>
+            <Switch isRequired={isRequired} isSelected={Boolean(value)} onChange={onChange}>
+                {fieldLabel(name, schema)}
+            </Switch>
+            <FieldContextualHelp
+                info={info ?? (!Array.isArray(schema['x-physicalai-ui']) ? schema['x-physicalai-ui']?.info : undefined)}
+            />
+        </Flex>
         {schema.description !== undefined && schema.description !== '' && <Text>{schema.description}</Text>}
     </Flex>
 );
 
-const TextFieldValue = ({ name, schema, value, isRequired, onChange }: FieldProps) => {
+const TextFieldValue = ({ name, schema, value, isRequired, onChange, info }: FieldProps) => {
     const isNumeric = schema.type === 'integer' || schema.type === 'number';
 
     const parseValue = (next: string): unknown => {
@@ -53,7 +70,7 @@ const TextFieldValue = ({ name, schema, value, isRequired, onChange }: FieldProp
 
     return (
         <TextField
-            {...commonProps({ name, schema, isRequired })}
+            {...commonProps({ name, schema, isRequired, info })}
             type={isNumeric ? 'number' : 'text'}
             value={value === undefined || value === null ? '' : String(value)}
             onChange={(next) => onChange(parseValue(next))}

--- a/application/ui/src/features/robots/robot-form/robot-schema/schema-field.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/schema-field.tsx
@@ -1,7 +1,7 @@
 import { Flex, Item, Picker, Switch, Text, TextField } from '@geti-ui/ui';
 
 import { FieldContextualHelp } from './components/field-contextual-help';
-import { fieldLabel } from './schema-utils';
+import { fieldContextualInfo, fieldLabel } from './schema-utils';
 import { ContextualInfo, FieldSchema } from './types';
 
 type FieldProps = {
@@ -18,17 +18,17 @@ const commonProps = ({
     schema,
     isRequired,
     info,
-}: Pick<FieldProps, 'name' | 'schema' | 'isRequired' | 'info'>) => ({
-    label: fieldLabel(name, schema),
-    description: schema.description,
-    contextualHelp: (
-        <FieldContextualHelp
-            info={info ?? (!Array.isArray(schema['x-physicalai-ui']) ? schema['x-physicalai-ui']?.info : undefined)}
-        />
-    ),
-    isRequired,
-    width: '100%' as const,
-});
+}: Pick<FieldProps, 'name' | 'schema' | 'isRequired' | 'info'>) => {
+    const contextualInfo = info ?? fieldContextualInfo(schema);
+
+    return {
+        label: fieldLabel(name, schema),
+        description: schema.description,
+        contextualHelp: contextualInfo === undefined ? undefined : <FieldContextualHelp info={contextualInfo} />,
+        isRequired,
+        width: '100%' as const,
+    };
+};
 
 const EnumPickerField = ({ name, schema, value, isRequired, onChange, info }: FieldProps) => (
     <Picker
@@ -42,19 +42,21 @@ const EnumPickerField = ({ name, schema, value, isRequired, onChange, info }: Fi
     </Picker>
 );
 
-const BooleanField = ({ name, schema, value, isRequired, onChange, info }: FieldProps) => (
-    <Flex direction='column' gap='size-50'>
-        <Flex alignItems='center' gap='size-75'>
-            <Switch isRequired={isRequired} isSelected={Boolean(value)} onChange={onChange}>
-                {fieldLabel(name, schema)}
-            </Switch>
-            <FieldContextualHelp
-                info={info ?? (!Array.isArray(schema['x-physicalai-ui']) ? schema['x-physicalai-ui']?.info : undefined)}
-            />
+const BooleanField = ({ name, schema, value, isRequired, onChange, info }: FieldProps) => {
+    const contextualInfo = info ?? fieldContextualInfo(schema);
+
+    return (
+        <Flex direction='column' gap='size-50'>
+            <Flex alignItems='center' gap='size-75'>
+                <Switch isRequired={isRequired} isSelected={Boolean(value)} onChange={onChange}>
+                    {fieldLabel(name, schema)}
+                </Switch>
+                {contextualInfo === undefined ? null : <FieldContextualHelp info={contextualInfo} />}
+            </Flex>
+            {schema.description !== undefined && schema.description !== '' && <Text>{schema.description}</Text>}
         </Flex>
-        {schema.description !== undefined && schema.description !== '' && <Text>{schema.description}</Text>}
-    </Flex>
-);
+    );
+};
 
 const TextFieldValue = ({ name, schema, value, isRequired, onChange, info }: FieldProps) => {
     const isNumeric = schema.type === 'integer' || schema.type === 'number';

--- a/application/ui/src/features/robots/robot-form/robot-schema/schema-form.test.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/schema-form.test.tsx
@@ -905,6 +905,82 @@ describe('SchemaForm', () => {
         expect(rows[3]).toHaveTextContent('wrist_flex');
     });
 
+    it('renders contextual help from field-level info metadata', async () => {
+        const schema: Parameters<typeof SchemaForm>[0]['schema'] = {
+            type: 'object',
+            properties: {
+                connection_string: {
+                    type: 'string',
+                    title: 'Connection String',
+                    'x-physicalai-ui': {
+                        info: {
+                            title: 'Connection setup',
+                            description: 'Use the full serial device path for manual setup.',
+                            link_url: 'https://example.com/serial-setup',
+                            variant: 'help',
+                        },
+                    },
+                },
+            },
+        };
+        const user = userEvent.setup();
+
+        render(
+            <RobotFormProvider>
+                <SchemaForm schema={schema} />
+            </RobotFormProvider>
+        );
+
+        await user.click(screen.getByRole('button', { name: /Help$/ }));
+
+        expect(await screen.findByRole('heading', { name: 'Connection setup' })).toBeVisible();
+        expect(screen.getByText('Use the full serial device path for manual setup.')).toBeVisible();
+        expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+            'href',
+            'https://example.com/serial-setup'
+        );
+    });
+
+    it('prefers item-level contextual help over field-level info metadata', async () => {
+        const schema: Parameters<typeof SchemaForm>[0]['schema'] = {
+            type: 'object',
+            properties: {
+                connection_string: {
+                    type: 'string',
+                    title: 'Connection String',
+                    'x-physicalai-ui': {
+                        info: {
+                            description: 'Field-level help text',
+                        },
+                    },
+                },
+            },
+            'x-physicalai-ui': [
+                {
+                    kind: 'field',
+                    name: 'connection_string',
+                    info: {
+                        title: 'Connection details',
+                        description: 'Item-level help text',
+                    },
+                },
+            ],
+        };
+        const user = userEvent.setup();
+
+        render(
+            <RobotFormProvider>
+                <SchemaForm schema={schema} />
+            </RobotFormProvider>
+        );
+
+        await user.click(screen.getByRole('button', { name: /Information$/ }));
+
+        expect(await screen.findByRole('heading', { name: 'Connection details' })).toBeVisible();
+        expect(screen.getByText('Item-level help text')).toBeVisible();
+        expect(screen.queryByText('Field-level help text')).not.toBeInTheDocument();
+    });
+
     it('keeps advanced configuration fields hidden when the toggle is hidden', () => {
         const schema: Parameters<typeof SchemaForm>[0]['schema'] = {
             type: 'object',

--- a/application/ui/src/features/robots/robot-form/robot-schema/schema-form.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/schema-form.tsx
@@ -19,7 +19,7 @@ import {
     schemaDefaults,
     updateObjectField,
 } from './schema-utils';
-import { FieldSchema, JsonSchema, ModelUiOptions, RobotUiItem } from './types';
+import { ContextualInfo, FieldSchema, JsonSchema, ModelUiOptions, RobotUiItem } from './types';
 
 const EMPTY_ITEMS: RobotUiItem[] = [];
 
@@ -76,6 +76,7 @@ type SchemaFormItemsProps = {
 type SchemaFormFieldProps = Omit<SchemaFormItemsProps, 'items' | 'renderUnownedFields'> & {
     name: string;
     field: FieldSchema;
+    info?: ContextualInfo;
 };
 
 const getResolvedField = ({ properties, definitions }: SchemaFormItemsProps, name: string) => {
@@ -95,11 +96,12 @@ const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
         if (field === undefined) {
             return null;
         }
+        const fieldInfo = !isUiItems(field['x-physicalai-ui']) ? field['x-physicalai-ui']?.info : undefined;
         return (
             <ConnectionField
                 robotType={props.robotType}
                 payload={props.values}
-                options={item}
+                options={{ ...item, info: item.info ?? fieldInfo }}
                 isRequired={isRequiredField(item.bind.connection, field, props.required)}
                 onChange={props.onChange}
             />
@@ -110,11 +112,12 @@ const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
         if (field === undefined) {
             return null;
         }
+        const fieldInfo = !isUiItems(field['x-physicalai-ui']) ? field['x-physicalai-ui']?.info : undefined;
         return (
             <IpAddressField
                 robotType={props.robotType}
                 payload={props.values}
-                options={item}
+                options={{ ...item, info: item.info ?? fieldInfo }}
                 isRequired={isRequiredField(item.name, field, props.required)}
                 onChange={props.onChange}
             />
@@ -133,6 +136,7 @@ const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
             <CalibrationField
                 label={item.label ?? fieldLabel(item.name, field)}
                 description={item.description ?? field.description}
+                info={item.info ?? (!isUiItems(field['x-physicalai-ui']) ? field['x-physicalai-ui']?.info : undefined)}
                 isRequired={isRequiredField(item.name, field, props.required)}
                 value={props.values[item.name]}
                 valueSchema={asFieldSchema(field.additionalProperties)}
@@ -143,7 +147,9 @@ const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
     }
     if (item.kind === 'field') {
         const field = props.properties[item.name];
-        return field === undefined ? null : <SchemaFormField {...props} name={item.name} field={field} />;
+        return field === undefined ? null : (
+            <SchemaFormField {...props} name={item.name} field={field} info={item.info} />
+        );
     }
     if (!props.isRenderable(item, props.properties, props.required)) {
         return null;
@@ -222,6 +228,7 @@ const SchemaFormField = ({ name, field, ...props }: SchemaFormFieldProps) => {
         <SchemaField
             name={name}
             schema={resolvedField}
+            info={props.info ?? (!isUiItems(fieldUi) ? fieldUi?.info : undefined)}
             value={props.values[name]}
             isRequired={isRequired}
             onChange={(value) => props.onChange(name, value)}

--- a/application/ui/src/features/robots/robot-form/robot-schema/schema-form.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/schema-form.tsx
@@ -13,6 +13,7 @@ import {
     asRecord,
     EMPTY_DEFINITIONS,
     EMPTY_PROPERTIES,
+    fieldContextualInfo,
     fieldLabel,
     isRequiredField,
     resolveReference,
@@ -96,12 +97,11 @@ const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
         if (field === undefined) {
             return null;
         }
-        const fieldInfo = !isUiItems(field['x-physicalai-ui']) ? field['x-physicalai-ui']?.info : undefined;
         return (
             <ConnectionField
                 robotType={props.robotType}
                 payload={props.values}
-                options={{ ...item, info: item.info ?? fieldInfo }}
+                options={{ ...item, info: item.info ?? fieldContextualInfo(field) }}
                 isRequired={isRequiredField(item.bind.connection, field, props.required)}
                 onChange={props.onChange}
             />
@@ -112,12 +112,11 @@ const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
         if (field === undefined) {
             return null;
         }
-        const fieldInfo = !isUiItems(field['x-physicalai-ui']) ? field['x-physicalai-ui']?.info : undefined;
         return (
             <IpAddressField
                 robotType={props.robotType}
                 payload={props.values}
-                options={{ ...item, info: item.info ?? fieldInfo }}
+                options={{ ...item, info: item.info ?? fieldContextualInfo(field) }}
                 isRequired={isRequiredField(item.name, field, props.required)}
                 onChange={props.onChange}
             />
@@ -136,7 +135,7 @@ const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
             <CalibrationField
                 label={item.label ?? fieldLabel(item.name, field)}
                 description={item.description ?? field.description}
-                info={item.info ?? (!isUiItems(field['x-physicalai-ui']) ? field['x-physicalai-ui']?.info : undefined)}
+                info={item.info ?? fieldContextualInfo(field)}
                 isRequired={isRequiredField(item.name, field, props.required)}
                 value={props.values[item.name]}
                 valueSchema={asFieldSchema(field.additionalProperties)}
@@ -228,7 +227,7 @@ const SchemaFormField = ({ name, field, ...props }: SchemaFormFieldProps) => {
         <SchemaField
             name={name}
             schema={resolvedField}
-            info={props.info ?? (!isUiItems(fieldUi) ? fieldUi?.info : undefined)}
+            info={props.info ?? fieldContextualInfo(resolvedField)}
             value={props.values[name]}
             isRequired={isRequired}
             onChange={(value) => props.onChange(name, value)}

--- a/application/ui/src/features/robots/robot-form/robot-schema/schema-utils.ts
+++ b/application/ui/src/features/robots/robot-form/robot-schema/schema-utils.ts
@@ -1,4 +1,4 @@
-import { FieldSchema } from './types';
+import { ContextualInfo, FieldSchema } from './types';
 
 export const EMPTY_PROPERTIES: Record<string, FieldSchema> = {};
 export const EMPTY_DEFINITIONS: Record<string, FieldSchema> = {};
@@ -22,6 +22,11 @@ export const resolveReference = (schema: FieldSchema, definitions: Record<string
 export const isRequiredField = (name: string, schema: FieldSchema, required: Set<string>) => {
     const uiOptions = schema['x-physicalai-ui'];
     return required.has(name) || (!Array.isArray(uiOptions) && uiOptions?.required === true);
+};
+
+export const fieldContextualInfo = (schema: FieldSchema): ContextualInfo | undefined => {
+    const uiOptions = schema['x-physicalai-ui'];
+    return Array.isArray(uiOptions) ? undefined : uiOptions?.info;
 };
 
 const schemaDefault = (schema: FieldSchema, definitions: Record<string, FieldSchema>): unknown => {

--- a/application/ui/src/features/robots/robot-form/robot-schema/types.ts
+++ b/application/ui/src/features/robots/robot-form/robot-schema/types.ts
@@ -7,6 +7,13 @@ export type InfoItem = {
     variant?: 'info' | 'warning';
 };
 
+export type ContextualInfo = {
+    title?: string;
+    description: string;
+    link_url?: string;
+    variant?: 'info' | 'help';
+};
+
 export type RobotUiConnectionBinding = {
     connection: string;
     serial_number?: string;
@@ -16,6 +23,7 @@ export type ConnectionItem = {
     kind: 'connection';
     label?: string;
     description?: string;
+    info?: ContextualInfo;
     device_discovery?: boolean;
     identify?: boolean;
     manual_entry?: boolean;
@@ -27,6 +35,7 @@ export type IpAddressItem = {
     name: string;
     label?: string;
     description?: string;
+    info?: ContextualInfo;
     identify?: boolean;
     identify_robot_type?: SchemaRobotType;
 };
@@ -36,11 +45,13 @@ export type CalibrationItem = {
     name: string;
     label?: string;
     description?: string;
+    info?: ContextualInfo;
 };
 
 export type FieldItem = {
     kind: 'field';
     name: string;
+    info?: ContextualInfo;
 };
 
 export type SectionItem = {
@@ -56,6 +67,7 @@ export type RobotUiItem = InfoItem | ConnectionItem | IpAddressItem | Calibratio
 export type FieldOptions = {
     required?: boolean;
     advanced_configuration?: boolean;
+    info?: ContextualInfo;
 };
 
 export type ModelUiOptions = RobotUiItem[];


### PR DESCRIPTION
Add a new `info` attribute that can be added to a plugin's schema, for instance we can add the contextual help that's shown in the screenshot below by adding,
```python
    calibration: dict[str, SO101JointCalibration] | None = Field(
        default=None,
        description=(
            "Provide SO101 calibration values. Studio uses these values as-is: it does not overwrite calibration on the control board and it skips the guided manual calibration flow."
        ),
        json_schema_extra=robot_field_ui(
            {
                "advanced_configuration": True,
                "info": {
                    "title": "Calibration values",
                    "description": (
                        "Upload a calibration JSON exported for this SO101. If provided, Studio uses these values as-is, "
                        "does not overwrite control-board calibration, and skips guided manual calibration."
                    ),
                    "link_url": "https://github.com/open-edge-platform/physical-ai-studio/tree/main/application/docs/calibration.md",
                    "variant": "help",
                },
            }
        ),
    )
```

To a robot's schema. This way we can keep the actual description small and include more info and even a docs link (removed in this PR, we need to update our docs first..) where users may find more info.

<img width="1279" height="719" alt="localhost_3000_projects_6480d24b-d339-45df-8fdb-fd2693351228_robots_new(720P) (2)" src="https://github.com/user-attachments/assets/3cc69106-6cc0-47c9-944b-683895ab0ff8" />
