### PR TITLE
feat: show advanced configuration options in robot forms

### DIFF
--- a/application/ui/src/features/robots/robot-form/robot-schema/schema-form.module.css
+++ b/application/ui/src/features/robots/robot-form/robot-schema/schema-form.module.css
@@ -1,0 +1,20 @@
+.advancedDisclosure {
+    padding: 0;
+    margin: 8px 0;
+    --spectrum-accordion-icon-gap: var(--spectrum-global-dimension-size-100);
+    --spectrum-accordion-item-padding: var(--spectrum-global-dimension-size-50);
+}
+
+.advancedDisclosureTitle {
+    padding: 2px 0;
+}
+
+.advancedDisclosureText {
+    font-size: 13px;
+}
+
+.advancedDisclosurePanel {
+    padding: 0;
+
+    margin-top: var(--spectrum-global-dimension-size-50);
+}

--- a/application/ui/src/features/robots/robot-form/robot-schema/schema-form.test.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/schema-form.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
@@ -628,7 +628,8 @@ describe('SchemaForm', () => {
         expect(screen.queryByRole('textbox', { name: 'Cameras' })).not.toBeInTheDocument();
     });
 
-    it('renders connection pickers from referenced nested object schemas', () => {
+    it('renders connection pickers from referenced nested object schemas with per-section advanced controls', async () => {
+        const user = userEvent.setup();
         render(
             <RobotFormProvider>
                 <SchemaForm schema={bimanualRebotSchema} />
@@ -638,12 +639,25 @@ describe('SchemaForm', () => {
 
         expect(screen.getByRole('heading', { name: 'Left Arm Config' })).toBeVisible();
         expect(screen.getByRole('heading', { name: 'Right Arm Config' })).toBeVisible();
-        expect(screen.queryByRole('switch', { name: 'Show advanced options' })).not.toBeInTheDocument();
+        expect(screen.getAllByRole('button', { name: 'Advanced options' })).toHaveLength(2);
         expect(screen.queryAllByRole('textbox', { name: 'Can Adapter' })).toHaveLength(0);
         expect(screen.getAllByRole('button', { name: /Select robot/ })).toHaveLength(2);
+
+        const leftArmSection = screen.getByRole('heading', { name: 'Left Arm Config' }).parentElement;
+        expect(leftArmSection).not.toBeNull();
+        if (leftArmSection === null) {
+            throw new Error('Expected left arm section container to be present.');
+        }
+        const leftArmAdvancedButtons = within(leftArmSection).getAllByRole('button', { name: 'Advanced options' });
+
+        await user.click(leftArmAdvancedButtons[leftArmAdvancedButtons.length - 1]);
+
+        expect(screen.getAllByRole('textbox', { name: 'Can Adapter' })).toHaveLength(1);
+        expect(leftArmAdvancedButtons[leftArmAdvancedButtons.length - 1]).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getAllByRole('button', { name: 'Advanced options' })).toHaveLength(2);
     });
 
-    it('hides a section when all of its fields are advanced configuration fields', () => {
+    it('keeps a section visible and gates advanced-only fields behind section control', async () => {
         const schema: Parameters<typeof SchemaForm>[0]['schema'] = {
             type: 'object',
             properties: {
@@ -670,6 +684,7 @@ describe('SchemaForm', () => {
                 },
             ],
         };
+        const user = userEvent.setup();
 
         render(
             <RobotFormProvider>
@@ -677,7 +692,16 @@ describe('SchemaForm', () => {
             </RobotFormProvider>
         );
 
-        expect(screen.queryByRole('heading', { name: 'Calibration' })).not.toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Calibration' })).toBeVisible();
+        const advancedButton = screen.getByRole('button', { name: 'Advanced options' });
+        expect(advancedButton).toBeVisible();
+        expect(advancedButton).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByRole('spinbutton', { name: 'Offset' })).not.toBeInTheDocument();
+
+        await user.click(advancedButton);
+
+        expect(advancedButton).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByRole('spinbutton', { name: 'Offset' })).toBeVisible();
     });
 
     it('renders defaulted fields unless they are advanced configuration fields', () => {
@@ -840,6 +864,7 @@ describe('SchemaForm', () => {
             </RobotFormProvider>
         );
 
+        expect(screen.getByRole('button', { name: 'Advanced options' })).toBeVisible();
         expect(screen.queryByRole('button', { name: 'Upload calibration JSON' })).not.toBeInTheDocument();
     });
 
@@ -981,7 +1006,7 @@ describe('SchemaForm', () => {
         expect(screen.queryByText('Field-level help text')).not.toBeInTheDocument();
     });
 
-    it('keeps advanced configuration fields hidden when the toggle is hidden', () => {
+    it('hides advanced configuration fields until show advanced is pressed in the current scope', async () => {
         const schema: Parameters<typeof SchemaForm>[0]['schema'] = {
             type: 'object',
             properties: {
@@ -994,6 +1019,7 @@ describe('SchemaForm', () => {
                 },
             },
         };
+        const user = userEvent.setup();
 
         render(
             <RobotFormProvider>
@@ -1002,8 +1028,86 @@ describe('SchemaForm', () => {
         );
 
         expect(screen.getByRole('textbox', { name: 'Connection String' })).toBeVisible();
-        expect(screen.queryByRole('switch', { name: 'Show advanced options' })).not.toBeInTheDocument();
+        const advancedButton = screen.getByRole('button', { name: 'Advanced options' });
+        expect(advancedButton).toBeVisible();
+        expect(advancedButton).toHaveAttribute('aria-expanded', 'false');
         expect(screen.queryByRole('switch', { name: 'Use ROS' })).not.toBeInTheDocument();
+
+        await user.click(advancedButton);
+
+        expect(advancedButton).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByRole('switch', { name: 'Use ROS' })).toBeVisible();
+    });
+
+    it('keeps nested section advanced visibility independent from parent section state', async () => {
+        const schema: Parameters<typeof SchemaForm>[0]['schema'] = {
+            type: 'object',
+            properties: {
+                connection_string: { type: 'string', title: 'Connection String' },
+                parent_advanced: {
+                    type: 'string',
+                    title: 'Parent Advanced',
+                    'x-physicalai-ui': { advanced_configuration: true },
+                },
+                child_advanced: {
+                    type: 'string',
+                    title: 'Child Advanced',
+                    'x-physicalai-ui': { advanced_configuration: true },
+                },
+            },
+            'x-physicalai-ui': [
+                {
+                    kind: 'section',
+                    id: 'parent',
+                    title: 'Parent',
+                    items: [
+                        { kind: 'field', name: 'connection_string' },
+                        { kind: 'field', name: 'parent_advanced' },
+                        {
+                            kind: 'section',
+                            id: 'child',
+                            title: 'Child',
+                            items: [{ kind: 'field', name: 'child_advanced' }],
+                        },
+                    ],
+                },
+            ],
+        };
+        const user = userEvent.setup();
+
+        render(
+            <RobotFormProvider>
+                <SchemaForm schema={schema} />
+            </RobotFormProvider>
+        );
+
+        expect(screen.getByRole('heading', { name: 'Parent' })).toBeVisible();
+        expect(screen.getByRole('heading', { name: 'Child' })).toBeVisible();
+        expect(screen.getAllByRole('button', { name: 'Advanced options' })).toHaveLength(2);
+        expect(screen.queryByRole('textbox', { name: 'Parent Advanced' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('textbox', { name: 'Child Advanced' })).not.toBeInTheDocument();
+
+        const parentSection = screen.getByRole('heading', { name: 'Parent' }).parentElement;
+        expect(parentSection).not.toBeNull();
+        if (parentSection === null) {
+            throw new Error('Expected parent section container to be present.');
+        }
+        const parentAdvancedButtons = within(parentSection).getAllByRole('button', { name: 'Advanced options' });
+
+        await user.click(parentAdvancedButtons[parentAdvancedButtons.length - 1]);
+
+        expect(screen.getByRole('textbox', { name: 'Parent Advanced' })).toBeVisible();
+        expect(screen.queryByRole('textbox', { name: 'Child Advanced' })).not.toBeInTheDocument();
+
+        const childSection = screen.getByRole('heading', { name: 'Child' }).parentElement;
+        expect(childSection).not.toBeNull();
+        if (childSection === null) {
+            throw new Error('Expected child section container to be present.');
+        }
+
+        await user.click(within(childSection).getByRole('button', { name: 'Advanced options' }));
+
+        expect(screen.getByRole('textbox', { name: 'Child Advanced' })).toBeVisible();
     });
 
     it('keeps advanced configuration field defaults in the payload', () => {

--- a/application/ui/src/features/robots/robot-form/robot-schema/schema-form.tsx
+++ b/application/ui/src/features/robots/robot-form/robot-schema/schema-form.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect } from 'react';
 
-import { Flex, Heading, Switch, Text, View } from '@geti-ui/ui';
+import { Disclosure, DisclosurePanel, DisclosureTitle, Flex, Heading, Text, View } from '@geti-ui/ui';
+import { partition } from 'lodash-es';
 
 import { SchemaRobotType } from '../../robot-types';
 import { useRobotForm } from '../provider';
@@ -21,6 +22,8 @@ import {
     updateObjectField,
 } from './schema-utils';
 import { ContextualInfo, FieldSchema, JsonSchema, ModelUiOptions, RobotUiItem } from './types';
+
+import classes from './schema-form.module.css';
 
 const EMPTY_ITEMS: RobotUiItem[] = [];
 
@@ -52,12 +55,23 @@ const fieldNamesOwnedByItems = (items: RobotUiItem[]): Set<string> =>
     );
 
 type OnChange = (name: string, value: unknown) => void;
-type IsFieldVisible = (name: string, field: FieldSchema, required: Set<string>) => boolean;
-type IsFieldEnabled = (name: string, field: FieldSchema, required: Set<string>) => boolean;
-type IsRenderable = (item: RobotUiItem, properties: Record<string, FieldSchema>, required: Set<string>) => boolean;
+type IsFieldVisible = (name: string, field: FieldSchema, required: Set<string>, showAdvanced: boolean) => boolean;
+type IsFieldEnabled = (name: string, field: FieldSchema, required: Set<string>, showAdvanced: boolean) => boolean;
+type IsRenderable = (
+    item: RobotUiItem,
+    properties: Record<string, FieldSchema>,
+    required: Set<string>,
+    showAdvanced: boolean
+) => boolean;
+
+type ItemEntry = {
+    item: RobotUiItem;
+    index: number;
+};
 
 type SchemaFormItemProps = SchemaFormItemsProps & {
     item: RobotUiItem;
+    showAdvanced: boolean;
 };
 
 type SchemaFormItemsProps = {
@@ -78,6 +92,17 @@ type SchemaFormFieldProps = Omit<SchemaFormItemsProps, 'items' | 'renderUnownedF
     name: string;
     field: FieldSchema;
     info?: ContextualInfo;
+    showAdvanced: boolean;
+};
+
+type SchemaFormItemListProps = SchemaFormItemsProps & {
+    entries: ItemEntry[];
+    showAdvanced: boolean;
+};
+
+type SchemaFormUnownedFieldListProps = Omit<SchemaFormItemsProps, 'items' | 'renderUnownedFields'> & {
+    fields: [string, FieldSchema][];
+    showAdvanced: boolean;
 };
 
 const getResolvedField = ({ properties, definitions }: SchemaFormItemsProps, name: string) => {
@@ -87,6 +112,42 @@ const getResolvedField = ({ properties, definitions }: SchemaFormItemsProps, nam
 
 const asFieldSchema = (value: FieldSchema | boolean | undefined): FieldSchema | undefined =>
     typeof value === 'object' && value !== null && !Array.isArray(value) ? value : undefined;
+
+const AdvancedOptions = ({ children }: { children: ReactNode }) => (
+    <Disclosure isQuiet UNSAFE_className={classes.advancedDisclosure}>
+        <DisclosureTitle UNSAFE_className={classes.advancedDisclosureTitle}>
+            <Text UNSAFE_className={classes.advancedDisclosureText}>Advanced options</Text>
+        </DisclosureTitle>
+        <DisclosurePanel
+            UNSAFE_className={classes.advancedDisclosurePanel}
+
+            UNSAFE_style={{ paddingBlock: 0 }}
+        >
+            {children}
+        </DisclosurePanel>
+    </Disclosure>
+);
+
+const SchemaFormItemList = ({ entries, showAdvanced, ...props }: SchemaFormItemListProps) => (
+    <>
+        {entries.map(({ item, index }) => (
+            <SchemaFormItem
+                {...props}
+                key={item.kind === 'section' ? item.id : `${item.kind}-${index}`}
+                item={item}
+                showAdvanced={showAdvanced}
+            />
+        ))}
+    </>
+);
+
+const SchemaFormUnownedFieldList = ({ fields, showAdvanced, ...props }: SchemaFormUnownedFieldListProps) => (
+    <>
+        {fields.map(([name, field]) => (
+            <SchemaFormField {...props} key={name} name={name} field={field} showAdvanced={showAdvanced} />
+        ))}
+    </>
+);
 
 const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
     if (item.kind === 'info') {
@@ -127,7 +188,7 @@ const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
         if (field === undefined) {
             return null;
         }
-        if (!props.isFieldEnabled(item.name, field, props.required)) {
+        if (!props.isFieldEnabled(item.name, field, props.required, props.showAdvanced)) {
             return null;
         }
 
@@ -147,10 +208,16 @@ const SchemaFormItem = ({ item, ...props }: SchemaFormItemProps) => {
     if (item.kind === 'field') {
         const field = props.properties[item.name];
         return field === undefined ? null : (
-            <SchemaFormField {...props} name={item.name} field={field} info={item.info} />
+            <SchemaFormField
+                {...props}
+                name={item.name}
+                field={field}
+                info={item.info}
+                showAdvanced={props.showAdvanced}
+            />
         );
     }
-    if (!props.isRenderable(item, props.properties, props.required)) {
+    if (!props.isRenderable(item, props.properties, props.required, true)) {
         return null;
     }
     return (
@@ -169,28 +236,54 @@ const SchemaFormItems = ({ items, renderUnownedFields, ...props }: SchemaFormIte
               return Object.entries(props.properties).filter(([name]) => !ownedFields.has(name));
           })()
         : [];
+    const indexedItems = items.map((item, index) => ({ item, index }));
+    const renderableItems = indexedItems.filter(({ item }) =>
+        props.isRenderable(item, props.properties, props.required, true)
+    );
+
+    const [basicItems, advancedItems] = partition(
+        renderableItems,
+        ({ item }) => item.kind === 'section' || props.isRenderable(item, props.properties, props.required, false)
+    );
+    const [basicUnownedFields, advancedUnownedFields] = renderUnownedFields
+        ? partition(
+              unownedFields.filter(([name, field]) => props.isFieldVisible(name, field, props.required, true)),
+              ([name, field]) => props.isFieldVisible(name, field, props.required, false)
+          )
+        : [[], []];
+
+    const hasAdvancedFields = advancedItems.length !== 0 || advancedUnownedFields.length !== 0;
 
     return (
-        <>
-            {items.map((item, index) => (
-                <SchemaFormItem
-                    {...props}
-                    key={item.kind === 'section' ? item.id : `${item.kind}-${index}`}
-                    item={item}
-                    items={items}
-                    renderUnownedFields={renderUnownedFields}
-                />
-            ))}
-            {renderUnownedFields &&
-                unownedFields.map(([name, field]) => (
-                    <SchemaFormField {...props} key={name} name={name} field={field} />
-                ))}
-        </>
+        <Flex direction='column' gap='size-100'>
+            <SchemaFormItemList
+                {...props}
+                entries={basicItems}
+                items={items}
+                renderUnownedFields={renderUnownedFields}
+                showAdvanced={false}
+            />
+            <SchemaFormUnownedFieldList {...props} fields={basicUnownedFields} showAdvanced={false} />
+            {hasAdvancedFields && (
+                <AdvancedOptions>
+                    <Flex direction='column' gap='size-100'>
+                        <SchemaFormItemList
+                            {...props}
+                            entries={advancedItems}
+                            items={items}
+                            renderUnownedFields={renderUnownedFields}
+                            showAdvanced
+                        />
+                        <SchemaFormUnownedFieldList {...props} fields={advancedUnownedFields} showAdvanced />
+                    </Flex>
+                </AdvancedOptions>
+            )}
+        </Flex>
     );
 };
 
 const SchemaFormField = ({ name, field, ...props }: SchemaFormFieldProps) => {
-    if (!props.isFieldVisible(name, field, props.required)) {
+    if (!props.isFieldVisible(name, field, props.required, props.showAdvanced)) {
         return null;
     }
 
@@ -237,7 +330,6 @@ const SchemaFormField = ({ name, field, ...props }: SchemaFormFieldProps) => {
 
 export const SchemaForm = ({ schema }: { schema: JsonSchema }) => {
     const { activeType, payload, setPayload, updatePayloadField } = useRobotForm();
-    const [showAdvanced, setShowAdvanced] = useState(false);
     const properties = schema.properties ?? EMPTY_PROPERTIES;
     const definitions = schema.$defs ?? EMPTY_DEFINITIONS;
     const required = new Set(schema.required ?? []);
@@ -253,16 +345,16 @@ export const SchemaForm = ({ schema }: { schema: JsonSchema }) => {
         }
     }, [definitions, payload, properties, setPayload]);
 
-    const isFieldVisible: IsFieldVisible = (name, field, fieldRequired) => {
+    const isFieldVisible: IsFieldVisible = (name, field, fieldRequired, showAdvanced) => {
         const resolvedField = resolveReference(field, definitions);
-        if (!isFieldEnabled(name, resolvedField, fieldRequired)) {
+        if (!isFieldEnabled(name, resolvedField, fieldRequired, showAdvanced)) {
             return false;
         }
 
         return resolvedField.type !== 'object' || resolvedField.properties !== undefined;
     };
 
-    const isFieldEnabled: IsFieldEnabled = (name, field, fieldRequired) => {
+    const isFieldEnabled: IsFieldEnabled = (name, field, fieldRequired, showAdvanced) => {
         const resolvedField = resolveReference(field, definitions);
         const fieldUi = resolvedField['x-physicalai-ui'];
         const isRequired = isRequiredField(name, resolvedField, fieldRequired);
@@ -270,41 +362,34 @@ export const SchemaForm = ({ schema }: { schema: JsonSchema }) => {
         return isRequired || isUiItems(fieldUi) || fieldUi?.advanced_configuration !== true || showAdvanced;
     };
 
-    const isRenderable: IsRenderable = (item, itemProperties, itemRequired) => {
+    const isRenderable: IsRenderable = (item, itemProperties, itemRequired, showAdvanced) => {
         if (item.kind === 'info' || item.kind === 'connection' || item.kind === 'ip_address') {
             return true;
         }
         if (item.kind === 'calibration') {
             const field = itemProperties[item.name];
-            return field !== undefined && isFieldEnabled(item.name, field, itemRequired);
+            return field !== undefined && isFieldEnabled(item.name, field, itemRequired, showAdvanced);
         }
         if (item.kind === 'field') {
             const field = itemProperties[item.name];
-            return field !== undefined && isFieldVisible(item.name, field, itemRequired);
+            return field !== undefined && isFieldVisible(item.name, field, itemRequired, showAdvanced);
         }
-        return item.items.some((child) => isRenderable(child, itemProperties, itemRequired));
+        return item.items.some((child) => isRenderable(child, itemProperties, itemRequired, showAdvanced));
     };
 
     return (
-        <Flex direction='column' gap='size-200'>
-            <Flex justifyContent='end'>
-                <Switch isSelected={showAdvanced} onChange={setShowAdvanced} isHidden>
-                    Show advanced options
-                </Switch>
-            </Flex>
-            <SchemaFormItems
-                items={items}
-                properties={properties}
-                required={required}
-                values={payload}
-                onChange={updatePayloadField}
-                robotType={activeType!}
-                definitions={definitions}
-                isFieldVisible={isFieldVisible}
-                isFieldEnabled={isFieldEnabled}
-                isRenderable={isRenderable}
-                renderUnownedFields
-            />
-        </Flex>
+        <SchemaFormItems
+            items={items}
+            properties={properties}
+            required={required}
+            values={payload}
+            onChange={updatePayloadField}
+            robotType={activeType!}
+            definitions={definitions}
+            isFieldVisible={isFieldVisible}
+            isFieldEnabled={isFieldEnabled}
+            isRenderable={isRenderable}
+            renderUnownedFields
+        />
     );
 };


### PR DESCRIPTION
This PR allows the user to open up the "Advanced configuration" options for a robot. These are configuration options that users are unlikely to need unless they're debugging or want more control on their robot.
One important distinction that this PR makes is that the schema form can render form fields inside of sections, which are used if for instance a payload references another payload,
```python
class TrossenBimanualPayload(BaseModel):
    """Connection configuration for Trossen bimanual robots."""

    left_arm: TrossenSingleArmPayload
    right_arm: TrossenSingleArmPayload
```

In this case if these payload contain any advanced options then we show a disclosure panel inside of the section.
In other cases (no section) we simply show the panel at the bottom of the form.

| **Advanced options for rebot** | **Multiple sections** |
|------------|-----------|
|  <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/2a163a80-1a6a-4795-a0a0-b5245147b4b8" />  |  <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/bdf15332-4681-425f-b5c1-bfbc46d83242" />  |



