### PR TITLE
docs(data): note pin_memory/persistent_workers RAM tradeoff

### DIFF
--- a/library/docs/explanation/data/datamodules.md
+++ b/library/docs/explanation/data/datamodules.md
@@ -33,3 +33,17 @@ class DataModule(LightningDataModule):
 - Combines datasets and gym environments
 - Wraps gyms with `StepLimit`
 - Configurable rollout counts for validation/test
+
+## `pin_memory` and `persistent_workers`
+
+Both default to speeding up training: `pin_memory="auto"` pins host memory for
+faster host-to-GPU transfers whenever an accelerator is available, and
+`persistent_workers=True` keeps train DataLoader workers alive between epochs
+instead of re-spawning them.
+
+These come at the cost of extra host RAM: pinned pages can't be swapped out,
+and persistent workers hold their process (and any prefetched batches) open
+for the whole run. If you're training a smaller policy (e.g. ACT, SmolVLA) on
+a machine with limited RAM and see OOM kills or heavy swapping, set
+`pin_memory=False` and/or `persistent_workers=False` in your datamodule
+config.

--- a/skills/library/physicalai-train-working-with-datasets/SKILL.md
+++ b/skills/library/physicalai-train-working-with-datasets/SKILL.md
@@ -70,6 +70,7 @@ data:
 - Missing/renamed feature → the config's dataset features disagree with the policy; align `Feature` names in `data/observation.py` conventions.
 - Slow/stalled first batch → the LeRobot `repo_id` is downloading; expected on first run (see the `requires_download` test marker for tests that need this).
 - Wrong batch dimensions → check `train_batch_size` and the datamodule's collate/observation handling before changing the policy.
+- OOM or heavy swapping during training (common on smaller policies like ACT/SmolVLA on low-RAM machines) → try `pin_memory=False` and/or `persistent_workers=False` on the `DataModule`; see `library/docs/explanation/data/datamodules.md`.
 
 ## Required checks
 


### PR DESCRIPTION
Follow-up to #1082. Alfie raised a concern there about users with limited RAM hitting OOM once `pin_memory`/`persistent_workers` default on, especially for smaller policies (ACT, SmolVLA).

- Documents the RAM tradeoff and when to disable each flag in `library/docs/explanation/data/datamodules.md`.
- Adds a matching debugging bullet to the `physicalai-train-working-with-datasets` skill.

No code changes.