### PR TITLE
feat(smolvla): align SnapFlow CD-sample padding exemption with Pi0.5

### DIFF
--- a/library/src/physicalai/policies/smolvla/model.py
+++ b/library/src/physicalai/policies/smolvla/model.py
@@ -215,13 +215,18 @@ class SmolVLAModel(Model):
         lang_tokens = batch[TOKENIZED_PROMPT]
         lang_masks = batch[TOKENIZED_PROMPT_MASK]
         loss_dict: dict[str, torch.Tensor | float] = {}
-        losses = self._model.forward(images, img_masks, lang_tokens, lang_masks, state, actions)
+        losses, cd_idx = self._model.forward(images, img_masks, lang_tokens, lang_masks, state, actions)
 
         # Truncate losses to actual action dimensions to avoid dilution from padding
         original_action_dim = int(self._dataset_stats[ACTION]["shape"][-1])
         losses = losses[:, :, :original_action_dim]
 
-        loss = reduce_losses(losses, in_episode_bound(batch))
+        # Mask out action steps that only exist because the chunk query was
+        # clamped at an episode boundary. SnapFlow consistency-distillation
+        # samples (cd_idx) are exempt: they regress onto a self-generated
+        # teacher velocity rather than the dataset action, so padded steps
+        # carry no bad supervision there.
+        loss = reduce_losses(losses, in_episode_bound(batch, cd_idx))
         # Detached tensor, not `.item()` float: see Model.compute_loss docstring.
         loss_dict["loss"] = loss.detach()
         return loss, loss_dict
@@ -1129,7 +1134,7 @@ class VLAFlowMatching(SnapFlowModelMixin, nn.Module):
         actions: torch.Tensor,
         noise: torch.Tensor | None = None,
         time: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Compute flow matching training loss, optionally with SnapFlow self-distillation.
 
         When ``snapflow_enabled`` is *False* this delegates to :meth:`_forward_fm`.
@@ -1148,10 +1153,17 @@ class VLAFlowMatching(SnapFlowModelMixin, nn.Module):
             time: Optional diffusion time step tensor.
 
         Returns:
-            Per-element MSE loss tensor of shape (batch_size, chunk_size, action_dim).
+            Tuple of (per-element MSE loss tensor of shape
+            ``(batch_size, chunk_size, action_dim)``, indices of samples
+            routed through the consistency-distillation branch, or ``None``
+            when SnapFlow is disabled). CD samples do not regress onto the
+            dataset action, so callers should treat ``cd_idx`` as exempt from
+            action-padding masking (see
+            :func:`physicalai.policies.base.in_episode_bound`).
         """
         if not self._snapflow_enabled:
-            return self._forward_fm(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
+            losses = self._forward_fm(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
+            return losses, None
 
         if noise is None:
             noise = self._sample_noise(actions.shape, actions.device)
@@ -1171,9 +1183,7 @@ class VLAFlowMatching(SnapFlowModelMixin, nn.Module):
         x_t = time_expanded * noise + (1 - time_expanded) * actions
         u_t = noise - actions
 
-        # SmolVLA does not exempt consistency-distillation samples from the
-        # action-padding mask (unlike Pi05); the CD indices are discarded here.
-        losses, _cd_idx = self.snapflow_mixed_loss(
+        losses, cd_idx = self.snapflow_mixed_loss(
             u_t=u_t,
             x_t=x_t,
             time=time,
@@ -1184,7 +1194,7 @@ class VLAFlowMatching(SnapFlowModelMixin, nn.Module):
             sample_noise=self._sample_noise,
             predict_velocity=self._predict_velocity,
         )
-        return losses
+        return losses, cd_idx
 
     def sample_actions(  # noqa: PLR0914
         self,

--- a/library/tests/unit/policies/test_action_pad_masking_regression.py
+++ b/library/tests/unit/policies/test_action_pad_masking_regression.py
@@ -119,7 +119,7 @@ def _smolvla_loss(action_is_pad: torch.Tensor) -> float:
         _preprocess_batch=lambda b: b,
         _prepare_state=lambda b: None,
         _prepare_action=lambda b: None,
-        _model=SimpleNamespace(forward=lambda *_a, **_kw: losses.clone()),
+        _model=SimpleNamespace(forward=lambda *_a, **_kw: (losses.clone(), None)),
         _dataset_stats={ACTION: {"shape": (ACTION_DIM,)}},
     )
     loss, _ = SmolVLAModel.compute_loss(stub, batch)

--- a/library/tests/unit/policies/test_smolvla.py
+++ b/library/tests/unit/policies/test_smolvla.py
@@ -708,7 +708,7 @@ class TestActionPaddingMask:
             _preprocess_batch=lambda b: b,
             _prepare_state=lambda b: None,
             _prepare_action=lambda b: None,
-            _model=SimpleNamespace(forward=lambda *_a, **_kw: losses.clone()),
+            _model=SimpleNamespace(forward=lambda *_a, **_kw: (losses.clone(), None)),
             _dataset_stats={ACTION: {"shape": (action_dim,)}},
         )
         loss, _ = SmolVLAModel.compute_loss(stub, batch)
@@ -791,7 +791,7 @@ class TestActionPaddingMask:
             _preprocess_batch=lambda b: b,
             _prepare_state=lambda b: None,
             _prepare_action=lambda b: None,
-            _model=SimpleNamespace(forward=lambda *_a, **_kw: source * 2.0),
+            _model=SimpleNamespace(forward=lambda *_a, **_kw: (source * 2.0, None)),
             _dataset_stats={ACTION: {"shape": (2,)}},
         )
         batch: dict = {
@@ -808,6 +808,44 @@ class TestActionPaddingMask:
         assert source.grad is not None
         assert torch.all(source.grad[0, :2] != 0), "valid steps must receive gradient"
         assert torch.all(source.grad[0, 2:] == 0), "padded steps must receive zero gradient"
+
+    def test_snapflow_distillation_steps_ignore_the_pad_mask(self) -> None:
+        """Consistency-distillation samples stay fully weighted, matching Pi05.
+
+        The SnapFlow branch regresses the one-step student onto a self-generated
+        two-step teacher, so it never reads the dataset action. Padded steps carry
+        no bad supervision there, and masking them would silently drop valid
+        distillation signal from the tail of every chunk.
+        """
+        from types import SimpleNamespace
+
+        from physicalai.data.constants import IMAGE_MASKS, TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
+        from physicalai.data.observation import ACTION, EXTRA, IMAGES
+        from physicalai.policies.smolvla.model import SmolVLAModel
+
+        # All four rows routed through the CD branch (mirrors alpha=0 in the
+        # inner model); the last two are also flagged as padded.
+        losses = torch.tensor([[[1.0, 1.0], [1.0, 1.0], [99.0, 99.0], [99.0, 99.0]]])
+        cd_idx = torch.tensor([0])
+
+        stub = SimpleNamespace(
+            _preprocess_batch=lambda b: b,
+            _prepare_state=lambda b: None,
+            _prepare_action=lambda b: None,
+            _model=SimpleNamespace(forward=lambda *_a, **_kw: (losses.clone(), cd_idx)),
+            _dataset_stats={ACTION: {"shape": (2,)}},
+        )
+        batch: dict = {
+            IMAGES: None,
+            IMAGE_MASKS: None,
+            TOKENIZED_PROMPT: None,
+            TOKENIZED_PROMPT_MASK: None,
+            EXTRA + ".action_is_pad": torch.tensor([[False, False, True, True]]),
+        }
+
+        loss, _ = SmolVLAModel.compute_loss(stub, batch)
+
+        assert float(loss) == pytest.approx(50.0), "distillation steps must not be masked"
 
     @staticmethod
     def _compute_val_loss(


### PR DESCRIPTION
SmolVLA's SnapFlow consistency-distillation (CD) branch regresses onto a self-generated teacher velocity instead of the dataset action, so padded action steps carry no bad supervision there. Pi0.5 already exempts these CD samples from the action-padding mask (#919); SmolVLA discarded `cd_idx` there to preserve its pre-SnapFlow masking behavior, which was a deliberate scope decision at the time, not a correctness argument against doing it.

This wires `cd_idx` through `VLAFlowMatching.forward` -> `SmolVLAModel.compute_loss`, mirroring `Pi05Model._flow_matching_loss`. Only affects SnapFlow-enabled training (`snapflow_enabled` defaults to `False`).

Testing: added `test_snapflow_distillation_steps_ignore_the_pad_mask` to `test_smolvla.py`, mirroring the existing Pi0.5 test. Full `tests/unit/policies/` suite (220 tests) passes locally.