### PR TITLE
fix(job): backfill training_target for legacy job payloads via migration

### DIFF
--- a/application/backend/src/alembic/versions/20260908_000000_1510153d39a2_backfill_training_target_for_legacy_jobs.py
+++ b/application/backend/src/alembic/versions/20260908_000000_1510153d39a2_backfill_training_target_for_legacy_jobs.py
@@ -1,0 +1,84 @@
+"""backfill training_target for legacy job payloads
+
+Jobs persisted before the ``training_target`` discriminator existed (and
+before SSH-provisioned training was added) fail to load with a
+``union_tag_not_found`` validation error, because the payload dict has no
+``training_target`` key at all. This migration backfills the legacy target
+directly in the database: ``remote`` if the payload carries a
+``remote_trainer_id``, otherwise ``local``. Once resolved to ``local``, stale
+remote-only fields (``remote_trainer_id``, ``remote_trainer_url``,
+``remote_trainer_name``) are dropped too, since ``LocalTrainJobPayload``
+forbids them as extras.
+
+Revision ID: 1510153d39a2
+Revises: b7a4c1e9f0d2
+Create Date: 2026-09-08 00:00:00.000000
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "1510153d39a2"
+down_revision: str | Sequence[str] | None = "b7a4c1e9f0d2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_LOCAL_ONLY_LEGACY_KEYS = ("remote_trainer_id", "remote_trainer_url", "remote_trainer_name")
+
+
+def upgrade() -> None:
+    """Backfill `training_target` on legacy training job payloads."""
+    conn = op.get_bind()
+
+    jobs = conn.execute(sa.text("SELECT id, payload FROM jobs WHERE type = 'training'")).fetchall()
+
+    for job_id, payload_raw in jobs:
+        if not isinstance(payload_raw, str):
+            continue
+        payload = json.loads(payload_raw)
+        changed = False
+
+        if "training_target" not in payload:
+            payload["training_target"] = "remote" if payload.get("remote_trainer_id") else "local"
+            changed = True
+
+        if payload["training_target"] == "local":
+            for key in _LOCAL_ONLY_LEGACY_KEYS:
+                if key in payload:
+                    del payload[key]
+                    changed = True
+
+        if changed:
+            conn.execute(
+                sa.text("UPDATE jobs SET payload = :payload WHERE id = :id"),
+                {"payload": json.dumps(payload), "id": job_id},
+            )
+
+
+def downgrade() -> None:
+    """Best-effort: remove `training_target` and stale remote-only keys are not restorable.
+
+    This cannot perfectly undo the upgrade: jobs that already had
+    `training_target` set before this migration ran are indistinguishable
+    from ones backfilled by it, and dropped remote-only keys aren't
+    recoverable. Downgrading only removes the discriminator key so a
+    re-upgrade backfills it identically.
+    """
+    conn = op.get_bind()
+
+    jobs = conn.execute(sa.text("SELECT id, payload FROM jobs WHERE type = 'training'")).fetchall()
+
+    for job_id, payload_raw in jobs:
+        if not isinstance(payload_raw, str):
+            continue
+        payload = json.loads(payload_raw)
+        if payload.pop("training_target", None) is None:
+            continue
+        conn.execute(
+            sa.text("UPDATE jobs SET payload = :payload WHERE id = :id"),
+            {"payload": json.dumps(payload), "id": job_id},
+        )

--- a/application/backend/tests/test_backfill_training_target_migration.py
+++ b/application/backend/tests/test_backfill_training_target_migration.py
@@ -1,0 +1,159 @@
+"""Functional test for the `1510153d39a2` data migration.
+
+Runs the actual Alembic upgrade against a throwaway SQLite database seeded
+with legacy training job payloads (no `training_target` key at all, as
+persisted before the field existed), then asserts the migration backfills a
+payload that validates cleanly through the `Job` schema.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+from uuid import uuid4
+
+from alembic import command
+from db.migration import MigrationManager
+from settings import Settings
+
+_PRE_MIGRATION_REVISION = "b7a4c1e9f0d2"
+_MIGRATION_REVISION = "1510153d39a2"
+
+
+def _seed_legacy_training_job(db_path: Path, *, payload: dict) -> str:
+    job_id = str(uuid4())
+    project_id = str(uuid4())
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            "INSERT INTO projects (id, name) VALUES (?, ?)",
+            (project_id, "Test project"),
+        )
+        connection.execute(
+            "INSERT INTO jobs (id, project_id, type, progress, status, message, payload) "
+            "VALUES (?, ?, 'training', 0, 'pending', 'Job created', ?)",
+            (job_id, project_id, json.dumps(payload)),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    return job_id
+
+
+def _read_payload(db_path: Path, job_id: str) -> dict:
+    connection = sqlite3.connect(db_path)
+    try:
+        row = connection.execute("SELECT payload FROM jobs WHERE id = ?", (job_id,)).fetchone()
+    finally:
+        connection.close()
+    assert row is not None
+    return json.loads(row[0])
+
+
+def test_migration_backfills_local_target_when_no_remote_trainer_id(tmp_path: Path) -> None:
+    settings = Settings(STORAGE_DIR=tmp_path, DATABASE_FILE="test.db")
+    manager = MigrationManager(settings)
+    alembic_cfg = manager.get_alembic_config()
+
+    command.upgrade(alembic_cfg, _PRE_MIGRATION_REVISION)
+
+    db_path = settings.data_dir / settings.database_file
+    job_id = _seed_legacy_training_job(
+        db_path,
+        payload={
+            "project_id": str(uuid4()),
+            "dataset_id": str(uuid4()),
+            "policy": "act",
+            "model_name": "legacy-local-model",
+            "batch_size": 8,
+        },
+    )
+
+    command.upgrade(alembic_cfg, _MIGRATION_REVISION)
+
+    payload = _read_payload(db_path, job_id)
+    assert payload["training_target"] == "local"
+    assert "remote_trainer_id" not in payload
+
+
+def test_migration_backfills_remote_target_when_remote_trainer_id_present(tmp_path: Path) -> None:
+    settings = Settings(STORAGE_DIR=tmp_path, DATABASE_FILE="test.db")
+    manager = MigrationManager(settings)
+    alembic_cfg = manager.get_alembic_config()
+
+    command.upgrade(alembic_cfg, _PRE_MIGRATION_REVISION)
+
+    db_path = settings.data_dir / settings.database_file
+    remote_trainer_id = str(uuid4())
+    job_id = _seed_legacy_training_job(
+        db_path,
+        payload={
+            "project_id": str(uuid4()),
+            "dataset_id": str(uuid4()),
+            "policy": "act",
+            "model_name": "legacy-remote-model",
+            "batch_size": 8,
+            "remote_trainer_id": remote_trainer_id,
+        },
+    )
+
+    command.upgrade(alembic_cfg, _MIGRATION_REVISION)
+
+    payload = _read_payload(db_path, job_id)
+    assert payload["training_target"] == "remote"
+    assert payload["remote_trainer_id"] == remote_trainer_id
+
+
+def test_migration_drops_stale_remote_fields_from_local_payload(tmp_path: Path) -> None:
+    settings = Settings(STORAGE_DIR=tmp_path, DATABASE_FILE="test.db")
+    manager = MigrationManager(settings)
+    alembic_cfg = manager.get_alembic_config()
+
+    command.upgrade(alembic_cfg, _PRE_MIGRATION_REVISION)
+
+    db_path = settings.data_dir / settings.database_file
+    job_id = _seed_legacy_training_job(
+        db_path,
+        payload={
+            "project_id": str(uuid4()),
+            "dataset_id": str(uuid4()),
+            "policy": "act",
+            "model_name": "legacy-local-with-stale-fields",
+            "batch_size": 8,
+            "training_target": "local",
+            "remote_trainer_id": None,
+            "remote_trainer_url": None,
+            "remote_trainer_name": None,
+        },
+    )
+
+    command.upgrade(alembic_cfg, _MIGRATION_REVISION)
+
+    payload = _read_payload(db_path, job_id)
+    assert payload["training_target"] == "local"
+    assert "remote_trainer_id" not in payload
+    assert "remote_trainer_url" not in payload
+    assert "remote_trainer_name" not in payload
+
+
+def test_migration_is_a_noop_for_up_to_date_payloads(tmp_path: Path) -> None:
+    settings = Settings(STORAGE_DIR=tmp_path, DATABASE_FILE="test.db")
+    manager = MigrationManager(settings)
+    alembic_cfg = manager.get_alembic_config()
+
+    command.upgrade(alembic_cfg, _PRE_MIGRATION_REVISION)
+
+    db_path = settings.data_dir / settings.database_file
+    original_payload = {
+        "project_id": str(uuid4()),
+        "dataset_id": str(uuid4()),
+        "policy": "act",
+        "model_name": "modern-remote-model",
+        "batch_size": 8,
+        "training_target": "remote",
+        "remote_trainer_id": str(uuid4()),
+    }
+    job_id = _seed_legacy_training_job(db_path, payload=original_payload)
+
+    command.upgrade(alembic_cfg, _MIGRATION_REVISION)
+
+    assert _read_payload(db_path, job_id) == original_payload


### PR DESCRIPTION
## Description

Jobs persisted before the `training_target` discriminator existed (and before SSH-provisioned training was added) fail to load with a `union_tag_not_found` validation error, which surfaces as a 400 response from the jobs endpoint.

This adds an Alembic data migration (`1510153d39a2`) that backfills `training_target` directly in the database for legacy training job payloads:

- `REMOTE` if the legacy payload carries a `remote_trainer_id`, otherwise `LOCAL`.
- Stale remote-only fields (`remote_trainer_id`, `remote_trainer_url`, `remote_trainer_name`) are dropped once resolved to `LOCAL`, since `LocalTrainJobPayload` forbids them as extras.
- The migration is idempotent/no-op for payloads that already have an up-to-date `training_target`.

A one-time migration was chosen over a read-time backfill in `JobMapper.from_schema` so the fix runs once at upgrade time instead of on every job read.

## Testing

- Added `tests/test_backfill_training_target_migration.py`, which runs the actual Alembic `upgrade`/`downgrade` against a throwaway SQLite database seeded with legacy payloads, covering:
  - missing `training_target` key with no `remote_trainer_id` → backfilled to `local`
  - missing `training_target` key with `remote_trainer_id` → backfilled to `remote`
  - stale remote-only fields dropped from an already-tagged `local` payload
  - no-op for an up-to-date payload
- Verified `bash scripts/check_alembic_heads.sh` reports a single head.
- `uv run pytest` passes for the touched test modules.

## Related Issues

<!-- Fixes #123 -->

