### PR TITLE
fix: Don't show remove files when removing dataset when there are no episodes and don't throw 500

### DIFF
--- a/application/backend/src/services/dataset_service.py
+++ b/application/backend/src/services/dataset_service.py
@@ -41,4 +41,4 @@ class DatasetService:
         await self.repo.delete_by_id(dataset_id)
 
         if remove_files:
-            shutil.rmtree(Path(dataset.path).expanduser())
+            shutil.rmtree(Path(dataset.path).expanduser(), ignore_errors=True)

--- a/application/backend/tests/services/test_dataset_service.py
+++ b/application/backend/tests/services/test_dataset_service.py
@@ -1,0 +1,55 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from schemas.dataset import Dataset
+from services.dataset_service import DatasetService
+
+def _make_dataset() -> Dataset:
+    return Dataset.model_validate(
+        {
+            "id": uuid4(),
+            "name": "Dataset 1",
+            "default_task": "Task",
+            "project_id": uuid4(),
+            "environment_id": uuid4(),
+        }
+    )
+
+def _service_with_dataset(dataset: Dataset) -> DatasetService:
+    session = MagicMock(spec=AsyncSession)
+    with patch("services.dataset_service.DatasetRepository") as repository_type:
+        service = DatasetService(session)
+    service.repo = AsyncMock()
+    service.repo.get_by_id.return_value = dataset
+    service.repo.delete_by_id.return_value = None
+    return service
+
+
+async def test_delete_dataset_remove_files_missing_dir_does_not_raise(tmp_path) -> None:
+    dataset = _make_dataset()
+    service = _service_with_dataset(dataset)
+
+    with patch('schemas.dataset.get_settings') as mock_settings:
+        mock_settings.return_value.dataset_dir = tmp_path
+        assert not (tmp_path / str(dataset.id)).exists()
+
+        await service.delete_dataset(dataset_id=dataset.id, remove_files=True)
+
+    service.repo.delete_by_id.assert_awaited_once_with(dataset.id)
+
+async def test_delete_dataset_remove_files_deletes_existing_dir(tmp_path) -> None:
+    dataset = _make_dataset()
+    service = _service_with_dataset(dataset)
+
+    with patch('schemas.dataset.get_settings') as mock_settings:
+        mock_settings.return_value.datasets_dir = tmp_path
+        dataset_dir = tmp_path / str(dataset.id)
+
+        dataset_dir.mkdir(parents=True)
+        (dataset_dir / "episode_0.parquet").write_text("data")
+
+        await service.delete_dataset(dataset_id=dataset.id, remove_files=True)
+
+        assert not dataset_dir.exists()

--- a/application/backend/tests/services/test_dataset_service.py
+++ b/application/backend/tests/services/test_dataset_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from schemas.dataset import Dataset
 from services.dataset_service import DatasetService
 
+
 def _make_dataset() -> Dataset:
     return Dataset.model_validate(
         {
@@ -17,9 +18,10 @@ def _make_dataset() -> Dataset:
         }
     )
 
+
 def _service_with_dataset(dataset: Dataset) -> DatasetService:
     session = MagicMock(spec=AsyncSession)
-    with patch("services.dataset_service.DatasetRepository") as repository_type:
+    with patch("services.dataset_service.DatasetRepository"):
         service = DatasetService(session)
     service.repo = AsyncMock()
     service.repo.get_by_id.return_value = dataset
@@ -31,19 +33,20 @@ async def test_delete_dataset_remove_files_missing_dir_does_not_raise(tmp_path) 
     dataset = _make_dataset()
     service = _service_with_dataset(dataset)
 
-    with patch('schemas.dataset.get_settings') as mock_settings:
-        mock_settings.return_value.dataset_dir = tmp_path
+    with patch("schemas.dataset.get_settings") as mock_settings:
+        mock_settings.return_value.datasets_dir = tmp_path
         assert not (tmp_path / str(dataset.id)).exists()
 
         await service.delete_dataset(dataset_id=dataset.id, remove_files=True)
 
     service.repo.delete_by_id.assert_awaited_once_with(dataset.id)
 
+
 async def test_delete_dataset_remove_files_deletes_existing_dir(tmp_path) -> None:
     dataset = _make_dataset()
     service = _service_with_dataset(dataset)
 
-    with patch('schemas.dataset.get_settings') as mock_settings:
+    with patch("schemas.dataset.get_settings") as mock_settings:
         mock_settings.return_value.datasets_dir = tmp_path
         dataset_dir = tmp_path / str(dataset.id)
 

--- a/application/ui/src/features/datasets/delete-dataset-dialog.tsx
+++ b/application/ui/src/features/datasets/delete-dataset-dialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { AlertDialog, Checkbox, Flex, Text } from '@geti-ui/ui';
+import { isEmpty } from 'lodash-es';
 
 import { $api } from '../../api/client';
 import { SchemaDatasetOutput } from '../../api/openapi-spec';
@@ -8,9 +9,27 @@ import { useProjectId } from '../projects/use-project';
 
 type Dataset = SchemaDatasetOutput;
 
+const useEpisodes = (datasetId: string | undefined) => {
+    return $api.useQuery(
+        'get',
+        '/api/dataset/{dataset_id}/episodes',
+        {
+            params: {
+                path: {
+                    dataset_id: String(datasetId),
+                },
+            },
+        },
+        {
+            enabled: datasetId !== undefined,
+        }
+    );
+};
+
 export const DeleteDatasetDialog = ({ dataset, onDone }: { dataset: Dataset; onDone: () => void }) => {
     const [removeFiles, setRemoveFiles] = useState(false);
     const { project_id } = useProjectId();
+    const { data: episodes } = useEpisodes(dataset.id);
     const deleteMutation = $api.useMutation('delete', '/api/dataset/{dataset_id}', {
         meta: {
             invalidates: [
@@ -43,9 +62,11 @@ export const DeleteDatasetDialog = ({ dataset, onDone }: { dataset: Dataset; onD
         <AlertDialog title='Delete dataset' variant='warning' primaryActionLabel='Delete' onPrimaryAction={onDelete}>
             <Flex direction='column' gap='size-200'>
                 <Text>Are you sure you want to delete this dataset?</Text>
-                <Checkbox isEmphasized isSelected={removeFiles} onChange={setRemoveFiles}>
-                    Also remove dataset files from disk
-                </Checkbox>
+                {!isEmpty(episodes) && (
+                    <Checkbox isEmphasized isSelected={removeFiles} onChange={setRemoveFiles}>
+                        Also remove dataset files from disk
+                    </Checkbox>
+                )}
             </Flex>
         </AlertDialog>
     );


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->

When UI sends a request to remove dataset and its files on the empty dataset, server has internal error (500 send to the UI) because there are no files.
After this PR: in the UI we don't display the checkbox when there are no episodes, on server we don't throw 500.

## Related Issues

<!-- Fixes #123 -->
