### PR TITLE
fix(ui): Make cameras tab content to be visible after click

### DIFF
--- a/application/ui/src/routes/cameras/layout.tsx
+++ b/application/ui/src/routes/cameras/layout.tsx
@@ -258,6 +258,14 @@ export const CamerasList = () => {
     );
 };
 
+const CamerasFallback = () => {
+    return (
+        <Grid width='100%' height='100%'>
+            <Loading mode='inline' />
+        </Grid>
+    );
+};
+
 export const Layout = () => {
     return (
         <Grid
@@ -268,7 +276,9 @@ export const Layout = () => {
             minHeight={0}
         >
             <View gridArea='camera' backgroundColor={'gray-100'} padding='size-400'>
-                <CamerasList />
+                <Suspense fallback={<CamerasFallback />}>
+                    <CamerasList />
+                </Suspense>
             </View>
             <View
                 gridArea='controls'
@@ -278,13 +288,7 @@ export const Layout = () => {
                 minWidth={0}
                 overflow='auto'
             >
-                <Suspense
-                    fallback={
-                        <Grid width='100%' height='100%'>
-                            <Loading mode='inline' />
-                        </Grid>
-                    }
-                >
+                <Suspense fallback={<CamerasFallback />}>
                     <Outlet />
                 </Suspense>
             </View>


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->

The issue was that cameras list uses suspense query to get all cameras (querying cameras takes around 2.5s). It caused cameras tab to be opened only after suspense query is fulfilled. Adding suspense around the list allows react to transition to cameras tab right away once that tab is clicked and show a loading inside the tab. It improves UX significantly.

## Related Issues

<!-- Fixes #123 -->
