### PR TITLE
fix(ui): Align 'Compile model' in the training parameters

### DIFF
--- a/application/ui/src/features/models/train-model-dialog/training-parameters.tsx
+++ b/application/ui/src/features/models/train-model-dialog/training-parameters.tsx
@@ -123,9 +123,8 @@ export const TrainingParameters = ({
                 <Item key='16'>16</Item>
             </Picker>
         </Flex>
-        <Flex direction='row' gap='size-150' width='100%'>
+        <Flex direction='row' gap='size-200' width='100%'>
             <Picker
-                width='100%'
                 label='Precision'
                 description={
                     deviceType
@@ -153,21 +152,19 @@ export const TrainingParameters = ({
                 <Item key='bf16-true'>BF16 True</Item>
                 <Item key='32-true'>32-bit</Item>
             </Picker>
-            <Flex direction='column' gap='size-150' width='100%' justifyContent='center'>
-                <Flex direction='row' gap='size-100' alignItems='center'>
-                    <Checkbox isEmphasized isSelected={compileModel} onChange={onCompileModelChange}>
-                        Compile model
-                    </Checkbox>
-                    <ContextualHelp variant='info'>
-                        <Heading>Compile model</Heading>
-                        <Content>
-                            <Text>
-                                Enables torch.compile for all policies. Can significantly speed up training after an
-                                initial compilation warmup, but increases startup time.
-                            </Text>
-                        </Content>
-                    </ContextualHelp>
-                </Flex>
+            <Flex direction='row' alignSelf={'end'} alignItems='center'>
+                <Checkbox isEmphasized isSelected={compileModel} onChange={onCompileModelChange}>
+                    Compile model
+                </Checkbox>
+                <ContextualHelp variant='info'>
+                    <Heading>Compile model</Heading>
+                    <Content>
+                        <Text>
+                            Enables torch.compile for all policies. Can significantly speed up training after an initial
+                            compilation warmup, but increases startup time.
+                        </Text>
+                    </Content>
+                </ContextualHelp>
             </Flex>
         </Flex>
     </Flex>


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->
Before:

<img width="715" height="689" alt="image" src="https://github.com/user-attachments/assets/80a59c1f-0aa3-4dc3-a886-7dd5f380ae71" />


After:

<img width="714" height="683" alt="image" src="https://github.com/user-attachments/assets/0cd0b3b3-17fc-43dd-aebc-3f1e04845b23" />


## Related Issues

<!-- Fixes #123 -->
