### PR TITLE
fix: Use SyncExecutor in studio as well

### DIFF
--- a/application/backend/src/runtime/config_builder.py
+++ b/application/backend/src/runtime/config_builder.py
@@ -74,9 +74,7 @@ def policy_source_fragment(
 ) -> dict[str, Any]:
     """Return the PolicySource recipe both the session and the export instantiate.
 
-    ``PolicySource`` defaults to ``SyncExecution``, which would stall the 30 Hz
-    loop. Studio overrides that with ``AsyncExecution``; the export must too.
-    Omit ``policy_name`` so the manifest is read. Omit ``duration_frames`` so
+    `` Omit ``policy_name`` so the manifest is read. Omit ``duration_frames`` so
     ``LerpSmoother`` keeps its upstream default of 5.
     """
     init_args: dict[str, Any] = {
@@ -85,7 +83,7 @@ def policy_source_fragment(
             {"export_dir": export_dir, "backend": backend, "device": device},
         ).to_dict(),
         "execution": Config(
-            "physicalai.runtime.AsyncExecution",
+            "physicalai.runtime.SyncExecution",
             {"request_threshold": POLICY_REQUEST_THRESHOLD},
         ).to_dict(),
         "action_queue": Config(
@@ -106,7 +104,7 @@ def policy_source_from_fragment(fragment: dict[str, Any]) -> PolicySource:
     the same constructors Studio already uses.
     """
     from physicalai.inference import InferenceModel
-    from physicalai.runtime import AsyncExecution, ChunkedActionQueue, LerpSmoother, PolicySource
+    from physicalai.runtime import ChunkedActionQueue, LerpSmoother, PolicySource, SyncExecution
 
     args = fragment["init_args"]
     model_args = args["model"]["init_args"]
@@ -118,7 +116,7 @@ def policy_source_from_fragment(fragment: dict[str, Any]) -> PolicySource:
             backend=model_args["backend"],
             device=model_args["device"],
         ),
-        execution=AsyncExecution(request_threshold=exec_args["request_threshold"]),
+        execution=SyncExecution(request_threshold=exec_args["request_threshold"]),
         action_queue=ChunkedActionQueue(smoother=LerpSmoother()),
         task=args.get("task"),
     )

--- a/application/backend/tests/api/test_model_download.py
+++ b/application/backend/tests/api/test_model_download.py
@@ -234,7 +234,7 @@ def test_openvino_export_download_with_recipe_includes_yaml_and_exports(tmp_path
         assert "model.xml" not in names
         yaml_text = archive.read("runtime.yaml").decode()
         assert "physicalai.runtime.PolicySource" in yaml_text
-        assert "physicalai.runtime.AsyncExecution" in yaml_text
+        assert "physicalai.runtime.SyncExecution" in yaml_text
         assert "./exports/openvino" in yaml_text
         assert "pick" in yaml_text
         readme = archive.read("README.md").decode()

--- a/application/backend/tests/runtime/test_action_source_policy.py
+++ b/application/backend/tests/runtime/test_action_source_policy.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from physicalai.capture import Frame
 from physicalai.inference.constants import IMAGES, STATE
-from physicalai.runtime import AsyncExecution, ChunkedActionQueue, LerpSmoother, PolicySource, WorkerDiedError
+from physicalai.runtime import ChunkedActionQueue, LerpSmoother, PolicySource, SyncExecution, WorkerDiedError
 
 from runtime.action_source import StudioActionSource
 from runtime.contract import (
@@ -148,7 +148,7 @@ def test_re_arming_sends_an_action_from_the_current_observation() -> None:
 
     policy = PolicySource(
         model=model,
-        execution=AsyncExecution(request_threshold=0.5),
+        execution=SyncExecution(),
         action_queue=ChunkedActionQueue(smoother=LerpSmoother()),
         task=None,
     )
@@ -286,7 +286,7 @@ def test_the_model_input_carries_the_task_string() -> None:
 
     policy = PolicySource(
         model=model,
-        execution=AsyncExecution(request_threshold=0.5),
+        execution=SyncExecution(),
         action_queue=ChunkedActionQueue(smoother=LerpSmoother()),
         task=None,
     )
@@ -308,7 +308,7 @@ def test_the_model_input_is_rgb() -> None:
 
     policy = PolicySource(
         model=model,
-        execution=AsyncExecution(request_threshold=0.5),
+        execution=SyncExecution(),
         action_queue=ChunkedActionQueue(smoother=LerpSmoother()),
         task=None,
     )

--- a/application/backend/tests/runtime/test_config_builder.py
+++ b/application/backend/tests/runtime/test_config_builder.py
@@ -247,7 +247,7 @@ def test_policy_source_fragment_matches_the_session_recipe() -> None:
     assert export["class_path"] == "physicalai.runtime.PolicySource"
     assert export["init_args"]["execution"] == session["init_args"]["execution"]
     assert export["init_args"]["action_queue"] == session["init_args"]["action_queue"]
-    assert export["init_args"]["execution"]["class_path"] == "physicalai.runtime.AsyncExecution"
+    assert export["init_args"]["execution"]["class_path"] == "physicalai.runtime.SyncExecution"
     assert export["init_args"]["execution"]["init_args"]["request_threshold"] == POLICY_REQUEST_THRESHOLD
     assert "duration_frames" not in export["init_args"]["action_queue"]["init_args"]["smoother"]["init_args"]
     assert "policy_name" not in export["init_args"]["model"]["init_args"]

--- a/application/backend/tests/runtime/test_policy_loader.py
+++ b/application/backend/tests/runtime/test_policy_loader.py
@@ -213,8 +213,8 @@ def test_a_single_camera_model_ignores_the_camera_name() -> None:
     check_camera_keys(model, ["wrist"])
 
 
-def test_loader_instantiates_async_execution(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from physicalai.runtime import AsyncExecution
+def test_loader_instantiates_sync_execution(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from physicalai.runtime import SyncExecution
 
     from runtime.config_builder import POLICY_REQUEST_THRESHOLD
 
@@ -226,7 +226,7 @@ def test_loader_instantiates_async_execution(tmp_path, monkeypatch: pytest.Monke
     source.update(follower.get_observation(), {}, 0)
     _wait_until(lambda: source._policy is not None)
     assert source._policy is not None
-    assert isinstance(source._policy._execution, AsyncExecution)
+    assert isinstance(source._policy._execution, SyncExecution)
     assert source._policy._execution._threshold_frac == POLICY_REQUEST_THRESHOLD
     source.shutdown_policy()
 


### PR DESCRIPTION
AsyncExecutor has bug where running inference gets worse over time.
This needs to get fixed, but temporary disable first