### PR TITLE
fix(ui): Display latest dataset name after rename

### DIFF
--- a/application/ui/src/features/datasets/rename-dataset-dialog.test.tsx
+++ b/application/ui/src/features/datasets/rename-dataset-dialog.test.tsx
@@ -27,12 +27,12 @@ const projectsListQueryKey = ['get', '/api/projects'] as const;
 
 const dataset = getMockedDataset({ id: DATASET_ID, project_id: PROJECT_ID, name: 'pick-dataset' });
 
-const renderDialog = (
+const renderRenameDatasetDialog = (
     onDone: (dataset: SchemaDatasetOutput | undefined) => void,
     queryClient: ReturnType<typeof createQueryClient>
 ) => render(<RenameDatasetDialog dataset={dataset} onDone={onDone} />, { queryClient });
 
-const renameViaUi = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
+const renameDataset = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
     const textField = await screen.findByLabelText(/Dataset name/);
     await user.clear(textField);
     await user.type(textField, name);
@@ -55,9 +55,9 @@ describe('RenameDatasetDialog', () => {
 
         const user = userEvent.setup();
         const onDone = vi.fn();
-        renderDialog(onDone, createQueryClient());
+        renderRenameDatasetDialog(onDone, createQueryClient());
 
-        await renameViaUi(user, '  renamed  ');
+        await renameDataset(user, '  renamed  ');
 
         await waitFor(() => expect(onDone).toHaveBeenCalledWith(updatedDataset));
 
@@ -76,9 +76,9 @@ describe('RenameDatasetDialog', () => {
         queryClient.setQueryData(projectsListQueryKey, [{ id: PROJECT_ID, name: 'test-project' }]);
 
         const user = userEvent.setup();
-        renderDialog(vi.fn(), queryClient);
+        renderRenameDatasetDialog(vi.fn(), queryClient);
 
-        await renameViaUi(user, 'renamed');
+        await renameDataset(user, 'renamed');
 
         await waitFor(() => {
             expect(queryClient.getQueryState(datasetQueryKey)?.isInvalidated).toBe(true);
@@ -98,7 +98,7 @@ describe('RenameDatasetDialog', () => {
 
         const user = userEvent.setup();
         const onDone = vi.fn();
-        renderDialog(onDone, createQueryClient());
+        renderRenameDatasetDialog(onDone, createQueryClient());
 
         await user.click(await screen.findByRole('button', { name: 'Cancel' }));
 
@@ -108,7 +108,7 @@ describe('RenameDatasetDialog', () => {
 
     it('field prefilled and Save disabled unless the name changes to a non-empty value', async () => {
         const user = userEvent.setup();
-        renderDialog(vi.fn(), createQueryClient());
+        renderRenameDatasetDialog(vi.fn(), createQueryClient());
 
         const textField = await screen.findByLabelText(/Dataset name/);
         const saveButton = screen.getByRole('button', { name: 'Save' });

--- a/application/ui/src/features/datasets/rename-dataset-dialog.test.tsx
+++ b/application/ui/src/features/datasets/rename-dataset-dialog.test.tsx
@@ -1,0 +1,115 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SchemaDatasetOutput } from '../../api/openapi-spec';
+import { http } from '../../api/utils';
+import { server } from '../../msw-node-setup';
+import { createQueryClient } from '../../query-client/query-client';
+import { getMockedDataset } from '../../test-utils/mocks/mock-dataset';
+import { render } from '../../test-utils/render';
+import { RenameDatasetDialog } from './rename-dataset-dialog';
+
+const DATASET_ID = 'dataset-1';
+const PROJECT_ID = 'project-1';
+
+const datasetQueryKey = ['get', '/api/dataset/{dataset_id}', { params: { path: { dataset_id: DATASET_ID } } }] as const;
+const projectQueryKey = [
+    'get',
+    '/api/projects/{project_id}',
+    { params: { path: { project_id: PROJECT_ID } } },
+] as const;
+
+const dataset = getMockedDataset({ id: DATASET_ID, project_id: PROJECT_ID, name: 'pick-dataset' });
+
+const renderDialog = (
+    onDone: (dataset: SchemaDatasetOutput | undefined) => void,
+    queryClient: ReturnType<typeof createQueryClient>
+) => render(<RenameDatasetDialog dataset={dataset} onDone={onDone} />, { queryClient });
+
+const renameViaUi = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
+    const textField = await screen.findByLabelText(/Dataset name/);
+    await user.clear(textField);
+    await user.type(textField, name);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+};
+
+describe('RenameDatasetDialog', () => {
+    it('submits trimmed name and calls onDone with updated dataset', async () => {
+        let receivedBody: unknown;
+        let receivedDatasetId: string | undefined;
+        const updatedDataset = getMockedDataset({ id: DATASET_ID, project_id: PROJECT_ID, name: 'renamed' });
+
+        server.use(
+            http.put('/api/dataset/{dataset_id}', async ({ request, params }) => {
+                receivedBody = await request.json();
+                receivedDatasetId = params.dataset_id;
+                return HttpResponse.json(updatedDataset);
+            })
+        );
+
+        const user = userEvent.setup();
+        const onDone = vi.fn();
+        renderDialog(onDone, createQueryClient());
+
+        await renameViaUi(user, '  renamed  ');
+
+        await waitFor(() => expect(onDone).toHaveBeenCalledWith(updatedDataset));
+
+        expect(receivedBody).toEqual({ name: 'renamed' });
+        expect(receivedDatasetId).toBe(DATASET_ID);
+    });
+
+    it('invalidates dataset and project queries after rename', async () => {
+        server.use(
+            http.put('/api/dataset/{dataset_id}', () => HttpResponse.json(getMockedDataset({ name: 'renamed' })))
+        );
+
+        const queryClient = createQueryClient();
+        queryClient.setQueryData(datasetQueryKey, dataset);
+        queryClient.setQueryData(projectQueryKey, { id: PROJECT_ID, name: 'test-project' });
+
+        const user = userEvent.setup();
+        renderDialog(vi.fn(), queryClient);
+
+        await renameViaUi(user, 'renamed');
+
+        await waitFor(() => expect(queryClient.getQueryState(datasetQueryKey)?.isInvalidated).toBe(true));
+        expect(queryClient.getQueryState(projectQueryKey)?.isInvalidated).toBe(true);
+    });
+
+    it('calls onDone(undefined) on cancel without submitting', async () => {
+        let putCalled = false;
+        server.use(
+            http.put('/api/dataset/{dataset_id}', () => {
+                putCalled = true;
+                return HttpResponse.json(dataset);
+            })
+        );
+
+        const user = userEvent.setup();
+        const onDone = vi.fn();
+        renderDialog(onDone, createQueryClient());
+
+        await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+        expect(onDone).toHaveBeenCalledWith(undefined);
+        expect(putCalled).toBe(false);
+    });
+
+    it('field prefilled and save disabled when name is whitespace only', async () => {
+        const user = userEvent.setup();
+        renderDialog(vi.fn(), createQueryClient());
+
+        const textField = await screen.findByLabelText(/Dataset name/);
+        expect(textField).toHaveValue(dataset.name);
+
+        await user.clear(textField);
+
+        expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+});

--- a/application/ui/src/features/datasets/rename-dataset-dialog.test.tsx
+++ b/application/ui/src/features/datasets/rename-dataset-dialog.test.tsx
@@ -23,6 +23,7 @@ const projectQueryKey = [
     '/api/projects/{project_id}',
     { params: { path: { project_id: PROJECT_ID } } },
 ] as const;
+const projectsListQueryKey = ['get', '/api/projects'] as const;
 
 const dataset = getMockedDataset({ id: DATASET_ID, project_id: PROJECT_ID, name: 'pick-dataset' });
 
@@ -64,7 +65,7 @@ describe('RenameDatasetDialog', () => {
         expect(receivedDatasetId).toBe(DATASET_ID);
     });
 
-    it('invalidates dataset and project queries after rename', async () => {
+    it('invalidates dataset, project, and projects list queries after rename', async () => {
         server.use(
             http.put('/api/dataset/{dataset_id}', () => HttpResponse.json(getMockedDataset({ name: 'renamed' })))
         );
@@ -72,14 +73,18 @@ describe('RenameDatasetDialog', () => {
         const queryClient = createQueryClient();
         queryClient.setQueryData(datasetQueryKey, dataset);
         queryClient.setQueryData(projectQueryKey, { id: PROJECT_ID, name: 'test-project' });
+        queryClient.setQueryData(projectsListQueryKey, [{ id: PROJECT_ID, name: 'test-project' }]);
 
         const user = userEvent.setup();
         renderDialog(vi.fn(), queryClient);
 
         await renameViaUi(user, 'renamed');
 
-        await waitFor(() => expect(queryClient.getQueryState(datasetQueryKey)?.isInvalidated).toBe(true));
-        expect(queryClient.getQueryState(projectQueryKey)?.isInvalidated).toBe(true);
+        await waitFor(() => {
+            expect(queryClient.getQueryState(datasetQueryKey)?.isInvalidated).toBe(true);
+            expect(queryClient.getQueryState(projectQueryKey)?.isInvalidated).toBe(true);
+            expect(queryClient.getQueryState(projectsListQueryKey)?.isInvalidated).toBe(true);
+        });
     });
 
     it('calls onDone(undefined) on cancel without submitting', async () => {
@@ -101,15 +106,22 @@ describe('RenameDatasetDialog', () => {
         expect(putCalled).toBe(false);
     });
 
-    it('field prefilled and save disabled when name is whitespace only', async () => {
+    it('field prefilled and Save disabled unless the name changes to a non-empty value', async () => {
         const user = userEvent.setup();
         renderDialog(vi.fn(), createQueryClient());
 
         const textField = await screen.findByLabelText(/Dataset name/);
+        const saveButton = screen.getByRole('button', { name: 'Save' });
+
         expect(textField).toHaveValue(dataset.name);
+        expect(saveButton).toBeDisabled();
+
+        await user.type(textField, '-2');
+
+        expect(saveButton).toBeEnabled();
 
         await user.clear(textField);
 
-        expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+        expect(saveButton).toBeDisabled();
     });
 });

--- a/application/ui/src/features/datasets/rename-dataset-dialog.tsx
+++ b/application/ui/src/features/datasets/rename-dataset-dialog.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react';
 
 import { Button, ButtonGroup, Content, Dialog, Divider, Heading, TextField } from '@geti-ui/ui';
+import { isEmpty } from 'lodash-es';
 
 import { $api } from '../../api/client';
 import { SchemaDatasetOutput } from '../../api/openapi-spec';
@@ -19,10 +20,12 @@ export const RenameDatasetDialog = ({
         meta: {
             invalidates: [
                 ['get', '/api/dataset/{dataset_id}', { params: { path: { dataset_id: dataset.id! } } }],
-                ['get', '/api/projects'],
+                ['get', '/api/projects/{project_id}', { params: { path: { project_id: dataset.project_id } } }],
             ],
         },
     });
+
+    const isSaveDisabled = isEmpty(name.trim()) || name === dataset.name;
 
     const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -69,7 +72,7 @@ export const RenameDatasetDialog = ({
                     <Button
                         variant='accent'
                         type='submit'
-                        isDisabled={name.trim() === ''}
+                        isDisabled={isSaveDisabled}
                         isPending={renameMutation.isPending}
                     >
                         Save

--- a/application/ui/src/features/datasets/rename-dataset-dialog.tsx
+++ b/application/ui/src/features/datasets/rename-dataset-dialog.tsx
@@ -21,6 +21,7 @@ export const RenameDatasetDialog = ({
             invalidates: [
                 ['get', '/api/dataset/{dataset_id}', { params: { path: { dataset_id: dataset.id! } } }],
                 ['get', '/api/projects/{project_id}', { params: { path: { project_id: dataset.project_id } } }],
+                ['get', '/api/projects'],
             ],
         },
     });


### PR DESCRIPTION
## Description

<!-- What does this PR do, and why? -->

The issue is that `project` cache is not invalidated.
This PR fixes that issue and adds unit tests for rename dataset feature.

## Related Issues

<!-- Fixes #123 -->
