### PR TITLE
feat: expose image augmentation in the training UI

### DIFF
--- a/application/backend/src/schemas/job.py
+++ b/application/backend/src/schemas/job.py
@@ -142,6 +142,10 @@ class TrainJobPayloadBase(BaseModel):
         description="Training precision ('32-true', 'bf16-mixed')",
     )
     compile_model: bool = Field(default=False, description="Enable torch.compile for supported policies")
+    augment_images: bool = Field(
+        default=False,
+        description="Apply the default image augmentation pipeline to training images",
+    )
     snapflow_enabled: bool = Field(
         default=False,
         description=(

--- a/application/backend/src/schemas/model.py
+++ b/application/backend/src/schemas/model.py
@@ -192,6 +192,7 @@ class TrainingSummary(BaseModel):
     num_workers: int | str | None = None
     precision: str | None = None
     compile_model: bool | None = None
+    augment_images: bool | None = None
     val_split: float | None = None
     device_type: str | None = None
     snapflow_enabled: bool | None = None

--- a/application/backend/src/services/model_service.py
+++ b/application/backend/src/services/model_service.py
@@ -92,6 +92,7 @@ class ModelService:
             batch_size=payload.batch_size,
             precision=str(payload.precision),
             compile_model=payload.compile_model,
+            augment_images=payload.augment_images,
             val_split=payload.val_split,
             auto_scale_batch_size=payload.auto_scale_batch_size,
             num_workers=payload.num_workers,

--- a/application/backend/src/services/training_backends/local.py
+++ b/application/backend/src/services/training_backends/local.py
@@ -119,6 +119,7 @@ def build_spec(context: TrainingContext) -> TrainingJobSpec:
         val_split=payload.val_split,
         precision=str(payload.precision),
         compile_model=payload.compile_model,
+        augment_images=payload.augment_images,
         auto_scale_batch_size=payload.auto_scale_batch_size,
         snapflow_start_epoch=payload.snapflow_start_epoch,
         device_type=str(device.type) if device else None,

--- a/application/backend/src/training/job.py
+++ b/application/backend/src/training/job.py
@@ -126,6 +126,10 @@ class TrainingJobSpec(BaseModel):
     val_split: float = Field(default=0.1, ge=0.0, lt=1.0, description="Fraction of episodes held out for validation.")
     precision: str = Field(default="bf16-mixed", description="Lightning precision, e.g. '32-true' or 'bf16-mixed'.")
     compile_model: bool = Field(default=False, description="Whether to torch.compile the policy forward pass.")
+    augment_images: bool = Field(
+        default=False,
+        description="Whether to augment training images with the default pipeline.",
+    )
     auto_scale_batch_size: bool = Field(default=False, description="Whether to search for the largest fitting batch.")
     snapflow_start_epoch: int | None = Field(
         default=None,
@@ -276,6 +280,7 @@ def run_training_job(
     from physicalai.data import LeRobotDataModule
     from physicalai.train.callbacks import ProgressReportingCallback
     from physicalai.train.trainer import Trainer
+    from physicalai.transforms import DefaultImageAugmentations
 
     from training.device import resolve_accelerator, resolve_devices, resolve_strategy
 
@@ -290,6 +295,9 @@ def run_training_job(
             train_batch_size=spec.batch_size,
             num_workers=spec.num_workers,
             val_split=spec.val_split,
+            # Applied to the train split only; the datamodule leaves validation
+            # images untouched so eval loss stays comparable across runs.
+            image_transforms=DefaultImageAugmentations() if spec.augment_images else None,
         )
         policy = build_policy(spec, resume_from=spec.run_options.resume_from)
 

--- a/application/backend/tests/schemas/test_job.py
+++ b/application/backend/tests/schemas/test_job.py
@@ -170,3 +170,13 @@ class TestSnapFlowDistillation:
         )
 
         assert (remote.snapflow_start_epoch, ssh.snapflow_start_epoch) == (5, 5)
+
+
+class TestTrainingOptions:
+    """Options shared by every target, so they are asserted once on the local one."""
+
+    def test_image_augmentation_is_off_unless_asked_for(self) -> None:
+        assert LocalTrainJobPayload(**_base_kwargs()).augment_images is False
+
+    def test_image_augmentation_can_be_enabled(self) -> None:
+        assert LocalTrainJobPayload(**_base_kwargs(), augment_images=True).augment_images is True

--- a/application/backend/tests/services/test_local_training_backend.py
+++ b/application/backend/tests/services/test_local_training_backend.py
@@ -127,6 +127,12 @@ class TestBuildSpec:
 
         assert (spec.device_type, spec.device_index) == (None, None)
 
+    @pytest.mark.parametrize("augment_images", [True, False])
+    def test_image_augmentation_choice_is_forwarded(self, tmp_path, augment_images):
+        spec = build_spec(_context(tmp_path, _payload(augment_images=augment_images)))
+
+        assert spec.augment_images is augment_images
+
     def test_resumed_run_trains_the_base_model_policy(self, tmp_path):
         """A resumed run's architecture comes from the checkpoint, not the request."""
         base_model = _model(tmp_path / "base", policy="pi0")

--- a/application/backend/tests/training/test_job.py
+++ b/application/backend/tests/training/test_job.py
@@ -46,6 +46,7 @@ class TestTrainingJobSpec:
         assert (spec.policy_source, spec.max_epochs, spec.batch_size) == ("physicalai", 5, 8)
         assert (spec.num_workers, spec.val_split, spec.precision) == ("auto", 0.1, "bf16-mixed")
         assert (spec.compile_model, spec.auto_scale_batch_size) == (False, False)
+        assert spec.augment_images is False
         assert (spec.device_type, spec.device_index) == (None, None)
 
     def test_unknown_field_is_rejected(self) -> None:
@@ -326,6 +327,35 @@ class TestRunTrainingJob:
         kwargs = datamodule.call_args.kwargs
         assert kwargs["root"] == str(tmp_path / "snapshot")
         assert (kwargs["train_batch_size"], kwargs["num_workers"], kwargs["val_split"]) == (16, 2, 0.25)
+
+    @pytest.mark.parametrize("augment_images", [True, False])
+    def test_image_augmentation_is_opt_in(self, tmp_path: Path, augment_images: bool) -> None:
+        """The GUI checkbox is the only thing standing between off and the default pipeline."""
+        from physicalai.transforms import DefaultImageAugmentations
+
+        spec = TrainingJobSpec(policy="act", augment_images=augment_images)
+        cache_dir = tmp_path / "cache" / "job"
+
+        with (
+            patch("physicalai.data.LeRobotDataModule") as datamodule,
+            patch(f"{JOB}.build_policy"),
+            patch("physicalai.train.trainer.Trainer") as trainer_class,
+        ):
+            trainer_class.return_value.fit.side_effect = lambda *a, **k: (cache_dir / CHECKPOINT_NAME).write_text("x")
+            run_training_job(
+                spec,
+                dataset_root=tmp_path / "snapshot",
+                output_dir=tmp_path / "model",
+                cache_dir=cache_dir,
+                report=MagicMock(),
+                should_stop=lambda: False,
+            )
+
+        transforms = datamodule.call_args.kwargs["image_transforms"]
+        if augment_images:
+            assert isinstance(transforms, DefaultImageAugmentations)
+        else:
+            assert transforms is None
 
     def test_completed_run_publishes_the_cache_as_the_model_directory(self, tmp_path: Path) -> None:
         """The final checkpoint comes solely from the ModelCheckpoint callback, not an explicit save."""

--- a/application/ui/src/features/models/job-table/job-table.test.tsx
+++ b/application/ui/src/features/models/job-table/job-table.test.tsx
@@ -9,6 +9,7 @@ import { server } from '../../../msw-node-setup';
 import { getMockedDataset } from '../../../test-utils/mocks/mock-dataset';
 import { getMockedEnvironment } from '../../../test-utils/mocks/mock-environment';
 import { getMockedRemoteTrainer } from '../../../test-utils/mocks/mock-remote-trainer';
+import { getMockedTrainJobPayload } from '../../../test-utils/mocks/mock-train-job-payload';
 import { render } from '../../../test-utils/render';
 import { TrainingRow } from './job-table';
 
@@ -43,21 +44,7 @@ const localJob: SchemaTrainJob = {
     created_at: '2026-07-14T09:00:00Z',
     extra_info: { 'train/loss_step': 0.123456 },
     type: 'training',
-    payload: {
-        project_id: 'project-1',
-        dataset_id: 'dataset-1',
-        policy: 'act',
-        model_name: 'pick-and-place',
-        batch_size: 8,
-        num_workers: 'auto',
-        auto_scale_batch_size: false,
-        val_split: 0.1,
-        precision: 'bf16-mixed',
-        compile_model: false,
-        snapflow_enabled: false,
-        snapflow_distill_epochs: 3,
-        training_target: 'local',
-    },
+    payload: getMockedTrainJobPayload(),
 };
 
 const remoteTrainer = getMockedRemoteTrainer();

--- a/application/ui/src/features/models/model-details/training-configuration.tsx
+++ b/application/ui/src/features/models/model-details/training-configuration.tsx
@@ -28,6 +28,9 @@ export const TrainingParameters = ({ summary }: { summary: SchemaModelDetailResp
                 {summary.compile_model !== null && summary.compile_model !== undefined && (
                     <DetailRow name='Compiled' value={summary.compile_model ? 'Yes' : 'No'} />
                 )}
+                {summary.augment_images !== null && summary.augment_images !== undefined && (
+                    <DetailRow name='Image augmentation' value={summary.augment_images ? 'On' : 'Off'} />
+                )}
                 {summary.val_split !== null && summary.val_split !== undefined && summary.val_split > 0 && (
                     <DetailRow name='Validation split' value={summary.val_split} />
                 )}

--- a/application/ui/src/features/models/models-table/model-row.test.tsx
+++ b/application/ui/src/features/models/models-table/model-row.test.tsx
@@ -8,6 +8,7 @@ import { http } from '../../../api/utils';
 import { server } from '../../../msw-node-setup';
 import { getMockedDataset } from '../../../test-utils/mocks/mock-dataset';
 import { getMockedEnvironment } from '../../../test-utils/mocks/mock-environment';
+import { getMockedTrainJobPayload } from '../../../test-utils/mocks/mock-train-job-payload';
 import { render } from '../../../test-utils/render';
 import { durationBetween } from '../shared/duration';
 import { ModelRow } from './model-row';
@@ -58,21 +59,7 @@ const trainingJob: SchemaTrainJob = {
     end_time: '2026-07-14T10:30:00Z',
     created_at: '2026-07-14T09:00:00Z',
     type: 'training',
-    payload: {
-        project_id: 'project-1',
-        dataset_id: 'dataset-1',
-        policy: 'act',
-        model_name: 'pick-and-place',
-        batch_size: 8,
-        num_workers: 'auto',
-        auto_scale_batch_size: false,
-        val_split: 0.1,
-        precision: 'bf16-mixed',
-        compile_model: false,
-        snapflow_enabled: false,
-        snapflow_distill_epochs: 3,
-        training_target: 'local',
-    },
+    payload: getMockedTrainJobPayload(),
 };
 
 const modelDetailResponse = {

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.test.tsx
@@ -281,4 +281,39 @@ describe('TrainModelDialog', () => {
         expect(await screen.findByText(/does not have access to this policy/i)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Train' })).toBeDisabled();
     });
+
+    describe('image augmentation', () => {
+        const submitAndCapturePayload = async (toggle: boolean) => {
+            const user = userEvent.setup();
+            let body: Record<string, unknown> | undefined;
+
+            mockProjectWithRemoteTrainer();
+            server.use(
+                http.post('/api/jobs:train', async ({ request }) => {
+                    body = (await request.json()) as Record<string, unknown>;
+                    return HttpResponse.json({}, { status: 201 });
+                })
+            );
+
+            renderDialog();
+
+            await user.click(await screen.findByRole('button', { name: /select…/i }));
+            await user.click(await screen.findByRole('option', { name: 'Test dataset' }));
+            if (toggle) {
+                await user.click(await screen.findByRole('checkbox', { name: /augment images/i }));
+            }
+            await user.click(screen.getByRole('button', { name: 'Train' }));
+
+            await waitFor(() => expect(body).toBeDefined());
+            return body;
+        };
+
+        it('is off unless the user opts in', async () => {
+            expect(await submitAndCapturePayload(false)).toMatchObject({ augment_images: false });
+        });
+
+        it('is submitted when the checkbox is ticked', async () => {
+            expect(await submitAndCapturePayload(true)).toMatchObject({ augment_images: true });
+        });
+    });
 });

--- a/application/ui/src/features/models/train-model-dialog/train-model-dialog.tsx
+++ b/application/ui/src/features/models/train-model-dialog/train-model-dialog.tsx
@@ -82,6 +82,7 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
     const [compileModel, setCompileModel] = useState<boolean>(false);
     const [snapflowEnabled, setSnapflowEnabled] = useState<boolean>(false);
     const [snapflowDistillEpochs, setSnapflowDistillEpochs] = useState<number>(DEFAULT_SNAPFLOW_DISTILL_EPOCHS);
+    const [augmentImages, setAugmentImages] = useState<boolean>(false);
     const [remoteTrainerId, setRemoteTrainerId] = useState<Key | null>('local');
     const isSnapflowSupported = supportsSnapflow(selectedPolicy);
     // snapflow_distill_epochs is additive on top of max_epochs (the teacher phase
@@ -163,6 +164,7 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
             compile_model: compileModel,
             snapflow_enabled: isSnapflowRequested,
             snapflow_distill_epochs: snapflowDistillEpochs,
+            augment_images: augmentImages,
             val_split: 0.1,
             ...extraPayload,
         } as const;
@@ -257,6 +259,8 @@ export const TrainModelDialog = ({ baseModel, close, defaultMaxEpochs = 5 }: Tra
                                 onPrecisionChange={setPrecision}
                                 compileModel={compileModel}
                                 onCompileModelChange={setCompileModel}
+                                augmentImages={augmentImages}
+                                onAugmentImagesChange={setAugmentImages}
                                 isAutoScaleBatchDisabled={activeDevice?.type !== 'cuda'}
                                 deviceType={activeDevice?.type}
                                 isSnapflowSupported={isSnapflowSupported}

--- a/application/ui/src/features/models/train-model-dialog/training-parameters.tsx
+++ b/application/ui/src/features/models/train-model-dialog/training-parameters.tsx
@@ -29,6 +29,8 @@ interface TrainingParametersProps {
     onPrecisionChange: (value: Key | null) => void;
     compileModel: boolean;
     onCompileModelChange: (value: boolean) => void;
+    augmentImages: boolean;
+    onAugmentImagesChange: (value: boolean) => void;
     isAutoScaleBatchDisabled: boolean;
     deviceType: string | undefined;
     /** False for policies without a flow-matching sampler; hides the SnapFlow controls entirely. */
@@ -52,6 +54,8 @@ export const TrainingParameters = ({
     onPrecisionChange,
     compileModel,
     onCompileModelChange,
+    augmentImages,
+    onAugmentImagesChange,
     isAutoScaleBatchDisabled,
     deviceType,
     isSnapflowSupported,
@@ -169,19 +173,38 @@ export const TrainingParameters = ({
                 <Item key='bf16-true'>BF16 True</Item>
                 <Item key='32-true'>32-bit</Item>
             </Picker>
-            <Flex direction='row' alignSelf={'end'} alignItems='center'>
-                <Checkbox isEmphasized isSelected={compileModel} onChange={onCompileModelChange}>
-                    Compile model
-                </Checkbox>
-                <ContextualHelp variant='info'>
-                    <Heading>Compile model</Heading>
-                    <Content>
-                        <Text>
-                            Enables torch.compile for all policies. Can significantly speed up training after an initial
-                            compilation warmup, but increases startup time.
-                        </Text>
-                    </Content>
-                </ContextualHelp>
+            <Flex direction='column' gap='size-150' alignSelf={'end'}>
+                <Flex direction='row' alignItems='center'>
+                    <Checkbox isEmphasized isSelected={compileModel} onChange={onCompileModelChange}>
+                        Compile model
+                    </Checkbox>
+                    <ContextualHelp variant='info'>
+                        <Heading>Compile model</Heading>
+                        <Content>
+                            <Text>
+                                Enables torch.compile for all policies. Can significantly speed up training after an
+                                initial compilation warmup, but increases startup time.
+                            </Text>
+                        </Content>
+                    </ContextualHelp>
+                </Flex>
+                <Flex direction='row' alignItems='center'>
+                    <Checkbox isEmphasized isSelected={augmentImages} onChange={onAugmentImagesChange}>
+                        Augment images
+                    </Checkbox>
+                    <ContextualHelp variant='info'>
+                        <Heading>Augment images</Heading>
+                        <Content>
+                            <Text>
+                                Randomly varies brightness, contrast, saturation, hue, sharpness and small rotations on
+                                training images, so the policy is less tied to the exact lighting and camera placement
+                                it was recorded under. This could help when your dataset is small or was recorded in one
+                                fixed setup but the robot will run somewhere more varied. It does not always improve
+                                results and makes each epoch slightly slower. Validation images are left untouched.
+                            </Text>
+                        </Content>
+                    </ContextualHelp>
+                </Flex>
             </Flex>
         </Flex>
         {isSnapflowSupported && (

--- a/application/ui/src/test-utils/mocks/mock-train-job-payload.ts
+++ b/application/ui/src/test-utils/mocks/mock-train-job-payload.ts
@@ -23,6 +23,7 @@ const basePayload = {
     compile_model: false,
     snapflow_enabled: false,
     snapflow_distill_epochs: 3,
+    augment_images: false,
 };
 
 type BaseKeys = keyof typeof basePayload;

--- a/library/configs/physicalai/act.yaml
+++ b/library/configs/physicalai/act.yaml
@@ -27,8 +27,8 @@ data:
                 - 0.8
                 - 1.2
               brightness:
-                - 0.7
-                - 1.3
+                - 0.8
+                - 1.2
 
 trainer:
   max_steps: 70000

--- a/library/configs/physicalai/act_xpu.yaml
+++ b/library/configs/physicalai/act_xpu.yaml
@@ -27,8 +27,8 @@ data:
                 - 0.8
                 - 1.2
               brightness:
-                - 0.7
-                - 1.3
+                - 0.8
+                - 1.2
 
 trainer:
   max_steps: 70000

--- a/library/configs/physicalai/smolvla.yaml
+++ b/library/configs/physicalai/smolvla.yaml
@@ -40,8 +40,8 @@ data:
                 - 0.8
                 - 1.2
               brightness:
-                - 0.7
-                - 1.3
+                - 0.8
+                - 1.2
 
 trainer:
   max_epochs: 100

--- a/library/configs/physicalai/smolvla_snapflow_distillation.yaml
+++ b/library/configs/physicalai/smolvla_snapflow_distillation.yaml
@@ -67,8 +67,8 @@ data:
                 - 0.8
                 - 1.2
               brightness:
-                - 0.7
-                - 1.3
+                - 0.8
+                - 1.2
 
 trainer:
   max_epochs: 2

--- a/library/docs/how-to/training/image_augmentations.md
+++ b/library/docs/how-to/training/image_augmentations.md
@@ -27,9 +27,47 @@ PhysicalAI provides two custom transforms alongside standard torchvision transfo
 
 Image transforms are configured under `data.init_args.image_transforms` in the training YAML config using the standard `class_path` / `init_args` pattern. They apply to all image observations during training only (not during validation or inference).
 
-### ACT Example
+### Quick Start
 
-The following configuration randomly applies 3 out of 6 available transforms to each training image. Default values match [LeRobot's augmentation pipeline](https://github.com/huggingface/lerobot).
+`physicalai.transforms.DefaultImageAugmentations` bundles the recommended pipeline, 3 of the 6 transforms below with the ranges from [Default Values Reference](#default-values-reference), so you don't have to spell the pool out:
+
+```yaml
+data:
+  class_path: physicalai.data.lerobot.LeRobotDataModule
+  init_args:
+    repo_id: "lerobot/pusht"
+    train_batch_size: 64
+    data_format: "physicalai"
+    image_transforms:
+      class_path: physicalai.transforms.DefaultImageAugmentations
+```
+
+It takes optional `n_subset` and `random_order` arguments if you want to tune how much is applied per image:
+
+```yaml
+image_transforms:
+  class_path: physicalai.transforms.DefaultImageAugmentations
+  init_args:
+    n_subset: 2
+```
+
+The same class backs the **Augment images** checkbox under _Advanced settings_ in the Studio training dialog, so a GUI run and a `DefaultImageAugmentations` config train on identically augmented images.
+
+From Python:
+
+```python
+from physicalai.data.lerobot import LeRobotDataModule
+from physicalai.transforms import DefaultImageAugmentations
+
+datamodule = LeRobotDataModule(
+    repo_id="lerobot/pusht",
+    image_transforms=DefaultImageAugmentations(),
+)
+```
+
+### Customizing the Pipeline
+
+To choose your own pool, weights, or ranges, build a `RandomChoice` directly. The following is exactly what `DefaultImageAugmentations` expands to, so start here and edit.
 
 ```yaml
 data:
@@ -79,6 +117,8 @@ data:
                 - 0.05
 ```
 
+Any callable works here, not just these transforms. Wrap several in `torchvision.transforms.v2.Compose` to apply them all every time instead of sampling a subset.
+
 The same configuration works for all supported policies (ACT, SmolVLA, Pi0, Pi0.5, GR00T).
 
 ### Default Values Reference
@@ -100,6 +140,5 @@ You can also enable augmentations from the command line without modifying the co
 ```bash
 physicalai fit \
     --config configs/physicalai/act.yaml \
-    --data.image_transforms.class_path physicalai.transforms.RandomChoice \
-    --data.image_transforms.init_args.n_subset 3
+    --data.image_transforms physicalai.transforms.DefaultImageAugmentations
 ```

--- a/library/src/physicalai/transforms/__init__.py
+++ b/library/src/physicalai/transforms/__init__.py
@@ -8,6 +8,7 @@ replacements for standard transforms.
 """
 
 from physicalai.transforms.image_transforms import (
+    DefaultImageAugmentations,
     RandomChoice,
     RandomSharpness,
 )
@@ -19,6 +20,7 @@ from physicalai.transforms.onnx_transforms import (
 
 __all__ = [
     "CenterCrop",
+    "DefaultImageAugmentations",
     "RandomChoice",
     "RandomSharpness",
     "center_crop_image",

--- a/library/src/physicalai/transforms/image_transforms.py
+++ b/library/src/physicalai/transforms/image_transforms.py
@@ -10,10 +10,13 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 import torch
-from torchvision.transforms.v2 import Transform
+from torchvision.transforms.v2 import ColorJitter, RandomAffine, Transform
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
 _EXPECTED_SHARPNESS_LEN = 2
+
+_DEFAULT_N_SUBSET = 3
+"""How many of the default transforms are applied per image."""
 
 
 class RandomChoice(Transform):
@@ -169,3 +172,58 @@ class RandomSharpness(Transform):
             The input with adjusted sharpness.
         """
         return self._call_kernel(F.adjust_sharpness, inpt, sharpness_factor=params["sharpness_factor"])
+
+
+class DefaultImageAugmentations(RandomChoice):
+    """The recommended image augmentation pipeline, ready to use.
+
+    Bundles the six transforms documented in
+    ``docs/how-to/training/image_augmentations.md`` (brightness, contrast,
+    saturation, hue, sharpness, and a small affine jitter) into a single
+    callable, so enabling augmentations does not require spelling the whole
+    pool out in YAML. See the guide for the exact ranges.
+
+    Only a random subset is applied per image, so any one image is perturbed
+    along a few axes rather than all six at once.
+
+    Use it from Python::
+
+        LeRobotDataModule(..., image_transforms=DefaultImageAugmentations())
+
+    or from a training config::
+
+        image_transforms:
+          class_path: physicalai.transforms.DefaultImageAugmentations
+
+    Pass *n_subset* to change how aggressive it is, or build a
+    :class:`RandomChoice` directly to choose your own pool.
+
+    Args:
+        n_subset: Number of transforms applied per image. Defaults to 3 of 6.
+        random_order: If ``True``, the selected transforms are applied in a
+            random order rather than the order listed above.
+
+    Example:
+        >>> augment = DefaultImageAugmentations()
+        >>> len(augment.transforms)
+        6
+    """
+
+    def __init__(
+        self,
+        n_subset: int = _DEFAULT_N_SUBSET,
+        random_order: bool = False,  # noqa: FBT001, FBT002
+    ) -> None:
+        """Initialise the default pool with the documented ranges."""
+        super().__init__(
+            transforms=[
+                ColorJitter(brightness=(0.8, 1.2)),
+                ColorJitter(contrast=(0.8, 1.2)),
+                ColorJitter(saturation=(0.5, 1.5)),
+                ColorJitter(hue=(-0.05, 0.05)),
+                RandomSharpness(sharpness=(0.5, 1.5)),
+                RandomAffine(degrees=(-5.0, 5.0), translate=(0.05, 0.05)),
+            ],
+            n_subset=n_subset,
+            random_order=random_order,
+        )

--- a/library/tests/unit/transforms/test_image_transforms.py
+++ b/library/tests/unit/transforms/test_image_transforms.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 from torchvision.transforms.v2 import ColorJitter, RandomAffine
 
-from physicalai.transforms import RandomChoice, RandomSharpness
+from physicalai.transforms import DefaultImageAugmentations, RandomChoice, RandomSharpness
 
 
 class TestRandomChoice:
@@ -107,3 +107,53 @@ class TestRandomSharpness:
         """Inverted range should raise ValueError."""
         with pytest.raises(ValueError, match="sharpness values"):
             RandomSharpness(sharpness=[1.5, 0.5])
+
+
+class TestDefaultImageAugmentations:
+    """Smoke tests for the ready-made augmentation pipeline."""
+
+    def test_usable_without_arguments(self) -> None:
+        """The pipeline is the one-liner alternative to spelling out the pool."""
+        transform = DefaultImageAugmentations()
+        assert isinstance(transform, RandomChoice)
+        assert len(transform.transforms) == 6
+        assert transform.n_subset == 3
+
+    def test_output_shape_preserved(self) -> None:
+        """Output image should have the same shape as input."""
+        transform = DefaultImageAugmentations()
+        image = torch.rand(3, 64, 64)
+        output = transform(image)
+        assert output.shape == image.shape
+
+    def test_output_shape_batch(self) -> None:
+        """Batched images should preserve shape."""
+        transform = DefaultImageAugmentations()
+        image = torch.rand(2, 3, 64, 64)
+        output = transform(image)
+        assert output.shape == image.shape
+
+    def test_image_is_actually_perturbed(self) -> None:
+        """The pipeline should change the image, not pass it through."""
+        torch.manual_seed(0)
+        transform = DefaultImageAugmentations()
+        image = torch.rand(3, 64, 64)
+        assert not torch.equal(transform(image), image)
+
+    def test_n_subset_override(self) -> None:
+        """n_subset controls how many transforms are applied per image."""
+        transform = DefaultImageAugmentations(n_subset=1)
+        assert transform.n_subset == 1
+        image = torch.rand(3, 64, 64)
+        assert transform(image).shape == image.shape
+
+    def test_n_subset_out_of_range_raises(self) -> None:
+        """Validation is inherited from RandomChoice."""
+        with pytest.raises(ValueError, match="n_subset"):
+            DefaultImageAugmentations(n_subset=7)
+
+    def test_random_order(self) -> None:
+        """random_order=True should not change output shape."""
+        transform = DefaultImageAugmentations(random_order=True)
+        image = torch.rand(3, 64, 64)
+        assert transform(image).shape == image.shape


### PR DESCRIPTION
Image augmentations were only reachable by hand-writing about 45 lines of `image_transforms` YAML, so runs started from the GUI never used them. This adds a ready-made pipeline class to the library and an "Augment images" checkbox in the training dialog's Advanced settings that switches it on.

## Changes

**Library.** `DefaultImageAugmentations(RandomChoice)` in `physicalai/transforms/image_transforms.py`, holding the six transforms and ranges from the existing docs table. `n_subset` and `random_order` stay configurable.

**Backend.** `augment_images: bool = False` on `TrainJobPayloadBase` and `TrainingJobSpec`, mapped in `build_spec` and applied at the one `LeRobotDataModule` construction site in `training/job.py`. `build_spec` is shared with the remote backend, so remote runs get it without extra plumbing. Also added to `TrainingSummary` for the model detail page.

**UI.** Checkbox with contextual help next to "Compile model", plus an "Image augmentation" row on the model detail page. The help text is deliberately hedged: it says augmentation *could* help on small or single-setup datasets, that it does not always improve results, and that epochs get slightly slower.

**Custom pipelines through `data.init_args.image_transforms` still work exactly as before.**
## Testing

- Library: 961 passed on `torch 2.11.0+cu128`, including 7 new tests for the pipeline
- Backend: 1234 passed, including coverage that the datamodule receives the transform when the flag is set and `None` when it is not
- UI: 285 passed, with two new tests asserting the checkbox reaches the request body; type-check, lint, format, cyclic-deps and production build all clean
- `prek run --from-ref origin/main --to-ref HEAD` clean

I regenerated the OpenAPI spec with `physicalai-studio gen-api`.

## Screenshots

The training dialog with the new "Augment images" checkbox under Advanced settings, checked and sitting next to "Compile model":

![Train dialog with Augment images checked](https://gist.githubusercontent.com/Daankrol/66a0672f88ac900f939945a0782026cc/raw/5f65146dc4af0633bba4029495b8de08d8eceb85/train-dialog.png)

The contextual help popover for it:

![Augment images contextual help popover](https://gist.githubusercontent.com/Daankrol/66a0672f88ac900f939945a0782026cc/raw/5f65146dc4af0633bba4029495b8de08d8eceb85/train-dialog-help.png)