### PR TITLE
fix(pi05): wire compile_mode through to torch.compile

### DIFF
--- a/library/src/physicalai/policies/pi05/model.py
+++ b/library/src/physicalai/policies/pi05/model.py
@@ -620,6 +620,7 @@ class Pi05Model(PeftModelMixin, SnapFlowModelMixin, RTCModelMixin, Model):
         train_expert_only: bool = True,
         gradient_checkpointing: bool = False,
         compile_model: bool = False,
+        compile_mode: str = "max-autotune",
         use_random_input_noise: bool = False,
     ) -> None:
         """Initialize Pi05Model.
@@ -652,6 +653,7 @@ class Pi05Model(PeftModelMixin, SnapFlowModelMixin, RTCModelMixin, Model):
             train_expert_only: Whether to train only the action expert.
             gradient_checkpointing: Whether to enable gradient checkpointing for memory optimization.
             compile_model: Whether to use torch.compile.
+            compile_mode: Torch compile mode (e.g. "default", "max-autotune").
             use_random_input_noise: Whether to use random noise as the initial input for the denoising
                 process during inference. If False, zeros are used instead.
 
@@ -713,9 +715,6 @@ class Pi05Model(PeftModelMixin, SnapFlowModelMixin, RTCModelMixin, Model):
 
         if compile_model:
             torch.set_float32_matmul_precision("high")
-            # TODO(Eugene): max-autotune currently failed.  # noqa: TD003, FIX002
-            # Set to default for now, need further investigation.
-            compile_mode = "default"
             self.sample_actions = torch.compile(self.sample_actions, mode=compile_mode)  # type: ignore[method-assign]
             self.forward = torch.compile(self.forward, mode=compile_mode)  # type: ignore[method-assign]
 

--- a/library/src/physicalai/policies/pi05/policy.py
+++ b/library/src/physicalai/policies/pi05/policy.py
@@ -322,6 +322,7 @@ class Pi05(PeftPolicyMixin, SnapFlowPolicyMixin, RTCPolicyMixin, ExportablePolic
             train_expert_only=self.config.train_expert_only,
             gradient_checkpointing=self.config.gradient_checkpointing,
             compile_model=self.config.compile_model,
+            compile_mode=self.config.compile_mode,
             use_random_input_noise=self.config.use_random_input_noise,
         )
         if weights_file is not None:


### PR DESCRIPTION
Pi0.5's torch.compile call always used mode=\"default\" no matter what compile_mode was set to in the config. This PR wires the config value through so max-autotune actually gets used.

`Pi05Config` already had a `compile_mode` field defaulting to `\"max-autotune\"`, and `Pi05Policy` threaded it through as a hyperparameter, but `Pi05Model.__init__` never accepted it. Instead it hardcoded a local `compile_mode = \"default\"` next to a comment saying max-autotune had failed and needed investigation. That override meant the config field had no effect.

I tested max-autotune directly on an H100 (torch 2.11+cu128): small test-fixture model inference, full-size (gemma_2b/gemma_300m) inference, and full-size training with gradient checkpointing all compiled and ran correctly. Whatever caused the original failure doesn't reproduce here, so the override was removed.

Changes:
- `Pi05Model.__init__` now takes a `compile_mode` parameter instead of hardcoding one.
- `Pi05Policy._initialize_model` passes `self.config.compile_mode` through to the model.

Testing: all 160 existing pi0.5 unit tests pass (`test_pi05.py`, `test_pi05_rtc.py`). Ran `prek` on both changed files, clean.