### PR TITLE
fix(ui): correct policy VRAM estimates from measurements

### DIFF
--- a/application/ui/src/features/models/train-model-dialog/policies.ts
+++ b/application/ui/src/features/models/train-model-dialog/policies.ts
@@ -9,7 +9,9 @@ export const formatBytes = (bytes: number): string => {
 /**
  * Available training policies with hardware requirements.
  *
- * `minVRAM` is the estimated minimum VRAM (in bytes) required to train with batch_size=1.
+ * `minVRAM` is the peak VRAM measured over one training step at batch_size=1.
+ * Optimizer state drives the peak, so it tracks the trainable parameter count
+ * and barely moves with batch size: Pi0.5 needs ~38 GB at both batch 1 and 8.
  */
 export const MODELS: ReadonlyArray<{
     id: string;
@@ -27,12 +29,12 @@ export const MODELS: ReadonlyArray<{
         id: 'smolvla',
         name: 'SmolVLA',
         description: 'Small Vision-Language-Action model based on SmolVLM2-500M',
-        minVRAM: 8 * GB,
+        minVRAM: 3 * GB,
     },
     {
         id: 'pi05',
         name: 'Pi0.5',
         description: 'Enhanced Pi0 with discrete state encoding and longer context',
-        minVRAM: 16 * GB,
+        minVRAM: 40 * GB,
     },
 ];


### PR DESCRIPTION
Pi0.5's `minVRAM` estimate (16 GB) dates from when only the action expert trained (#352); #525 reverted to full fine-tuning without updating it, and a real training step now peaks around 37 GB. This updates all three `minVRAM` values to measured peak memory, so the dialog warns 24 GB users instead of letting Pi0.5 runs start and OOM (#1001).

Measured over one training step at batch size 1 on an H100 (act 1.03 GB, smolvla 1.99 GB, pi05 36.98 GB); neither `torch.compile` nor batch size moves the pi05 number, since optimizer state sets the peak, not activations.